### PR TITLE
fix(pos): finalize pending checkout inventory reviews

### DIFF
--- a/docs/solutions/architecture-patterns/athena-pending-checkout-inventory-resolution-2026-07-03.md
+++ b/docs/solutions/architecture-patterns/athena-pending-checkout-inventory-resolution-2026-07-03.md
@@ -1,0 +1,114 @@
+---
+title: Athena Pending Checkout Inventory Resolution
+date: 2026-07-03
+category: architecture-patterns
+module: athena-webapp
+problem_type: architecture_pattern
+component: service_object
+resolution_type: workflow_improvement
+severity: high
+applies_when:
+  - "Finalizing POS pending checkout items from the product page"
+  - "Resolving synced sale inventory review work"
+  - "Linking checkout evidence to trusted catalog inventory"
+tags:
+  - athena-webapp
+  - pos
+  - pending-checkout
+  - inventory
+  - open-work
+  - catalog
+  - convex
+---
+
+# Athena Pending Checkout Inventory Resolution
+
+## Problem
+
+POS checkout recovery creates real sale evidence before the catalog has trusted
+stock data. If product-page review, POS sync, and Open Work each invent their
+own resolution rules, Athena can either trust cashier-created quantities too
+early or leave inventory review work stuck after a manager has already repaired
+the affected SKU.
+
+## Solution
+
+Keep the source of authority split by workflow:
+
+- Product-page pending checkout finalization owns the transition from checkout
+  evidence to trusted catalog inventory. It must validate the pending checkout
+  item, the draft product/SKU anchors, the sale evidence fingerprint, and the
+  reviewed SKU fingerprint before updating catalog fields or writing inventory
+  movement.
+- POS synced sale ingestion owns the durable local-to-cloud identity for skipped
+  stock mutations. It should create an `inventoryReviewWorkItem` mapping for the
+  completed sale so local precursor events can settle when the server accepts
+  the sale with an inventory review conflict.
+- Operations owns completion of synced sale inventory review work only after
+  there is proof that stock has been repaired. A post-review stock movement is
+  the strongest proof; a positive current SKU inventory state is an acceptable
+  fallback when the movement was not attached to the original review.
+- Open Work and Daily Operations should expose calm, source-aware rows with
+  enough product, receipt, and provisional SKU metadata to route the operator,
+  but they should not mutate catalog or inventory state directly.
+
+The product page can reuse the existing trusted inventory preview shape for
+both legacy import provisional SKUs and POS pending checkout items, but the
+mutation reference must stay source-specific. Pending checkout finalization
+returns the updated product/SKU state so the UI can immediately leave draft or
+hidden stock copy behind after the manager commits trusted values.
+
+## Why This Matters
+
+The cashier flow stays unblocked while managers retain control over catalog
+truth. Sale evidence remains auditable, pending checkout rows do not become
+trusted stock by accident, and local POS review rows can settle without making
+terminal health look blocked by inventory work that now belongs in Operations.
+
+## Prevention
+
+- Validate sale and SKU fingerprints before product-page finalization so stale
+  product edits cannot overwrite newer catalog work.
+- Write inventory movements only from manager/admin review boundaries, never
+  from pending checkout sale creation or cashier reuse.
+- Keep local sync settlement tests that prove inventory-review sale conflicts
+  mark the sale and local precursor rows synced without persisting drawer
+  authority blocks.
+- Keep Open Work tests for missing stock proof, mismatched store or terminal
+  context, stale work status, and already-reviewed pending checkout items.
+- Keep UI tests for product-page pending checkout linking, Operations queue
+  metadata, and terminal detail copy so operator surfaces do not regress into
+  raw backend wording.
+
+## Examples
+
+A pending checkout item reviewed from the product page should call the POS
+catalog finalization mutation, not a generic Open Work resolver. That mutation
+patches the product, patches the SKU, records a trusted inventory movement when
+the reviewed stock count changes, completes the pending checkout item, and
+records an operational event tied to the original sale evidence.
+
+A synced offline sale that skipped stock mutation should create a sale mapping
+and an `inventoryReviewWorkItem` mapping:
+
+```text
+localIdKind = inventoryReviewWorkItem
+localId = ${localTransactionId}:inventory-review
+cloudTable = operationalWorkItem
+```
+
+When the operator later resolves the review from Operations, the resolver should
+require a stock repair proof before completing the work item. It should not
+require the original terminal, register session, or cloud sale ids when the work
+item's metadata and affected SKU provide enough durable context to verify the
+review.
+
+## Related
+
+- `docs/solutions/architecture-patterns/athena-open-work-resolution-ownership-2026-07-02.md`
+- `docs/solutions/architecture/athena-pos-pending-checkout-item-recovery-2026-06-06.md`
+- `docs/solutions/architecture/athena-pos-provisional-import-availability-2026-06-11.md`
+- `docs/solutions/logic-errors/athena-terminal-sync-review-currentness-2026-06-28.md`
+- `packages/athena-webapp/convex/pos/public/catalog.ts`
+- `packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts`
+- `packages/athena-webapp/src/components/add-product/ProductStock.tsx`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8483 nodes · 10217 edges · 2085 communities detected
+- 8500 nodes · 10249 edges · 2085 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2295,60 +2295,60 @@ Cohesion: 0.16
 Nodes (25): acknowledgeTerminalRecoveryCommand(), arraysEqualAsSets(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), hasRuntimeLocalReviewDetails(), isActiveCommand() (+17 more)
 
 ### Community 43 - "Community 43"
-Cohesion: 0.09
-Nodes (6): getConversionRequestId(), handleClick(), handleFinalize(), isSkuReserved(), normalizeCommandMessage(), shouldDisable()
-
-### Community 44 - "Community 44"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.12
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.16
 Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.09
 Nodes (5): buildPersistedRuntimeStatus(), buildQueryCtx(), buildRegisterSession(), buildRuntimeStatus(), buildTrackedQueryCtx()
 
-### Community 48 - "Community 48"
+### Community 47 - "Community 47"
 Cohesion: 0.09
 Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.16
 Nodes (20): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getRuntimeReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady() (+12 more)
 
-### Community 51 - "Community 51"
+### Community 50 - "Community 50"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 52 - "Community 52"
+### Community 51 - "Community 51"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.2
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.18
 Nodes (23): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+15 more)
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.14
 Nodes (18): findCurrentStoreDayOpening(), findLatestStoreDayOpening(), getTodaySummary(), getTransactionById(), isActivePosSummaryOpeningAt(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames() (+10 more)
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
+
+### Community 56 - "Community 56"
+Cohesion: 0.09
+Nodes (2): isSkuReserved(), shouldDisable()
 
 ### Community 57 - "Community 57"
 Cohesion: 0.17
@@ -2367,28 +2367,28 @@ Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
 ### Community 61 - "Community 61"
+Cohesion: 0.16
+Nodes (16): actionableWorkItemTimestamp(), buildOperationalWorkItem(), compareOperationalWorkItems(), compareStrings(), createOperationalWorkItemWithCtx(), filterArchivedPendingCheckoutWorkItems(), joinSourceIdentity(), metadataArrayCount() (+8 more)
+
+### Community 62 - "Community 62"
 Cohesion: 0.1
 Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.13
 Nodes (11): dateInputToCalendarDate(), formatDateLabel(), formatNextCloseSummaryLabel(), formatNextOpenSummaryLabel(), formatScheduleSummaryLabel(), formatTimeLabel(), getCurrentOpenWindow(), getDayLabel() (+3 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
-
-### Community 66 - "Community 66"
-Cohesion: 0.17
-Nodes (15): actionableWorkItemTimestamp(), buildOperationalWorkItem(), compareOperationalWorkItems(), compareStrings(), createOperationalWorkItemWithCtx(), joinSourceIdentity(), metadataArrayCount(), metadataNumber() (+7 more)
 
 ### Community 67 - "Community 67"
 Cohesion: 0.18
@@ -2619,656 +2619,656 @@ Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
 ### Community 124 - "Community 124"
+Cohesion: 0.29
+Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
+
+### Community 125 - "Community 125"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.18
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
+Cohesion: 0.22
+Nodes (5): buildPendingCheckoutFinalizationPayloadHash(), buildPendingCheckoutSaleEvidenceFingerprint(), buildTrustedSkuFingerprint(), listPendingCheckoutProductPageBindingWithCtx(), stableStringify()
+
+### Community 128 - "Community 128"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 127 - "Community 127"
+### Community 129 - "Community 129"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 128 - "Community 128"
+### Community 130 - "Community 130"
 Cohesion: 0.22
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 129 - "Community 129"
+### Community 131 - "Community 131"
 Cohesion: 0.18
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 130 - "Community 130"
+### Community 132 - "Community 132"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 131 - "Community 131"
+### Community 133 - "Community 133"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 132 - "Community 132"
+### Community 134 - "Community 134"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 133 - "Community 133"
+### Community 135 - "Community 135"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 134 - "Community 134"
+### Community 136 - "Community 136"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 135 - "Community 135"
+### Community 137 - "Community 137"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 136 - "Community 136"
+### Community 138 - "Community 138"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 137 - "Community 137"
+### Community 139 - "Community 139"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 138 - "Community 138"
+### Community 140 - "Community 140"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 0.17
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 140 - "Community 140"
+### Community 142 - "Community 142"
 Cohesion: 0.18
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 141 - "Community 141"
+### Community 143 - "Community 143"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 142 - "Community 142"
+### Community 144 - "Community 144"
+Cohesion: 0.29
+Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
+
+### Community 145 - "Community 145"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 143 - "Community 143"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (2): expenseItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 144 - "Community 144"
+### Community 147 - "Community 147"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 145 - "Community 145"
+### Community 148 - "Community 148"
 Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
-### Community 146 - "Community 146"
+### Community 149 - "Community 149"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 147 - "Community 147"
-Cohesion: 0.35
-Nodes (10): buildCtx(), buildMapping(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal(), buildTransaction(), buildWorkItem() (+2 more)
+### Community 150 - "Community 150"
+Cohesion: 0.38
+Nodes (10): conflictError(), findPostReviewStockUpdateWithCtx(), idMetadataValue(), inventoryReviewLocalId(), optionalMetadataMatches(), readPositiveCurrentInventoryProofWithCtx(), resolveSyncedSaleInventoryReviewWithCtx(), stringMetadataValue() (+2 more)
 
-### Community 148 - "Community 148"
+### Community 151 - "Community 151"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 149 - "Community 149"
+### Community 152 - "Community 152"
 Cohesion: 0.2
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 150 - "Community 150"
+### Community 153 - "Community 153"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 151 - "Community 151"
+### Community 154 - "Community 154"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 152 - "Community 152"
+### Community 155 - "Community 155"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 153 - "Community 153"
+### Community 156 - "Community 156"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 154 - "Community 154"
+### Community 157 - "Community 157"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 155 - "Community 155"
+### Community 158 - "Community 158"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 156 - "Community 156"
+### Community 159 - "Community 159"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 157 - "Community 157"
+### Community 160 - "Community 160"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 158 - "Community 158"
+### Community 161 - "Community 161"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 159 - "Community 159"
+### Community 162 - "Community 162"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 160 - "Community 160"
+### Community 163 - "Community 163"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 161 - "Community 161"
+### Community 164 - "Community 164"
 Cohesion: 0.25
 Nodes (6): buildGitProcessEnv(), clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 162 - "Community 162"
+### Community 165 - "Community 165"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 163 - "Community 163"
+### Community 166 - "Community 166"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 164 - "Community 164"
+### Community 167 - "Community 167"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 165 - "Community 165"
+### Community 168 - "Community 168"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 166 - "Community 166"
+### Community 169 - "Community 169"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 167 - "Community 167"
+### Community 170 - "Community 170"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 168 - "Community 168"
+### Community 171 - "Community 171"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 169 - "Community 169"
+### Community 172 - "Community 172"
 Cohesion: 0.27
 Nodes (5): getLocalOperatingDate(), getLocalOperatingDateRange(), getReadinessDiagnosticRows(), getReadinessLoadingBlockers(), POSReadinessLoadingState()
 
-### Community 170 - "Community 170"
+### Community 173 - "Community 173"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 171 - "Community 171"
+### Community 174 - "Community 174"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 172 - "Community 172"
+### Community 175 - "Community 175"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 173 - "Community 173"
+### Community 176 - "Community 176"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 174 - "Community 174"
+### Community 177 - "Community 177"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 175 - "Community 175"
+### Community 178 - "Community 178"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 176 - "Community 176"
+### Community 179 - "Community 179"
 Cohesion: 0.31
 Nodes (7): architectureSolutionNote(), createFixtureRepo(), gitEnv(), nonFoundationalArchitectureSolutionNote(), runGit(), solutionNote(), write()
 
-### Community 177 - "Community 177"
+### Community 180 - "Community 180"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 178 - "Community 178"
+### Community 181 - "Community 181"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 179 - "Community 179"
+### Community 182 - "Community 182"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 180 - "Community 180"
+### Community 183 - "Community 183"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 181 - "Community 181"
+### Community 184 - "Community 184"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 182 - "Community 182"
+### Community 185 - "Community 185"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 183 - "Community 183"
+### Community 186 - "Community 186"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 187 - "Community 187"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 185 - "Community 185"
+### Community 188 - "Community 188"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 186 - "Community 186"
+### Community 189 - "Community 189"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 187 - "Community 187"
-Cohesion: 0.33
-Nodes (6): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), saveProduct(), updateVariantSku()
-
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 190 - "Community 190"
+### Community 192 - "Community 192"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 192 - "Community 192"
+### Community 194 - "Community 194"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 193 - "Community 193"
+### Community 195 - "Community 195"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 194 - "Community 194"
+### Community 196 - "Community 196"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 195 - "Community 195"
+### Community 197 - "Community 197"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 196 - "Community 196"
+### Community 198 - "Community 198"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 197 - "Community 197"
+### Community 199 - "Community 199"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 198 - "Community 198"
+### Community 200 - "Community 200"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 199 - "Community 199"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 206 - "Community 206"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 205 - "Community 205"
+### Community 207 - "Community 207"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 206 - "Community 206"
+### Community 208 - "Community 208"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 207 - "Community 207"
+### Community 209 - "Community 209"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 208 - "Community 208"
+### Community 210 - "Community 210"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 209 - "Community 209"
+### Community 211 - "Community 211"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 210 - "Community 210"
+### Community 212 - "Community 212"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 211 - "Community 211"
+### Community 213 - "Community 213"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 212 - "Community 212"
+### Community 214 - "Community 214"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 213 - "Community 213"
+### Community 215 - "Community 215"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 214 - "Community 214"
+### Community 216 - "Community 216"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 215 - "Community 215"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 216 - "Community 216"
-Cohesion: 0.5
-Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
 ### Community 217 - "Community 217"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 218 - "Community 218"
+Cohesion: 0.5
+Nodes (7): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
+
+### Community 219 - "Community 219"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 221 - "Community 221"
 Cohesion: 0.36
 Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
-### Community 220 - "Community 220"
+### Community 222 - "Community 222"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 221 - "Community 221"
+### Community 223 - "Community 223"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 222 - "Community 222"
+### Community 224 - "Community 224"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 223 - "Community 223"
+### Community 225 - "Community 225"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 224 - "Community 224"
+### Community 226 - "Community 226"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 225 - "Community 225"
+### Community 227 - "Community 227"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
-
-### Community 226 - "Community 226"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 227 - "Community 227"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 228 - "Community 228"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 229 - "Community 229"
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
+
+### Community 230 - "Community 230"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 231 - "Community 231"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 230 - "Community 230"
+### Community 232 - "Community 232"
 Cohesion: 0.39
 Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
-### Community 231 - "Community 231"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 232 - "Community 232"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 233 - "Community 233"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 234 - "Community 234"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 235 - "Community 235"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 234 - "Community 234"
+### Community 236 - "Community 236"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 235 - "Community 235"
+### Community 237 - "Community 237"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 236 - "Community 236"
+### Community 238 - "Community 238"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 237 - "Community 237"
+### Community 239 - "Community 239"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 240 - "Community 240"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 239 - "Community 239"
+### Community 241 - "Community 241"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 240 - "Community 240"
+### Community 242 - "Community 242"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 241 - "Community 241"
+### Community 243 - "Community 243"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 242 - "Community 242"
+### Community 244 - "Community 244"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 243 - "Community 243"
+### Community 245 - "Community 245"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 244 - "Community 244"
-Cohesion: 0.52
-Nodes (6): conflictError(), inventoryReviewLocalId(), resolveSyncedSaleInventoryReviewWithCtx(), stringMetadataValue(), terminalStatusForOutcome(), validationError()
-
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.43
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.52
 Nodes (5): getBlockingRegisterSessionIdFromConflict(), isRegisterSessionConflict(), resolveScopedRegisterSession(), resolveTerminalRegisterConflict(), resolveTerminalRegisterSessionConflict()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 262 - "Community 262"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 263 - "Community 263"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 264 - "Community 264"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 265 - "Community 265"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 266 - "Community 266"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 267 - "Community 267"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 268 - "Community 268"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 269 - "Community 269"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 271 - "Community 271"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 272 - "Community 272"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 273 - "Community 273"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 274 - "Community 274"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 275 - "Community 275"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 276 - "Community 276"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 277 - "Community 277"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 278 - "Community 278"
 Cohesion: 0.52
-Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 279 - "Community 279"
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+
+### Community 280 - "Community 280"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
-
-### Community 286 - "Community 286"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.33
@@ -3279,120 +3279,120 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 289 - "Community 289"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 290 - "Community 290"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 297 - "Community 297"
+### Community 298 - "Community 298"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 298 - "Community 298"
+### Community 299 - "Community 299"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 302 - "Community 302"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 303 - "Community 303"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 304 - "Community 304"
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
+
+### Community 305 - "Community 305"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 311 - "Community 311"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 313 - "Community 313"
-Cohesion: 0.47
-Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
-
-### Community 314 - "Community 314"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 314 - "Community 314"
+Cohesion: 0.47
+Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+
 ### Community 315 - "Community 315"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 316 - "Community 316"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 317 - "Community 317"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.33
@@ -3479,156 +3479,156 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 339 - "Community 339"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 340 - "Community 340"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.53
 Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 347 - "Community 347"
+### Community 348 - "Community 348"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 352 - "Community 352"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 353 - "Community 353"
 Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 354 - "Community 354"
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+
+### Community 355 - "Community 355"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.5
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 357 - "Community 357"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 358 - "Community 358"
 Cohesion: 0.6
-Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 359 - "Community 359"
+Cohesion: 0.6
+Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+
+### Community 360 - "Community 360"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
-
-### Community 366 - "Community 366"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 367 - "Community 367"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 368 - "Community 368"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 376 - "Community 376"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.4
@@ -3643,12 +3643,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 380 - "Community 380"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 381 - "Community 381"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 381 - "Community 381"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 382 - "Community 382"
 Cohesion: 0.4
@@ -3659,20 +3659,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 384 - "Community 384"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 385 - "Community 385"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 385 - "Community 385"
+### Community 386 - "Community 386"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 386 - "Community 386"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 387 - "Community 387"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.4
@@ -3691,80 +3691,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 392 - "Community 392"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 393 - "Community 393"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 395 - "Community 395"
+### Community 396 - "Community 396"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 396 - "Community 396"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 397 - "Community 397"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 399 - "Community 399"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 400 - "Community 400"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 400 - "Community 400"
+### Community 401 - "Community 401"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 401 - "Community 401"
+### Community 402 - "Community 402"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 404 - "Community 404"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 406 - "Community 406"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 407 - "Community 407"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 408 - "Community 408"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 410 - "Community 410"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 411 - "Community 411"
 Cohesion: 0.4
@@ -3775,48 +3775,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 415 - "Community 415"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 416 - "Community 416"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 417 - "Community 417"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 419 - "Community 419"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 420 - "Community 420"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 421 - "Community 421"
+### Community 422 - "Community 422"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 422 - "Community 422"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 423 - "Community 423"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.4
@@ -3827,72 +3827,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 426 - "Community 426"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 427 - "Community 427"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 430 - "Community 430"
+### Community 431 - "Community 431"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 431 - "Community 431"
+### Community 432 - "Community 432"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 434 - "Community 434"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 435 - "Community 435"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 436 - "Community 436"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 437 - "Community 437"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 439 - "Community 439"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 440 - "Community 440"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 440 - "Community 440"
+### Community 441 - "Community 441"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 441 - "Community 441"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 442 - "Community 442"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.5
@@ -3911,76 +3911,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 447 - "Community 447"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 448 - "Community 448"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.83
 Nodes (3): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), formatOnlineOrderLabel()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 453 - "Community 453"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 454 - "Community 454"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 455 - "Community 455"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 456 - "Community 456"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 456 - "Community 456"
+### Community 457 - "Community 457"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 457 - "Community 457"
+### Community 458 - "Community 458"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 458 - "Community 458"
+### Community 459 - "Community 459"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 459 - "Community 459"
+### Community 460 - "Community 460"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 460 - "Community 460"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 462 - "Community 462"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 463 - "Community 463"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 464 - "Community 464"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 464 - "Community 464"
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.5
@@ -3991,12 +3991,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 467 - "Community 467"
-Cohesion: 0.67
-Nodes (2): buildCtx(), buildQueryCtx()
-
-### Community 468 - "Community 468"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 468 - "Community 468"
+Cohesion: 0.67
+Nodes (2): buildCtx(), buildQueryCtx()
 
 ### Community 469 - "Community 469"
 Cohesion: 0.5

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2158
-- Graph nodes: 8483
-- Graph edges: 10217
+- Graph nodes: 8500
+- Graph edges: 10249
 - Communities: 2085
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 65) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 66) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 83) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 99) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 100) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 205) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 207) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 100) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 100) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 100) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts
+++ b/packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
 });
 
 describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
-  it("resolves current synced sale inventory review work through the canonical local mapping", async () => {
+  it("resolves current synced sale inventory review work after the affected SKU has a stock update", async () => {
     const ctx = buildCtx();
 
     const result = await resolveSyncedSaleInventoryReviewWithCtx(
@@ -75,14 +75,14 @@ describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
             domainTrace: {
               boundary:
                 "operations.openWorkInventoryReviews.resolveSyncedSaleInventoryReview",
-              mappingId: "mapping-inventory-review",
+              inventoryMovementId: "movement-1",
+              proofKind: "stock_update_movement",
             },
             nextState: { status: "completed" },
             outcome: "completed",
             priorState: { status: "open" },
             reason: "Inventory was corrected from the sale review.",
             source: expect.objectContaining({
-              localId: "local-txn-1:inventory-review",
               localIdKind: "inventoryReviewWorkItem",
               localRegisterSessionId: "local-register-1",
               localTransactionId: "local-txn-1",
@@ -95,6 +95,17 @@ describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
               displayName: "Front register",
               registerNumber: "1",
               terminalId: "terminal-1",
+            },
+            stockState: null,
+            stockUpdate: {
+              createdAt: 1_772_549_999_000,
+              inventoryMovementId: "movement-1",
+              movementType: "cycle_count",
+              productSkuId: "sku-1",
+              quantityDelta: 4,
+              reasonCode: "cycle_count_reconciliation",
+              sourceId: "stock_adjustment_batch:batch-1",
+              sourceType: "stock_adjustment_batch",
             },
           }),
         }),
@@ -112,7 +123,7 @@ describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
         subjectType: "synced_sale_inventory_review",
         workItemId: "work-item-1",
         metadata: expect.objectContaining({
-          mappingId: "mapping-inventory-review",
+          inventoryMovementId: "movement-1",
           nextState: { status: "completed" },
           outcome: "completed",
           priorState: { status: "open" },
@@ -207,7 +218,7 @@ describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
     expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
-  it("rejects wrong terminal, session, sale, and store context", async () => {
+  it("rejects wrong terminal, session, sale, and store context when that context is supplied", async () => {
     await expectRejectedContext(
       { terminalId: "terminal-other" as Id<"posTerminal"> },
       "Terminal does not match the inventory review store.",
@@ -245,7 +256,7 @@ describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
     );
   });
 
-  it("rejects cloud-id-only, receipt-only, and SKU-only idempotency attempts", async () => {
+  it("allows work-item-only resolution when stock was updated for the affected SKU", async () => {
     const cloudIdOnly = await resolveSyncedSaleInventoryReviewWithCtx(
       buildCtx() as never,
       {
@@ -255,51 +266,125 @@ describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
         workItemId: "work-item-1" as Id<"operationalWorkItem">,
       },
     );
-    expect(cloudIdOnly).toEqual({
-      kind: "user_error",
-      error: {
-        code: "validation_failed",
-        message:
-          "Inventory review resolution requires terminal, local register session, and local transaction context.",
+    expect(cloudIdOnly).toMatchObject({
+      kind: "ok",
+      data: {
+        action: "resolved",
+        outcome: "completed",
+        status: "completed",
+        workItemId: "work-item-1",
       },
     });
     assertConformsToExportedReturns(
       resolveSyncedSaleInventoryReview,
       cloudIdOnly,
     );
+  });
 
-    const receiptOnly = await resolveSyncedSaleInventoryReviewWithCtx(
-      buildCtx() as never,
-      defaultArgs({
-        localTransactionId: undefined,
-        receiptNumber: "LR-001",
+  it("allows completion without a stock movement when current affected SKU stock is positive", async () => {
+    const ctx = buildCtx({
+      inventoryMovement: null,
+      productSku: buildProductSku({
+        inventoryCount: 2,
+        quantityAvailable: 2,
       }),
-    );
-    expect(receiptOnly).toMatchObject({
-      error: {
-        message:
-          "Inventory review resolution requires terminal, local register session, and local transaction context.",
-      },
-      kind: "user_error",
     });
 
-    const skuOnly = await resolveSyncedSaleInventoryReviewWithCtx(
-      buildCtx() as never,
+    const result = await resolveSyncedSaleInventoryReviewWithCtx(
+      ctx as never,
       defaultArgs({
-        localTransactionId: "sku-1",
+        localRegisterSessionId: undefined,
+        localTransactionId: undefined,
+        registerSessionId: undefined,
+        sourceId: undefined,
+        terminalId: undefined,
       }),
     );
-    expect(skuOnly).toEqual({
-      kind: "user_error",
-      error: {
-        code: "validation_failed",
-        message:
-          "Work item metadata does not match the sale context.",
+
+    expect(result).toMatchObject({
+      data: {
+        action: "resolved",
+        outcome: "completed",
+        status: "completed",
+        workItemId: "work-item-1",
       },
+      kind: "ok",
+    });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-item-1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          resolution: expect.objectContaining({
+            domainTrace: expect.objectContaining({
+              proofKind: "current_inventory_state",
+            }),
+            stockUpdate: null,
+            stockState: {
+              inventoryCount: 2,
+              productSkuId: "sku-1",
+              proofKind: "current_inventory_state",
+              quantityAvailable: 2,
+              reviewedAt: 1_772_550_000_000,
+            },
+          }),
+        }),
+        status: "completed",
+      }),
+    );
+  });
+
+  it("rejects completion before the affected SKU has a stock update", async () => {
+    const result = await resolveSyncedSaleInventoryReviewWithCtx(
+      buildCtx({
+        inventoryMovement: null,
+        productSku: buildProductSku({
+          inventoryCount: 0,
+          quantityAvailable: 0,
+        }),
+      }) as never,
+      defaultArgs({
+        localRegisterSessionId: undefined,
+        localTransactionId: undefined,
+        registerSessionId: undefined,
+        sourceId: undefined,
+        terminalId: undefined,
+      }),
+    );
+    expect(result).toMatchObject({
+      error: {
+        message:
+          "Update the affected SKU's stock count before marking this inventory review complete.",
+      },
+      kind: "user_error",
     });
   });
 
-  it("rejects transaction and receipt mappings that do not use the canonical inventory-review key", async () => {
+  it("rejects stock updates that predate the synced sale inventory review", async () => {
+    const result = await resolveSyncedSaleInventoryReviewWithCtx(
+      buildCtx({
+        inventoryMovement: buildInventoryMovement({
+          createdAt: 0,
+        }),
+      }) as never,
+      defaultArgs({
+        localRegisterSessionId: undefined,
+        localTransactionId: undefined,
+        registerSessionId: undefined,
+        sourceId: undefined,
+        terminalId: undefined,
+      }),
+    );
+    expect(result).toMatchObject({
+      error: {
+        message:
+          "Update the affected SKU's stock count before marking this inventory review complete.",
+      },
+      kind: "user_error",
+    });
+  });
+
+  it("does not require the canonical local mapping when stock update proof exists", async () => {
     const ctx = buildCtx({
       posLocalSyncMapping: buildMapping({
         cloudId: "transaction-1",
@@ -314,15 +399,16 @@ describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
       defaultArgs(),
     );
 
-    expect(result).toEqual({
-      kind: "user_error",
-      error: {
-        code: "validation_failed",
-        message:
-          "Inventory review resolution requires the canonical local work-item mapping.",
+    expect(result).toMatchObject({
+      data: {
+        action: "resolved",
+        outcome: "completed",
+        status: "completed",
+        workItemId: "work-item-1",
       },
+      kind: "ok",
     });
-    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.patch).toHaveBeenCalled();
   });
 });
 
@@ -376,8 +462,10 @@ function defaultArgs(
 }
 
 type BuildCtxSeed = Partial<{
+  inventoryMovement: Doc<"inventoryMovement"> | null;
   operationalWorkItem: Doc<"operationalWorkItem">;
   posLocalSyncMapping: Doc<"posLocalSyncMapping">;
+  productSku: Doc<"productSku"> | null;
   posTerminal: Doc<"posTerminal">;
   posTransaction: Doc<"posTransaction">;
   registerSession: Doc<"registerSession">;
@@ -387,8 +475,14 @@ type BuildCtxSeed = Partial<{
 
 function buildCtx(seed: BuildCtxSeed = {}) {
   const rows = {
+    inventoryMovement:
+      seed.inventoryMovement === undefined
+        ? buildInventoryMovement()
+        : seed.inventoryMovement,
     operationalWorkItem: seed.operationalWorkItem ?? buildWorkItem(),
     posLocalSyncMapping: seed.posLocalSyncMapping ?? buildMapping(),
+    productSku:
+      seed.productSku === undefined ? buildProductSku() : seed.productSku,
     posTerminal: seed.posTerminal ?? buildTerminal(),
     posTransaction: seed.posTransaction ?? buildTransaction(),
     registerSession: seed.registerSession ?? buildRegisterSession(),
@@ -499,6 +593,7 @@ function buildWorkItem(
       registerSessionId: "register-session-1",
       sourceId: "transaction-1",
       sourceType: "posTransaction",
+      terminalId: "terminal-1",
     },
     organizationId: "org-1" as Id<"organization">,
     priority: "high",
@@ -508,6 +603,46 @@ function buildWorkItem(
     type: "synced_sale_inventory_review",
     ...overrides,
   } as Doc<"operationalWorkItem">;
+}
+
+function buildInventoryMovement(
+  overrides: Partial<Doc<"inventoryMovement">> = {},
+): Doc<"inventoryMovement"> {
+  return {
+    _creationTime: 1,
+    _id: "movement-1" as Id<"inventoryMovement">,
+    actorUserId: "user-1" as Id<"athenaUser">,
+    createdAt: 1_772_549_999_000,
+    movementType: "cycle_count",
+    organizationId: "org-1" as Id<"organization">,
+    productId: "product-1" as Id<"product">,
+    productSkuId: "sku-1" as Id<"productSku">,
+    quantityDelta: 4,
+    reasonCode: "cycle_count_reconciliation",
+    sourceId: "stock_adjustment_batch:batch-1",
+    sourceType: "stock_adjustment_batch",
+    storeId: "store-1" as Id<"store">,
+    ...overrides,
+  } as Doc<"inventoryMovement">;
+}
+
+function buildProductSku(
+  overrides: Partial<Doc<"productSku">> = {},
+): Doc<"productSku"> {
+  return {
+    _creationTime: 1,
+    _id: "sku-1" as Id<"productSku">,
+    barcode: "SKU-1",
+    cost: 0,
+    inventoryCount: 0,
+    price: 2500,
+    productId: "product-1" as Id<"product">,
+    quantityAvailable: 0,
+    sku: "SKU-1",
+    storeId: "store-1" as Id<"store">,
+    updatedAt: 1,
+    ...overrides,
+  } as Doc<"productSku">;
 }
 
 function buildTerminal(

--- a/packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts
+++ b/packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 
-import type { Id } from "../_generated/dataModel";
+import type { Id, TableNames } from "../_generated/dataModel";
 import { mutation, type MutationCtx } from "../_generated/server";
 import { commandResultValidator } from "../lib/commandResultValidators";
 import {
@@ -13,6 +13,8 @@ import { recordOperationalEventWithCtx } from "./operationalEvents";
 const SYNCED_SALE_INVENTORY_REVIEW_TYPE = "synced_sale_inventory_review";
 const INVENTORY_REVIEW_LOCAL_ID_KIND = "inventoryReviewWorkItem";
 const TERMINAL_STATUSES = new Set(["completed", "cancelled"]);
+const STOCK_UPDATE_SOURCE_TYPE = "stock_adjustment_batch";
+const STOCK_UPDATE_MOVEMENT_TYPES = new Set(["adjustment", "cycle_count"]);
 
 const syncedSaleInventoryReviewOutcomeValidator = v.union(
   v.literal("completed"),
@@ -74,6 +76,75 @@ function conflictError(message: string) {
   });
 }
 
+function idMetadataValue<TableName extends TableNames>(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = stringMetadataValue(metadata, key);
+  return value as Id<TableName> | null;
+}
+
+function optionalMetadataMatches(
+  metadata: Record<string, unknown>,
+  key: string,
+  value: string | undefined,
+) {
+  return !value || stringMetadataValue(metadata, key) === value;
+}
+
+async function findPostReviewStockUpdateWithCtx(
+  ctx: MutationCtx,
+  args: {
+    createdAt: number;
+    productSkuId: Id<"productSku">;
+    storeId: Id<"store">;
+  },
+) {
+  // eslint-disable-next-line @convex-dev/no-collect-in-query -- SKU-scoped stock adjustments are bounded by one operational SKU review.
+  const movements = await ctx.db
+    .query("inventoryMovement")
+    .withIndex("by_storeId_productSkuId", (q) =>
+      q.eq("storeId", args.storeId).eq("productSkuId", args.productSkuId),
+    )
+    .collect();
+
+  return (
+    movements
+      .filter(
+        (movement) =>
+          movement.createdAt >= args.createdAt &&
+          movement.sourceType === STOCK_UPDATE_SOURCE_TYPE &&
+          STOCK_UPDATE_MOVEMENT_TYPES.has(movement.movementType),
+      )
+      .sort((left, right) => right.createdAt - left.createdAt)[0] ?? null
+  );
+}
+
+async function readPositiveCurrentInventoryProofWithCtx(
+  ctx: MutationCtx,
+  args: {
+    productSkuId: Id<"productSku">;
+    storeId: Id<"store">;
+  },
+) {
+  const productSku = await ctx.db.get("productSku", args.productSkuId);
+  if (
+    !productSku ||
+    productSku.storeId !== args.storeId ||
+    productSku.inventoryCount <= 0
+  ) {
+    return null;
+  }
+
+  return {
+    inventoryCount: productSku.inventoryCount,
+    productSkuId: args.productSkuId,
+    proofKind: "current_inventory_state" as const,
+    quantityAvailable: productSku.quantityAvailable,
+    reviewedAt: Date.now(),
+  };
+}
+
 function terminalStatusForOutcome(
   outcome: SyncedSaleInventoryReviewOutcome,
 ): "completed" | "cancelled" {
@@ -84,21 +155,6 @@ export async function resolveSyncedSaleInventoryReviewWithCtx(
   ctx: MutationCtx,
   args: ResolveSyncedSaleInventoryReviewArgs,
 ): Promise<CommandResult<ResolveSyncedSaleInventoryReviewData>> {
-  const requiredLocalContext = [
-    args.terminalId,
-    args.localRegisterSessionId,
-    args.localTransactionId,
-  ];
-  if (requiredLocalContext.some((value) => !value)) {
-    return validationError(
-      "Inventory review resolution requires terminal, local register session, and local transaction context.",
-    );
-  }
-  if (!args.registerSessionId || !args.sourceId) {
-    return validationError(
-      "Inventory review resolution requires the linked register session and sale.",
-    );
-  }
   if (!args.reason.trim()) {
     return validationError("Reason is required to resolve inventory review work.");
   }
@@ -157,45 +213,93 @@ export async function resolveSyncedSaleInventoryReviewWithCtx(
   }
 
   const actorStaffProfileId = actorStaffProfile?._id;
-
-  const terminal = await ctx.db.get("posTerminal", args.terminalId!);
-  if (!terminal || terminal.storeId !== args.storeId) {
-    return validationError("Terminal does not match the inventory review store.");
-  }
-
-  const registerSession = await ctx.db.get(
-    "registerSession",
-    args.registerSessionId,
+  const metadata = workItem.metadata ?? {};
+  const primaryProductSkuId = idMetadataValue<"productSku">(
+    metadata,
+    "primaryProductSkuId",
   );
-  if (
-    !registerSession ||
-    registerSession.storeId !== args.storeId ||
-    registerSession.terminalId !== args.terminalId
-  ) {
+  if (!primaryProductSkuId) {
     return validationError(
-      "Register session does not match the inventory review terminal.",
+      "Inventory review work item is missing the affected SKU.",
     );
   }
 
-  const sale = await ctx.db.get("posTransaction", args.sourceId);
-  if (
-    !sale ||
-    sale.storeId !== args.storeId ||
-    sale.registerSessionId !== args.registerSessionId ||
-    sale.terminalId !== args.terminalId
-  ) {
-    return validationError("Sale does not match the inventory review context.");
+  const stockUpdate = await findPostReviewStockUpdateWithCtx(ctx, {
+    createdAt: workItem.createdAt,
+    productSkuId: primaryProductSkuId,
+    storeId: args.storeId,
+  });
+  const stockState = stockUpdate
+    ? null
+    : await readPositiveCurrentInventoryProofWithCtx(ctx, {
+        productSkuId: primaryProductSkuId,
+        storeId: args.storeId,
+      });
+  if (!stockUpdate && !stockState) {
+    return validationError(
+      "Update the affected SKU's stock count before marking this inventory review complete.",
+    );
   }
 
-  const metadata = workItem.metadata ?? {};
+  const terminal = args.terminalId
+    ? await ctx.db.get("posTerminal", args.terminalId)
+    : null;
+  if (args.terminalId && (!terminal || terminal.storeId !== args.storeId)) {
+    return validationError("Terminal does not match the inventory review store.");
+  }
+
+  const registerSession = args.registerSessionId
+    ? await ctx.db.get("registerSession", args.registerSessionId)
+    : null;
+  if (args.registerSessionId) {
+    if (!registerSession || registerSession.storeId !== args.storeId) {
+      return validationError(
+        "Register session does not match the inventory review terminal.",
+      );
+    }
+    if (args.terminalId && registerSession.terminalId !== args.terminalId) {
+      return validationError(
+        "Register session does not match the inventory review terminal.",
+      );
+    }
+  }
+
+  const sale = args.sourceId
+    ? await ctx.db.get("posTransaction", args.sourceId)
+    : null;
+  if (args.sourceId) {
+    if (!sale || sale.storeId !== args.storeId) {
+      return validationError("Sale does not match the inventory review context.");
+    }
+    if (
+      args.registerSessionId &&
+      sale.registerSessionId !== args.registerSessionId
+    ) {
+      return validationError("Sale does not match the inventory review context.");
+    }
+    if (args.terminalId && sale.terminalId !== args.terminalId) {
+      return validationError("Sale does not match the inventory review context.");
+    }
+  }
+
   if (
-    stringMetadataValue(metadata, "localRegisterSessionId") !==
-      args.localRegisterSessionId ||
-    stringMetadataValue(metadata, "localTransactionId") !==
-      args.localTransactionId ||
-    stringMetadataValue(metadata, "registerSessionId") !==
-      args.registerSessionId ||
-    stringMetadataValue(metadata, "sourceId") !== args.sourceId
+    !optionalMetadataMatches(
+      metadata,
+      "localRegisterSessionId",
+      args.localRegisterSessionId,
+    ) ||
+    !optionalMetadataMatches(
+      metadata,
+      "localTransactionId",
+      args.localTransactionId,
+    ) ||
+    !optionalMetadataMatches(
+      metadata,
+      "registerSessionId",
+      args.registerSessionId,
+    ) ||
+    !optionalMetadataMatches(metadata, "sourceId", args.sourceId) ||
+    !optionalMetadataMatches(metadata, "terminalId", args.terminalId)
   ) {
     return validationError("Work item metadata does not match the sale context.");
   }
@@ -205,34 +309,21 @@ export async function resolveSyncedSaleInventoryReviewWithCtx(
   ) {
     return validationError("Receipt number does not match the inventory review.");
   }
-  if (args.receiptNumber && sale.transactionNumber !== args.receiptNumber) {
+  if (args.receiptNumber && sale && sale.transactionNumber !== args.receiptNumber) {
     return validationError("Sale receipt does not match the inventory review.");
-  }
-
-  const canonicalLocalId = inventoryReviewLocalId(args.localTransactionId!);
-  const mapping = await ctx.db
-    .query("posLocalSyncMapping")
-    .withIndex("by_store_terminal_local", (q) =>
-      q
-        .eq("storeId", args.storeId)
-        .eq("terminalId", args.terminalId!)
-        .eq("localRegisterSessionId", args.localRegisterSessionId!)
-        .eq("localIdKind", INVENTORY_REVIEW_LOCAL_ID_KIND)
-        .eq("localId", canonicalLocalId),
-    )
-    .unique();
-  if (
-    !mapping ||
-    mapping.cloudTable !== "operationalWorkItem" ||
-    mapping.cloudId !== args.workItemId
-  ) {
-    return validationError(
-      "Inventory review resolution requires the canonical local work-item mapping.",
-    );
   }
 
   const resolvedAt = Date.now();
   const status = terminalStatusForOutcome(args.outcome);
+  const canonicalLocalId = args.localTransactionId
+    ? inventoryReviewLocalId(args.localTransactionId)
+    : null;
+  const terminalIdFromMetadata = idMetadataValue<"posTerminal">(
+    metadata,
+    "terminalId",
+  );
+  const registerNumber =
+    terminal?.registerNumber ?? registerSession?.registerNumber;
   const resolution = {
     actorStaffProfileId,
     actorUserId: athenaUser._id,
@@ -243,7 +334,8 @@ export async function resolveSyncedSaleInventoryReviewWithCtx(
     domainTrace: {
       boundary:
         "operations.openWorkInventoryReviews.resolveSyncedSaleInventoryReview",
-      mappingId: mapping._id,
+      proofKind: stockUpdate ? "stock_update_movement" : "current_inventory_state",
+      ...(stockUpdate ? { inventoryMovementId: stockUpdate._id } : {}),
     },
     outcome: args.outcome,
     priorState: {
@@ -254,18 +346,48 @@ export async function resolveSyncedSaleInventoryReviewWithCtx(
     source: {
       localId: canonicalLocalId,
       localIdKind: INVENTORY_REVIEW_LOCAL_ID_KIND,
-      localRegisterSessionId: args.localRegisterSessionId,
-      localTransactionId: args.localTransactionId,
-      receiptNumber: args.receiptNumber,
-      registerSessionId: args.registerSessionId,
-      sourceId: args.sourceId,
-      terminalId: args.terminalId,
+      localRegisterSessionId:
+        args.localRegisterSessionId ??
+        stringMetadataValue(metadata, "localRegisterSessionId"),
+      localTransactionId:
+        args.localTransactionId ??
+        stringMetadataValue(metadata, "localTransactionId"),
+      receiptNumber:
+        args.receiptNumber ?? stringMetadataValue(metadata, "receiptNumber"),
+      registerSessionId:
+        args.registerSessionId ?? idMetadataValue<"registerSession">(
+          metadata,
+          "registerSessionId",
+        ),
+      sourceId:
+        args.sourceId ?? idMetadataValue<"posTransaction">(
+          metadata,
+          "sourceId",
+        ),
+      terminalId: args.terminalId ?? terminalIdFromMetadata,
     },
-    terminalAudit: {
-      displayName: terminal.displayName,
-      registerNumber: terminal.registerNumber ?? registerSession.registerNumber,
-      terminalId: args.terminalId,
-    },
+    stockState,
+    stockUpdate: stockUpdate
+      ? {
+          createdAt: stockUpdate.createdAt,
+          inventoryMovementId: stockUpdate._id,
+          movementType: stockUpdate.movementType,
+          productSkuId: primaryProductSkuId,
+          quantityDelta: stockUpdate.quantityDelta,
+          reasonCode: stockUpdate.reasonCode,
+          sourceId: stockUpdate.sourceId,
+          sourceType: stockUpdate.sourceType,
+        }
+      : null,
+    ...(terminal || registerNumber
+      ? {
+          terminalAudit: {
+            displayName: terminal?.displayName,
+            registerNumber,
+            terminalId: args.terminalId ?? terminalIdFromMetadata,
+          },
+        }
+      : {}),
     nextState: {
       status,
     },
@@ -298,13 +420,15 @@ export async function resolveSyncedSaleInventoryReviewWithCtx(
     metadata: {
       authority: resolution.authority,
       domainTrace: resolution.domainTrace,
-      mappingId: mapping._id,
+      inventoryMovementId: stockUpdate?._id,
       nextState: resolution.nextState,
       outcome: args.outcome,
       priorState: resolution.priorState,
       reason: resolution.reason,
       source: resolution.source,
-      terminalAudit: resolution.terminalAudit,
+      stockState: resolution.stockState,
+      stockUpdate: resolution.stockUpdate,
+      terminalAudit: "terminalAudit" in resolution ? resolution.terminalAudit : null,
     },
   });
 

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
@@ -45,14 +45,16 @@ function approvalRequest(overrides: Partial<QueueTestRow> = {}) {
   } as QueueTestRow;
 }
 
-function createQueueContext(args: {
-  approvalRequests?: QueueTestRow[];
-  stores?: QueueTestRow[];
-  workItems?: QueueTestRow[];
-} = {}) {
-  const stores = args.stores ?? [
-    { _id: "store-1", organizationId: "org-1" },
-  ];
+function createQueueContext(
+  args: {
+    approvalRequests?: QueueTestRow[];
+    products?: QueueTestRow[];
+    stores?: QueueTestRow[];
+    workItems?: QueueTestRow[];
+  } = {},
+) {
+  const stores = args.stores ?? [{ _id: "store-1", organizationId: "org-1" }];
+  const products = args.products ?? [];
   const workItems = args.workItems ?? [];
   const approvalRequests = args.approvalRequests ?? [];
 
@@ -64,6 +66,9 @@ function createQueueContext(args: {
         }
         if (tableName === "operationalWorkItem") {
           return workItems.find((item) => item._id === id) ?? null;
+        }
+        if (tableName === "product") {
+          return products.find((product) => product._id === id) ?? null;
         }
         return null;
       }),
@@ -111,7 +116,9 @@ function createQueueContext(args: {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(athenaUserAuth.requireAuthenticatedAthenaUserWithCtx).mockResolvedValue({
+  vi.mocked(
+    athenaUserAuth.requireAuthenticatedAthenaUserWithCtx,
+  ).mockResolvedValue({
     _id: "user-1",
   } as never);
 });
@@ -215,6 +222,19 @@ describe("getQueueSnapshot", () => {
           },
           type: "synced_sale_inventory_review",
         }),
+        workItem({
+          _id: "work-pending-checkout" as Id<"operationalWorkItem">,
+          metadata: {
+            lookupCode: "hodor",
+            pendingCheckoutItemId: "pending-checkout-1",
+            price: 55000,
+            provisionalProductId: "product-pending-1",
+            provisionalProductSkuId: "sku-pending-1",
+            rawPendingCheckoutPayload: { shouldNotLeak: true },
+            totalQuantitySold: 6,
+          },
+          type: "pos_pending_checkout_item_review",
+        }),
       ],
     });
 
@@ -226,6 +246,17 @@ describe("getQueueSnapshot", () => {
       expect.objectContaining({
         _id: "work-carry-forward",
         details: { businessDate: "2026-07-01", followUpReason: null },
+      }),
+      expect.objectContaining({
+        _id: "work-pending-checkout",
+        details: {
+          lookupCode: "hodor",
+          price: 55000,
+          provisionalProductId: "product-pending-1",
+          provisionalProductSkuId: "sku-pending-1",
+          quantitySold: null,
+          totalQuantitySold: 6,
+        },
       }),
       expect.objectContaining({
         _id: "work-inventory-review",
@@ -247,6 +278,9 @@ describe("getQueueSnapshot", () => {
     );
     expect(JSON.stringify(result.workItems)).not.toContain(
       "card-token-should-not-leave-server",
+    );
+    expect(JSON.stringify(result.workItems)).not.toContain(
+      "rawPendingCheckoutPayload",
     );
   });
 
@@ -285,6 +319,57 @@ describe("getQueueSnapshot", () => {
       result.approvalRequests.map((request: QueueTestRow) => request._id),
     ).toEqual(["approval-service-deposit", "approval-variance"]);
     expect(result.overflow.approvalRequests).toBe(false);
+  });
+
+  it("omits POS pending checkout review items when their provisional product is archived", async () => {
+    const ctx = createQueueContext({
+      products: [
+        {
+          _id: "product-live" as Id<"product">,
+          availability: "live",
+          storeId: "store-1" as Id<"store">,
+        },
+        {
+          _id: "product-archived" as Id<"product">,
+          availability: "archived",
+          storeId: "store-1" as Id<"store">,
+        },
+      ],
+      workItems: [
+        workItem({
+          _id: "work-live-pending-checkout" as Id<"operationalWorkItem">,
+          metadata: {
+            pendingCheckoutItemId: "pending-checkout-live",
+            provisionalProductId: "product-live",
+          },
+          title: "Review pending checkout item: Live item",
+          type: "pos_pending_checkout_item_review",
+        }),
+        workItem({
+          _id: "work-archived-pending-checkout" as Id<"operationalWorkItem">,
+          metadata: {
+            pendingCheckoutItemId: "pending-checkout-archived",
+            provisionalProductId: "product-archived",
+          },
+          title: "Review pending checkout item: Archived item",
+          type: "pos_pending_checkout_item_review",
+        }),
+        workItem({
+          _id: "work-service-case" as Id<"operationalWorkItem">,
+          title: "Service case",
+          type: "service_case",
+        }),
+      ],
+    });
+
+    const result = await getHandler(getQueueSnapshot)(ctx, {
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.workItems.map((item: QueueTestRow) => item._id)).toEqual([
+      "work-live-pending-checkout",
+      "work-service-case",
+    ]);
   });
 
   it("surfaces supported return and legacy item adjustment approvals", async () => {
@@ -503,13 +588,15 @@ describe("getQueueSnapshot", () => {
   });
 
   it("marks overflow when exact status-cap lanes combine beyond the display cap", async () => {
-    const openItems = Array.from({ length: TEST_MAX_QUEUE_ITEMS }, (_value, index) =>
-      workItem({
-        _id: `work-open-exact-${String(index).padStart(3, "0")}` as Id<"operationalWorkItem">,
-        createdAt: index,
-        metadata: { sourceId: `open-exact-${index}` },
-        status: "open",
-      }),
+    const openItems = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS },
+      (_value, index) =>
+        workItem({
+          _id: `work-open-exact-${String(index).padStart(3, "0")}` as Id<"operationalWorkItem">,
+          createdAt: index,
+          metadata: { sourceId: `open-exact-${index}` },
+          status: "open",
+        }),
     );
     const inProgressItems = Array.from(
       { length: TEST_MAX_QUEUE_ITEMS },
@@ -712,7 +799,7 @@ describe("getQueueSnapshot", () => {
     ]);
   });
 
-  it("prefers the complete synced sale resolver row when duplicate current rows exist", async () => {
+  it("prefers the synced sale resolver row with an affected SKU when duplicate current rows exist", async () => {
     const ctx = createQueueContext({
       workItems: [
         workItem({
@@ -731,6 +818,7 @@ describe("getQueueSnapshot", () => {
           metadata: {
             localRegisterSessionId: "local-session-1",
             localTransactionId: "txn-1",
+            primaryProductSkuId: "sku-1",
             registerSessionId: "register-session-1",
             sourceId: "transaction-1",
             sourceType: "posTransaction",
@@ -749,25 +837,26 @@ describe("getQueueSnapshot", () => {
       expect.objectContaining({
         _id: "work-synced-complete",
         details: expect.objectContaining({
-          registerSessionId: "register-session-1",
-          sourceId: "transaction-1",
+          primaryProductSkuId: "sku-1",
         }),
       }),
     ]);
   });
 
-  it("dedupes current lane probes before the queue cap hides complete resolver rows", async () => {
-    const incompleteDuplicates = Array.from({ length: TEST_MAX_QUEUE_ITEMS + 1 }, (_, index) =>
-      workItem({
-        _id: `work-synced-incomplete-${index}` as Id<"operationalWorkItem">,
-        createdAt: index + 1,
-        metadata: {
-          localRegisterSessionId: "local-session-1",
-          localTransactionId: "txn-1",
-          terminalId: "terminal-1",
-        },
-        type: "synced_sale_inventory_review",
-      }),
+  it("dedupes current lane probes before the queue cap hides rows with affected SKUs", async () => {
+    const incompleteDuplicates = Array.from(
+      { length: TEST_MAX_QUEUE_ITEMS + 1 },
+      (_, index) =>
+        workItem({
+          _id: `work-synced-incomplete-${index}` as Id<"operationalWorkItem">,
+          createdAt: index + 1,
+          metadata: {
+            localRegisterSessionId: "local-session-1",
+            localTransactionId: "txn-1",
+            terminalId: "terminal-1",
+          },
+          type: "synced_sale_inventory_review",
+        }),
     );
     const ctx = createQueueContext({
       workItems: [
@@ -778,6 +867,7 @@ describe("getQueueSnapshot", () => {
           metadata: {
             localRegisterSessionId: "local-session-1",
             localTransactionId: "txn-1",
+            primaryProductSkuId: "sku-1",
             registerSessionId: "register-session-1",
             sourceId: "transaction-1",
             sourceType: "posTransaction",
@@ -796,8 +886,7 @@ describe("getQueueSnapshot", () => {
       expect.objectContaining({
         _id: "work-synced-complete",
         details: expect.objectContaining({
-          registerSessionId: "register-session-1",
-          sourceId: "transaction-1",
+          primaryProductSkuId: "sku-1",
         }),
       }),
     ]);
@@ -875,13 +964,13 @@ describe("getQueueSnapshot", () => {
                 : [];
 
             return {
-            collect: vi.fn(async () => {
-              return rows;
-            }),
-            take: vi.fn(async () => {
-              return rows;
-            }),
-          };
+              collect: vi.fn(async () => {
+                return rows;
+              }),
+              take: vi.fn(async () => {
+                return rows;
+              }),
+            };
           }),
         })),
       },
@@ -990,13 +1079,13 @@ describe("getQueueSnapshot", () => {
                 : [];
 
             return {
-            collect: vi.fn(async () => {
-              return rows;
-            }),
-            take: vi.fn(async () => {
-              return rows;
-            }),
-          };
+              collect: vi.fn(async () => {
+                return rows;
+              }),
+              take: vi.fn(async () => {
+                return rows;
+              }),
+            };
           }),
         })),
       },
@@ -1069,8 +1158,7 @@ describe("getQueueSnapshot", () => {
                     sequence: 2,
                     status: "needs_review",
                     storeId: "store-1",
-                    summary:
-                      "Register was not open before this sale synced.",
+                    summary: "Register was not open before this sale synced.",
                     terminalId: "terminal-1",
                   },
                 ];

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.ts
@@ -2,6 +2,7 @@ import {
   internalMutation,
   internalQuery,
   MutationCtx,
+  QueryCtx,
   query,
 } from "../_generated/server";
 import { Doc, Id } from "../_generated/dataModel";
@@ -39,9 +40,7 @@ const QUEUE_WORK_ITEM_TYPES = [
   "stock_adjustment_review",
   "synced_sale_inventory_review",
 ] as const;
-const APPROVAL_BLOCKED_WORK_ITEM_TYPES = new Set([
-  "stock_adjustment_review",
-]);
+const APPROVAL_BLOCKED_WORK_ITEM_TYPES = new Set(["stock_adjustment_review"]);
 const SOURCE_RESOLVER_WORK_ITEM_TYPES = new Set([
   "daily_close_carry_forward",
   "pos_pending_checkout_item_review",
@@ -225,12 +224,7 @@ function resolverCompletenessBucket(item: Doc<"operationalWorkItem">) {
 
   const metadata = item.metadata;
   const hasRequiredResolverContext = Boolean(
-    metadataString(metadata, "terminalId") &&
-      metadataString(metadata, "localRegisterSessionId") &&
-      metadataString(metadata, "localTransactionId") &&
-      metadataString(metadata, "registerSessionId") &&
-      metadataString(metadata, "sourceId") &&
-      metadataString(metadata, "sourceType") === "posTransaction",
+    metadataString(metadata, "primaryProductSkuId"),
   );
 
   return hasRequiredResolverContext ? 0 : 1;
@@ -257,7 +251,9 @@ function compareOperationalWorkItems(
   );
 }
 
-function sortAndDedupeCurrentWorkItems(items: Array<Doc<"operationalWorkItem">>) {
+function sortAndDedupeCurrentWorkItems(
+  items: Array<Doc<"operationalWorkItem">>,
+) {
   const seenSourceIdentities = new Set<string>();
 
   return [...items].sort(compareOperationalWorkItems).filter((item) => {
@@ -268,6 +264,45 @@ function sortAndDedupeCurrentWorkItems(items: Array<Doc<"operationalWorkItem">>)
     seenSourceIdentities.add(sourceIdentity);
     return true;
   });
+}
+
+async function filterArchivedPendingCheckoutWorkItems(
+  ctx: QueryCtx,
+  items: Array<Doc<"operationalWorkItem">>,
+) {
+  const productCache = new Map<Id<"product">, Doc<"product"> | null>();
+  const filteredItems = [];
+
+  for (const item of items) {
+    if (item.type !== "pos_pending_checkout_item_review") {
+      filteredItems.push(item);
+      continue;
+    }
+
+    const provisionalProductId = metadataString(
+      item.metadata,
+      "provisionalProductId",
+    ) as Id<"product"> | null;
+    if (!provisionalProductId) {
+      filteredItems.push(item);
+      continue;
+    }
+
+    if (!productCache.has(provisionalProductId)) {
+      productCache.set(
+        provisionalProductId,
+        await ctx.db.get("product", provisionalProductId),
+      );
+    }
+
+    if (productCache.get(provisionalProductId)?.availability === "archived") {
+      continue;
+    }
+
+    filteredItems.push(item);
+  }
+
+  return filteredItems;
 }
 
 function metadataNumber(
@@ -286,9 +321,7 @@ function metadataArrayCount(
   return Array.isArray(value) ? value.length : null;
 }
 
-function sanitizeOperationalWorkItemDetails(
-  item: Doc<"operationalWorkItem">,
-) {
+function sanitizeOperationalWorkItemDetails(item: Doc<"operationalWorkItem">) {
   const metadata = item.metadata;
 
   switch (item.type) {
@@ -301,6 +334,11 @@ function sanitizeOperationalWorkItemDetails(
       return {
         lookupCode: metadataString(metadata, "lookupCode"),
         price: metadataNumber(metadata, "price"),
+        provisionalProductId: metadataString(metadata, "provisionalProductId"),
+        provisionalProductSkuId: metadataString(
+          metadata,
+          "provisionalProductSkuId",
+        ),
         quantitySold: metadataNumber(metadata, "quantitySold"),
         totalQuantitySold: metadataNumber(metadata, "totalQuantitySold"),
       };
@@ -600,7 +638,11 @@ export const getQueueSnapshot = query({
       userId: athenaUser._id,
     });
 
-    const [workItemLanes, approvalRequestLanes, syncConflictsBySessionId] =
+    const [
+      rawWorkItemLanes,
+      approvalRequestLanes,
+      syncConflictsBySessionId,
+    ] =
       await Promise.all([
         Promise.all(
           OPEN_WORK_ITEM_STATUSES.flatMap((status) =>
@@ -645,6 +687,20 @@ export const getQueueSnapshot = query({
         ),
         listOpenLocalSyncConflictsByRegisterSession(ctx, args.storeId),
       ]);
+    const workItemLanes = await Promise.all(
+      rawWorkItemLanes.map(async (lane) => {
+        const items = await filterArchivedPendingCheckoutWorkItems(
+          ctx,
+          lane.items,
+        );
+
+        return {
+          ...lane,
+          items,
+          overflow: items.length > MAX_QUEUE_ITEMS,
+        };
+      }),
+    );
 
     const sortedWorkItems = sortAndDedupeCurrentWorkItems(
       workItemLanes.flatMap((lane) => lane.items),
@@ -725,54 +781,54 @@ export const getQueueSnapshot = query({
       posTransactions,
       registerSessions,
     ] = await Promise.all([
-        Promise.all(
-          Array.from(customerIds).map(async (customerId) => {
-            const customer = await ctx.db.get(
-              "customerProfile",
-              customerId as Id<"customerProfile">,
-            );
-            return customer ? [customer._id, customer] : null;
-          }),
-        ),
-        Promise.all(
-          Array.from(staffIds).map(async (staffId) => {
-            const staffProfile = await ctx.db.get(
-              "staffProfile",
-              staffId as Id<"staffProfile">,
-            );
-            return staffProfile ? [staffProfile._id, staffProfile] : null;
-          }),
-        ),
-        Promise.all(
-          Array.from(workItemIds).map(async (workItemId) => {
-            const workItem = await ctx.db.get(
-              "operationalWorkItem",
-              workItemId as Id<"operationalWorkItem">,
-            );
-            return workItem ? [workItem._id, workItem] : null;
-          }),
-        ),
-        Promise.all(
-          Array.from(posTransactionIds).map(async (transactionId) => {
-            const transaction = await ctx.db.get(
-              "posTransaction",
-              transactionId as Id<"posTransaction">,
-            );
-            return transaction ? [transaction._id, transaction] : null;
-          }),
-        ),
-        Promise.all(
-          Array.from(registerSessionIds).map(async (registerSessionId) => {
-            const registerSession = await ctx.db.get(
-              "registerSession",
-              registerSessionId as Id<"registerSession">,
-            );
-            return registerSession
-              ? [registerSession._id, registerSession]
-              : null;
-          }),
-        ),
-      ]);
+      Promise.all(
+        Array.from(customerIds).map(async (customerId) => {
+          const customer = await ctx.db.get(
+            "customerProfile",
+            customerId as Id<"customerProfile">,
+          );
+          return customer ? [customer._id, customer] : null;
+        }),
+      ),
+      Promise.all(
+        Array.from(staffIds).map(async (staffId) => {
+          const staffProfile = await ctx.db.get(
+            "staffProfile",
+            staffId as Id<"staffProfile">,
+          );
+          return staffProfile ? [staffProfile._id, staffProfile] : null;
+        }),
+      ),
+      Promise.all(
+        Array.from(workItemIds).map(async (workItemId) => {
+          const workItem = await ctx.db.get(
+            "operationalWorkItem",
+            workItemId as Id<"operationalWorkItem">,
+          );
+          return workItem ? [workItem._id, workItem] : null;
+        }),
+      ),
+      Promise.all(
+        Array.from(posTransactionIds).map(async (transactionId) => {
+          const transaction = await ctx.db.get(
+            "posTransaction",
+            transactionId as Id<"posTransaction">,
+          );
+          return transaction ? [transaction._id, transaction] : null;
+        }),
+      ),
+      Promise.all(
+        Array.from(registerSessionIds).map(async (registerSessionId) => {
+          const registerSession = await ctx.db.get(
+            "registerSession",
+            registerSessionId as Id<"registerSession">,
+          );
+          return registerSession
+            ? [registerSession._id, registerSession]
+            : null;
+        }),
+      ),
+    ]);
 
     const customerMap = new Map<Id<"customerProfile">, Doc<"customerProfile">>(
       customers.filter(Boolean) as Array<
@@ -814,13 +870,17 @@ export const getQueueSnapshot = query({
       }
     }
     const transactionRegisterSessions = await Promise.all(
-      Array.from(transactionRegisterSessionIds).map(async (registerSessionId) => {
-        const registerSession = await ctx.db.get(
-          "registerSession",
-          registerSessionId,
-        );
-        return registerSession ? [registerSession._id, registerSession] : null;
-      }),
+      Array.from(transactionRegisterSessionIds).map(
+        async (registerSessionId) => {
+          const registerSession = await ctx.db.get(
+            "registerSession",
+            registerSessionId,
+          );
+          return registerSession
+            ? [registerSession._id, registerSession]
+            : null;
+        },
+      ),
     );
     const registerSessionMap = new Map<
       Id<"registerSession">,
@@ -828,9 +888,7 @@ export const getQueueSnapshot = query({
     >(
       [...registerSessions, ...transactionRegisterSessions].filter(
         Boolean,
-      ) as Array<
-        [Id<"registerSession">, Doc<"registerSession">]
-      >,
+      ) as Array<[Id<"registerSession">, Doc<"registerSession">]>,
     );
     for (const registerSession of registerSessionMap.values()) {
       if (registerSession.terminalId) {
@@ -854,73 +912,73 @@ export const getQueueSnapshot = query({
     );
 
     const mappedApprovalRequests = approvalRequests.map((request) => {
-        const linkedTransactionId = approvalRequestTransactionId(request);
-        const linkedTransaction = linkedTransactionId
-          ? posTransactionMap.get(linkedTransactionId)
-          : null;
-        let linkedRegisterSession: Doc<"registerSession"> | null | undefined =
-          null;
-        if (request.registerSessionId) {
-          linkedRegisterSession = registerSessionMap.get(
-            request.registerSessionId,
-          );
-        } else if (linkedTransaction?.registerSessionId) {
-          linkedRegisterSession = registerSessionMap.get(
-            linkedTransaction.registerSessionId,
-          );
-        } else if (
-          request.requestType === "variance_review" &&
-          request.subjectType === "register_session"
-        ) {
-          linkedRegisterSession = registerSessionMap.get(
-            request.subjectId as Id<"registerSession">,
-          );
-        }
+      const linkedTransactionId = approvalRequestTransactionId(request);
+      const linkedTransaction = linkedTransactionId
+        ? posTransactionMap.get(linkedTransactionId)
+        : null;
+      let linkedRegisterSession: Doc<"registerSession"> | null | undefined =
+        null;
+      if (request.registerSessionId) {
+        linkedRegisterSession = registerSessionMap.get(
+          request.registerSessionId,
+        );
+      } else if (linkedTransaction?.registerSessionId) {
+        linkedRegisterSession = registerSessionMap.get(
+          linkedTransaction.registerSessionId,
+        );
+      } else if (
+        request.requestType === "variance_review" &&
+        request.subjectType === "register_session"
+      ) {
+        linkedRegisterSession = registerSessionMap.get(
+          request.subjectId as Id<"registerSession">,
+        );
+      }
 
-        return {
-          _id: request._id,
-          createdAt: request.createdAt,
-          metadata: sanitizeApprovalRequestMetadata(request.metadata),
-          notes: request.notes,
-          reason: request.reason,
-          requestType: request.requestType,
-          status: request.status,
-          storeId: request.storeId,
-          subjectId: request.subjectId,
-          subjectType: request.subjectType,
-          requestedByStaffName: request.requestedByStaffProfileId
-            ? staffMap.get(request.requestedByStaffProfileId)?.fullName
-            : null,
-          transactionSummary: linkedTransaction
-            ? {
-                completedAt: linkedTransaction.completedAt,
-                paymentMethod: linkedTransaction.paymentMethod ?? null,
-                total: linkedTransaction.total,
-                totalPaid: linkedTransaction.totalPaid,
-                transactionId: linkedTransaction._id,
-                transactionNumber: linkedTransaction.transactionNumber,
-              }
-            : null,
-          registerSessionSummary: linkedRegisterSession
-            ? {
-                countedCash: linkedRegisterSession.countedCash ?? null,
-                expectedCash: linkedRegisterSession.expectedCash,
-                registerNumber: linkedRegisterSession.registerNumber ?? null,
-                registerSessionId: linkedRegisterSession._id,
-                status: linkedRegisterSession.status,
-                terminalName: linkedRegisterSession.terminalId
-                  ? (terminalMap
-                      .get(linkedRegisterSession.terminalId)
-                      ?.displayName?.trim() ?? null)
-                  : null,
-                variance: linkedRegisterSession.variance ?? null,
-              }
-            : null,
-          workItemTitle: request.workItemId
-            ? workItemMap.get(request.workItemId)?.title
-            : null,
-        };
-      });
+      return {
+        _id: request._id,
+        createdAt: request.createdAt,
+        metadata: sanitizeApprovalRequestMetadata(request.metadata),
+        notes: request.notes,
+        reason: request.reason,
+        requestType: request.requestType,
+        status: request.status,
+        storeId: request.storeId,
+        subjectId: request.subjectId,
+        subjectType: request.subjectType,
+        requestedByStaffName: request.requestedByStaffProfileId
+          ? staffMap.get(request.requestedByStaffProfileId)?.fullName
+          : null,
+        transactionSummary: linkedTransaction
+          ? {
+              completedAt: linkedTransaction.completedAt,
+              paymentMethod: linkedTransaction.paymentMethod ?? null,
+              total: linkedTransaction.total,
+              totalPaid: linkedTransaction.totalPaid,
+              transactionId: linkedTransaction._id,
+              transactionNumber: linkedTransaction.transactionNumber,
+            }
+          : null,
+        registerSessionSummary: linkedRegisterSession
+          ? {
+              countedCash: linkedRegisterSession.countedCash ?? null,
+              expectedCash: linkedRegisterSession.expectedCash,
+              registerNumber: linkedRegisterSession.registerNumber ?? null,
+              registerSessionId: linkedRegisterSession._id,
+              status: linkedRegisterSession.status,
+              terminalName: linkedRegisterSession.terminalId
+                ? (terminalMap
+                    .get(linkedRegisterSession.terminalId)
+                    ?.displayName?.trim() ?? null)
+                : null,
+              variance: linkedRegisterSession.variance ?? null,
+            }
+          : null,
+        workItemTitle: request.workItemId
+          ? workItemMap.get(request.workItemId)?.title
+          : null,
+      };
+    });
     const mappedSyncReviewRequests = Array.from(
       syncConflictsBySessionId.entries(),
     ).map(([registerSessionId, conflicts]) => {

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -257,6 +257,83 @@ describe("createLocalSyncIngestionService", () => {
     expect(repository.createdPaymentAllocations).toHaveLength(2);
   });
 
+  it("returns inventory review work item mappings when a conflicted sale is retried", async () => {
+    const repository = createFakeSyncRepository();
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+    const sale = buildSaleCompletedEvent({
+      sequence: 1,
+      payload: {
+        ...buildSaleCompletedEvent({ sequence: 1 }).payload,
+        totals: {
+          subtotal: 275,
+          tax: 0,
+          total: 275,
+        },
+        items: [
+          {
+            localTransactionItemId: "local-txn-item-1",
+            productId: "product-1" as never,
+            productSkuId: "sku-1" as never,
+            productName: "Wig Cap",
+            productSku: "CAP-1",
+            quantity: 11,
+            unitPrice: 25,
+          },
+        ],
+        payments: [
+          {
+            localPaymentId: "local-payment-1",
+            method: "cash",
+            amount: 275,
+            timestamp: 21,
+          },
+        ],
+      },
+    });
+    const batch = buildBatch({ events: [sale] });
+
+    const first = await service.ingestBatch(batch);
+    const second = await service.ingestBatch(batch);
+
+    expect(first.kind).toBe("ok");
+    expect(second.kind).toBe("ok");
+    if (first.kind !== "ok" || second.kind !== "ok") {
+      throw new Error("Expected ok result");
+    }
+    for (const result of [first, second]) {
+      expect(result.data.accepted).toEqual([
+        expect.objectContaining({
+          localEventId: "event-sale-completed-1",
+          status: "conflicted",
+        }),
+      ]);
+      expect(result.data.mappings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            localId: "local-txn-1",
+            localIdKind: "transaction",
+          }),
+          expect.objectContaining({
+            cloudTable: "operationalWorkItem",
+            localId: "local-txn-1:inventory-review",
+            localIdKind: "inventoryReviewWorkItem",
+          }),
+        ]),
+      );
+      expect(result.data.conflicts).toEqual([
+        expect.objectContaining({
+          conflictType: "inventory",
+          status: "needs_review",
+        }),
+      ]);
+    }
+    expect(repository.createdTransactions).toHaveLength(1);
+  });
+
   it("rejects and preserves a projected event when a duplicate local event id has changed data", async () => {
     const repository = createFakeSyncRepository();
     const service = createLocalSyncIngestionService({
@@ -825,7 +902,8 @@ describe("createLocalSyncIngestionService", () => {
         eventType: "expense_recorded",
         status: "rejected",
         rejectionCode: "validation_failed",
-        rejectionMessage: "Expense sync event is missing required local identifiers.",
+        rejectionMessage:
+          "Expense sync event is missing required local identifiers.",
       }),
     ]);
     expect(repository.createdTransactions).toHaveLength(0);
@@ -988,9 +1066,9 @@ describe("createLocalSyncIngestionService", () => {
       acceptedThroughSequence: 2,
     });
     expect(repository.createdTransactions).toHaveLength(2);
-    expect(repository.events.find((event) => event.sequence === 2)?.status).toBe(
-      "projected",
-    );
+    expect(
+      repository.events.find((event) => event.sequence === 2)?.status,
+    ).toBe("projected");
   });
 
   it("rejects a terminal/store mismatch before recording events", async () => {
@@ -2692,7 +2770,9 @@ describe("createLocalSyncIngestionService", () => {
         totals: { subtotal: 75, tax: 0, total: 75 },
         items: [],
         serviceLines: [
-          buildServiceLine({ serviceCatalogId: "not-a-service-catalog-id" as never }),
+          buildServiceLine({
+            serviceCatalogId: "not-a-service-catalog-id" as never,
+          }),
         ],
         payments: [
           {
@@ -3913,7 +3993,9 @@ function buildPendingCheckoutItemDefinedEvent(
 }
 
 function buildServiceLine(
-  overrides: Partial<NonNullable<PosLocalSalePayload["serviceLines"]>[number]> = {},
+  overrides: Partial<
+    NonNullable<PosLocalSalePayload["serviceLines"]>[number]
+  > = {},
 ): NonNullable<PosLocalSalePayload["serviceLines"]>[number] {
   return {
     localServiceLineId: "local-service-line-1",
@@ -4043,12 +4125,12 @@ function createFakeSyncRepository(
   createdExpenseSessionItems: unknown[];
   createdExpenseTransactions: unknown[];
   createdExpenseTransactionItems: unknown[];
-	  createdRegisterSessions: unknown[];
-	  createdTransactions: unknown[];
-	  events: LocalSyncEventRecord[];
-	  mappings: LocalSyncMappingRecord[];
-	  registerSessionPatches: Array<{ registerSessionId: string; patch: unknown }>;
-	  roleChecks: Array<{
+  createdRegisterSessions: unknown[];
+  createdTransactions: unknown[];
+  events: LocalSyncEventRecord[];
+  mappings: LocalSyncMappingRecord[];
+  registerSessionPatches: Array<{ registerSessionId: string; patch: unknown }>;
+  roleChecks: Array<{
     allowedRoles: string[];
     staffProfileId: string;
     storeId: string;
@@ -4064,17 +4146,17 @@ function createFakeSyncRepository(
     staffProfileId: string;
     storeId: string;
   }> = [];
-	  const createdRegisterSessions: unknown[] = [];
-	  const createdTransactions: unknown[] = [];
-	  const createdPaymentAllocations: unknown[] = [];
+  const createdRegisterSessions: unknown[] = [];
+  const createdTransactions: unknown[] = [];
+  const createdPaymentAllocations: unknown[] = [];
   const createdExpenseSessions: unknown[] = [];
   const createdExpenseSessionItems: unknown[] = [];
   const createdExpenseTransactions: unknown[] = [];
   const createdExpenseTransactionItems: unknown[] = [];
-	  const registerSessionPatches: Array<{
-	    registerSessionId: string;
-	    patch: unknown;
-	  }> = [];
+  const registerSessionPatches: Array<{
+    registerSessionId: string;
+    patch: unknown;
+  }> = [];
   const acceptedThroughSequenceByCursor = new Map<string, number>();
   const terminal = overrides.terminal ?? {
     _id: "terminal-1",
@@ -4109,10 +4191,10 @@ function createFakeSyncRepository(
     createdExpenseTransactionItems,
     createdRegisterSessions,
     createdTransactions,
-	    events,
-	    mappings,
-	    registerSessionPatches,
-	    roleChecks,
+    events,
+    mappings,
+    registerSessionPatches,
+    roleChecks,
     async getTerminal(terminalId) {
       return terminal && terminal._id === terminalId
         ? (terminal as never)
@@ -4190,7 +4272,7 @@ function createFakeSyncRepository(
           } as never)
         : null;
     },
-	    async getPendingCheckoutItem(pendingCheckoutItemId) {
+    async getPendingCheckoutItem(pendingCheckoutItemId) {
       const created = createdPendingCheckoutItems.find(
         (item): item is { _id: string } & Record<string, unknown> =>
           typeof item === "object" &&
@@ -4207,7 +4289,7 @@ function createFakeSyncRepository(
           provisionalProductSkuId: "sku-1",
         } as never;
       }
-	      return pendingCheckoutItemId === "pending-checkout-item-1"
+      return pendingCheckoutItemId === "pending-checkout-item-1"
         ? ({
             _id: "pending-checkout-item-1",
             storeId: "store-1",
@@ -4215,15 +4297,15 @@ function createFakeSyncRepository(
             provisionalProductId: "product-1",
             provisionalProductSkuId: "sku-1",
           } as never)
-	        : null;
-	    },
+        : null;
+    },
     async getInventoryImportProvisionalSku() {
       return null;
     },
     async recordInventoryImportProvisionalSkuSaleEvidence() {
       // No-op for ingestion tests that do not seed provisional import rows.
     },
-	    async getServiceCatalog(serviceCatalogId) {
+    async getServiceCatalog(serviceCatalogId) {
       return serviceCatalogId === "service-catalog-1"
         ? ({
             _id: "service-catalog-1",
@@ -4280,14 +4362,12 @@ function createFakeSyncRepository(
       return 0;
     },
     async readActiveInventoryHoldQuantitiesForSession() {
-      return (
-        overrides.consumedHoldQuantities ?? new Map([["sku-1", 1]])
-      ) as never;
+      return (overrides.consumedHoldQuantities ??
+        new Map([["sku-1", 1]])) as never;
     },
     async consumeInventoryHoldsForSession() {
-      return (
-        overrides.consumedHoldQuantities ?? new Map([["sku-1", 1]])
-      ) as never;
+      return (overrides.consumedHoldQuantities ??
+        new Map([["sku-1", 1]])) as never;
     },
     async releaseActiveInventoryHoldsForSession() {
       return {
@@ -4427,33 +4507,34 @@ function createFakeSyncRepository(
       return null;
     },
     async listOpenRegisterReviewConflictFacts(args) {
-      return [...(overrides.registerSessionsWithCloseoutReview ?? new Set())]
-        .map((registerSessionId, index) => ({
-          conflict: {
-            _id: `review-conflict-${registerSessionId}`,
-            conflictType: "permission" as const,
-            createdAt: 1_700_000_000_000 + index,
-            details: {
-              countedCash: 100,
-              expectedCash: 90,
-              variance: 10,
-            },
-            localEventId: `review-event-${registerSessionId}`,
-            localRegisterSessionId: registerSessionId,
-            sequence: 0,
-            status: "needs_review" as const,
-            storeId: args.storeId,
-            summary:
-              "Register closeout variance requires manager review before synced closeout can be applied.",
-            terminalId: args.terminalId,
+      return [
+        ...(overrides.registerSessionsWithCloseoutReview ?? new Set()),
+      ].map((registerSessionId, index) => ({
+        conflict: {
+          _id: `review-conflict-${registerSessionId}`,
+          conflictType: "permission" as const,
+          createdAt: 1_700_000_000_000 + index,
+          details: {
+            countedCash: 100,
+            expectedCash: 90,
+            variance: 10,
           },
-          directRegisterSession: {
-            _id: registerSessionId as Id<"registerSession">,
-            storeId: args.storeId,
-            terminalId: args.terminalId,
-          },
-          registerSessionMapping: null,
-        }));
+          localEventId: `review-event-${registerSessionId}`,
+          localRegisterSessionId: registerSessionId,
+          sequence: 0,
+          status: "needs_review" as const,
+          storeId: args.storeId,
+          summary:
+            "Register closeout variance requires manager review before synced closeout can be applied.",
+          terminalId: args.terminalId,
+        },
+        directRegisterSession: {
+          _id: registerSessionId as Id<"registerSession">,
+          storeId: args.storeId,
+          terminalId: args.terminalId,
+        },
+        registerSessionMapping: null,
+      }));
     },
     async getRegisterSessionByLocalId(args) {
       const mapping = mappings.find(
@@ -4512,9 +4593,9 @@ function createFakeSyncRepository(
         ? (existing as never)
         : null;
     },
-	    async patchRegisterSession(registerSessionId, patch) {
-	      registerSessionPatches.push({ registerSessionId, patch });
-	      const session = createdRegisterSessions.find(
+    async patchRegisterSession(registerSessionId, patch) {
+      registerSessionPatches.push({ registerSessionId, patch });
+      const session = createdRegisterSessions.find(
         (candidate) =>
           typeof candidate === "object" &&
           candidate !== null &&
@@ -4611,11 +4692,11 @@ function createFakeSyncRepository(
     async createTransactionServiceLine() {
       return `transaction-service-line-${nextId++}` as never;
     },
-	    async patchProductSku() {},
-	    async recordSaleInventoryMovement() {
-	      return "inserted";
-	    },
-	    async createPaymentAllocation(input) {
+    async patchProductSku() {},
+    async recordSaleInventoryMovement() {
+      return "inserted";
+    },
+    async createPaymentAllocation(input) {
       const id = `payment-allocation-${createdPaymentAllocations.length + 1}`;
       createdPaymentAllocations.push({ _id: id, ...input });
       return id as never;

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -326,15 +326,23 @@ async function projectExpenseRecorded(
   repository: SyncProjectionRepository,
   args: ExpenseRecordedArgs,
 ): Promise<ProjectionResult> {
-  const existingTransactionMapping = await findMappingForTerminal(repository, args, {
-    localIdKind: "expenseTransaction",
-    localId: args.event.payload.localExpenseEventId,
-  });
+  const existingTransactionMapping = await findMappingForTerminal(
+    repository,
+    args,
+    {
+      localIdKind: "expenseTransaction",
+      localId: args.event.payload.localExpenseEventId,
+    },
+  );
   if (existingTransactionMapping) {
-    const existingSessionMapping = await findMappingForTerminal(repository, args, {
-      localIdKind: "expenseSession",
-      localId: args.event.payload.localExpenseSessionId,
-    });
+    const existingSessionMapping = await findMappingForTerminal(
+      repository,
+      args,
+      {
+        localIdKind: "expenseSession",
+        localId: args.event.payload.localExpenseSessionId,
+      },
+    );
     return {
       status: "projected",
       mappings: [
@@ -385,8 +393,7 @@ async function projectExpenseRecorded(
           localExpenseEventId: args.event.payload.localExpenseEventId,
           localTransactionItemId: item.localTransactionItemId,
           pendingCheckoutItemId: item.pendingCheckoutItemId,
-          inventoryImportProvisionalSkuId:
-            item.inventoryImportProvisionalSkuId,
+          inventoryImportProvisionalSkuId: item.inventoryImportProvisionalSkuId,
           productId: item.productId,
           productSkuId: item.productSkuId,
         },
@@ -425,7 +432,8 @@ async function projectExpenseRecorded(
     ) {
       const conflict = await createConflict(repository, args, {
         conflictType: "inventory",
-        summary: "Expense line item catalog reference does not belong to this store.",
+        summary:
+          "Expense line item catalog reference does not belong to this store.",
         details: {
           blocksProjection: true,
           productId,
@@ -444,7 +452,8 @@ async function projectExpenseRecorded(
       if (!normalizedPendingCheckoutItemId) {
         const conflict = await createConflict(repository, args, {
           conflictType: "inventory",
-          summary: "Expense pending checkout reference does not match this line.",
+          summary:
+            "Expense pending checkout reference does not match this line.",
           details: {
             blocksProjection: true,
             pendingCheckoutItemId: item.pendingCheckoutItemId,
@@ -465,7 +474,8 @@ async function projectExpenseRecorded(
       ) {
         const conflict = await createConflict(repository, args, {
           conflictType: "inventory",
-          summary: "Expense pending checkout reference does not match this line.",
+          summary:
+            "Expense pending checkout reference does not match this line.",
           details: {
             blocksProjection: true,
             pendingCheckoutItemId: item.pendingCheckoutItemId,
@@ -490,10 +500,12 @@ async function projectExpenseRecorded(
       if (!normalizedInventoryImportProvisionalSkuId) {
         const conflict = await createConflict(repository, args, {
           conflictType: "inventory",
-          summary: "Expense provisional import reference does not match this line.",
+          summary:
+            "Expense provisional import reference does not match this line.",
           details: {
             blocksProjection: true,
-            inventoryImportProvisionalSkuId: item.inventoryImportProvisionalSkuId,
+            inventoryImportProvisionalSkuId:
+              item.inventoryImportProvisionalSkuId,
             productId,
             productSkuId,
           },
@@ -513,10 +525,12 @@ async function projectExpenseRecorded(
       ) {
         const conflict = await createConflict(repository, args, {
           conflictType: "inventory",
-          summary: "Expense provisional import reference does not match this line.",
+          summary:
+            "Expense provisional import reference does not match this line.",
           details: {
             blocksProjection: true,
-            inventoryImportProvisionalSkuId: item.inventoryImportProvisionalSkuId,
+            inventoryImportProvisionalSkuId:
+              item.inventoryImportProvisionalSkuId,
             productId,
             productSkuId,
           },
@@ -553,7 +567,10 @@ async function projectExpenseRecorded(
     const inventoryAvailable =
       aggregate.inventoryCount >= aggregate.requestedQuantity &&
       aggregate.quantityAvailable >= aggregate.requestedQuantity;
-    trustedExpenseSkuAvailability.set(aggregate.productSkuId, inventoryAvailable);
+    trustedExpenseSkuAvailability.set(
+      aggregate.productSkuId,
+      inventoryAvailable,
+    );
 
     if (!inventoryAvailable) {
       reviewConflicts.push(
@@ -573,10 +590,14 @@ async function projectExpenseRecorded(
     }
   }
 
-  const existingSessionMapping = await findMappingForTerminal(repository, args, {
-    localIdKind: "expenseSession",
-    localId: args.event.payload.localExpenseSessionId,
-  });
+  const existingSessionMapping = await findMappingForTerminal(
+    repository,
+    args,
+    {
+      localIdKind: "expenseSession",
+      localId: args.event.payload.localExpenseSessionId,
+    },
+  );
   const existingSession = await repository.getExpenseSessionByLocalId({
     storeId: args.storeId,
     terminalId: args.terminalId,
@@ -933,7 +954,9 @@ async function getOpenRegisterCloseoutReviewState(
   };
 }
 
-function getConflictCloseoutReviewBoundaryAt(conflict: LocalSyncConflictRecord) {
+function getConflictCloseoutReviewBoundaryAt(
+  conflict: LocalSyncConflictRecord,
+) {
   return typeof conflict.details.closeoutOccurredAt === "number"
     ? conflict.details.closeoutOccurredAt
     : conflict.createdAt;
@@ -1001,7 +1024,8 @@ async function projectRegisterOpened(
     ) {
       const conflict = await createConflict(repository, args, {
         conflictType: "duplicate_local_id",
-        summary: "Local register session id was reused by a different synced register open.",
+        summary:
+          "Local register session id was reused by a different synced register open.",
         details: {
           existingLocalEventId: existing.localEventId,
           localIdKind: "registerSession",
@@ -1026,11 +1050,11 @@ async function projectRegisterOpened(
     );
     if (
       registerSession &&
-      await canReuseCloudRegisterSessionForLocalOpen(
+      (await canReuseCloudRegisterSessionForLocalOpen(
         repository,
         args,
         registerSession,
-      )
+      ))
     ) {
       const mapping = await createMapping(repository, args, {
         localIdKind: "registerSession",
@@ -1311,15 +1335,15 @@ async function projectSaleCompleted(
     saleSession,
     session: sessionResolution,
   });
-	  const itemMappings = await persistSaleItemsAndInventory(repository, args, {
-	    catalogItemsByLocalId: validation.catalogValidation.itemsByLocalId,
-	    inventoryValidation,
-	    payload: validation.payload,
-	    sale,
-	    saleSession,
-	    session: sessionResolution,
-	    store: validation.store,
-	  });
+  const itemMappings = await persistSaleItemsAndInventory(repository, args, {
+    catalogItemsByLocalId: validation.catalogValidation.itemsByLocalId,
+    inventoryValidation,
+    payload: validation.payload,
+    sale,
+    saleSession,
+    session: sessionResolution,
+    store: validation.store,
+  });
   const serviceProjection = await persistSaleServiceLines(repository, args, {
     payload: validation.payload,
     payments,
@@ -1354,7 +1378,7 @@ async function projectSaleCompleted(
     ...(validation.catalogValidation.conflict
       ? [validation.catalogValidation.conflict]
       : []),
-	    ...(inventoryValidation.conflict ? [inventoryValidation.conflict] : []),
+    ...(inventoryValidation.conflict ? [inventoryValidation.conflict] : []),
     ...(payments.paymentConflict ? [payments.paymentConflict] : []),
   ];
 
@@ -1555,7 +1579,8 @@ async function resolveSaleRegisterAndSession(
     return conflictResult(conflict);
   }
 
-  const registerSessionSaleUsable = isRegisterSessionSaleUsable(registerSession);
+  const registerSessionSaleUsable =
+    isRegisterSessionSaleUsable(registerSession);
   const reviewedClosingRegisterSaleAllowed =
     args.options?.allowReviewedClosingRegisterSaleProjection === true &&
     registerSession.status === "closing";
@@ -1673,7 +1698,8 @@ async function resolveSaleRegisterAndSession(
   if (existingPosSession?.status === "void") {
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
-      summary: "Cleared POS sessions cannot be completed from synced local history.",
+      summary:
+        "Cleared POS sessions cannot be completed from synced local history.",
       details: {
         localPosSessionId: payload.localPosSessionId,
         localTransactionId: payload.localTransactionId,
@@ -1800,7 +1826,8 @@ async function projectSaleCleared(
   ) {
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
-      summary: "Completed POS sessions cannot be cleared from synced local history.",
+      summary:
+        "Completed POS sessions cannot be cleared from synced local history.",
       details: {
         localPosSessionId: args.event.payload.localPosSessionId,
         posSessionId: existingPosSession._id,
@@ -1980,7 +2007,10 @@ function planSalePaymentAllocations(args: {
       serviceTargets.reduce((sum, target) => sum + target.remaining, 0),
   );
   const retailAllocations: PlannedPaymentAllocation[] = [];
-  const serviceAllocationsByLineKey = new Map<string, PlannedPaymentAllocation[]>();
+  const serviceAllocationsByLineKey = new Map<
+    string,
+    PlannedPaymentAllocation[]
+  >();
 
   for (const payment of normalizedPayments) {
     let remainingPayment = roundMoney(payment.amount);
@@ -2067,7 +2097,9 @@ async function persistSaleRecord(
   const transactionId = await repository.createTransaction({
     transactionNumber: payload.receiptNumber,
     storeId: args.storeId,
-    ...(saleSession.posSessionId ? { sessionId: saleSession.posSessionId } : {}),
+    ...(saleSession.posSessionId
+      ? { sessionId: saleSession.posSessionId }
+      : {}),
     registerSessionId: session.registerSession._id,
     staffProfileId: args.event.staffProfileId,
     registerNumber: session.resolvedRegisterNumber,
@@ -2122,32 +2154,37 @@ async function persistSaleRecord(
 async function persistSaleItemsAndInventory(
   repository: SyncProjectionRepository,
   args: SaleCompletedArgs,
-	  input: {
-	    catalogItemsByLocalId: Map<string, CanonicalSaleItem>;
-	    inventoryValidation: SaleInventoryValidation;
-	    payload: PosLocalSalePayload;
-	    sale: PersistedSale;
-	    saleSession: PersistedSaleSession;
-	    session: SaleSessionResolution;
-	    store: StoreRecord;
-	  },
-	): Promise<LocalSyncMappingRecord[]> {
-	  const { catalogItemsByLocalId, inventoryValidation, payload, sale, saleSession } =
-	    input;
-	  const itemMappings: LocalSyncMappingRecord[] = [];
-	  const consumedHoldQuantities =
+  input: {
+    catalogItemsByLocalId: Map<string, CanonicalSaleItem>;
+    inventoryValidation: SaleInventoryValidation;
+    payload: PosLocalSalePayload;
+    sale: PersistedSale;
+    saleSession: PersistedSaleSession;
+    session: SaleSessionResolution;
+    store: StoreRecord;
+  },
+): Promise<LocalSyncMappingRecord[]> {
+  const {
+    catalogItemsByLocalId,
+    inventoryValidation,
+    payload,
+    sale,
+    saleSession,
+  } = input;
+  const itemMappings: LocalSyncMappingRecord[] = [];
+  const consumedHoldQuantities =
     inventoryValidation.stockMutationAllowed &&
     saleSession.reusedExistingSession &&
     saleSession.posSessionId
       ? await repository.consumeInventoryHoldsForSession({
           sessionId: saleSession.posSessionId,
-        items: trustedInventorySaleItems(payload).map((item) => ({
-          productSkuId: item.productSkuId as Id<"productSku">,
-          quantity: item.quantity,
-        })),
-        now: args.event.occurredAt,
-      })
-    : new Map<Id<"productSku">, number>();
+          items: trustedInventorySaleItems(payload).map((item) => ({
+            productSkuId: item.productSkuId as Id<"productSku">,
+            quantity: item.quantity,
+          })),
+          now: args.event.occurredAt,
+        })
+      : new Map<Id<"productSku">, number>();
   const pendingEvidenceByItemId = new Map<
     Id<"posPendingCheckoutItem">,
     {
@@ -2270,13 +2307,20 @@ async function persistSaleItemsAndInventory(
   }
 
   if (!inventoryValidation.stockMutationAllowed) {
-    await createSkippedInventoryReviewWorkItem(repository, args, {
-      inventoryValidation,
-      payload,
-      sale,
-      session: input.session,
-      store: input.store,
-    });
+    const reviewWorkItemMapping = await createSkippedInventoryReviewWorkItem(
+      repository,
+      args,
+      {
+        inventoryValidation,
+        payload,
+        sale,
+        session: input.session,
+        store: input.store,
+      },
+    );
+    if (reviewWorkItemMapping) {
+      itemMappings.push(reviewWorkItemMapping);
+    }
     return itemMappings;
   }
 
@@ -2323,9 +2367,9 @@ async function createSkippedInventoryReviewWorkItem(
     session: SaleSessionResolution;
     store: StoreRecord;
   },
-) {
+): Promise<LocalSyncMappingRecord | null> {
   if (!input.store?.organizationId) {
-    return;
+    return null;
   }
 
   const trustedLines = trustedInventorySaleItems(input.payload).map((item) => ({
@@ -2338,32 +2382,32 @@ async function createSkippedInventoryReviewWorkItem(
     unitPrice: item.unitPrice,
   }));
   if (trustedLines.length === 0) {
-    return;
+    return null;
   }
 
   const primarySkippedItem = input.inventoryValidation.skippedMutationItems[0];
   const primaryProductName =
     primarySkippedItem?.productName ?? trustedLines[0]?.productName;
-	  const title = primaryProductName
-	    ? `Review inventory for ${primaryProductName}`
-	    : `Review inventory for sale #${input.payload.receiptNumber}`;
-	  const sourceType = "posTransaction";
-	  const localInventoryReviewWorkItemId = [
-	    input.payload.localTransactionId,
-	    "inventory-review",
-	  ].join(":");
-	  const existingWorkItemMapping = await repository.findMapping({
-	    localId: localInventoryReviewWorkItemId,
-	    localIdKind: "inventoryReviewWorkItem",
-	    localRegisterSessionId: args.event.localRegisterSessionId,
-	    storeId: args.storeId,
-	    terminalId: args.terminalId,
-	  });
-	  if (existingWorkItemMapping) {
-	    return;
-	  }
+  const title = primaryProductName
+    ? `Review inventory for ${primaryProductName}`
+    : `Review inventory for sale #${input.payload.receiptNumber}`;
+  const sourceType = "posTransaction";
+  const localInventoryReviewWorkItemId = [
+    input.payload.localTransactionId,
+    "inventory-review",
+  ].join(":");
+  const existingWorkItemMapping = await repository.findMapping({
+    localId: localInventoryReviewWorkItemId,
+    localIdKind: "inventoryReviewWorkItem",
+    localRegisterSessionId: args.event.localRegisterSessionId,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+  if (existingWorkItemMapping) {
+    return existingWorkItemMapping;
+  }
 
-	  const workItemId = await repository.createServiceWorkItem({
+  const workItemId = await repository.createServiceWorkItem({
     approvalState: "not_required",
     createdByStaffProfileId:
       args.options?.reviewActorStaffProfileId ?? args.event.staffProfileId,
@@ -2388,16 +2432,16 @@ async function createSkippedInventoryReviewWorkItem(
     priority: "high",
     status: "open",
     storeId: args.storeId,
-	    title,
-	    type: "synced_sale_inventory_review",
-	  });
-	  await createMapping(repository, args, {
-	    cloudId: workItemId,
-	    cloudTable: "operationalWorkItem",
-	    localId: localInventoryReviewWorkItemId,
-	    localIdKind: "inventoryReviewWorkItem",
-	  });
-	}
+    title,
+    type: "synced_sale_inventory_review",
+  });
+  return createMapping(repository, args, {
+    cloudId: workItemId,
+    cloudTable: "operationalWorkItem",
+    localId: localInventoryReviewWorkItemId,
+    localIdKind: "inventoryReviewWorkItem",
+  });
+}
 
 async function persistSaleServiceLines(
   repository: SyncProjectionRepository,
@@ -2444,7 +2488,8 @@ async function persistSaleServiceLines(
           canonicalLine?.serviceCatalogName ?? line.serviceCatalogName,
         store: input.store,
       }));
-    const serviceCase = existingServiceCase ?? (await repository.getServiceCase(serviceCaseId));
+    const serviceCase =
+      existingServiceCase ?? (await repository.getServiceCase(serviceCaseId));
     const workItemId = serviceCase?.operationalWorkItemId;
     const serviceCaseLineItemId = await repository.createServiceCaseLineItem({
       serviceCaseId,
@@ -2461,7 +2506,8 @@ async function persistSaleServiceLines(
         transactionId: input.sale.transactionId,
         serviceCaseId,
         serviceCatalogId: line.serviceCatalogId,
-        serviceName: canonicalLine?.serviceCatalogName ?? line.serviceCatalogName,
+        serviceName:
+          canonicalLine?.serviceCatalogName ?? line.serviceCatalogName,
         serviceMode: canonicalLine?.serviceMode ?? line.serviceMode,
         pricingSource:
           line.pricingModel === "fixed"
@@ -2496,8 +2542,9 @@ async function persistSaleServiceLines(
       );
     }
 
-    for (const payment of input.payments.serviceAllocationsByLineKey.get(lineKey) ??
-      []) {
+    for (const payment of input.payments.serviceAllocationsByLineKey.get(
+      lineKey,
+    ) ?? []) {
       const allocationId = await repository.createPaymentAllocation({
         storeId: args.storeId,
         organizationId: input.store?.organizationId,
@@ -2715,11 +2762,13 @@ function buildSaleProjectedMessage(args: {
   const lineCount = getSaleLineCount(args.payload);
   const paymentLabel = getPaymentSummaryLabel(args.payments.validPayments);
 
-  return [
-    `Sale${transactionLabel} synced: ${formatSaleLineCount(lineCount)}`,
-    formatSaleTotal(args.currency, args.payload.totals.total),
-    paymentLabel,
-  ].join(", ") + ".";
+  return (
+    [
+      `Sale${transactionLabel} synced: ${formatSaleLineCount(lineCount)}`,
+      formatSaleTotal(args.currency, args.payload.totals.total),
+      paymentLabel,
+    ].join(", ") + "."
+  );
 }
 
 function getSaleLineCount(payload: PosLocalSalePayload) {
@@ -3066,7 +3115,8 @@ async function validateSaleCustomerReference(
   }
 
   for (const line of payload.serviceLines ?? []) {
-    const lineCustomerProfileId = line.customerProfileId ?? payload.customerProfileId;
+    const lineCustomerProfileId =
+      line.customerProfileId ?? payload.customerProfileId;
     if (!lineCustomerProfileId) {
       if (line.existingServiceCaseId) continue;
       return createConflict(repository, args, {
@@ -3079,7 +3129,9 @@ async function validateSaleCustomerReference(
         },
       });
     }
-    const lineCustomer = await repository.getCustomerProfile(lineCustomerProfileId);
+    const lineCustomer = await repository.getCustomerProfile(
+      lineCustomerProfileId,
+    );
     if (!lineCustomer || lineCustomer.storeId !== args.storeId) {
       return createConflict(repository, args, {
         conflictType: "permission",
@@ -3115,12 +3167,15 @@ async function validateSaleCatalogReferences(
   const provisionalImportSkusByLocalId = new Map<
     string,
     NonNullable<
-      Awaited<ReturnType<SyncProjectionRepository["getInventoryImportProvisionalSku"]>>
+      Awaited<
+        ReturnType<SyncProjectionRepository["getInventoryImportProvisionalSku"]>
+      >
     >
   >();
   let priceConflict: LocalSyncConflictRecord | null = null;
   const dualSourceItem = payload.items.find(
-    (item) => item.pendingCheckoutItemId && item.inventoryImportProvisionalSkuId,
+    (item) =>
+      item.pendingCheckoutItemId && item.inventoryImportProvisionalSkuId,
   );
   if (dualSourceItem) {
     return {
@@ -3143,7 +3198,8 @@ async function validateSaleCatalogReferences(
     };
   }
 
-  const mixedInventorySourceSkuId = findMixedTrustedAndProvisionalSkuId(payload);
+  const mixedInventorySourceSkuId =
+    findMixedTrustedAndProvisionalSkuId(payload);
   if (mixedInventorySourceSkuId) {
     return {
       conflict: await createConflict(repository, args, {
@@ -3191,7 +3247,8 @@ async function validateSaleCatalogReferences(
         };
       }
 
-      item.pendingCheckoutItemId = cloudPendingId as Id<"posPendingCheckoutItem">;
+      item.pendingCheckoutItemId =
+        cloudPendingId as Id<"posPendingCheckoutItem">;
       const pendingItem = await repository.getPendingCheckoutItem(
         item.pendingCheckoutItemId as Id<"posPendingCheckoutItem">,
       );
@@ -3204,7 +3261,8 @@ async function validateSaleCatalogReferences(
         return {
           conflict: await createConflict(repository, args, {
             conflictType: "inventory",
-            summary: "Pending checkout item reference does not match this sale line.",
+            summary:
+              "Pending checkout item reference does not match this sale line.",
             details: {
               localTransactionId: payload.localTransactionId,
               pendingCheckoutItemId: item.pendingCheckoutItemId,
@@ -3228,7 +3286,8 @@ async function validateSaleCatalogReferences(
         return {
           conflict: await createConflict(repository, args, {
             conflictType: "inventory",
-            summary: "Pending checkout item reference does not match this sale line.",
+            summary:
+              "Pending checkout item reference does not match this sale line.",
             details: {
               localTransactionId: payload.localTransactionId,
               pendingCheckoutItemId: item.pendingCheckoutItemId,
@@ -3413,7 +3472,9 @@ async function validateSaleCatalogReferences(
     }
 
     if (line.existingServiceCaseId) {
-      const serviceCase = await repository.getServiceCase(line.existingServiceCaseId);
+      const serviceCase = await repository.getServiceCase(
+        line.existingServiceCaseId,
+      );
       if (
         !serviceCase ||
         serviceCase.storeId !== args.storeId ||
@@ -3423,7 +3484,8 @@ async function validateSaleCatalogReferences(
         return {
           conflict: await createConflict(repository, args, {
             conflictType: "permission",
-            summary: "Service case is not available for synced POS service sale.",
+            summary:
+              "Service case is not available for synced POS service sale.",
             details: {
               localTransactionId: payload.localTransactionId,
               existingServiceCaseId: line.existingServiceCaseId,
@@ -3711,9 +3773,7 @@ async function projectRegisterClosed(
       storeId: args.storeId,
     })) ?? [];
 
-  if (
-    closeoutHolds.some((hold) => hold.cashAffecting && hold.count > 0)
-  ) {
+  if (closeoutHolds.some((hold) => hold.cashAffecting && hold.count > 0)) {
     const [store, terminal] = await Promise.all([
       repository.getStore(args.storeId),
       repository.getTerminal(args.terminalId),
@@ -3989,6 +4049,10 @@ async function collectExistingSaleMappings(
   }> = [
     { localIdKind: "posSession", localId: payload.localPosSessionId },
     { localIdKind: "transaction", localId: payload.localTransactionId },
+    {
+      localIdKind: "inventoryReviewWorkItem",
+      localId: `${payload.localTransactionId}:inventory-review`,
+    },
     { localIdKind: "receipt", localId: payload.localReceiptNumber },
     ...payload.items
       .filter((item) => item.localTransactionItemId)

--- a/packages/athena-webapp/convex/pos/public/catalog.test.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.test.ts
@@ -5,8 +5,10 @@ import type { Id } from "../../_generated/dataModel";
 const mocks = vi.hoisted(() => ({
   createOrReusePendingCheckoutItem: vi.fn(),
   findStoreSkuByBarcode: vi.fn(),
+  refreshCatalogSummaryWithCtx: vi.fn(),
   listRegisterCatalogAvailabilitySnapshot: vi.fn(),
   quickAddCatalogItem: vi.fn(),
+  recordInventoryMovementWithCtx: vi.fn(),
   recordOperationalEventWithCtx: vi.fn(),
   requireAuthenticatedAthenaUserWithCtx: vi.fn(),
   requireOrganizationMemberRoleWithCtx: vi.fn(),
@@ -25,14 +27,22 @@ vi.mock("../../inventory/skuSearch", () => ({
   upsertProductSkuSearchProjection: mocks.upsertProductSkuSearchProjection,
 }));
 
+vi.mock("../../inventory/catalogSummary", () => ({
+  refreshCatalogSummaryWithCtx: mocks.refreshCatalogSummaryWithCtx,
+}));
+
+vi.mock("../../operations/inventoryMovements", () => ({
+  recordInventoryMovementWithCtx: mocks.recordInventoryMovementWithCtx,
+}));
+
 vi.mock("../application/queries/listRegisterCatalog", () => ({
   REGISTER_CATALOG_AVAILABILITY_LIMIT: 50,
   isTrustedRegisterCatalogSku: vi.fn(
-    ({ product, sku }) =>
+    ({ category, product, sku }) =>
       product.availability !== "archived" &&
       product.availability !== "draft" &&
-      product.isVisible !== false &&
-      sku.isVisible !== false,
+      (product.isVisible !== false || category?.slug === "pos-quick-add") &&
+      (sku.isVisible !== false || category?.slug === "pos-quick-add"),
   ),
   listRegisterCatalog: vi.fn(),
   listRegisterCatalogAvailability: vi.fn(),
@@ -69,7 +79,9 @@ vi.mock("../infrastructure/repositories/catalogRepository", () => ({
 import {
   barcodeLookup,
   createOrReusePendingCheckoutItemForSale,
+  finalizePendingCheckoutTrustedInventoryFromProductPage,
   listPendingCheckoutItemsForReview,
+  listPendingCheckoutProductPageBinding,
   listRegisterCatalogSnapshot,
   listRegisterCatalogAvailability,
   listRegisterCatalogAvailabilitySnapshot,
@@ -112,6 +124,10 @@ describe("POS public catalog queries", () => {
       status: "pending_review",
     });
     mocks.findStoreSkuByBarcode.mockResolvedValue(null);
+    mocks.recordInventoryMovementWithCtx.mockResolvedValue({
+      _id: "movement-1",
+    });
+    mocks.refreshCatalogSummaryWithCtx.mockResolvedValue("summary-1");
     mocks.quickAddCatalogItem.mockResolvedValue({
       areProcessingFeesAbsorbed: false,
       barcode: "123456789012",
@@ -203,6 +219,40 @@ describe("POS public catalog queries", () => {
       resolvePendingCheckoutItemReview,
       pendingReviewItem,
     );
+    assertConformsToExportedReturns(listPendingCheckoutProductPageBinding, {
+      activeRowCount: 1,
+      row: {
+        _id: "pending-1",
+        importKey: "pending-checkout",
+        importedQuantity: 1,
+        provisionalSoldQuantity: 1,
+        rowNumber: 1,
+        saleCount: 1,
+      },
+      saleEvidenceFingerprint: "sale-fingerprint",
+      state: "unique",
+      trustedSkuFingerprint: "sku-fingerprint",
+    });
+    assertConformsToExportedReturns(
+      finalizePendingCheckoutTrustedInventoryFromProductPage,
+      {
+        data: {
+          finalTrustedQuantity: 2,
+          product: {
+            availability: "live",
+            inventoryCount: 2,
+            isVisible: true,
+            quantityAvailable: 2,
+          },
+          productId: "product-1",
+          productSkuId: "sku-1",
+          provisionalSkuId: "pending-1",
+          provisionalSoldQuantity: 1,
+          quantityAvailable: 2,
+        },
+        kind: "ok",
+      },
+    );
   });
 
   it("maps pending checkout review decisions to source-owned work item states", () => {
@@ -240,14 +290,19 @@ describe("POS public catalog queries", () => {
         quantityAvailable: 3,
       }),
     ]);
-    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(ctx);
-    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage:
-        "You cannot view register catalog availability for this store.",
-      organizationId: "org-1",
-      userId: "athena-user-1",
-    });
+    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(
+      ctx,
+    );
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      {
+        allowedRoles: ["full_admin", "pos_only"],
+        failureMessage:
+          "You cannot view register catalog availability for this store.",
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      },
+    );
     expect(mocks.listRegisterCatalogAvailabilitySnapshot).toHaveBeenCalledWith(
       ctx,
       { storeId: "store-1" },
@@ -255,9 +310,8 @@ describe("POS public catalog queries", () => {
   });
 
   it("requires same-organization POS access before returning the full register catalog snapshot", async () => {
-    const readRegisterCatalog = await import(
-      "../application/queries/listRegisterCatalog"
-    );
+    const readRegisterCatalog =
+      await import("../application/queries/listRegisterCatalog");
     vi.mocked(readRegisterCatalog.listRegisterCatalog).mockResolvedValue([
       {
         areProcessingFeesAbsorbed: false,
@@ -293,23 +347,27 @@ describe("POS public catalog queries", () => {
       }),
     ]);
     assertConformsToExportedReturns(listRegisterCatalogSnapshot, rows);
-    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(ctx);
-    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage:
-        "You cannot view register catalog availability for this store.",
-      organizationId: "org-1",
-      userId: "athena-user-1",
-    });
+    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(
+      ctx,
+    );
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      {
+        allowedRoles: ["full_admin", "pos_only"],
+        failureMessage:
+          "You cannot view register catalog availability for this store.",
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      },
+    );
     expect(readRegisterCatalog.listRegisterCatalog).toHaveBeenCalledWith(ctx, {
       storeId: "store-1",
     });
   });
 
   it("does not return the register catalog snapshot when the caller is unauthenticated", async () => {
-    const readRegisterCatalog = await import(
-      "../application/queries/listRegisterCatalog"
-    );
+    const readRegisterCatalog =
+      await import("../application/queries/listRegisterCatalog");
     mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
       new Error("Sign in again to continue."),
     );
@@ -326,9 +384,8 @@ describe("POS public catalog queries", () => {
 
   it("requires same-organization POS access before returning bounded availability", async () => {
     mocks.listRegisterCatalogAvailabilitySnapshot.mockResolvedValue([]);
-    const readRegisterCatalogAvailability = await import(
-      "../application/queries/listRegisterCatalog"
-    );
+    const readRegisterCatalogAvailability =
+      await import("../application/queries/listRegisterCatalog");
     vi.mocked(
       readRegisterCatalogAvailability.listRegisterCatalogAvailability,
     ).mockResolvedValue([
@@ -342,10 +399,13 @@ describe("POS public catalog queries", () => {
     ]);
     const ctx = buildCtx();
 
-    const rows = await getHandler(listRegisterCatalogAvailability)(ctx as never, {
-      storeId: "store-1",
-      productSkuIds: ["sku-1"],
-    });
+    const rows = await getHandler(listRegisterCatalogAvailability)(
+      ctx as never,
+      {
+        storeId: "store-1",
+        productSkuIds: ["sku-1"],
+      },
+    );
 
     expect(rows).toEqual([
       expect.objectContaining({
@@ -353,13 +413,16 @@ describe("POS public catalog queries", () => {
         quantityAvailable: 3,
       }),
     ]);
-    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage:
-        "You cannot view register catalog availability for this store.",
-      organizationId: "org-1",
-      userId: "athena-user-1",
-    });
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      {
+        allowedRoles: ["full_admin", "pos_only"],
+        failureMessage:
+          "You cannot view register catalog availability for this store.",
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      },
+    );
     expect(
       readRegisterCatalogAvailability.listRegisterCatalogAvailability,
     ).toHaveBeenCalledWith(ctx, {
@@ -380,13 +443,14 @@ describe("POS public catalog queries", () => {
       }),
     ).rejects.toThrow("Sign in again to continue.");
 
-    expect(mocks.listRegisterCatalogAvailabilitySnapshot).not.toHaveBeenCalled();
+    expect(
+      mocks.listRegisterCatalogAvailabilitySnapshot,
+    ).not.toHaveBeenCalled();
   });
 
   it("does not return bounded availability when the caller is unauthenticated", async () => {
-    const readRegisterCatalogAvailability = await import(
-      "../application/queries/listRegisterCatalog"
-    );
+    const readRegisterCatalogAvailability =
+      await import("../application/queries/listRegisterCatalog");
     mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
       new Error("Sign in again to continue."),
     );
@@ -416,13 +480,18 @@ describe("POS public catalog queries", () => {
       storeId: "store-1",
     });
 
-    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(ctx);
-    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage: "You cannot quick add products for this store.",
-      organizationId: "org-1",
-      userId: "athena-user-1",
-    });
+    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(
+      ctx,
+    );
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      {
+        allowedRoles: ["full_admin", "pos_only"],
+        failureMessage: "You cannot quick add products for this store.",
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      },
+    );
     expect(mocks.quickAddCatalogItem).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({
@@ -471,14 +540,18 @@ describe("POS public catalog queries", () => {
       pendingCheckoutItemId: "pending-1",
       status: "pending_review",
     });
-    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(ctx);
-    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage:
-        "You cannot add pending checkout items for this store.",
-      organizationId: "org-1",
-      userId: "athena-user-1",
-    });
+    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(
+      ctx,
+    );
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      {
+        allowedRoles: ["full_admin", "pos_only"],
+        failureMessage: "You cannot add pending checkout items for this store.",
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      },
+    );
     expect(mocks.createOrReusePendingCheckoutItem).toHaveBeenCalledWith(ctx, {
       createdByStaffProfileId: "staff-1",
       createdByUserId: "athena-user-1",
@@ -596,9 +669,411 @@ describe("POS public catalog queries", () => {
       getHandler(listPendingCheckoutItemsForReview)(ctx as never, {
         storeId: "store-1",
       }),
-    ).rejects.toThrow("You cannot review pending checkout items for this store.");
+    ).rejects.toThrow(
+      "You cannot review pending checkout items for this store.",
+    );
 
     expect(ctx.db.query).not.toHaveBeenCalled();
+  });
+
+  it("lists pending checkout review items using the public review shape", async () => {
+    const ctx = buildCtx({
+      pendingCheckoutItems: [
+        {
+          _creationTime: 1,
+          _id: "pending-1",
+          createdAt: 10,
+          createdByStaffProfileId: "staff-1",
+          createdByUserId: "athena-user-1",
+          createdFrom: "offline_sync",
+          currency: "ghs",
+          evidence: {
+            firstSeenAt: 10,
+            lastSeenAt: 20,
+            observedLookupCodes: [],
+            observedPrices: [350000],
+            offlineSaleCount: 16,
+            totalQuantitySold: 20,
+            transactionCount: 16,
+          },
+          name: "Missing item",
+          normalizedName: "missing item",
+          operationalWorkItemId: "work-item-1",
+          organizationId: "org-1",
+          provisionalPrice: 350000,
+          provisionalProductId: "product-provisional-1",
+          provisionalProductSkuId: "sku-provisional-1",
+          reviewPriority: "high",
+          status: "pending_review",
+          storeId: "store-1",
+          updatedAt: 20,
+        },
+      ],
+    });
+
+    const rows = await getHandler(listPendingCheckoutItemsForReview)(
+      ctx as never,
+      {
+        storeId: "store-1",
+      },
+    );
+
+    expect(rows).toEqual([
+      {
+        _id: "pending-1",
+        createdAt: 10,
+        createdFrom: "offline_sync",
+        evidence: expect.objectContaining({
+          totalQuantitySold: 20,
+          transactionCount: 16,
+        }),
+        name: "Missing item",
+        provisionalPrice: 350000,
+        reviewPriority: "high",
+        status: "pending_review",
+        updatedAt: 20,
+      },
+    ]);
+    expect(rows[0]).not.toHaveProperty("_creationTime");
+    expect(rows[0]).not.toHaveProperty("organizationId");
+    expect(rows[0]).not.toHaveProperty("provisionalProductId");
+    assertConformsToExportedReturns(listPendingCheckoutItemsForReview, rows);
+  });
+
+  it("returns the pending checkout product-page binding for the provisional SKU", async () => {
+    const ctx = buildCtx({
+      pendingCheckoutItems: [
+        {
+          _id: "pending-1",
+          createdAt: 10,
+          createdFrom: "offline_sync",
+          currency: "ghs",
+          evidence: {
+            firstSeenAt: 10,
+            lastPosTransactionId: "transaction-1",
+            lastRegisterSessionId: "register-1",
+            lastSeenAt: 20,
+            observedLookupCodes: [],
+            observedPrices: [350000],
+            totalQuantitySold: 20,
+            transactionCount: 16,
+          },
+          name: "Missing item",
+          normalizedName: "missing item",
+          organizationId: "org-1",
+          provisionalPrice: 350000,
+          provisionalProductId: "product-provisional-1",
+          provisionalProductSkuId: "sku-provisional-1",
+          reviewPriority: "high",
+          status: "pending_review",
+          storeId: "store-1",
+          updatedAt: 20,
+        },
+      ],
+      product: {
+        _id: "product-provisional-1",
+        availability: "draft",
+        inventoryCount: 0,
+        isVisible: false,
+        quantityAvailable: 0,
+        storeId: "store-1",
+      },
+      productSku: {
+        _id: "sku-provisional-1",
+        inventoryCount: 0,
+        isVisible: false,
+        price: 350000,
+        productId: "product-provisional-1",
+        quantityAvailable: 0,
+        storeId: "store-1",
+      },
+    });
+
+    const binding = await getHandler(listPendingCheckoutProductPageBinding)(
+      ctx as never,
+      {
+        productSkuId: "sku-provisional-1",
+        storeId: "store-1",
+      },
+    );
+
+    expect(binding).toMatchObject({
+      activeRowCount: 1,
+      row: {
+        _id: "pending-1",
+        importKey: "pending-checkout",
+        importedQuantity: 20,
+        lastPosTransactionId: "transaction-1",
+        lastRegisterSessionId: "register-1",
+        lastSoldAt: 20,
+        provisionalSoldQuantity: 20,
+        rowNumber: 1,
+        saleCount: 16,
+        updatedAt: 20,
+      },
+      state: "unique",
+    });
+    expect(binding.saleEvidenceFingerprint).toEqual(expect.any(String));
+    expect(binding.trustedSkuFingerprint).toEqual(expect.any(String));
+    assertConformsToExportedReturns(
+      listPendingCheckoutProductPageBinding,
+      binding,
+    );
+  });
+
+  it("returns linked checkout product-page binding target details", async () => {
+    const ctx = buildCtx({
+      pendingCheckoutItems: [
+        {
+          _id: "pending-1",
+          approvedProductId: "product-linked-1",
+          approvedProductSkuId: "sku-linked-1",
+          createdAt: 10,
+          createdFrom: "offline_sync",
+          currency: "ghs",
+          evidence: {
+            firstSeenAt: 10,
+            lastPosTransactionId: "transaction-1",
+            lastRegisterSessionId: "register-1",
+            lastSeenAt: 20,
+            observedLookupCodes: [],
+            observedPrices: [350000],
+            totalQuantitySold: 20,
+            transactionCount: 16,
+          },
+          name: "Missing item",
+          normalizedName: "missing item",
+          organizationId: "org-1",
+          provisionalPrice: 350000,
+          provisionalProductId: "product-provisional-1",
+          provisionalProductSkuId: "sku-provisional-1",
+          reviewPriority: "high",
+          status: "linked_to_catalog",
+          storeId: "store-1",
+          updatedAt: 20,
+        },
+      ],
+      products: [
+        {
+          _id: "product-provisional-1",
+          availability: "draft",
+          inventoryCount: 0,
+          isVisible: false,
+          name: "Missing item",
+          quantityAvailable: 0,
+          storeId: "store-1",
+        },
+        {
+          _id: "product-linked-1",
+          availability: "live",
+          inventoryCount: 5,
+          isVisible: true,
+          name: "Trusted item",
+          quantityAvailable: 5,
+          storeId: "store-1",
+        },
+      ],
+      productSkus: [
+        {
+          _id: "sku-provisional-1",
+          inventoryCount: 0,
+          isVisible: false,
+          price: 350000,
+          productId: "product-provisional-1",
+          quantityAvailable: 0,
+          sku: "PENDING-1",
+          storeId: "store-1",
+        },
+        {
+          _id: "sku-linked-1",
+          inventoryCount: 5,
+          isVisible: true,
+          price: 60000,
+          productId: "product-linked-1",
+          quantityAvailable: 4,
+          sku: "TRUSTED-1",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const binding = await getHandler(listPendingCheckoutProductPageBinding)(
+      ctx as never,
+      {
+        productSkuId: "sku-provisional-1",
+        storeId: "store-1",
+      },
+    );
+
+    expect(binding).toMatchObject({
+      activeRowCount: 1,
+      row: {
+        _id: "pending-1",
+        linkedTarget: {
+          price: 60000,
+          productId: "product-linked-1",
+          productName: "Trusted item",
+          quantityAvailable: 4,
+          sku: "TRUSTED-1",
+          skuId: "sku-linked-1",
+        },
+        status: "linked_to_catalog",
+      },
+      state: "unique",
+    });
+    assertConformsToExportedReturns(
+      listPendingCheckoutProductPageBinding,
+      binding,
+    );
+  });
+
+  it("finalizes a POS pending checkout draft SKU as trusted inventory", async () => {
+    const pendingCheckoutItem = {
+      _id: "pending-1",
+      createdAt: 10,
+      createdFrom: "offline_sync",
+      currency: "ghs",
+      evidence: {
+        firstSeenAt: 10,
+        lastPosTransactionId: "transaction-1",
+        lastRegisterSessionId: "register-1",
+        lastSeenAt: 20,
+        observedLookupCodes: [],
+        observedPrices: [350000],
+        totalQuantitySold: 20,
+        transactionCount: 16,
+      },
+      name: "Missing item",
+      normalizedName: "missing item",
+      operationalWorkItemId: "work-item-1",
+      organizationId: "org-1",
+      provisionalPrice: 350000,
+      provisionalProductId: "product-provisional-1",
+      provisionalProductSkuId: "sku-provisional-1",
+      reviewPriority: "high",
+      status: "pending_review",
+      storeId: "store-1",
+      updatedAt: 20,
+    };
+    const product = {
+      _id: "product-provisional-1",
+      availability: "draft",
+      inventoryCount: 0,
+      isVisible: false,
+      quantityAvailable: 0,
+      storeId: "store-1",
+    };
+    const productSku = {
+      _id: "sku-provisional-1",
+      inventoryCount: 0,
+      isVisible: true,
+      price: 350000,
+      productId: "product-provisional-1",
+      quantityAvailable: 0,
+      storeId: "store-1",
+    };
+    const ctx = buildCtx({
+      pendingCheckoutItem,
+      pendingCheckoutItems: [pendingCheckoutItem],
+      product,
+      productSku,
+    });
+    const binding = await getHandler(listPendingCheckoutProductPageBinding)(
+      ctx as never,
+      {
+        productSkuId: "sku-provisional-1",
+        storeId: "store-1",
+      },
+    );
+
+    const result = await getHandler(
+      finalizePendingCheckoutTrustedInventoryFromProductPage,
+    )(ctx as never, {
+      conversionRequestId: "conversion-1",
+      productId: "product-provisional-1",
+      productSkuId: "sku-provisional-1",
+      provisionalSkuId: "pending-1",
+      reviewedInventoryCount: 20,
+      reviewedIsVisible: true,
+      reviewedNetPrice: 350000,
+      reviewedPrice: 350000,
+      reviewedQuantityAvailable: 20,
+      reviewedUnitCost: 0,
+      saleEvidenceFingerprint: binding.saleEvidenceFingerprint,
+      sourceSurface: "product_edit",
+      storeId: "store-1",
+      trustedSkuFingerprint: binding.trustedSkuFingerprint,
+    });
+
+    expect(result).toMatchObject({
+      data: {
+        finalTrustedQuantity: 20,
+        product: {
+          availability: "live",
+          inventoryCount: 20,
+          isVisible: true,
+          quantityAvailable: 20,
+        },
+        productId: "product-provisional-1",
+        productSkuId: "sku-provisional-1",
+        provisionalSkuId: "pending-1",
+        provisionalSoldQuantity: 20,
+        quantityAvailable: 20,
+      },
+      kind: "ok",
+    });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "productSku",
+      "sku-provisional-1",
+      {
+        inventoryCount: 20,
+        isVisible: true,
+        netPrice: 350000,
+        price: 350000,
+        quantityAvailable: 20,
+        unitCost: 0,
+      },
+    );
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "product",
+      "product-provisional-1",
+      {
+        availability: "live",
+        inventoryCount: 20,
+        isVisible: true,
+        quantityAvailable: 20,
+      },
+    );
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "posPendingCheckoutItem",
+      "pending-1",
+      expect.objectContaining({
+        approvedProductId: "product-provisional-1",
+        approvedProductSkuId: "sku-provisional-1",
+        status: "approved",
+      }),
+    );
+    expect(mocks.recordInventoryMovementWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        movementType: "pending_checkout_trusted_finalization",
+        quantityDelta: 20,
+        sourceId: "pending-1",
+        sourceType: "pos_pending_checkout_item",
+      }),
+    );
+    expect(mocks.updateOperationalWorkItemStatusWithCtx).toHaveBeenCalledWith(
+      ctx,
+      {
+        approvalState: "approved",
+        status: "completed",
+        workItemId: "work-item-1",
+      },
+    );
+    assertConformsToExportedReturns(
+      finalizePendingCheckoutTrustedInventoryFromProductPage,
+      result,
+    );
   });
 
   it("does not resolve pending checkout review items when manager authorization fails", async () => {
@@ -629,7 +1104,9 @@ describe("POS public catalog queries", () => {
         status: "flagged",
         storeId: "store-1",
       }),
-    ).rejects.toThrow("You cannot resolve pending checkout items for this store.");
+    ).rejects.toThrow(
+      "You cannot resolve pending checkout items for this store.",
+    );
 
     expect(ctx.db.patch).not.toHaveBeenCalled();
     expect(ctx.db.query).not.toHaveBeenCalled();
@@ -663,7 +1140,9 @@ describe("POS public catalog queries", () => {
         status: "approved",
         storeId: "store-1",
       }),
-    ).rejects.toThrow("Choose a valid catalog product and SKU from this store.");
+    ).rejects.toThrow(
+      "Choose a valid catalog product and SKU from this store.",
+    );
   });
 
   it("rejects provisional hidden anchors as pending checkout review links", async () => {
@@ -707,7 +1186,67 @@ describe("POS public catalog queries", () => {
         status: "linked_to_catalog",
         storeId: "store-1",
       }),
-    ).rejects.toThrow("Choose a valid catalog product and SKU from this store.");
+    ).rejects.toThrow(
+      "Choose a valid catalog product and SKU from this store.",
+    );
+  });
+
+  it("allows pending checkout review links to POS quick add trusted SKUs", async () => {
+    const ctx = buildCtx({
+      category: {
+        _id: "category-pos-quick-add",
+        slug: "pos-quick-add",
+        storeId: "store-1",
+      },
+      pendingCheckoutItem: {
+        _id: "pending-1",
+        evidence: {
+          observedLookupCodes: [],
+          observedPrices: [12000],
+          totalQuantitySold: 1,
+          transactionCount: 1,
+        },
+        name: "Missing item",
+        provisionalPrice: 12000,
+        provisionalProductId: "product-provisional-1",
+        provisionalProductSkuId: "sku-provisional-1",
+        reviewPriority: "normal",
+        status: "pending_review",
+        storeId: "store-1",
+        updatedAt: 1,
+      },
+      product: {
+        _id: "product-quick-add-1",
+        availability: "live",
+        categoryId: "category-pos-quick-add",
+        isVisible: false,
+        storeId: "store-1",
+      },
+      productSku: {
+        _id: "sku-quick-add-1",
+        isVisible: false,
+        productId: "product-quick-add-1",
+        storeId: "store-1",
+      },
+    });
+
+    await getHandler(resolvePendingCheckoutItemReview)(ctx as never, {
+      approvedProductId: "product-quick-add-1",
+      approvedProductSkuId: "sku-quick-add-1",
+      pendingCheckoutItemId: "pending-1",
+      status: "linked_to_catalog",
+      storeId: "store-1",
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "posPendingCheckoutItem",
+      "pending-1",
+      expect.objectContaining({
+        approvedProductId: "product-quick-add-1",
+        approvedProductSkuId: "sku-quick-add-1",
+        status: "linked_to_catalog",
+      }),
+    );
   });
 
   it("attaches the observed lookup code to a linked trusted SKU when barcode is empty", async () => {
@@ -821,7 +1360,9 @@ describe("POS public catalog queries", () => {
         status: "linked_to_catalog",
         storeId: "store-1",
       }),
-    ).rejects.toThrow("This lookup code already belongs to another catalog SKU.");
+    ).rejects.toThrow(
+      "This lookup code already belongs to another catalog SKU.",
+    );
 
     expect(ctx.db.patch).not.toHaveBeenCalledWith(
       "productSku",
@@ -854,8 +1395,12 @@ describe("POS public catalog queries", () => {
 
 function buildCtx(seed?: {
   pendingCheckoutItem?: Record<string, unknown>;
+  pendingCheckoutItems?: Array<Record<string, unknown>>;
+  category?: Record<string, unknown>;
   product?: Record<string, unknown>;
+  products?: Array<Record<string, unknown>>;
   productSku?: Record<string, unknown>;
+  productSkus?: Array<Record<string, unknown>>;
   registerSession?: Record<string, unknown>;
   staffProfile?: Record<string, unknown>;
   terminal?: Record<string, unknown>;
@@ -877,6 +1422,9 @@ function buildCtx(seed?: {
     storeId: "store-1",
     terminalId: "terminal-1",
   };
+  type QueryIndexBuilder = {
+    eq: (field: string, value: unknown) => QueryIndexBuilder;
+  };
 
   return {
     db: {
@@ -893,10 +1441,7 @@ function buildCtx(seed?: {
         if (tableName === "posTerminal" && terminal?._id === id) {
           return terminal;
         }
-        if (
-          tableName === "registerSession" &&
-          registerSession?._id === id
-        ) {
+        if (tableName === "registerSession" && registerSession?._id === id) {
           return registerSession;
         }
         if (
@@ -905,22 +1450,74 @@ function buildCtx(seed?: {
         ) {
           return seed.pendingCheckoutItem;
         }
+        const products = [
+          ...(seed?.product ? [seed.product] : []),
+          ...(seed?.products ?? []),
+        ];
+        const productSkus = [
+          ...(seed?.productSku ? [seed.productSku] : []),
+          ...(seed?.productSkus ?? []),
+        ];
+        if (
+          tableName === "product" &&
+          products.some((product) => product._id === id)
+        ) {
+          return products.find((product) => product._id === id);
+        }
         if (tableName === "product" && seed?.product?._id === id) {
           return seed.product;
         }
-        if (tableName === "productSku" && seed?.productSku?._id === id) {
-          return seed.productSku;
+        if (
+          tableName === "productSku" &&
+          productSkus.some((sku) => sku._id === id)
+        ) {
+          return productSkus.find((sku) => sku._id === id);
+        }
+        if (tableName === "category" && seed?.category?._id === id) {
+          return seed.category;
         }
 
         return null;
       }),
-      query: vi.fn(() => ({
-        withIndex: vi.fn(() => ({
-          order: vi.fn(() => ({
-            take: vi.fn(async () => []),
-          })),
-        })),
-      })),
+      query: vi.fn((tableName: string) => {
+        const filters: Record<string, unknown> = {};
+
+        return {
+          withIndex: vi.fn(
+            (
+              _indexName: string,
+              applyIndex: (builder: QueryIndexBuilder) => unknown,
+            ) => {
+              const builder: QueryIndexBuilder = {
+                eq(field: string, value: unknown) {
+                  filters[field] = value;
+                  return builder;
+                },
+              };
+              applyIndex(builder);
+
+              const take = vi.fn(async (limit: number) => {
+                if (tableName !== "posPendingCheckoutItem") return [];
+
+                return (seed?.pendingCheckoutItems ?? [])
+                  .filter((item) =>
+                    Object.entries(filters).every(
+                      ([field, value]) => item[field] === value,
+                    ),
+                  )
+                  .slice(0, limit);
+              });
+
+              return {
+                take,
+                order: vi.fn(() => ({
+                  take,
+                })),
+              };
+            },
+          ),
+        };
+      }),
       patch: vi.fn(),
     },
   };

--- a/packages/athena-webapp/convex/pos/public/catalog.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.ts
@@ -1,14 +1,22 @@
 import { v } from "convex/values";
 
-import { mutation, query, type QueryCtx } from "../../_generated/server";
-import type { Id } from "../../_generated/dataModel";
+import {
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
+import { commandResultValidator } from "../../lib/commandResultValidators";
 import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
 } from "../../lib/athenaUserAuth";
 import { upsertProductSkuSearchProjection } from "../../inventory/skuSearch";
+import { refreshCatalogSummaryWithCtx } from "../../inventory/catalogSummary";
 import { quickAddCatalogItem } from "../application/commands/quickAddCatalogItem";
 import { createOrReusePendingCheckoutItem } from "../application/commands/createOrReusePendingCheckoutItem";
+import { recordInventoryMovementWithCtx } from "../../operations/inventoryMovements";
 import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
 import { updateOperationalWorkItemStatusWithCtx } from "../../operations/operationalWorkItems";
 import {
@@ -24,6 +32,7 @@ import {
   listRegisterCatalogAvailabilitySnapshot as readRegisterCatalogAvailabilitySnapshot,
 } from "../application/queries/listRegisterCatalog";
 import { isPosUsableRegisterSessionStatus } from "../../../shared/registerSessionStatus";
+import { ok, userError } from "../../../shared/commandResult";
 
 const catalogResultValidator = v.object({
   id: v.id("productSku"),
@@ -150,6 +159,38 @@ type PendingCheckoutReviewStatus =
   | "rejected"
   | "flagged";
 
+type PendingCheckoutTrustedInventoryFinalizationArgs = {
+  conversionRequestId: string;
+  productId: Id<"product">;
+  productSkuId: Id<"productSku">;
+  provisionalSkuId: Id<"posPendingCheckoutItem">;
+  reviewedInventoryCount: number;
+  reviewedIsVisible: boolean;
+  reviewedNetPrice?: number;
+  reviewedPrice: number;
+  reviewedQuantityAvailable: number;
+  reviewedUnitCost?: number;
+  saleEvidenceFingerprint: string;
+  sourceSurface: "product_edit";
+  storeId: Id<"store">;
+  trustedSkuFingerprint: string;
+};
+
+function toPendingCheckoutReviewItem(item: Doc<"posPendingCheckoutItem">) {
+  return {
+    _id: item._id,
+    ...(item.lookupCode ? { lookupCode: item.lookupCode } : {}),
+    createdAt: item.createdAt,
+    createdFrom: item.createdFrom,
+    evidence: item.evidence,
+    name: item.name,
+    provisionalPrice: item.provisionalPrice,
+    reviewPriority: item.reviewPriority,
+    status: item.status,
+    updatedAt: item.updatedAt,
+  };
+}
+
 export function mapPendingCheckoutReviewStatusToWorkItemPatch(
   status: PendingCheckoutReviewStatus,
 ) {
@@ -165,6 +206,139 @@ export function mapPendingCheckoutReviewStatusToWorkItemPatch(
       status === "rejected" ? ("rejected" as const) : ("approved" as const),
     status: "completed" as const,
   };
+}
+
+function buildPendingCheckoutSaleEvidenceFingerprint(
+  item: Doc<"posPendingCheckoutItem">,
+) {
+  return stableStringify({
+    lastPosTransactionId: item.evidence.lastPosTransactionId,
+    lastRegisterSessionId: item.evidence.lastRegisterSessionId,
+    lastSeenAt: item.evidence.lastSeenAt,
+    totalQuantitySold: item.evidence.totalQuantitySold,
+    transactionCount: item.evidence.transactionCount,
+    updatedAt: item.updatedAt,
+  });
+}
+
+function buildTrustedSkuFingerprint(productSku: Doc<"productSku">) {
+  return stableStringify({
+    inventoryCount: productSku.inventoryCount,
+    isVisible: productSku.isVisible,
+    netPrice: productSku.netPrice,
+    price: productSku.price,
+    quantityAvailable: productSku.quantityAvailable,
+    unitCost: productSku.unitCost,
+  });
+}
+
+function validateReviewedTrustedInventoryFields(
+  args: PendingCheckoutTrustedInventoryFinalizationArgs,
+) {
+  if (
+    !Number.isInteger(args.reviewedInventoryCount) ||
+    args.reviewedInventoryCount < 0
+  ) {
+    return userError({
+      code: "validation_failed",
+      message: "Stock must be a non-negative whole number.",
+    });
+  }
+
+  if (
+    !Number.isInteger(args.reviewedQuantityAvailable) ||
+    args.reviewedQuantityAvailable < 0
+  ) {
+    return userError({
+      code: "validation_failed",
+      message: "Quantity available must be a non-negative whole number.",
+    });
+  }
+
+  if (args.reviewedQuantityAvailable > args.reviewedInventoryCount) {
+    return userError({
+      code: "validation_failed",
+      message: "Quantity available cannot exceed stock.",
+    });
+  }
+
+  if (!args.reviewedIsVisible) {
+    return userError({
+      code: "precondition_failed",
+      message: "Make this SKU visible before finalizing trusted inventory.",
+    });
+  }
+
+  if (!Number.isFinite(args.reviewedPrice) || args.reviewedPrice <= 0) {
+    return userError({
+      code: "validation_failed",
+      message: "Price is required before finalizing trusted inventory.",
+    });
+  }
+
+  if (
+    args.reviewedNetPrice !== undefined &&
+    (!Number.isFinite(args.reviewedNetPrice) || args.reviewedNetPrice < 0)
+  ) {
+    return userError({
+      code: "validation_failed",
+      message: "Net price must be zero or greater.",
+    });
+  }
+
+  if (
+    args.reviewedUnitCost !== undefined &&
+    (!Number.isFinite(args.reviewedUnitCost) || args.reviewedUnitCost < 0)
+  ) {
+    return userError({
+      code: "validation_failed",
+      message: "Unit cost must be zero or greater.",
+    });
+  }
+
+  return null;
+}
+
+function buildPendingCheckoutFinalizationPayloadHash(
+  args: PendingCheckoutTrustedInventoryFinalizationArgs,
+) {
+  return stableStringify({
+    productId: args.productId,
+    productSkuId: args.productSkuId,
+    provisionalSkuId: args.provisionalSkuId,
+    reviewedInventoryCount: args.reviewedInventoryCount,
+    reviewedIsVisible: args.reviewedIsVisible,
+    reviewedNetPrice: args.reviewedNetPrice,
+    reviewedPrice: args.reviewedPrice,
+    reviewedQuantityAvailable: args.reviewedQuantityAvailable,
+    reviewedUnitCost: args.reviewedUnitCost,
+    saleEvidenceFingerprint: args.saleEvidenceFingerprint,
+    sourceSurface: args.sourceSurface,
+    storeId: args.storeId,
+    trustedSkuFingerprint: args.trustedSkuFingerprint,
+  });
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
 }
 
 async function requireRegisterCatalogStoreAccess(
@@ -244,6 +418,124 @@ async function requirePendingCheckoutSaleContext(
     createdByStaffProfileId: staffProfile._id,
     registerSessionId: registerSession._id,
     terminalId: terminal._id,
+  };
+}
+
+async function requirePendingCheckoutReviewAccess(
+  ctx: Pick<QueryCtx | MutationCtx, "auth" | "db">,
+  args: { storeId: Id<"store"> },
+) {
+  const store = await ctx.db.get("store", args.storeId);
+  if (!store) {
+    throw new Error("Store not found.");
+  }
+
+  const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+  await requireOrganizationMemberRoleWithCtx(ctx, {
+    allowedRoles: ["full_admin"],
+    failureMessage: "You cannot review pending checkout items for this store.",
+    organizationId: store.organizationId,
+    userId: athenaUser._id,
+  });
+
+  return { athenaUser, store };
+}
+
+async function listPendingCheckoutProductPageBindingWithCtx(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    productSkuId: Id<"productSku">;
+    storeId: Id<"store">;
+  },
+) {
+  const rows = (
+    await ctx.db
+      .query("posPendingCheckoutItem")
+      .withIndex("by_storeId_provisionalProductSkuId", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("provisionalProductSkuId", args.productSkuId),
+      )
+      .take(3)
+  ).filter(
+    (row) =>
+      row.status === "pending_review" ||
+      row.status === "flagged" ||
+      row.status === "linked_to_catalog",
+  );
+
+  if (rows.length === 0) {
+    return { activeRowCount: 0, state: "none" as const };
+  }
+
+  if (rows.length > 1) {
+    return { activeRowCount: rows.length, state: "ambiguous" as const };
+  }
+
+  const row = rows[0];
+  if (!row.provisionalProductSkuId || !row.provisionalProductId) {
+    return { activeRowCount: 0, state: "none" as const };
+  }
+
+  const [product, productSku, linkedProduct, linkedSku] = await Promise.all([
+    ctx.db.get("product", row.provisionalProductId),
+    ctx.db.get("productSku", row.provisionalProductSkuId),
+    row.approvedProductId ? ctx.db.get("product", row.approvedProductId) : null,
+    row.approvedProductSkuId
+      ? ctx.db.get("productSku", row.approvedProductSkuId)
+      : null,
+  ]);
+
+  if (
+    !product ||
+    product.storeId !== args.storeId ||
+    product.availability !== "draft" ||
+    productSku?._id !== args.productSkuId ||
+    productSku.storeId !== args.storeId ||
+    productSku.productId !== product._id
+  ) {
+    return { activeRowCount: 0, state: "none" as const };
+  }
+
+  return {
+    activeRowCount: 1,
+    row: {
+      _id: row._id,
+      importKey: "pending-checkout",
+      importedQuantity: row.evidence.totalQuantitySold,
+      lastPosTransactionId: row.evidence.lastPosTransactionId,
+      lastRegisterSessionId: row.evidence.lastRegisterSessionId,
+      lastSoldAt: row.evidence.lastSeenAt,
+      ...(row.status === "linked_to_catalog" &&
+      linkedProduct &&
+      linkedSku &&
+      linkedProduct.storeId === args.storeId &&
+      linkedSku.storeId === args.storeId &&
+      linkedSku.productId === linkedProduct._id
+        ? {
+            linkedTarget: {
+              ...(typeof linkedSku.price === "number"
+                ? { price: linkedSku.price }
+                : {}),
+              productId: linkedProduct._id,
+              productName: linkedProduct.name,
+              ...(typeof linkedSku.quantityAvailable === "number"
+                ? { quantityAvailable: linkedSku.quantityAvailable }
+                : {}),
+              ...(linkedSku.sku ? { sku: linkedSku.sku } : {}),
+              skuId: linkedSku._id,
+            },
+          }
+        : {}),
+      provisionalSoldQuantity: row.evidence.totalQuantitySold,
+      rowNumber: 1,
+      saleCount: row.evidence.transactionCount,
+      status: row.status,
+      updatedAt: row.updatedAt,
+    },
+    saleEvidenceFingerprint: buildPendingCheckoutSaleEvidenceFingerprint(row),
+    state: "unique" as const,
+    trustedSkuFingerprint: buildTrustedSkuFingerprint(productSku),
   };
 }
 
@@ -425,7 +717,230 @@ export const listPendingCheckoutItemsForReview = query({
 
     return [...pendingItems, ...flaggedItems]
       .sort((left, right) => right.updatedAt - left.updatedAt)
-      .slice(0, 100);
+      .slice(0, 100)
+      .map(toPendingCheckoutReviewItem);
+  },
+});
+
+export const listPendingCheckoutProductPageBinding = query({
+  args: {
+    productSkuId: v.id("productSku"),
+    refreshNonce: v.optional(v.number()),
+    storeId: v.id("store"),
+  },
+  returns: v.any(),
+  handler: async (ctx, args) => {
+    await requirePendingCheckoutReviewAccess(ctx, args);
+    return listPendingCheckoutProductPageBindingWithCtx(ctx, args);
+  },
+});
+
+export const finalizePendingCheckoutTrustedInventoryFromProductPage = mutation({
+  args: {
+    conversionRequestId: v.string(),
+    productId: v.id("product"),
+    productSkuId: v.id("productSku"),
+    provisionalSkuId: v.id("posPendingCheckoutItem"),
+    reviewedInventoryCount: v.number(),
+    reviewedIsVisible: v.boolean(),
+    reviewedNetPrice: v.optional(v.number()),
+    reviewedPrice: v.number(),
+    reviewedQuantityAvailable: v.number(),
+    reviewedUnitCost: v.optional(v.number()),
+    saleEvidenceFingerprint: v.string(),
+    sourceSurface: v.literal("product_edit"),
+    storeId: v.id("store"),
+    trustedSkuFingerprint: v.string(),
+  },
+  returns: commandResultValidator(v.any()),
+  handler: async (ctx, args) => {
+    const normalizedArgs = {
+      ...args,
+      conversionRequestId: args.conversionRequestId.trim(),
+    };
+    const access = await requirePendingCheckoutReviewAccess(
+      ctx,
+      normalizedArgs,
+    );
+    const validationError =
+      validateReviewedTrustedInventoryFields(normalizedArgs);
+    if (validationError) return validationError;
+
+    if (!normalizedArgs.conversionRequestId) {
+      return userError({
+        code: "validation_failed",
+        message: "Finalization request id is required.",
+      });
+    }
+
+    const [item, product, productSku] = await Promise.all([
+      ctx.db.get("posPendingCheckoutItem", normalizedArgs.provisionalSkuId),
+      ctx.db.get("product", normalizedArgs.productId),
+      ctx.db.get("productSku", normalizedArgs.productSkuId),
+    ]);
+
+    if (!item || item.storeId !== normalizedArgs.storeId) {
+      return userError({
+        code: "not_found",
+        message: "Pending checkout item was not found.",
+      });
+    }
+
+    if (item.status !== "pending_review" && item.status !== "flagged") {
+      return userError({
+        code: "conflict",
+        message: "This pending checkout item has already been reviewed.",
+      });
+    }
+
+    if (
+      !product ||
+      product.storeId !== normalizedArgs.storeId ||
+      product.availability !== "draft" ||
+      product._id !== item.provisionalProductId
+    ) {
+      return userError({
+        code: "precondition_failed",
+        message:
+          "Open the draft pending checkout product before finalizing trusted inventory.",
+      });
+    }
+
+    if (
+      !productSku ||
+      productSku.storeId !== normalizedArgs.storeId ||
+      productSku.productId !== product._id ||
+      productSku._id !== item.provisionalProductSkuId
+    ) {
+      return userError({
+        code: "precondition_failed",
+        message:
+          "Open the pending checkout SKU before finalizing trusted inventory.",
+      });
+    }
+
+    const currentSaleEvidenceFingerprint =
+      buildPendingCheckoutSaleEvidenceFingerprint(item);
+    if (
+      normalizedArgs.saleEvidenceFingerprint !== currentSaleEvidenceFingerprint
+    ) {
+      return userError({
+        code: "conflict",
+        message:
+          "Pending checkout sales changed while you were reviewing. Refresh before finalizing.",
+      });
+    }
+
+    const currentTrustedSkuFingerprint = buildTrustedSkuFingerprint(productSku);
+    if (normalizedArgs.trustedSkuFingerprint !== currentTrustedSkuFingerprint) {
+      return userError({
+        code: "conflict",
+        message:
+          "SKU stock or price changed while you were reviewing. Refresh before finalizing.",
+      });
+    }
+
+    const now = Date.now();
+    const payloadHash =
+      buildPendingCheckoutFinalizationPayloadHash(normalizedArgs);
+    const productSkuPatch = omitUndefined({
+      inventoryCount: normalizedArgs.reviewedInventoryCount,
+      isVisible: normalizedArgs.reviewedIsVisible,
+      netPrice: normalizedArgs.reviewedNetPrice,
+      price: normalizedArgs.reviewedPrice,
+      quantityAvailable: normalizedArgs.reviewedQuantityAvailable,
+      unitCost: normalizedArgs.reviewedUnitCost,
+    });
+    const productPatch = {
+      availability: "live" as const,
+      inventoryCount: normalizedArgs.reviewedInventoryCount,
+      isVisible: true,
+      quantityAvailable: normalizedArgs.reviewedQuantityAvailable,
+    };
+
+    await ctx.db.patch(
+      "productSku",
+      normalizedArgs.productSkuId,
+      productSkuPatch,
+    );
+    await ctx.db.patch("product", normalizedArgs.productId, productPatch);
+    await upsertProductSkuSearchProjection(ctx, normalizedArgs.productSkuId);
+
+    let inventoryMovementId: Id<"inventoryMovement"> | undefined;
+    const stockDelta =
+      normalizedArgs.reviewedInventoryCount - productSku.inventoryCount;
+    if (stockDelta !== 0) {
+      const movement = await recordInventoryMovementWithCtx(ctx, {
+        actorUserId: access.athenaUser._id,
+        movementType: "pending_checkout_trusted_finalization",
+        notes: "Trusted inventory finalized from pending checkout review.",
+        organizationId: access.store.organizationId,
+        productId: normalizedArgs.productId,
+        productSkuId: normalizedArgs.productSkuId,
+        quantityDelta: stockDelta,
+        reasonCode: "trusted_inventory_conversion",
+        sourceId: String(item._id),
+        sourceType: "pos_pending_checkout_item",
+        storeId: normalizedArgs.storeId,
+      });
+      inventoryMovementId = movement?._id;
+    }
+
+    await ctx.db.patch("posPendingCheckoutItem", item._id, {
+      approvedProductId: normalizedArgs.productId,
+      approvedProductSkuId: normalizedArgs.productSkuId,
+      reviewedAt: now,
+      reviewedByUserId: access.athenaUser._id,
+      reviewNote: "Trusted inventory finalized from product edit.",
+      status: "approved",
+      updatedAt: now,
+    });
+
+    if (item.operationalWorkItemId) {
+      const workItemPatch =
+        mapPendingCheckoutReviewStatusToWorkItemPatch("approved");
+      await updateOperationalWorkItemStatusWithCtx(ctx, {
+        approvalState: workItemPatch.approvalState,
+        status: workItemPatch.status,
+        workItemId: item.operationalWorkItemId,
+      });
+    }
+
+    await refreshCatalogSummaryWithCtx(ctx, normalizedArgs.storeId);
+
+    await recordOperationalEventWithCtx(ctx, {
+      actorUserId: access.athenaUser._id,
+      eventType: "pos_pending_checkout_item_trusted_finalized",
+      message: `Pending checkout item ${item.name} was finalized as trusted inventory.`,
+      metadata: {
+        conversionRequestId: normalizedArgs.conversionRequestId,
+        finalTrustedQuantity: normalizedArgs.reviewedInventoryCount,
+        inventoryMovementId,
+        pendingCheckoutItemId: item._id,
+        previousStatus: item.status,
+        quantityAvailable: normalizedArgs.reviewedQuantityAvailable,
+        saleEvidenceFingerprint: normalizedArgs.saleEvidenceFingerprint,
+        stockQuantityDelta: stockDelta,
+        trustedSkuFingerprint: normalizedArgs.trustedSkuFingerprint,
+        trustedInventoryPayloadHash: payloadHash,
+      },
+      organizationId: access.store.organizationId,
+      storeId: normalizedArgs.storeId,
+      subjectId: String(item._id),
+      subjectLabel: item.name,
+      subjectType: "pos_pending_checkout_item",
+    });
+
+    return ok({
+      finalTrustedQuantity: normalizedArgs.reviewedInventoryCount,
+      product: productPatch,
+      productId: normalizedArgs.productId,
+      productSkuId: normalizedArgs.productSkuId,
+      provisionalSkuId: item._id,
+      provisionalSoldQuantity: item.evidence.totalQuantitySold,
+      quantityAvailable: normalizedArgs.reviewedQuantityAvailable,
+      ...(inventoryMovementId ? { inventoryMovementId } : {}),
+    });
   },
 });
 
@@ -472,6 +987,9 @@ export const resolvePendingCheckoutItemReview = mutation({
     const approvedSku = args.approvedProductSkuId
       ? await ctx.db.get("productSku", args.approvedProductSkuId)
       : null;
+    const approvedProductCategory = approvedProduct?.categoryId
+      ? await ctx.db.get("category", approvedProduct.categoryId)
+      : null;
     if (
       args.status === "approved" ||
       args.status === "linked_to_catalog" ||
@@ -487,6 +1005,7 @@ export const resolvePendingCheckoutItemReview = mutation({
         approvedProduct._id === item.provisionalProductId ||
         approvedSku._id === item.provisionalProductSkuId ||
         !isTrustedRegisterCatalogSku({
+          category: approvedProductCategory,
           product: approvedProduct,
           sku: approvedSku,
         })
@@ -574,6 +1093,6 @@ export const resolvePendingCheckoutItemReview = mutation({
       subjectType: "pos_pending_checkout_item",
     });
 
-    return reviewedItem;
+    return toPendingCheckoutReviewItem(reviewedItem);
   },
 });

--- a/packages/athena-webapp/src/components/add-product/ProductStock.test.ts
+++ b/packages/athena-webapp/src/components/add-product/ProductStock.test.ts
@@ -77,6 +77,49 @@ describe("ProductStock money inputs", () => {
     });
   });
 
+  it("treats linked pending checkout provisional SKUs as reviewed", () => {
+    const state = resolveTrustedInventoryReviewState({
+      binding: {
+        state: "unique",
+        activeRowCount: 1,
+        row: {
+          _id: "pending-1" as never,
+          importKey: "pending-checkout",
+          importedQuantity: 1,
+          linkedTarget: {
+            productId: "product-linked-1" as never,
+            productName: "Trusted item",
+            sku: "TRUSTED-1",
+            skuId: "sku-linked-1" as never,
+          },
+          provisionalSoldQuantity: 1,
+          rowNumber: 1,
+          saleCount: 1,
+          status: "linked_to_catalog",
+        },
+        saleEvidenceFingerprint: "sale-fingerprint",
+        trustedSkuFingerprint: "sku-fingerprint",
+      },
+      variant: {
+        id: "sku-1",
+        existsInDB: true,
+        isVisible: false,
+        stock: 0,
+        quantityAvailable: 0,
+        netPrice: 25,
+        cost: 10,
+      },
+    });
+
+    expect(state).toMatchObject({
+      action: "none",
+      ctaLabel: "Linked to trusted SKU",
+      disabled: true,
+      message: "Pending checkout item is linked to an existing trusted SKU.",
+      status: "success",
+    });
+  });
+
   it("routes the trusted inventory CTA through make-visible, refresh, and finalize actions", () => {
     const makeVisibleState = resolveTrustedInventoryReviewState({
       binding: undefined,

--- a/packages/athena-webapp/src/components/add-product/ProductStock.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductStock.tsx
@@ -16,7 +16,7 @@ import {
   PlusCircledIcon,
   TrashIcon,
 } from "@radix-ui/react-icons";
-import { getErrorForField } from "@/lib/utils";
+import { capitalizeWords, getErrorForField } from "@/lib/utils";
 import { CardFooter } from "../ui/card";
 import { useProduct } from "@/contexts/ProductContext";
 import { ImageFile } from "../ui/image-uploader";
@@ -29,6 +29,7 @@ import {
   Info,
   RefreshCw,
   RotateCcw,
+  Search,
   ShieldCheck,
   ShoppingCart,
   TriangleAlert,
@@ -56,16 +57,34 @@ import {
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
 import { useSheet } from "./SheetProvider";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { CopyImagesView } from "./copy-images/CopyImagesView";
 import { useSkusReservedInCheckout } from "@/hooks/useSkusReservedInCheckout";
 import { useSkusReservedInPosSession } from "@/hooks/useSkusReservedInPosSession";
 import { AlertModal } from "../ui/modals/alert-modal";
 import { presentUnexpectedErrorToast } from "~/src/lib/errors/presentUnexpectedErrorToast";
-import { currencyDisplaySymbol } from "~/shared/currencyFormatter";
+import {
+  currencyDisplaySymbol,
+  currencyFormatter,
+} from "~/shared/currencyFormatter";
 import type { Product } from "~/types";
+import type { Product as PosProduct } from "@/components/pos/types";
 import type { FunctionReference } from "convex/server";
 import type { CommandResult } from "~/shared/commandResult";
+import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
+import {
+  usePOSProductSearch,
+  usePOSResolvePendingCheckoutItemReview,
+} from "~/src/hooks/usePOSProducts";
+import { useDebounce } from "~/src/hooks/useDebounce";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Skeleton } from "../ui/skeleton";
 import {
   buildTrustedInventoryFinalizationPayload,
   parseVariantInputValue,
@@ -105,9 +124,17 @@ export type ProductVariant = {
 
 type ProductPageTrustedInventoryFinalizationResult = {
   finalTrustedQuantity: number;
+  product?: {
+    availability?: Product["availability"];
+    inventoryCount?: number;
+    isVisible?: boolean;
+    quantityAvailable?: number;
+  };
   productId: Id<"product">;
   productSkuId: Id<"productSku">;
-  provisionalSkuId: Id<"inventoryImportProvisionalSku">;
+  provisionalSkuId:
+    | Id<"inventoryImportProvisionalSku">
+    | Id<"posPendingCheckoutItem">;
   provisionalSoldQuantity: number;
   quantityAvailable: number;
 };
@@ -135,6 +162,12 @@ const catalogImportApi = api.inventory.catalogImport as unknown as {
   listProductPageProvisionalSkuBinding: ProductPageProvisionalSkuBindingQuery;
 };
 
+const pendingCheckoutTrustedInventoryApi = api.pos.public
+  .catalog as unknown as {
+  finalizePendingCheckoutTrustedInventoryFromProductPage: ProductPageTrustedInventoryFinalizationMutation;
+  listPendingCheckoutProductPageBinding: ProductPageProvisionalSkuBindingQuery;
+};
+
 const StockHeader = ({
   isSkuReserved,
 }: {
@@ -150,7 +183,7 @@ const StockHeader = ({
         <CopyImagesView />
       </div>,
     );
-  }, []);
+  }, [setSheetContent]);
 
   const restock = () => {
     updateProductVariants((prevVariants) =>
@@ -253,22 +286,42 @@ function isLegacyImportDraftProduct(activeProduct?: Product | null) {
   );
 }
 
+function isPendingCheckoutDraftProduct(activeProduct?: Product | null) {
+  return (
+    activeProduct?.availability === "draft" &&
+    activeProduct?.categorySlug === "pos-pending-checkout"
+  );
+}
+
 function LegacyImportTrustPreview({
   activeProduct,
   areProcessingFeesAbsorbed,
+  canLinkPendingCheckoutItem,
+  finalizeTrustedInventoryMutation,
   finalized,
   isContextRefreshing,
+  listProvisionalSkuBindingQuery,
   onFinalized,
   onMakeVisible,
   reservationType,
+  sourceLabel,
   storeId,
   variant,
 }: {
   activeProduct?: Product | null;
   areProcessingFeesAbsorbed?: boolean;
+  canLinkPendingCheckoutItem?: boolean;
+  finalizeTrustedInventoryMutation: ProductPageTrustedInventoryFinalizationMutation;
   finalized?: boolean;
   isContextRefreshing?: boolean;
+  listProvisionalSkuBindingQuery: ProductPageProvisionalSkuBindingQuery;
   onFinalized: (result: {
+    product?: {
+      availability?: Product["availability"];
+      inventoryCount?: number;
+      isVisible?: boolean;
+      quantityAvailable?: number;
+    };
     sku: {
       id: string;
       stock: number;
@@ -281,6 +334,7 @@ function LegacyImportTrustPreview({
   }) => void;
   onMakeVisible: (id: string) => void;
   reservationType: "checkout" | "pos" | null;
+  sourceLabel: string;
   storeId?: Id<"store">;
   variant: ProductVariant;
 }) {
@@ -289,12 +343,14 @@ function LegacyImportTrustPreview({
     Record<string, string>
   >({});
   const [isFinalizing, setIsFinalizing] = useState(false);
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+  const [isLinkedToCatalog, setIsLinkedToCatalog] = useState(false);
   const [commandMessage, setCommandMessage] = useState<string | null>(null);
   const [requiresReviewRefresh, setRequiresReviewRefresh] = useState(false);
   const [bindingRefreshNonce, setBindingRefreshNonce] = useState(0);
 
   const binding = useQuery(
-    catalogImportApi.listProductPageProvisionalSkuBinding,
+    listProvisionalSkuBindingQuery,
     activeProduct && storeId && variant.existsInDB
       ? {
           productSkuId: variant.id as Id<"productSku">,
@@ -305,7 +361,7 @@ function LegacyImportTrustPreview({
   );
 
   const finalizeTrustedInventory = useMutation(
-    catalogImportApi.finalizeTrustedInventoryFromProductPage,
+    finalizeTrustedInventoryMutation,
   );
 
   const reviewState = resolveTrustedInventoryReviewState({
@@ -316,13 +372,26 @@ function LegacyImportTrustPreview({
     reservationType,
     variant,
   });
+  const bindingSaleEvidenceFingerprint =
+    binding?.state === "unique" ? binding.saleEvidenceFingerprint : undefined;
+  const bindingTrustedSkuFingerprint =
+    binding?.state === "unique" ? binding.trustedSkuFingerprint : undefined;
+  const bindingState = binding?.state;
+  const linkedTarget =
+    binding?.state === "unique" ? binding.row.linkedTarget : undefined;
+  const linkedSkuFormatter = useMemo(
+    () => currencyFormatter(activeProduct?.currency ?? "GHS"),
+    [activeProduct?.currency],
+  );
 
   useEffect(() => {
     setRequiresReviewRefresh(false);
     setCommandMessage(null);
+    setIsLinkedToCatalog(false);
   }, [
-    binding?.state === "unique" ? binding.saleEvidenceFingerprint : binding?.state,
-    binding?.state === "unique" ? binding.trustedSkuFingerprint : undefined,
+    bindingSaleEvidenceFingerprint,
+    bindingState,
+    bindingTrustedSkuFingerprint,
   ]);
 
   const getConversionRequestId = () => {
@@ -375,6 +444,7 @@ function LegacyImportTrustPreview({
       }
 
       onFinalized({
+        product: result.data.product,
         sku: {
           id: result.data.productSkuId,
           stock: result.data.finalTrustedQuantity,
@@ -433,6 +503,15 @@ function LegacyImportTrustPreview({
     : reviewState.ctaLabel;
   const isCtaDisabled = requiresReviewRefresh ? false : reviewState.disabled;
   const isFinalized = reviewState.status === "success";
+  const isLinkedToCatalogState = isLinkedToCatalog || Boolean(linkedTarget);
+  const canOpenLinkDialog = Boolean(
+    canLinkPendingCheckoutItem &&
+      activeProduct &&
+      storeId &&
+      binding?.state === "unique" &&
+      !isFinalized &&
+      !isLinkedToCatalogState,
+  );
 
   return (
     <TableRow
@@ -466,7 +545,7 @@ function LegacyImportTrustPreview({
                   className="gap-1.5 border-action-workflow-border bg-background text-action-workflow"
                 >
                   <Check className="h-3.5 w-3.5" />
-                  Finalized
+                  {linkedTarget ? "Linked SKU" : "Finalized"}
                 </Badge>
               ) : null}
             </div>
@@ -477,18 +556,53 @@ function LegacyImportTrustPreview({
             >
               {statusMessage}
             </p>
-            {binding?.state === "unique" && (
+            {linkedTarget ? (
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] leading-4 text-muted-foreground">
+                <span className="font-medium text-foreground">
+                  Linked to {capitalizeWords(linkedTarget.productName)}
+                </span>
+                <span>{linkedTarget.sku || "No SKU"}</span>
+                {typeof linkedTarget.price === "number" ? (
+                  <span>{formatStoredAmount(linkedSkuFormatter, linkedTarget.price)}</span>
+                ) : null}
+                {typeof linkedTarget.quantityAvailable === "number" ? (
+                  <span>{linkedTarget.quantityAvailable} available</span>
+                ) : null}
+              </div>
+            ) : binding?.state === "unique" ? (
               <p className="text-[11px] leading-4 text-muted-foreground">
-                Linked import row {binding.row.rowNumber}
+                {sourceLabel === "Linked import row"
+                  ? `${sourceLabel} ${binding.row.rowNumber}`
+                  : sourceLabel}
                 {binding.row.provisionalSoldQuantity !== undefined
                   ? ` · provisional sales ${binding.row.provisionalSoldQuantity}`
                   : ""}
               </p>
-            )}
+            ) : null}
           </div>
 
           <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-            {isFinalized ? (
+            {canOpenLinkDialog ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="min-h-10"
+                onClick={() => setLinkDialogOpen(true)}
+              >
+                Link existing SKU
+              </Button>
+            ) : null}
+            {isLinkedToCatalogState ? (
+              <div
+                className="inline-flex min-h-10 items-center gap-2 rounded-md px-3 text-xs font-medium text-muted-foreground"
+                role="status"
+                aria-live="polite"
+              >
+                <Check className="h-3.5 w-3.5 text-action-workflow" />
+                Linked to catalog
+              </div>
+            ) : isFinalized ? (
               <div
                 className="inline-flex min-h-10 items-center gap-2 rounded-md px-3 text-xs font-medium text-muted-foreground"
                 role="status"
@@ -511,8 +625,287 @@ function LegacyImportTrustPreview({
             )}
           </div>
         </div>
+        {canLinkPendingCheckoutItem && activeProduct && storeId ? (
+          <PendingCheckoutLinkDialog
+            activeProduct={activeProduct}
+            binding={binding}
+            currency={activeProduct.currency ?? "GHS"}
+            onLinked={() => {
+              setLinkDialogOpen(false);
+              setIsLinkedToCatalog(true);
+              setCommandMessage(
+                "Pending checkout item linked to an existing trusted SKU.",
+              );
+            }}
+            open={linkDialogOpen}
+            onOpenChange={setLinkDialogOpen}
+            storeId={storeId}
+            variant={variant}
+          />
+        ) : null}
       </TableCell>
     </TableRow>
+  );
+}
+
+function PendingCheckoutLinkDialog({
+  activeProduct,
+  binding,
+  currency,
+  onLinked,
+  onOpenChange,
+  open,
+  storeId,
+  variant,
+}: {
+  activeProduct: Product;
+  binding?: ProductPageProvisionalSkuBinding;
+  currency: string;
+  onLinked: () => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  storeId: Id<"store">;
+  variant: ProductVariant;
+}) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedProduct, setSelectedProduct] = useState<PosProduct | null>(
+    null,
+  );
+  const [isLinking, setIsLinking] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const debouncedSearchQuery = useDebounce(open ? searchQuery : "", 200);
+  const searchResults = usePOSProductSearch(storeId, debouncedSearchQuery);
+  const resolvePendingCheckoutItemReview =
+    usePOSResolvePendingCheckoutItemReview();
+  const formatter = useMemo(() => currencyFormatter(currency), [currency]);
+  const trimmedSearchQuery = searchQuery.trim();
+  const trimmedDebouncedSearchQuery = debouncedSearchQuery.trim();
+  const trustedSearchResults = useMemo(
+    () =>
+      (searchResults ?? []).filter(
+        (product) =>
+          product.productId &&
+          product.skuId &&
+          product.availabilityPolicy !== "pending_checkout" &&
+          product.productId !== activeProduct._id &&
+          product.skuId !== variant.id,
+      ),
+    [activeProduct._id, searchResults, variant.id],
+  );
+  const showSearchResults = trimmedSearchQuery.length > 0;
+  const isSearching =
+    showSearchResults &&
+    (trimmedSearchQuery !== trimmedDebouncedSearchQuery ||
+      (trimmedDebouncedSearchQuery.length > 0 && searchResults === undefined));
+
+  useEffect(() => {
+    if (!open) {
+      setSearchQuery("");
+      setSelectedProduct(null);
+      setErrorMessage(null);
+    }
+  }, [open]);
+
+  const handleLink = async () => {
+    if (
+      binding?.state !== "unique" ||
+      !selectedProduct?.productId ||
+      !selectedProduct.skuId
+    ) {
+      setErrorMessage("Choose a trusted SKU before linking.");
+      return;
+    }
+
+    setIsLinking(true);
+    setErrorMessage(null);
+
+    try {
+      await resolvePendingCheckoutItemReview({
+        approvedProductId: selectedProduct.productId,
+        approvedProductSkuId: selectedProduct.skuId as Id<"productSku">,
+        pendingCheckoutItemId: binding.row._id as Id<"posPendingCheckoutItem">,
+        status: "linked_to_catalog",
+        storeId,
+      });
+      toast.success("Pending checkout item linked");
+      onLinked();
+    } catch (error) {
+      console.error(error);
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Pending checkout item was not linked.",
+      );
+      presentUnexpectedErrorToast("Pending checkout item was not linked");
+    } finally {
+      setIsLinking(false);
+    }
+  };
+
+  const provisionalSoldQuantity =
+    binding?.state === "unique" ? binding.row.provisionalSoldQuantity : null;
+  const pendingItemPrice =
+    typeof variant.netPrice === "number"
+      ? variant.netPrice
+      : typeof variant.price === "number"
+        ? variant.price
+        : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[680px] max-h-[calc(100vh-2rem)] max-w-3xl flex-col gap-0 overflow-hidden p-0">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle>Link pending checkout item</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-4 px-5 py-4">
+          <div className="grid gap-3 rounded-md border bg-muted/20 p-3 text-sm sm:grid-cols-4">
+            <div>
+              <p className="text-xs text-muted-foreground">Pending item</p>
+              <p className="font-medium text-foreground">
+                {capitalizeWords(activeProduct.name)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Provisional SKU</p>
+              <p className="font-medium text-foreground">{variant.sku}</p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Price</p>
+              <p className="font-medium text-foreground">
+                {pendingItemPrice === null
+                  ? "-"
+                  : formatter.format(pendingItemPrice)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-muted-foreground">Sold</p>
+              <p className="font-medium text-foreground">
+                {provisionalSoldQuantity ?? "-"}
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-2 pt-2">
+            <Label htmlFor="pending-checkout-sku-search">
+              Product SKU search
+            </Label>
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="pending-checkout-sku-search"
+                autoFocus
+                className="pl-9"
+                value={searchQuery}
+                onChange={(event) => {
+                  setSearchQuery(event.target.value);
+                  setSelectedProduct(null);
+                  setErrorMessage(null);
+                }}
+                placeholder="Search by product, SKU, or barcode"
+              />
+            </div>
+          </div>
+
+          {showSearchResults ? (
+            <div className="max-h-80 overflow-y-auto rounded-md border">
+              {isSearching ? (
+                <PendingCheckoutSkuSearchLoadingRows />
+              ) : trustedSearchResults.length === 0 ? (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No trusted SKU matches this search.
+                </div>
+              ) : (
+                <div className="divide-y">
+                  {trustedSearchResults.map((product) => {
+                    const selected = selectedProduct?.skuId === product.skuId;
+                    return (
+                      <button
+                        key={`${product.productId}:${product.skuId}`}
+                        type="button"
+                        className={`flex w-full items-center justify-between gap-6 px-4 py-4 text-left transition-colors hover:bg-muted/50 focus:bg-muted/50 focus:outline-none ${
+                          selected ? "bg-action-workflow/10" : ""
+                        }`}
+                        onClick={() => {
+                          setSelectedProduct(product);
+                          setErrorMessage(null);
+                        }}
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate text-sm font-medium text-foreground">
+                            {capitalizeWords(product.name)}
+                          </span>
+                          <span className="mt-1.5 block truncate text-xs text-muted-foreground">
+                            {product.sku || "No SKU"}
+                            {product.barcode ? ` · ${product.barcode}` : ""}
+                            {product.category ? ` · ${product.category}` : ""}
+                          </span>
+                        </span>
+                        <span className="shrink-0 text-right">
+                          <span className="block text-sm font-semibold text-foreground">
+                            {formatStoredAmount(formatter, product.price)}
+                          </span>
+                          <span className="mt-1 block text-xs text-muted-foreground">
+                            {product.quantityAvailable ?? 0} available
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ) : null}
+
+          {errorMessage ? (
+            <p className="text-sm font-medium text-destructive" role="alert">
+              {errorMessage}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter className="border-t px-5 py-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLinking}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="workflow"
+            onClick={handleLink}
+            disabled={!selectedProduct || isLinking}
+          >
+            {isLinking ? "Linking..." : "Link SKU"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PendingCheckoutSkuSearchLoadingRows() {
+  return (
+    <div aria-label="Searching SKUs" className="divide-y" role="status">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          className="flex items-center justify-between gap-6 px-4 py-4"
+          key={index}
+        >
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-4 w-28 rounded-sm" />
+            <Skeleton className="h-3 w-48 max-w-full rounded-sm" />
+          </div>
+          <div className="shrink-0 space-y-2 text-right">
+            <Skeleton className="ml-auto h-4 w-16 rounded-sm" />
+            <Skeleton className="ml-auto h-3 w-20 rounded-sm" />
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -812,9 +1205,32 @@ function Stock({
     );
   };
 
-  const shouldShowTrustPreview = isLegacyImportDraftProduct(activeProduct);
+  const isPendingCheckoutDraft = isPendingCheckoutDraftProduct(activeProduct);
+  const shouldShowTrustPreview =
+    isLegacyImportDraftProduct(activeProduct) || isPendingCheckoutDraft;
+  const trustedInventoryApi = isPendingCheckoutDraft
+    ? {
+        finalizeTrustedInventoryMutation:
+          pendingCheckoutTrustedInventoryApi.finalizePendingCheckoutTrustedInventoryFromProductPage,
+        listProvisionalSkuBindingQuery:
+          pendingCheckoutTrustedInventoryApi.listPendingCheckoutProductPageBinding,
+        sourceLabel: "Pending checkout sales",
+      }
+    : {
+        finalizeTrustedInventoryMutation:
+          catalogImportApi.finalizeTrustedInventoryFromProductPage,
+        listProvisionalSkuBindingQuery:
+          catalogImportApi.listProductPageProvisionalSkuBinding,
+        sourceLabel: "Linked import row",
+      };
 
   const handleTrustedInventoryFinalized = (result: {
+    product?: {
+      availability?: Product["availability"];
+      inventoryCount?: number;
+      isVisible?: boolean;
+      quantityAvailable?: number;
+    };
     sku: {
       id: string;
       stock: number;
@@ -1241,24 +1657,36 @@ function Stock({
                     </div>
                   </TableCell>
                 </TableRow>
-                {shouldShowTrustPreview && activeProduct && variant.existsInDB && (
-                  <LegacyImportTrustPreview
-                    activeProduct={activeProduct}
-                    areProcessingFeesAbsorbed={
-                      resolveTrustedInventoryFinalizationPricingPolicy({
-                        persistedAreProcessingFeesAbsorbed:
-                          activeProduct.areProcessingFeesAbsorbed,
-                      })
-                    }
-                    finalized={finalizedTrustedInventorySkuIds.has(variant.id)}
-                    isContextRefreshing={isLoading || showLoaderForProduct}
-                    onFinalized={handleTrustedInventoryFinalized}
-                    onMakeVisible={setVisibility}
-                    reservationType={getReservationType(variant.sku)}
-                    storeId={activeStore?._id}
-                    variant={variant}
-                  />
-                )}
+                {shouldShowTrustPreview &&
+                  activeProduct &&
+                  variant.existsInDB && (
+                    <LegacyImportTrustPreview
+                      activeProduct={activeProduct}
+                      areProcessingFeesAbsorbed={resolveTrustedInventoryFinalizationPricingPolicy(
+                        {
+                          persistedAreProcessingFeesAbsorbed:
+                            activeProduct.areProcessingFeesAbsorbed,
+                        },
+                      )}
+                      canLinkPendingCheckoutItem={isPendingCheckoutDraft}
+                      finalizeTrustedInventoryMutation={
+                        trustedInventoryApi.finalizeTrustedInventoryMutation
+                      }
+                      finalized={finalizedTrustedInventorySkuIds.has(
+                        variant.id,
+                      )}
+                      isContextRefreshing={isLoading || showLoaderForProduct}
+                      listProvisionalSkuBindingQuery={
+                        trustedInventoryApi.listProvisionalSkuBindingQuery
+                      }
+                      onFinalized={handleTrustedInventoryFinalized}
+                      onMakeVisible={setVisibility}
+                      reservationType={getReservationType(variant.sku)}
+                      sourceLabel={trustedInventoryApi.sourceLabel}
+                      storeId={activeStore?._id}
+                      variant={variant}
+                    />
+                  )}
               </Fragment>
             ))}
           </TableBody>

--- a/packages/athena-webapp/src/components/add-product/ProductStockInput.ts
+++ b/packages/athena-webapp/src/components/add-product/ProductStockInput.ts
@@ -103,7 +103,8 @@ export function resolveTrustedInventoryCommandError(
     message.includes("fingerprint")
   ) {
     return {
-      message: "Provisional sales changed. Refresh and review the counts again.",
+      message:
+        "Provisional sales changed. Refresh and review the counts again.",
       requiresReviewRefresh: true,
     };
   }
@@ -169,13 +170,22 @@ export type ProductPageProvisionalSkuBinding =
       state: "unique";
       activeRowCount: 1;
       row: {
-        _id: Id<"inventoryImportProvisionalSku">;
+        _id: Id<"inventoryImportProvisionalSku"> | Id<"posPendingCheckoutItem">;
         importKey: string;
         importedQuantity: number;
         lastSoldAt?: number;
+        linkedTarget?: {
+          price?: number;
+          productId: Id<"product">;
+          productName: string;
+          quantityAvailable?: number;
+          sku?: string;
+          skuId: Id<"productSku">;
+        };
         provisionalSoldQuantity: number;
         rowNumber: number;
         saleCount: number;
+        status?: "pending_review" | "flagged" | "linked_to_catalog";
       };
       saleEvidenceFingerprint: string;
       trustedSkuFingerprint: string;
@@ -218,7 +228,9 @@ export type TrustedInventoryFinalizationPayload = {
   storeId: Id<"store">;
   productId: Id<"product">;
   productSkuId: Id<"productSku">;
-  provisionalSkuId: Id<"inventoryImportProvisionalSku">;
+  provisionalSkuId:
+    | Id<"inventoryImportProvisionalSku">
+    | Id<"posPendingCheckoutItem">;
   conversionRequestId: string;
   saleEvidenceFingerprint: string;
   trustedSkuFingerprint: string;
@@ -303,6 +315,19 @@ export function resolveTrustedInventoryReviewState({
       disabled: true,
       message: "Refreshing product inventory state.",
       status: "blocked",
+    };
+  }
+
+  if (
+    binding?.state === "unique" &&
+    binding.row.status === "linked_to_catalog"
+  ) {
+    return {
+      action: "none",
+      ctaLabel: "Linked to trusted SKU",
+      disabled: true,
+      message: "Pending checkout item is linked to an existing trusted SKU.",
+      status: "success",
     };
   }
 

--- a/packages/athena-webapp/src/components/add-product/ProductView.test.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductView.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildVariantSkuMoneyPayload } from "./ProductView";
+import {
+  buildVariantSkuMoneyPayload,
+  getArchivedProductRedirect,
+} from "./ProductView";
 
 describe("ProductView SKU money payloads", () => {
   it("persists decimal net price and unit cost as minor units when fees are absorbed", () => {
@@ -32,6 +35,46 @@ describe("ProductView SKU money payloads", () => {
       netPrice: 10000,
       price: 10200,
       unitCost: 999,
+    });
+  });
+});
+
+describe("ProductView archived product redirects", () => {
+  it("prefers the origin search param after archiving", () => {
+    expect(
+      getArchivedProductRedirect({
+        categorySlug: "makeup",
+        origin: "/wigclub/store/wigclub/products/ks753/edit?o=%2Freturn",
+      }),
+    ).toEqual({
+      kind: "origin",
+      to: "/wigclub/store/wigclub/products/ks753/edit?o=/return",
+    });
+  });
+
+  it("unwraps same-product origins to avoid returning to an archived product page", () => {
+    expect(
+      getArchivedProductRedirect({
+        categorySlug: "makeup",
+        origin:
+          "%2Fwigclub%2Fstore%2Fwigclub%2Fproducts%2Fks753%3Fo%3D%25252Fwigclub%25252Fstore%25252Fwigclub%25252Fproducts%25253FcategorySlug%25253Dmakeup",
+        productId: "ks753",
+      }),
+    ).toEqual({
+      kind: "origin",
+      to: "/wigclub/store/wigclub/products?categorySlug=makeup",
+    });
+  });
+
+  it("falls back to the product category when no origin is present", () => {
+    expect(
+      getArchivedProductRedirect({
+        categorySlug: "makeup",
+        origin: "",
+      }),
+    ).toEqual({
+      categorySlug: "makeup",
+      kind: "category",
     });
   });
 });

--- a/packages/athena-webapp/src/components/add-product/ProductView.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductView.tsx
@@ -38,6 +38,60 @@ export function buildVariantSkuMoneyPayload(
   return buildTrustedInventoryMoneyPayload(variant, areProcessingFeesAbsorbed);
 }
 
+export function getArchivedProductRedirect(args: {
+  categorySlug?: string | null;
+  origin?: string | null;
+  productId?: string | null;
+}):
+  | { kind: "origin"; to: string }
+  | { categorySlug?: string; kind: "category" } {
+  const origin = decodeOriginValue(args.origin);
+  if (origin) {
+    const nestedOrigin = archivedProductNestedOrigin({
+      origin,
+      productId: args.productId,
+    });
+    return { kind: "origin", to: nestedOrigin ?? origin };
+  }
+
+  return { categorySlug: args.categorySlug ?? undefined, kind: "category" };
+}
+
+function decodeOriginValue(origin?: string | null) {
+  let decoded = origin?.trim() ?? "";
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const nextDecoded = decodeURIComponent(decoded);
+      if (nextDecoded === decoded) break;
+      decoded = nextDecoded;
+    } catch {
+      break;
+    }
+  }
+  return decoded;
+}
+
+function archivedProductNestedOrigin(args: {
+  origin: string;
+  productId?: string | null;
+}) {
+  if (!args.productId) return null;
+
+  try {
+    const originUrl = new URL(args.origin, "http://athena.local");
+    const productPathPattern = new RegExp(
+      `/products/${args.productId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:/edit)?/?$`,
+    );
+    if (!productPathPattern.test(originUrl.pathname)) {
+      return null;
+    }
+
+    return decodeOriginValue(originUrl.searchParams.get("o"));
+  } catch {
+    return null;
+  }
+}
+
 function ProductViewContent() {
   const { productData, revertChanges, productVariants, updateProductVariants } =
     useProduct();
@@ -86,7 +140,15 @@ function ProductViewContent() {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
 
-      if (o) {
+      const redirect = getArchivedProductRedirect({
+        categorySlug: activeProduct.categorySlug,
+        origin: o,
+        productId: activeProduct._id,
+      });
+
+      if (redirect.kind === "origin") {
+        navigate({ to: redirect.to });
+      } else {
         navigate({
           to: "/$orgUrlSlug/store/$storeUrlSlug/products",
           params: (prev) => ({
@@ -94,7 +156,7 @@ function ProductViewContent() {
             orgUrlSlug: prev.orgUrlSlug!,
             storeUrlSlug: prev.storeUrlSlug!,
           }),
-          search: { categorySlug: activeProduct.categorySlug },
+          search: { categorySlug: redirect.categorySlug },
         });
       }
     } catch {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -115,15 +115,28 @@ vi.mock("recharts", () => ({
   }: {
     children?: React.ReactNode;
     className?: string;
-    data?: Array<{ displayDate?: string; displayLabel?: string }>;
+    data?: Array<{
+      displayDate?: string;
+      displayLabel?: string;
+      hasKnownItemCount?: boolean;
+      totalItemsSold?: number;
+    }>;
     margin?: { bottom?: number; left?: number; right?: number; top?: number };
   }) => (
     <svg
       className={className}
       data-display-dates={data.map((day) => day.displayDate).join("|")}
       data-display-labels={data.map((day) => day.displayLabel).join("|")}
+      data-known-item-counts={data
+        .map((day) =>
+          day.hasKnownItemCount === false ? "unknown" : "known",
+        )
+        .join("|")}
       data-margin-right={margin?.right ?? ""}
       data-testid="store-pulse-chart"
+      data-total-items-sold={data
+        .map((day) => String(day.totalItemsSold ?? 0))
+        .join("|")}
     >
       {children}
     </svg>
@@ -2615,6 +2628,11 @@ describe("DailyOperationsView", () => {
       "data-display-labels",
       "Sun, May 3|Mon, May 4|Tue, May 5|Wed, May 6|Thu, May 7|Fri, May 8",
     );
+    expect(chart).toHaveAttribute("data-total-items-sold", "0|0|0|0|0|0");
+    expect(chart).toHaveAttribute(
+      "data-known-item-counts",
+      "unknown|unknown|unknown|unknown|unknown|unknown",
+    );
 
     shouldReturnPulseDetail = true;
     view.rerender(<DailyOperationsView />);
@@ -2626,6 +2644,14 @@ describe("DailyOperationsView", () => {
     expect(screen.getByTestId("store-pulse-chart")).toHaveAttribute(
       "data-display-labels",
       "Sun, May 3|Mon, May 4|Tue, May 5|Wed, May 6|Thu, May 7|Fri, May 8",
+    );
+    expect(screen.getByTestId("store-pulse-chart")).toHaveAttribute(
+      "data-total-items-sold",
+      "0|0|0|0|0|0",
+    );
+    expect(screen.getByTestId("store-pulse-chart")).toHaveAttribute(
+      "data-known-item-counts",
+      "unknown|unknown|unknown|unknown|unknown|unknown",
     );
     expect(screen.getByTestId("store-pulse-area")).toHaveAttribute(
       "data-replay-key",

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -1806,21 +1806,10 @@ function buildWeekToDateStorePulseSummary(
   const weekToDateTrend = snapshot.weekMetrics
     .filter((metric) => metric.operatingDate <= snapshot.operatingDate)
     .map((metric): StorePulseTrendDay => {
-      const knownTrendDay = knownTrendByDate.get(metric.operatingDate);
-
-      return {
-        averageTransaction:
-          metric.transactionCount > 0
-            ? metric.salesTotal / metric.transactionCount
-            : 0,
-        date: metric.operatingDate,
-        hasKnownItemCount: knownTrendDay ? true : false,
-        label:
-          knownTrendDay?.label ?? formatOperatingDate(metric.operatingDate),
-        totalItemsSold: knownTrendDay?.totalItemsSold ?? 0,
-        totalSales: metric.salesTotal,
-        transactionCount: metric.transactionCount,
-      };
+      return buildStorePulseTrendDayFromMetric(
+        metric,
+        knownTrendByDate.get(metric.operatingDate),
+      );
     });
 
   if (weekToDateTrend.length === 0) return summary;
@@ -1847,7 +1836,6 @@ function buildCachedWeekStorePulseSummary(
 ): StorePulseSummary | null | undefined {
   const summary = snapshot.storePulse;
   const operatorSnapshot = summary?.operatorSnapshot;
-
   if (!summary || !operatorSnapshot) {
     return buildWeekMetricStorePulseSummary(snapshot);
   }
@@ -1856,20 +1844,10 @@ function buildCachedWeekStorePulseSummary(
     operatorSnapshot.trend.map((day) => [day.date, day]),
   );
   const weekTrend = snapshot.weekMetrics.map((metric): StorePulseTrendDay => {
-    const knownTrendDay = knownTrendByDate.get(metric.operatingDate);
-
-    return {
-      averageTransaction:
-        metric.transactionCount > 0
-          ? metric.salesTotal / metric.transactionCount
-          : 0,
-      date: metric.operatingDate,
-      hasKnownItemCount: knownTrendDay ? true : false,
-      label: knownTrendDay?.label ?? formatOperatingDate(metric.operatingDate),
-      totalItemsSold: knownTrendDay?.totalItemsSold ?? 0,
-      totalSales: metric.salesTotal,
-      transactionCount: metric.transactionCount,
-    };
+    return buildStorePulseTrendDayFromMetric(
+      metric,
+      knownTrendByDate.get(metric.operatingDate),
+    );
   });
 
   if (weekTrend.length === 0) return summary;
@@ -1892,19 +1870,7 @@ function buildWeekMetricStorePulseSummary(
   snapshot: DailyOperationsSnapshot,
 ): StorePulseSummary | null {
   const trend = snapshot.weekMetrics.map((metric): StorePulseTrendDay => {
-    const averageTransaction =
-      metric.transactionCount > 0
-        ? metric.salesTotal / metric.transactionCount
-        : 0;
-
-    return {
-      averageTransaction,
-      date: metric.operatingDate,
-      label: formatOperatingDate(metric.operatingDate),
-      totalItemsSold: 0,
-      totalSales: metric.salesTotal,
-      transactionCount: metric.transactionCount,
-    };
+    return buildStorePulseTrendDayFromMetric(metric);
   });
   const selectedMetric =
     snapshot.weekMetrics.find(
@@ -1950,6 +1916,24 @@ function buildWeekMetricStorePulseSummary(
   };
 }
 
+function buildStorePulseTrendDayFromMetric(
+  metric: DailyOperationsSnapshot["weekMetrics"][number],
+  knownTrendDay?: StorePulseTrendDay,
+): StorePulseTrendDay {
+  return {
+    averageTransaction:
+      metric.transactionCount > 0
+        ? metric.salesTotal / metric.transactionCount
+        : 0,
+    date: metric.operatingDate,
+    hasKnownItemCount: false,
+    label: knownTrendDay?.label ?? formatOperatingDate(metric.operatingDate),
+    totalItemsSold: 0,
+    totalSales: metric.salesTotal,
+    transactionCount: metric.transactionCount,
+  };
+}
+
 function buildCachedStorePulseForOperatingDate({
   operatingDate,
   selectedDayStorePulse,
@@ -1972,7 +1956,10 @@ function buildCachedStorePulseForOperatingDate({
           operatorSnapshot: {
             ...selectedDayOperatorSnapshot,
             historyDays: weekOperatorSnapshot.historyDays,
-            trend: weekOperatorSnapshot.trend,
+            trend: mergeSelectedStorePulseTrend(
+              weekOperatorSnapshot.trend,
+              selectedDayOperatorSnapshot.trend,
+            ),
             usableHistoryDays: weekOperatorSnapshot.usableHistoryDays,
           },
         }
@@ -1982,6 +1969,26 @@ function buildCachedStorePulseForOperatingDate({
     combinedSummary,
     operatingDate,
   );
+}
+
+function mergeSelectedStorePulseTrend(
+  weekTrend: StorePulseTrendDay[],
+  selectedDayTrend: StorePulseTrendDay[],
+) {
+  const selectedTrendByDate = new Map(
+    selectedDayTrend.map((day) => [day.date, day]),
+  );
+
+  return weekTrend.map((weekDay) => {
+    const selectedDay = selectedTrendByDate.get(weekDay.date);
+    if (!selectedDay) return weekDay;
+
+    return {
+      ...weekDay,
+      hasKnownItemCount: false,
+      totalItemsSold: 0,
+    };
+  });
 }
 
 function selectStorePulseTrendThroughOperatingDate(

--- a/packages/athena-webapp/src/components/operations/OperationReviewItemCard.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationReviewItemCard.tsx
@@ -18,6 +18,7 @@ type OperationReviewItemCardProps = {
   contextLabel: string;
   contextLabelClassName?: string;
   description?: string | null;
+  headerActionSlot?: ReactNode;
   itemId: string;
   metadataEntries?: OperationReviewMetadataEntry[];
   selectionSlot?: ReactNode;
@@ -34,6 +35,7 @@ export function OperationReviewItemCard({
   contextLabel,
   contextLabelClassName,
   description,
+  headerActionSlot,
   itemId,
   metadataEntries = [],
   selectionSlot,
@@ -105,6 +107,7 @@ export function OperationReviewItemCard({
 
         <div className="flex shrink-0 flex-wrap items-center gap-2 md:justify-end">
           {badgeSlot}
+          {headerActionSlot}
           {detailsToggle}
         </div>
       </div>

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -371,7 +371,9 @@ describe("OperationsQueueViewContent", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Work type")).toBeInTheDocument();
     expect(screen.getByText("2 work types")).toBeInTheDocument();
-    expect(screen.getAllByText("POS pending checkout").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("POS pending checkout").length).toBeGreaterThan(
+      0,
+    );
     expect(screen.getAllByText("Service case").length).toBeGreaterThan(0);
     expect(screen.getAllByText("1 item")).toHaveLength(2);
     expect(
@@ -420,7 +422,9 @@ describe("OperationsQueueViewContent", () => {
         /Showing the first 1 open work items\. Resolve visible work/i,
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/change the sort order/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/change the sort order/i),
+    ).not.toBeInTheDocument();
   });
 
   it("shows when pending approvals are capped by the server", () => {
@@ -445,7 +449,9 @@ describe("OperationsQueueViewContent", () => {
       />,
     );
 
-    expect(screen.getByText("More approvals are available")).toBeInTheDocument();
+    expect(
+      screen.getByText("More approvals are available"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         /Showing the first 1 pending approvals\. Resolve visible approvals/i,
@@ -562,7 +568,9 @@ describe("OperationsQueueViewContent", () => {
     expect(screen.getAllByText("No pending approvals")).toHaveLength(1);
     expect(screen.queryByText("0 pending approvals")).not.toBeInTheDocument();
     expect(
-      screen.getByText("High-variance deposits and stock reviews will surface here."),
+      screen.getByText(
+        "High-variance deposits and stock reviews will surface here.",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -683,7 +691,9 @@ describe("OperationsQueueViewContent", () => {
     );
     expect(screen.getByText("Created")).toBeInTheDocument();
     expect(screen.getByText("Due")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /show details/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /show details/i }),
+    ).toBeInTheDocument();
   });
 
   it("paginates open work items five per page with the shared list controls", async () => {
@@ -749,7 +759,7 @@ describe("OperationsQueueViewContent", () => {
     expect(screen.getByText("Page 1 of 2")).toBeInTheDocument();
   });
 
-  it("routes pending checkout work items to unresolved catalog review first", () => {
+  it("routes pending checkout work items to the provisional product edit page", () => {
     render(
       <OperationsQueueViewContent
         {...baseProps}
@@ -761,7 +771,10 @@ describe("OperationsQueueViewContent", () => {
             _id: "work-item-1" as Id<"operationalWorkItem">,
             approvalState: "not_required",
             createdAt: Date.now() - 5 * 60 * 1000,
-            details: {},
+            details: {
+              provisionalProductId: "product-pending-1",
+              provisionalProductSkuId: "sku-pending-1",
+            },
             priority: "normal",
             status: "open",
             title: "Review pending checkout item: BRUDDAH",
@@ -772,27 +785,31 @@ describe("OperationsQueueViewContent", () => {
     );
 
     expect(
-      screen.getByText((_content, element) =>
-        element?.tagName.toLowerCase() === "p" &&
-        element.textContent === "Review pending checkout item: Bruddah",
+      screen.getByText(
+        (_content, element) =>
+          element?.tagName.toLowerCase() === "p" &&
+          element.textContent === "Review pending checkout item: Bruddah",
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Bruddah" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Bruddah" }),
+    ).not.toBeInTheDocument();
 
     const actionHref = new URL(
       screen
-        .getByRole("link", { name: "Review unresolved catalog" })
+        .getByRole("link", { name: "Review POS pending checkout" })
         .getAttribute("href") ?? "",
       "http://localhost",
     );
     expect(actionHref.pathname).toBe(
-      "/$orgUrlSlug/store/$storeUrlSlug/products/unresolved",
+      "/wigclub/store/wigclub/products/product-pending-1/edit",
     );
+    expect(actionHref.searchParams.get("variant")).toBe("sku-pending-1");
     expect(actionHref.searchParams.get("o")).toBeTruthy();
     expect(
       screen.queryByRole("link", { name: "Open stock adjustments" }),
     ).not.toBeInTheDocument();
-    expect(actionHref.searchParams.get("sku")).toBeNull();
+    expect(actionHref.searchParams.get("categorySlug")).toBeNull();
   });
 
   it("keeps pending checkout work item titles plain without provisional SKU metadata", () => {
@@ -907,31 +924,45 @@ describe("OperationsQueueViewContent", () => {
     );
 
     expect(screen.getAllByText("Service case").length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: "Open service case" })).toHaveAttribute(
+    expect(
+      screen.getByRole("link", { name: "Open service case" }),
+    ).toHaveAttribute(
       "href",
       "/$orgUrlSlug/store/$storeUrlSlug/services/active-cases?o=%252F",
     );
-    expect(screen.getAllByText("Service appointment").length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: "Open appointment" })).toHaveAttribute(
+    expect(screen.getAllByText("Service appointment").length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.getByRole("link", { name: "Open appointment" }),
+    ).toHaveAttribute(
       "href",
       "/$orgUrlSlug/store/$storeUrlSlug/services/appointments?o=%252F",
     );
     expect(screen.getAllByText("Purchase order").length).toBeGreaterThan(0);
-    expect(screen.getByRole("link", { name: "Open purchase order" })).toHaveAttribute(
+    expect(
+      screen.getByRole("link", { name: "Open purchase order" }),
+    ).toHaveAttribute(
       "href",
       "/$orgUrlSlug/store/$storeUrlSlug/procurement?o=%252F",
     );
     expect(screen.getByText("PO-103")).toBeInTheDocument();
     expect(screen.getByText("Salon Supply Co.")).toBeInTheDocument();
     expect(screen.getByText("4 items")).toBeInTheDocument();
-    expect(screen.getAllByText("Stock adjustment approval").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Stock adjustment approval").length,
+    ).toBeGreaterThan(0);
     expect(screen.getByText("Approval requests")).toBeInTheDocument();
     expect(screen.getByText("Cycle count variance")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Review approval" })).toHaveAttribute(
+    expect(
+      screen.getByRole("link", { name: "Review approval" }),
+    ).toHaveAttribute(
       "href",
       "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals?o=%252F",
     );
-    expect(screen.getAllByText("Daily close follow-up").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Daily close follow-up").length).toBeGreaterThan(
+      0,
+    );
     expect(screen.getByText("July 1, 2026")).toBeInTheDocument();
     const dailyCloseHref = new URL(
       screen
@@ -970,7 +1001,9 @@ describe("OperationsQueueViewContent", () => {
       />,
     );
 
-    expect(screen.getAllByText("Unsupported work type").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Unsupported work type").length).toBeGreaterThan(
+      0,
+    );
     expect(
       screen.getByText("Service deposit review is not available in Open Work."),
     ).toBeInTheDocument();
@@ -1004,8 +1037,12 @@ describe("OperationsQueueViewContent", () => {
       />,
     );
 
-    expect(screen.getAllByText("Daily close follow-up").length).toBeGreaterThan(0);
-    expect(screen.queryByText("proof-visible-if-leaked")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Daily close follow-up").length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.queryByText("proof-visible-if-leaked"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText("card-token-should-stay-server-side"),
     ).not.toBeInTheDocument();
@@ -1057,16 +1094,18 @@ describe("OperationsQueueViewContent", () => {
     );
 
     expect(
-      screen.getByText((_content, element) =>
-        element?.tagName.toLowerCase() === "p" &&
-        element.textContent === "Review inventory for Adore Dye",
+      screen.getByText(
+        (_content, element) =>
+          element?.tagName.toLowerCase() === "p" &&
+          element.textContent === "Review inventory for Adore Dye",
       ),
     ).toBeInTheDocument();
-    expect(screen.getAllByText("Synced sale inventory").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Synced sale inventory").length).toBeGreaterThan(
+      0,
+    );
     const titleHref = new URL(
-      screen
-        .getByRole("link", { name: "Adore Dye" })
-        .getAttribute("href") ?? "",
+      screen.getByRole("link", { name: "Adore Dye" }).getAttribute("href") ??
+        "",
       "http://localhost",
     );
     expect(titleHref.pathname).toBe(
@@ -1133,7 +1172,7 @@ describe("OperationsQueueViewContent", () => {
     );
   });
 
-  it("does not render synced sale resolution when resolver details are incomplete", () => {
+  it("renders synced sale resolution when the affected SKU is available", () => {
     const onResolveSyncedSaleInventoryReview = vi.fn();
 
     render(
@@ -1163,10 +1202,49 @@ describe("OperationsQueueViewContent", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: "Mark reviewed" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Mark reviewed" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Open stock adjustments" }),
     ).toBeInTheDocument();
+  });
+
+  it("does not render synced sale resolution without an affected SKU", () => {
+    const onResolveSyncedSaleInventoryReview = vi.fn();
+
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        orgUrlSlug="wigclub"
+        onResolveSyncedSaleInventoryReview={onResolveSyncedSaleInventoryReview}
+        storeUrlSlug="wigclub"
+        workItems={[
+          {
+            _id: "work-item-1" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            createdAt: Date.now() - 5 * 60 * 1000,
+            details: {
+              inventoryReviewLineCount: 1,
+              receiptNumber: "939540",
+              sourceId: "transaction-1",
+            },
+            priority: "high",
+            status: "open",
+            title: "Review inventory for ADORE DYE",
+            type: "synced_sale_inventory_review",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Mark reviewed" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Open stock adjustments" }),
+    ).not.toBeInTheDocument();
   });
 
   it("disables peer synced sale review buttons while one review is resolving", () => {
@@ -1402,14 +1480,14 @@ describe("OperationsQueueViewContent", () => {
       screen.getByText(
         (_, element) =>
           element?.textContent?.replace(/\s+/g, " ").trim() ===
-          "2 counted against 6 on hand",
+          "Counted 2 of 6 on hand",
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
         (_, element) =>
           element?.textContent?.replace(/\s+/g, " ").trim() ===
-          "9 counted against 6 on hand",
+          "Counted 9 of 6 on hand",
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("-4")).toBeInTheDocument();
@@ -1421,6 +1499,38 @@ describe("OperationsQueueViewContent", () => {
       approvalRequestId: "approval-1",
       decision: "approved",
     });
+  });
+
+  it("renders manual stock approval quantity context without counted placeholders", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        approvalRequests={[
+          {
+            _id: "approval-manual-1" as Id<"approvalRequest">,
+            metadata: {
+              lineItems: [
+                {
+                  productName: "yuhh",
+                  productSkuId: "sku-1" as Id<"productSku">,
+                  quantityDelta: 100,
+                  sku: "6N2Y-9J7-NR0",
+                  systemQuantity: 1,
+                },
+              ],
+              netQuantityDelta: 100,
+            },
+            requestType: "inventory_adjustment_review",
+            status: "pending",
+            workItemTitle: "Stock Adjustment Review · 1 SKU",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Yuhh")).toBeInTheDocument();
+    expect(screen.getByText("1 on hand before adjustment")).toBeInTheDocument();
+    expect(screen.queryByText("- counted against 1 on hand")).not.toBeInTheDocument();
   });
 
   it("renders unsupported approval rows as retire-only actions", async () => {
@@ -1650,7 +1760,9 @@ describe("OperationsQueueViewContent", () => {
       />,
     );
 
-    expect(screen.getAllByText("Review item adjustment").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Review item adjustment").length,
+    ).toBeGreaterThan(0);
     expect(screen.getByText("#434898")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "#434898" })).toHaveAttribute(
       "href",
@@ -1919,7 +2031,9 @@ describe("OperationsQueueViewContent", () => {
 
     expect(screen.getByText("Synced register activity")).toBeInTheDocument();
     expect(
-      screen.getByText("Review local register activity before it is applied to cash controls."),
+      screen.getByText(
+        "Review local register activity before it is applied to cash controls.",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /wigshop \/ register 2/i }),
@@ -2019,46 +2133,44 @@ describe("OperationsQueueViewContent", () => {
     };
 
     mockedHooks.useQuery.mockReset();
-    mockedHooks.useQuery.mockImplementation((_query: unknown, args: unknown) => {
-      if (args === "skip") return undefined;
-      if (
-        args &&
-        typeof args === "object" &&
-        "productSkuIds" in args
-      ) {
-        return [linkedInventoryItem];
-      }
-      if (
-        args &&
-        typeof args === "object" &&
-        "query" in args &&
-        "limit" in args
-      ) {
-        return {
-          candidateOverflow: false,
-          results: [],
-          truncated: false,
-        };
-      }
-      if (args && typeof args === "object" && "storeId" in args) {
-        return {
-          approvalRequests: [],
-          availableUnits: 7,
-          checkoutReservedUnits: 0,
-          fallbackReservedUnits: 0,
-          hasMoreSkus: false,
-          onHandUnits: 7,
-          posReservedUnits: 0,
-          reservedUnits: 0,
-          skuCount: 1,
-          unavailableSkuCount: 0,
-          unavailableUnits: 0,
-          workItems: [],
-        };
-      }
+    mockedHooks.useQuery.mockImplementation(
+      (_query: unknown, args: unknown) => {
+        if (args === "skip") return undefined;
+        if (args && typeof args === "object" && "productSkuIds" in args) {
+          return [linkedInventoryItem];
+        }
+        if (
+          args &&
+          typeof args === "object" &&
+          "query" in args &&
+          "limit" in args
+        ) {
+          return {
+            candidateOverflow: false,
+            results: [],
+            truncated: false,
+          };
+        }
+        if (args && typeof args === "object" && "storeId" in args) {
+          return {
+            approvalRequests: [],
+            availableUnits: 7,
+            checkoutReservedUnits: 0,
+            fallbackReservedUnits: 0,
+            hasMoreSkus: false,
+            onHandUnits: 7,
+            posReservedUnits: 0,
+            reservedUnits: 0,
+            skuCount: 1,
+            unavailableSkuCount: 0,
+            unavailableUnits: 0,
+            workItems: [],
+          };
+        }
 
-      return undefined;
-    });
+        return undefined;
+      },
+    );
     mockedHooks.usePaginatedQuery.mockReturnValue({
       isLoading: false,
       loadMore: vi.fn(),
@@ -2562,7 +2674,9 @@ describe("OperationsQueueViewContent", () => {
     mockedHooks.useMutation.mockImplementation((functionReference) => {
       const functionName = getFunctionName(functionReference as never);
 
-      if (functionName === "operations/approvalRequests:decideApprovalRequest") {
+      if (
+        functionName === "operations/approvalRequests:decideApprovalRequest"
+      ) {
         return decideApprovalRequest;
       }
 
@@ -2581,8 +2695,7 @@ describe("OperationsQueueViewContent", () => {
       }
 
       if (
-        functionName ===
-        "cashControls/closeouts:reviewRegisterSessionCloseout"
+        functionName === "cashControls/closeouts:reviewRegisterSessionCloseout"
       ) {
         return reviewRegisterSessionCloseout;
       }
@@ -2680,12 +2793,15 @@ describe("OperationsQueueViewContent", () => {
     mockedHooks.useMutation.mockImplementation((functionReference) => {
       const functionName = getFunctionName(functionReference as never);
 
-      if (functionName === "operations/approvalRequests:decideApprovalRequest") {
+      if (
+        functionName === "operations/approvalRequests:decideApprovalRequest"
+      ) {
         return decideApprovalRequest;
       }
 
       if (
-        functionName === "cashControls/deposits:resolveRegisterSessionSyncReview"
+        functionName ===
+        "cashControls/deposits:resolveRegisterSessionSyncReview"
       ) {
         return resolveRegisterSessionSyncReview;
       }

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -86,6 +86,21 @@ const UNCATEGORIZED_COUNT_SCOPE_KEY = "__uncategorized";
 const openWorkActionLinkClassName =
   "inline-flex items-center gap-1.5 text-sm font-medium text-foreground underline-offset-4 transition-colors hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
 
+function buildProductEditHref(args: {
+  orgUrlSlug: string;
+  productId: string;
+  productSkuId: string;
+  storeUrlSlug: string;
+}) {
+  const search = new URLSearchParams({
+    o: getOrigin(),
+    variant: args.productSkuId,
+  });
+  return `/${encodeURIComponent(args.orgUrlSlug)}/store/${encodeURIComponent(
+    args.storeUrlSlug,
+  )}/products/${encodeURIComponent(args.productId)}/edit?${search.toString()}`;
+}
+
 type ProductSkuSearchResponse = {
   results: Array<{
     productSkuId: Id<"productSku">;
@@ -111,6 +126,8 @@ type QueueWorkItem = {
     lookupCode?: string | null;
     price?: number | null;
     primaryProductSkuId?: string | null;
+    provisionalProductId?: string | null;
+    provisionalProductSkuId?: string | null;
     purchaseOrderNumber?: string | null;
     quantitySold?: number | null;
     reasonLabel?: string | null;
@@ -250,10 +267,7 @@ function preserveOperationalAcronyms(value: string) {
 }
 
 function formatWorkItemTitle(title: string) {
-  const prefixes = [
-    "Review inventory for ",
-    "Review pending checkout item: ",
-  ];
+  const prefixes = ["Review inventory for ", "Review pending checkout item: "];
 
   for (const prefix of prefixes) {
     if (title.startsWith(prefix)) {
@@ -273,9 +287,7 @@ function getWorkItemTitleSubject(title: string, prefix: string) {
 
   const subject = title.slice(prefix.length).trim();
 
-  return subject
-    ? preserveOperationalAcronyms(capitalizeWords(subject))
-    : null;
+  return subject ? preserveOperationalAcronyms(capitalizeWords(subject)) : null;
 }
 
 function getQueueWorkItemTypeLabel(type: string) {
@@ -376,13 +388,7 @@ function CappedQueueNotice({
 }
 
 function hasSyncedSaleInventoryResolverDetails(item: QueueWorkItem) {
-  return Boolean(
-    getQueueWorkItemStringDetail(item, "terminalId") &&
-      getQueueWorkItemStringDetail(item, "localRegisterSessionId") &&
-      getQueueWorkItemStringDetail(item, "localTransactionId") &&
-      getQueueWorkItemStringDetail(item, "registerSessionId") &&
-      getQueueWorkItemStringDetail(item, "sourceId"),
-  );
+  return Boolean(getQueueWorkItemStringDetail(item, "primaryProductSkuId"));
 }
 
 function getQueueWorkItemContextPresentation(type: string) {
@@ -479,22 +485,20 @@ function getQueueWorkItemNumberDetail(
   key: keyof NonNullable<QueueWorkItem["details"]>,
 ): number | undefined {
   const value = item.details?.[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 function getQueueWorkItemInventoryReviewLineCount(item: QueueWorkItem) {
-  return getQueueWorkItemNumberDetail(
-    item,
-    "inventoryReviewLineCount",
-  );
+  return getQueueWorkItemNumberDetail(item, "inventoryReviewLineCount");
 }
 
 function getQueueWorkItemStockAdjustmentSkuId(item: QueueWorkItem) {
   if (item.type === "synced_sale_inventory_review") {
-    return getQueueWorkItemStringDetail(
-      item,
-      "primaryProductSkuId",
-    ) as Id<"productSku"> | undefined;
+    return getQueueWorkItemStringDetail(item, "primaryProductSkuId") as
+      | Id<"productSku">
+      | undefined;
   }
 
   return undefined;
@@ -621,18 +625,12 @@ function StockAdjustmentReferenceLink({
 }
 
 function QueueWorkItemActionSlot({
-  isSyncedSaleInventoryReviewResolutionDisabled,
-  isResolvingSyncedSaleInventoryReview,
   item,
-  onResolveSyncedSaleInventoryReview,
   orgUrlSlug,
   stockAdjustmentSkuId,
   storeUrlSlug,
 }: {
-  isSyncedSaleInventoryReviewResolutionDisabled?: boolean;
-  isResolvingSyncedSaleInventoryReview?: boolean;
   item: QueueWorkItem;
-  onResolveSyncedSaleInventoryReview?: (item: QueueWorkItem) => void;
   orgUrlSlug?: string;
   stockAdjustmentSkuId?: Id<"productSku">;
   storeUrlSlug?: string;
@@ -640,14 +638,34 @@ function QueueWorkItemActionSlot({
   if (!orgUrlSlug || !storeUrlSlug) return null;
 
   if (item.type === "pos_pending_checkout_item_review") {
+    if (
+      item.details?.provisionalProductId &&
+      item.details.provisionalProductSkuId
+    ) {
+      return (
+        <a
+          className={openWorkActionLinkClassName}
+          href={buildProductEditHref({
+            orgUrlSlug,
+            productId: item.details.provisionalProductId,
+            productSkuId: item.details.provisionalProductSkuId,
+            storeUrlSlug,
+          })}
+        >
+          Review POS pending checkout
+          <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+        </a>
+      );
+    }
+
     return (
       <Link
         className={openWorkActionLinkClassName}
         params={{ orgUrlSlug, storeUrlSlug }}
-        search={{ o: getOrigin() }}
-        to="/$orgUrlSlug/store/$storeUrlSlug/products/unresolved"
+        search={{ categorySlug: "pos-pending-checkout", o: getOrigin() }}
+        to="/$orgUrlSlug/store/$storeUrlSlug/products"
       >
-        Review unresolved catalog
+        Review POS pending checkout
         <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
       </Link>
     );
@@ -670,22 +688,6 @@ function QueueWorkItemActionSlot({
             Open stock adjustments
             <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
           </Link>
-        ) : null}
-        {onResolveSyncedSaleInventoryReview &&
-        hasSyncedSaleInventoryResolverDetails(item) ? (
-          <LoadingButton
-            className="h-8 px-3 text-xs"
-            disabled={Boolean(
-              isSyncedSaleInventoryReviewResolutionDisabled,
-            )}
-            isLoading={Boolean(isResolvingSyncedSaleInventoryReview)}
-            onClick={() => onResolveSyncedSaleInventoryReview(item)}
-            size="sm"
-            type="button"
-            variant="secondary"
-          >
-            Mark reviewed
-          </LoadingButton>
         ) : null}
       </div>
     );
@@ -884,29 +886,30 @@ function QueueWorkItemCard({
             value: item.dueAt ? getRelativeTime(item.dueAt) : "Not scheduled",
           },
         ];
-  const purchaseOrderCollapsedMetadataEntries: OperationReviewMetadataEntry[] = [
-    {
-      label: "Purchase order",
-      value:
-        getQueueWorkItemStringDetail(item, "purchaseOrderNumber") ??
-        getQueueWorkItemStringDetail(item, "displayNumber") ??
-        "Not recorded",
-    },
-    {
-      label: "Vendor",
-      value: getQueueWorkItemStringDetail(item, "vendorName") ?? "No vendor",
-    },
-    {
-      label: "Items",
-      value: formatOptionalItemCount(
-        getQueueWorkItemNumberDetail(item, "itemCount"),
-      ),
-    },
-    {
-      label: "Next action",
-      value: "Continue procurement",
-    },
-  ];
+  const purchaseOrderCollapsedMetadataEntries: OperationReviewMetadataEntry[] =
+    [
+      {
+        label: "Purchase order",
+        value:
+          getQueueWorkItemStringDetail(item, "purchaseOrderNumber") ??
+          getQueueWorkItemStringDetail(item, "displayNumber") ??
+          "Not recorded",
+      },
+      {
+        label: "Vendor",
+        value: getQueueWorkItemStringDetail(item, "vendorName") ?? "No vendor",
+      },
+      {
+        label: "Items",
+        value: formatOptionalItemCount(
+          getQueueWorkItemNumberDetail(item, "itemCount"),
+        ),
+      },
+      {
+        label: "Next action",
+        value: "Continue procurement",
+      },
+    ];
   const stockAdjustmentReviewCollapsedMetadataEntries: OperationReviewMetadataEntry[] =
     [
       {
@@ -923,8 +926,7 @@ function QueueWorkItemCard({
       {
         label: "Reason",
         value:
-          getQueueWorkItemStringDetail(item, "reasonLabel") ??
-          "Stock review",
+          getQueueWorkItemStringDetail(item, "reasonLabel") ?? "Stock review",
       },
       {
         label: "Created",
@@ -1064,16 +1066,7 @@ function QueueWorkItemCard({
     <OperationReviewItemCard
       actionSlot={
         <QueueWorkItemActionSlot
-          isSyncedSaleInventoryReviewResolutionDisabled={
-            isSyncedSaleInventoryReviewResolutionDisabled
-          }
-          isResolvingSyncedSaleInventoryReview={
-            isResolvingSyncedSaleInventoryReview
-          }
           item={item}
-          onResolveSyncedSaleInventoryReview={
-            onResolveSyncedSaleInventoryReview
-          }
           orgUrlSlug={orgUrlSlug}
           stockAdjustmentSkuId={stockAdjustmentSkuId}
           storeUrlSlug={storeUrlSlug}
@@ -1106,13 +1099,28 @@ function QueueWorkItemCard({
       contextLabel={getQueueWorkItemTypeLabel(item.type)}
       contextLabelClassName={contextPresentation.contextLabelClassName}
       description={null}
+      headerActionSlot={
+        item.type === "synced_sale_inventory_review" &&
+        onResolveSyncedSaleInventoryReview &&
+        hasSyncedSaleInventoryResolverDetails(item) ? (
+          <LoadingButton
+            className="h-8 px-3 text-xs"
+            disabled={Boolean(isSyncedSaleInventoryReviewResolutionDisabled)}
+            isLoading={Boolean(isResolvingSyncedSaleInventoryReview)}
+            onClick={() => onResolveSyncedSaleInventoryReview(item)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            Mark reviewed
+          </LoadingButton>
+        ) : null
+      }
       itemId={item._id}
       metadataEntries={metadataEntries}
       title={
         pendingCheckoutTitleSubject ? (
-          <>
-            Review pending checkout item: {pendingCheckoutTitleSubject}
-          </>
+          <>Review pending checkout item: {pendingCheckoutTitleSubject}</>
         ) : syncedSaleTitleSubject ? (
           <>
             Review inventory for{" "}
@@ -1254,6 +1262,33 @@ function formatQuantityDelta(quantityDelta: number) {
   return String(quantityDelta);
 }
 
+function formatInventoryApprovalQuantityReview(
+  lineItem: QueueApprovalLineItem,
+) {
+  const countedQuantity =
+    typeof lineItem.countedQuantity === "number"
+      ? lineItem.countedQuantity
+      : null;
+  const systemQuantity =
+    typeof lineItem.systemQuantity === "number"
+      ? lineItem.systemQuantity
+      : null;
+
+  if (countedQuantity !== null && systemQuantity !== null) {
+    return `Counted ${countedQuantity} of ${systemQuantity} on hand`;
+  }
+
+  if (systemQuantity !== null) {
+    return `${systemQuantity} on hand before adjustment`;
+  }
+
+  if (countedQuantity !== null) {
+    return `Counted ${countedQuantity}`;
+  }
+
+  return "Stock quantity not captured";
+}
+
 function formatSkuProductName(productName?: string) {
   const normalizedName = productName?.trim();
 
@@ -1375,7 +1410,8 @@ function getItemAdjustmentSummary(request: QueueApprovalRequest) {
 
   return {
     adjustedTotal: request.metadata?.adjustedTotal,
-    lineItems: request.metadata?.lineItems?.filter(hasItemAdjustmentChange) ?? [],
+    lineItems:
+      request.metadata?.lineItems?.filter(hasItemAdjustmentChange) ?? [],
     originalTotal: request.metadata?.originalTotal,
     registerSession: request.registerSessionSummary ?? null,
     settlementAmount: request.metadata?.settlementAmount,
@@ -1776,9 +1812,9 @@ export function OperationsQueueViewContent({
                     <div className="space-y-layout-2xl">
                       {visibleWorkItems.map((item) => (
                         <QueueWorkItemCard
-                          isSyncedSaleInventoryReviewResolutionDisabled={
-                            Boolean(isResolvingSyncedSaleInventoryReviewId)
-                          }
+                          isSyncedSaleInventoryReviewResolutionDisabled={Boolean(
+                            isResolvingSyncedSaleInventoryReviewId,
+                          )}
                           isResolvingSyncedSaleInventoryReview={
                             isResolvingSyncedSaleInventoryReviewId === item._id
                           }
@@ -1918,9 +1954,7 @@ export function OperationsQueueViewContent({
                           request.requestType,
                         );
                         const retireOnlyApprovalCopy =
-                          getRetireOnlyApprovalRequestCopy(
-                            request.requestType,
-                          );
+                          getRetireOnlyApprovalRequestCopy(request.requestType);
                         const requestLabel = request.workItemTitle
                           ? formatWorkItemTitle(request.workItemTitle)
                           : formatApprovalRequestType(request.requestType);
@@ -2031,14 +2065,9 @@ export function OperationsQueueViewContent({
                                       </div>
                                       <div className="flex shrink-0 flex-col items-start gap-2 text-sm md:items-end">
                                         <p className="text-muted-foreground">
-                                          <span className="font-numeric font-medium tabular-nums text-foreground">
-                                            {lineItem.countedQuantity ?? "-"}
-                                          </span>{" "}
-                                          counted against{" "}
-                                          <span className="font-numeric font-medium tabular-nums text-foreground">
-                                            {lineItem.systemQuantity ?? "-"}
-                                          </span>{" "}
-                                          on hand
+                                          {formatInventoryApprovalQuantityReview(
+                                            lineItem,
+                                          )}
                                         </p>
                                         <Badge
                                           className={getQuantityDeltaBadgeClass(
@@ -2334,7 +2363,11 @@ export function OperationsQueueViewContent({
                                     {itemAdjustmentSummary.registerSession &&
                                     orgUrlSlug &&
                                     storeUrlSlug ? (
-                                      <Button asChild size="sm" variant="utility">
+                                      <Button
+                                        asChild
+                                        size="sm"
+                                        variant="utility"
+                                      >
                                         <Link
                                           params={{
                                             orgUrlSlug,
@@ -2355,7 +2388,11 @@ export function OperationsQueueViewContent({
                                     {itemAdjustmentSummary.transaction &&
                                     orgUrlSlug &&
                                     storeUrlSlug ? (
-                                      <Button asChild size="sm" variant="utility">
+                                      <Button
+                                        asChild
+                                        size="sm"
+                                        variant="utility"
+                                      >
                                         <Link
                                           params={{
                                             orgUrlSlug,
@@ -2415,7 +2452,7 @@ export function OperationsQueueViewContent({
                                             ghsCurrencyFormatter,
                                             itemAdjustmentSummary.adjustedTotal,
                                           )
-                                      : "Unknown"}
+                                        : "Unknown"}
                                     </dd>
                                   </div>
                                   <div>
@@ -2797,7 +2834,8 @@ export function OperationsQueueViewContent({
                                                 registerSessionId:
                                                   request.registerSessionSummary
                                                     ?.registerSessionId,
-                                                requestType: request.requestType,
+                                                requestType:
+                                                  request.requestType,
                                               }
                                             : {}),
                                         })
@@ -2825,7 +2863,8 @@ export function OperationsQueueViewContent({
                                                 registerSessionId:
                                                   request.registerSessionSummary
                                                     ?.registerSessionId,
-                                                requestType: request.requestType,
+                                                requestType:
+                                                  request.requestType,
                                               }
                                             : {}),
                                         })
@@ -2850,8 +2889,8 @@ export function OperationsQueueViewContent({
                                     <Button
                                       disabled={Boolean(
                                         isDecidingApprovalRequestId ||
-                                          (approvalDecisionUnlockRequired &&
-                                            !approvalDecisionUnlocked),
+                                        (approvalDecisionUnlockRequired &&
+                                          !approvalDecisionUnlocked),
                                       )}
                                       onClick={() =>
                                         onDecideApprovalRequest({
@@ -2949,9 +2988,7 @@ export function OperationsQueueView({
     activeWorkflow !== "approvals";
   const inventorySnapshotPage = usePaginatedQuery(
     stockOpsApi.adjustments.listInventorySnapshotPage,
-    shouldLoadStockWorkspace
-      ? { storeId: activeStore!._id }
-      : "skip",
+    shouldLoadStockWorkspace ? { storeId: activeStore!._id } : "skip",
     { initialNumItems: 100 },
   );
   const inventoryItems =
@@ -3365,7 +3402,8 @@ export function OperationsQueueView({
       let result: NormalizedApprovalCommandResult<unknown>;
 
       if (args.requestType === "register_sync_review") {
-        const registerSessionId = args.registerSessionId as Id<"registerSession">;
+        const registerSessionId =
+          args.registerSessionId as Id<"registerSession">;
         result = await runCommand(() =>
           resolveRegisterSessionSyncReview({
             approvalProofId: approvalProofResult.data.approvalProofId,
@@ -3375,7 +3413,8 @@ export function OperationsQueueView({
           }),
         );
       } else if (args.requestType === "variance_review") {
-        const registerSessionId = args.registerSessionId as Id<"registerSession">;
+        const registerSessionId =
+          args.registerSessionId as Id<"registerSession">;
         result = await runCommand(() =>
           reviewRegisterSessionCloseout({
             approvalProofId: approvalProofResult.data.approvalProofId,
@@ -3410,15 +3449,17 @@ export function OperationsQueueView({
         args.decision === "approved"
           ? (approvalCopy?.approvedToast ?? "Approval request approved")
           : (approvalCopy?.rejectedToast ??
-            retireOnlyApprovalCopy?.rejectedToast ??
-            "Approval request rejected"),
+              retireOnlyApprovalCopy?.rejectedToast ??
+              "Approval request rejected"),
       );
     } finally {
       setDecisioningApprovalRequestId(null);
     }
   };
 
-  const handleResolveSyncedSaleInventoryReview = async (item: QueueWorkItem) => {
+  const handleResolveSyncedSaleInventoryReview = async (
+    item: QueueWorkItem,
+  ) => {
     if (resolvingSyncedSaleInventoryReviewId) return;
 
     if (!activeStore?._id) {
@@ -3550,7 +3591,9 @@ export function OperationsQueueView({
         isDecidingApprovalRequestId={decisioningApprovalRequestId}
         isLoadingMoreInventoryItems={isInventorySnapshotLoadingMore}
         isLoadingPermissions={false}
-        isLoadingQueue={queue === undefined || isInventorySnapshotLoadingFirstPage}
+        isLoadingQueue={
+          queue === undefined || isInventorySnapshotLoadingFirstPage
+        }
         isLoadingStock={isInventorySnapshotLoadingFirstPage}
         isResolvingSyncedSaleInventoryReviewId={
           resolvingSyncedSaleInventoryReviewId

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -367,9 +367,9 @@ describe("POSTerminalDetailViewContent", () => {
     expect(
       screen.getByText("Local runtime review / next upload #14"),
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByText("Cloud sync evidence").length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Cloud sync evidence").length).toBeGreaterThan(
+      0,
+    );
     expect(
       screen.getByText("Staff authority changed before sync."),
     ).toBeInTheDocument();
@@ -897,7 +897,9 @@ describe("POSTerminalDetailViewContent", () => {
     ).toBeGreaterThan(0);
     expect(screen.getByText("Review evidence")).toBeInTheDocument();
     expect(screen.getByText("17")).toBeInTheDocument();
-    expect(screen.getByText("Synced Sale Inventory Review")).toBeInTheDocument();
+    expect(
+      screen.getByText("Synced Sale Inventory Review"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", {
         name: /resolve safe cloud repair/i,
@@ -1110,13 +1112,15 @@ describe("POSTerminalDetailViewContent", () => {
               {
                 commandContext: {
                   expectedBlockerType: "local_review",
-                  reason: "Local review items need terminal-local evidence collection.",
+                  reason:
+                    "Local review items need terminal-local evidence collection.",
                 },
                 commandType: "collect_local_review",
                 expectedEvidence: {
                   localReviewDetailsCollected: true,
                 },
-                reason: "Local review items need terminal-local evidence collection.",
+                reason:
+                  "Local review items need terminal-local evidence collection.",
               },
             ],
           },
@@ -1258,6 +1262,128 @@ describe("POSTerminalDetailViewContent", () => {
       });
     });
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Terminal command queued.");
+  });
+
+  it("surfaces dangerous clear-all from the current recovery preview when legacy recovery is present", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          operationalExplanation: {
+            blockingDomain: "sync_review",
+            detail:
+              "Manual review must finish before support repairs this terminal.",
+            evidenceReferences: [
+              {
+                count: 2,
+                source: "local_runtime",
+                summary: "2 local review items are still on this terminal.",
+                type: "local_review",
+              },
+            ],
+            headline: "Manager review needed",
+            lane: "needs_manual_review",
+            nextStep:
+              "Use the linked review workspace before running support repair.",
+            primaryOwner: "manager",
+            saleImpact: "not_ready",
+            secondaryActions: [],
+            severity: "critical",
+            summaryMeta: {
+              hasSecondarySafeRepair: false,
+              reviewBacklogCount: 2,
+              targetResolutionIncomplete: false,
+            },
+            supportAction: "manual_review",
+          },
+          recovery: {
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review",
+                  reason:
+                    "Local review items need terminal-local evidence collection.",
+                },
+                commandType: "collect_local_review",
+                expectedEvidence: {
+                  localReviewDetailsCollected: true,
+                },
+                reason:
+                  "Local review items need terminal-local evidence collection.",
+              },
+            ],
+          },
+          recoveryPreview: {
+            readiness: "needs_manual_review",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review_clear_all",
+                  localReviewClearAll: true,
+                  localReviewClearLimit: 2,
+                  localReviewEventIds: ["local-review-1", "local-review-2"],
+                  reason: "Dangerous cleanup for local review items.",
+                },
+                commandType: "clear_local_review_items",
+                expectedEvidence: {
+                  localReviewClearedEventIds: [
+                    "local-review-1",
+                    "local-review-2",
+                  ],
+                  localReviewEventCount: 0,
+                },
+                reason:
+                  "Dangerous cleanup can clear all local review items from this terminal.",
+              },
+            ],
+          },
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              reviewEventCount: 2,
+              reviewEvents: [
+                {
+                  createdAt: Date.now() - 6 * 60_000,
+                  localEventId: "local-review-1",
+                  localRegisterSessionId: "local-session-2",
+                  sequence: 4535,
+                  status: "needs_review",
+                  type: "transaction.completed",
+                  uploaded: true,
+                  uploadSequence: 1,
+                },
+                {
+                  createdAt: Date.now() - 5 * 60_000,
+                  localEventId: "local-review-2",
+                  localRegisterSessionId: "local-session-2",
+                  sequence: 4484,
+                  status: "needs_review",
+                  type: "transaction.completed",
+                  uploaded: true,
+                  uploadSequence: 2,
+                },
+              ],
+              status: "needs_review",
+            },
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={vi.fn()}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getAllByText("Manager review needed").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText("#4535")).toBeInTheDocument();
+    expect(screen.getByText("Dangerous action")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear all review items/i }),
+    ).toBeInTheDocument();
   });
 
   it("hides dangerous clear-all when the action lacks evidenced review ids", () => {
@@ -1507,13 +1633,15 @@ describe("POSTerminalDetailViewContent", () => {
               {
                 commandContext: {
                   expectedBlockerType: "local_review",
-                  reason: "Local review items need terminal-local evidence collection.",
+                  reason:
+                    "Local review items need terminal-local evidence collection.",
                 },
                 commandType: "collect_local_review",
                 expectedEvidence: {
                   localReviewDetailsCollected: true,
                 },
-                reason: "Local review items need terminal-local evidence collection.",
+                reason:
+                  "Local review items need terminal-local evidence collection.",
               },
             ],
           },
@@ -2129,13 +2257,15 @@ describe("POSTerminalDetailViewContent", () => {
               {
                 commandContext: {
                   expectedBlockerType: "local_review",
-                  reason: "Local review items need terminal-local evidence collection.",
+                  reason:
+                    "Local review items need terminal-local evidence collection.",
                 },
                 commandType: "collect_local_review",
                 expectedEvidence: {
                   localReviewDetailsCollected: true,
                 },
-                reason: "Local review items need terminal-local evidence collection.",
+                reason:
+                  "Local review items need terminal-local evidence collection.",
               },
             ],
           },
@@ -2217,13 +2347,15 @@ describe("POSTerminalDetailViewContent", () => {
               {
                 commandContext: {
                   expectedBlockerType: "local_review",
-                  reason: "Local review items need terminal-local evidence collection.",
+                  reason:
+                    "Local review items need terminal-local evidence collection.",
                 },
                 commandType: "collect_local_review",
                 expectedEvidence: {
                   localReviewDetailsCollected: true,
                 },
-                reason: "Local review items need terminal-local evidence collection.",
+                reason:
+                  "Local review items need terminal-local evidence collection.",
               },
             ],
           },
@@ -2370,6 +2502,63 @@ describe("POSTerminalDetailViewContent", () => {
         terminalId: "terminal-1",
       });
     });
+  });
+
+  it("does not show stale collected local review evidence after the latest check-in is clear", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          health: "online",
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              failedEventCount: 0,
+              pendingEventCount: 0,
+              reviewEventCount: 0,
+              reviewEvents: [],
+              status: "idle",
+              uploadableEventCount: 0,
+            },
+          },
+          recovery: {
+            commandStatus: {
+              commandType: "collect_local_review",
+              label: "Collect local review items",
+              localReviewEvents: [
+                {
+                  createdAt: Date.now() - 1_000,
+                  localEventId: "event-review-1",
+                  sequence: 4535,
+                  status: "needs_review",
+                  type: "transaction.completed",
+                  uploaded: true,
+                  uploadSequence: 3,
+                },
+              ],
+              status: "completed",
+              verificationStatus: "verified",
+            },
+            readiness: "needs_manual_review",
+            terminalActions: [],
+          },
+          syncEvidence: {
+            ...detail.syncEvidence,
+            unresolvedConflicts: [],
+            unresolvedConflictCount: 0,
+          },
+        }}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.queryByText("#4535")).not.toBeInTheDocument();
+    expect(screen.queryByText("transaction.completed")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Local review item"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders no-data and query unavailable states", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -1076,18 +1076,19 @@ function ConflictSection({
   const [isLocalReviewListExpanded, setIsLocalReviewListExpanded] =
     useState(false);
   const runtimeLocalReviewEvents = runtimeStatus?.sync.reviewEvents ?? [];
-  const recoveryPreview = detail?.recovery ?? detail?.recoveryPreview;
+  const recoveryPreview = detail?.recoveryPreview ?? detail?.recovery;
   const collectedLocalReviewEvents =
-    recoveryPreview?.commandStatus?.commandType ===
-      "collect_local_review" &&
+    recoveryPreview?.commandStatus?.commandType === "collect_local_review" &&
     recoveryPreview.commandStatus.verificationStatus === "verified"
       ? (recoveryPreview.commandStatus.localReviewEvents ?? [])
       : [];
+  const runtimeReviewCount = runtimeStatus?.sync.reviewEventCount ?? 0;
   const localReviewEvents =
     runtimeLocalReviewEvents.length > 0
       ? runtimeLocalReviewEvents
-      : collectedLocalReviewEvents;
-  const runtimeReviewCount = runtimeStatus?.sync.reviewEventCount ?? 0;
+      : runtimeStatus == null || runtimeReviewCount > 0
+        ? collectedLocalReviewEvents
+        : [];
   const missingRuntimeReviewDetails =
     runtimeReviewCount > 0 && localReviewEvents.length === 0;
   const unresolvedConflicts = syncEvidence.unresolvedConflicts ?? [];
@@ -1228,7 +1229,9 @@ function ConflictSection({
               <div className="flex justify-end">
                 <AttentionReasonAction
                   detail={detail}
-                  onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+                  onIssueTerminalRecoveryCommand={
+                    onIssueTerminalRecoveryCommand
+                  }
                   reason={localReviewActionReason}
                 />
               </div>
@@ -1383,7 +1386,8 @@ function isValidLocalReviewClearAllAction(
     return false;
   }
   const eventIds = action.commandContext.localReviewEventIds ?? [];
-  const clearedEventIds = action.expectedEvidence.localReviewClearedEventIds ?? [];
+  const clearedEventIds =
+    action.expectedEvidence.localReviewClearedEventIds ?? [];
   return (
     eventIds.length > 0 &&
     action.commandContext.localReviewClearLimit === eventIds.length &&
@@ -1728,7 +1732,9 @@ function AttentionReasonAction({
       return (
         <div className="grid justify-items-start gap-layout-xs">
           <Button
-            disabled={!canIssue || !onIssueTerminalRecoveryCommand || isIssuingCommand}
+            disabled={
+              !canIssue || !onIssueTerminalRecoveryCommand || isIssuingCommand
+            }
             onClick={() => {
               void issueRecoveryCommand();
             }}
@@ -1864,10 +1870,7 @@ function getAttentionReasonCommandType(reason: TerminalHealthAttentionReason) {
   ) {
     return "repair_terminal_seed";
   }
-  if (
-    reason.type === "sync_failed" ||
-    reason.type === "sync_unavailable"
-  ) {
+  if (reason.type === "sync_failed" || reason.type === "sync_unavailable") {
     return "retry_sync";
   }
   return null;

--- a/packages/athena-webapp/src/components/products/ProductsListView.logic.ts
+++ b/packages/athena-webapp/src/components/products/ProductsListView.logic.ts
@@ -1,10 +1,5 @@
 import type { ProductAvailability } from "~/src/hooks/useGetProducts";
 
-const POS_OPERATIONAL_CATEGORY_SLUGS = new Set([
-  "pos-pending-checkout",
-  "pos-quick-add",
-]);
-
 type CategoryProductQueryOptions = {
   availability?: ProductAvailability;
   isVisible?: boolean;
@@ -13,14 +8,17 @@ type CategoryProductQueryOptions = {
 export function getCategoryProductQueryOptions(
   categorySlug: string | undefined,
 ): CategoryProductQueryOptions {
-  if (categorySlug === "legacy-import") {
+  if (
+    categorySlug === "legacy-import" ||
+    categorySlug === "pos-pending-checkout"
+  ) {
     return {
       availability: "draft",
       isVisible: false,
     };
   }
 
-  if (categorySlug && POS_OPERATIONAL_CATEGORY_SLUGS.has(categorySlug)) {
+  if (categorySlug === "pos-quick-add") {
     return { availability: "live" };
   }
 

--- a/packages/athena-webapp/src/components/products/ProductsListView.test.ts
+++ b/packages/athena-webapp/src/components/products/ProductsListView.test.ts
@@ -9,9 +9,10 @@ describe("ProductsListView category query", () => {
     });
   });
 
-  it("requests live products for the reserved POS pending-checkout category", () => {
+  it("requests hidden draft products for the reserved POS pending-checkout category", () => {
     expect(getCategoryProductQueryOptions("pos-pending-checkout")).toEqual({
-      availability: "live",
+      availability: "draft",
+      isVisible: false,
     });
   });
 

--- a/packages/athena-webapp/src/components/products/ProductsListView.test.tsx
+++ b/packages/athena-webapp/src/components/products/ProductsListView.test.tsx
@@ -12,6 +12,10 @@ const mockedProducts = vi.hoisted(() => ({
     slug: string;
   }>,
   products: undefined as Product[] | undefined,
+  routeSearch: {
+    categorySlug: "beverages",
+    o: "/wigclub/store/wigclub/products",
+  },
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -19,10 +23,7 @@ vi.mock("@tanstack/react-router", () => ({
     <a href="#products">{children}</a>
   ),
   useNavigate: () => vi.fn(),
-  useSearch: () => ({
-    categorySlug: "beverages",
-    o: "/wigclub/store/wigclub/products",
-  }),
+  useSearch: () => mockedProducts.routeSearch,
 }));
 
 vi.mock("~/src/hooks/useGetProducts", () => ({
@@ -65,6 +66,10 @@ describe("ProductsListView", () => {
   beforeEach(() => {
     mockedProducts.categories = [];
     mockedProducts.products = undefined;
+    mockedProducts.routeSearch = {
+      categorySlug: "beverages",
+      o: "/wigclub/store/wigclub/products",
+    };
     window.scrollTo = vi.fn();
   });
 
@@ -79,5 +84,37 @@ describe("ProductsListView", () => {
       screen.queryByRole("region", { name: "Category controls" }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText("No beverages")).not.toBeInTheDocument();
+  });
+
+  it("renders POS pending checkout as a standard product category page", () => {
+    mockedProducts.routeSearch = {
+      categorySlug: "pos-pending-checkout",
+      o: "/wigclub/store/wigclub/products",
+    };
+    mockedProducts.products = [];
+
+    render(<ProductsListView />);
+
+    expect(
+      screen.getByRole("heading", { name: "Pos Pending Checkout" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Pending checkout review" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Choose SKU")).not.toBeInTheDocument();
+    expect(screen.getByText("No pos pending checkout")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add product" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps pending checkout review off other product category pages", () => {
+    mockedProducts.products = [];
+
+    render(<ProductsListView />);
+
+    expect(
+      screen.queryByRole("region", { name: "Pending checkout review" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/products/UnresolvedProducts.test.tsx
+++ b/packages/athena-webapp/src/components/products/UnresolvedProducts.test.tsx
@@ -1,29 +1,16 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Id } from "~/convex/_generated/dataModel";
 import { UnresolvedProducts } from "./UnresolvedProducts";
 
 const mocks = vi.hoisted(() => ({
-	  resolvePendingCheckoutItem: vi.fn(),
-	  useGetUnresolvedProducts: vi.fn(),
-	  usePOSPendingCheckoutItemsForReview: vi.fn(),
-	  usePOSRegisterCatalog: vi.fn(),
-	}));
+  useGetUnresolvedProducts: vi.fn(),
+}));
 
 vi.mock("~/src/hooks/useGetProducts", () => ({
   useGetUnresolvedProducts: () => mocks.useGetUnresolvedProducts(),
 }));
-
-vi.mock("~/src/hooks/usePOSProducts", () => ({
-	  usePOSPendingCheckoutItemsForReview: (storeId: Id<"store"> | undefined) =>
-	    mocks.usePOSPendingCheckoutItemsForReview(storeId),
-	  usePOSRegisterCatalog: (storeId: Id<"store"> | undefined) =>
-	    mocks.usePOSRegisterCatalog(storeId),
-	  usePOSResolvePendingCheckoutItemReview: () => mocks.resolvePendingCheckoutItem,
-	}));
 
 vi.mock("~/src/hooks/useGetActiveStore", () => ({
   default: () => ({
@@ -71,79 +58,20 @@ vi.mock("./products-table/components/productColumns", () => ({
 describe("UnresolvedProducts", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-	    mocks.useGetUnresolvedProducts.mockReturnValue([
-	      {
-	        _id: "unresolved-product-1",
-	        name: "Unresolved product",
-	        skus: [],
-	      },
-	    ]);
-	    mocks.usePOSRegisterCatalog.mockReturnValue([
-	      {
-	        name: "Catalog gel",
-	        productId: "product-1",
-	        sku: "GEL-1",
-	        skuId: "sku-1",
-	      },
-	    ]);
-	    mocks.usePOSPendingCheckoutItemsForReview.mockReturnValue([
+    mocks.useGetUnresolvedProducts.mockReturnValue([
       {
-        _id: "pending-1",
-        createdAt: 1,
-        createdFrom: "online",
-        evidence: {
-          totalQuantitySold: 2,
-          transactionCount: 1,
-        },
-        lookupCode: "999999999999",
-        name: "Uncataloged gel",
-        provisionalPrice: 2500,
-        reviewPriority: "elevated",
-        status: "pending_review",
-        updatedAt: 2,
+        _id: "unresolved-product-1",
+        name: "Unresolved product",
+        skus: [],
       },
     ]);
   });
 
-  it("lists pending checkout items and lets a manager flag or reject them", async () => {
-    const user = userEvent.setup();
-
+  it("renders unresolved products without the pending checkout review queue", () => {
     render(<UnresolvedProducts />);
 
-	    expect(mocks.usePOSPendingCheckoutItemsForReview).toHaveBeenCalledWith(
-	      "store-1",
-	    );
-	    expect(mocks.usePOSRegisterCatalog).toHaveBeenCalledWith("store-1");
-    expect(screen.getByText("Pending checkout items")).toBeInTheDocument();
-    expect(screen.getByText("Uncataloged gel")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Sold 2 across 1 sale .* 999999999999/),
-    ).toBeInTheDocument();
-
-    await user.selectOptions(
-      screen.getByLabelText("Catalog SKU for Uncataloged gel"),
-      "product-1:sku-1",
-    );
-    await user.click(screen.getByRole("button", { name: "Link" }));
-    await user.click(screen.getByRole("button", { name: "Flag" }));
-    await user.click(screen.getByRole("button", { name: "Reject" }));
-
-    expect(mocks.resolvePendingCheckoutItem).toHaveBeenNthCalledWith(1, {
-      approvedProductId: "product-1",
-      approvedProductSkuId: "sku-1",
-      pendingCheckoutItemId: "pending-1",
-      status: "linked_to_catalog",
-      storeId: "store-1",
-    });
-    expect(mocks.resolvePendingCheckoutItem).toHaveBeenNthCalledWith(2, {
-      pendingCheckoutItemId: "pending-1",
-      status: "flagged",
-      storeId: "store-1",
-    });
-    expect(mocks.resolvePendingCheckoutItem).toHaveBeenNthCalledWith(3, {
-      pendingCheckoutItemId: "pending-1",
-      status: "rejected",
-      storeId: "store-1",
-    });
+    expect(screen.getByText("Unresolved Products")).toBeInTheDocument();
+    expect(screen.getByTestId("unresolved-products-table")).toBeInTheDocument();
+    expect(screen.queryByText("Pending checkout items")).not.toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/products/UnresolvedProducts.tsx
+++ b/packages/athena-webapp/src/components/products/UnresolvedProducts.tsx
@@ -1,10 +1,4 @@
 import { useGetUnresolvedProducts } from "~/src/hooks/useGetProducts";
-import {
-  usePOSPendingCheckoutItemsForReview,
-  usePOSRegisterCatalog,
-  usePOSResolvePendingCheckoutItemReview,
-} from "~/src/hooks/usePOSProducts";
-import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
 import { GenericDataTable } from "../base/table/data-table";
@@ -20,14 +14,6 @@ import { useNavigateBack } from "~/src/hooks/use-navigate-back";
 import { useSearch } from "@tanstack/react-router";
 import { useState, useMemo } from "react";
 import { Input } from "../ui/input";
-import type { Id } from "~/convex/_generated/dataModel";
-
-type CatalogLinkOption = {
-  label: string;
-  productId: Id<"product">;
-  value: string;
-  skuId: Id<"productSku">;
-};
 
 const Navigation = () => {
   const navigateBack = useNavigateBack();
@@ -49,16 +35,7 @@ const Navigation = () => {
 
 export const UnresolvedProducts = () => {
   const products = useGetUnresolvedProducts();
-  const { activeStore } = useGetActiveStore();
-  const registerCatalog = usePOSRegisterCatalog(activeStore?._id);
-  const pendingCheckoutItems = usePOSPendingCheckoutItemsForReview(
-    activeStore?._id,
-  );
-  const resolvePendingCheckoutItem = usePOSResolvePendingCheckoutItemReview();
   const [searchValue, setSearchValue] = useState("");
-  const [selectedCatalogLinks, setSelectedCatalogLinks] = useState<
-    Record<string, string>
-  >({});
 
   const filteredProducts = useMemo(() => {
     if (!products) return null;
@@ -79,29 +56,6 @@ export const UnresolvedProducts = () => {
     });
   }, [products, searchValue]);
 
-  const catalogLinkOptions = useMemo<CatalogLinkOption[]>(() => {
-    if (!registerCatalog) return [];
-
-    return registerCatalog.map((row) => {
-      const skuLabel = row.sku ? ` · ${row.sku}` : "";
-
-      return {
-        label: `${row.name}${skuLabel}`,
-        productId: row.productId,
-        skuId: row.skuId,
-        value: `${row.productId}:${row.skuId}`,
-      };
-    });
-  }, [registerCatalog]);
-
-  const catalogOptionsByValue = useMemo(
-    () =>
-      new Map(
-        catalogLinkOptions.map((option) => [option.value, option]),
-      ),
-    [catalogLinkOptions],
-  );
-
   if (!products) return null;
 
   const hasSearchInput = searchValue.trim().length > 0;
@@ -120,113 +74,6 @@ export const UnresolvedProducts = () => {
       header={<Navigation />}
     >
       <FadeIn className="py-8 space-y-4">
-        {pendingCheckoutItems && pendingCheckoutItems.length > 0 ? (
-          <section className="space-y-3">
-            <div>
-              <h2 className="text-sm font-semibold">
-                Pending checkout items
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                Items cashiers sold before catalog review.
-              </p>
-            </div>
-            <div className="divide-y rounded-md border bg-background">
-              {pendingCheckoutItems.map((item) => (
-                <div
-                  key={item._id}
-                  className="grid gap-3 p-4 md:grid-cols-[1fr_auto]"
-                >
-                  <div className="min-w-0 space-y-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <p className="font-medium">{item.name}</p>
-                      <span className="rounded border px-2 py-0.5 text-xs text-muted-foreground">
-                        {item.reviewPriority}
-                      </span>
-                    </div>
-                    <p className="text-sm text-muted-foreground">
-                      Sold {item.evidence.totalQuantitySold ?? 0} across{" "}
-                      {item.evidence.transactionCount ?? 0} sale
-                      {(item.evidence.transactionCount ?? 0) === 1 ? "" : "s"}
-                      {item.lookupCode ? ` · ${item.lookupCode}` : ""}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center justify-end gap-2">
-                    <select
-                      aria-label={`Catalog SKU for ${item.name}`}
-                      className="h-9 min-w-48 rounded-md border bg-background px-2 text-sm"
-                      value={selectedCatalogLinks[item._id] ?? ""}
-                      onChange={(event) =>
-                        setSelectedCatalogLinks((current) => ({
-                          ...current,
-                          [item._id]: event.target.value,
-                        }))
-                      }
-                    >
-                      <option value="">Choose SKU</option>
-                      {catalogLinkOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={!selectedCatalogLinks[item._id]}
-                      onClick={() => {
-                        const selectedOption = catalogOptionsByValue.get(
-                          selectedCatalogLinks[item._id] ?? "",
-                        );
-                        if (!activeStore?._id || !selectedOption) return;
-
-                        resolvePendingCheckoutItem({
-                          storeId: activeStore._id,
-                          pendingCheckoutItemId: item._id,
-                          status: "linked_to_catalog",
-                          approvedProductId: selectedOption.productId,
-                          approvedProductSkuId: selectedOption.skuId,
-                        });
-                      }}
-                    >
-                      Link
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() =>
-                        activeStore?._id &&
-                        resolvePendingCheckoutItem({
-                          storeId: activeStore._id,
-                          pendingCheckoutItemId: item._id,
-                          status: "flagged",
-                        })
-                      }
-                    >
-                      Flag
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() =>
-                        activeStore?._id &&
-                        resolvePendingCheckoutItem({
-                          storeId: activeStore._id,
-                          pendingCheckoutItemId: item._id,
-                          status: "rejected",
-                        })
-                      }
-                    >
-                      Reject
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
-        ) : null}
         <Input
           placeholder="Filter by name or SKU..."
           value={searchValue}

--- a/packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceAppointmentsView.test.tsx
@@ -1,8 +1,25 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import { GENERIC_UNEXPECTED_ERROR_MESSAGE, userError } from "~/shared/commandResult";
 import { ServiceAppointmentsViewContent } from "./ServiceAppointmentsView";
+
+vi.mock("../common/PageLevelHeader", () => ({
+  PageLevelHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+  PageWorkspaceGrid: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PageWorkspaceMain: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  PageWorkspaceRail: ({ children }: { children: ReactNode }) => (
+    <aside>{children}</aside>
+  ),
+  PageWorkspace: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
 
 const baseProps = {
   appointments: [

--- a/packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceAppointmentsView.tsx
@@ -202,6 +202,7 @@ export function ServiceAppointmentsViewContent({
       <FadeIn className="container mx-auto py-layout-xl">
         <PageWorkspace>
           <PageLevelHeader
+            showBackButton
             eyebrow="Service Ops"
             title="Appointments"
             description="Schedule service bookings, adjust appointment times, and convert confirmed work into service cases."

--- a/packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx
@@ -1,8 +1,25 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import { GENERIC_UNEXPECTED_ERROR_MESSAGE, userError } from "~/shared/commandResult";
 import { ServiceCasesViewContent } from "./ServiceCasesView";
+
+vi.mock("../common/PageLevelHeader", () => ({
+  PageLevelHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+  PageWorkspaceGrid: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PageWorkspaceMain: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  PageWorkspaceRail: ({ children }: { children: ReactNode }) => (
+    <aside>{children}</aside>
+  ),
+  PageWorkspace: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
 
 const baseProps = {
   catalogItems: [

--- a/packages/athena-webapp/src/components/services/ServiceCasesView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCasesView.tsx
@@ -290,6 +290,7 @@ export function ServiceCasesViewContent({
       <FadeIn className="container mx-auto py-layout-xl">
         <PageWorkspace>
           <PageLevelHeader
+            showBackButton
             eyebrow="Service Ops"
             title="Active Cases"
             description="Open service cases, review payment and approval pressure, and run the actions needed to move work forward."
@@ -395,7 +396,9 @@ export function ServiceCasesViewContent({
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="case-service-catalog">Service catalog</Label>
+                    <Label htmlFor="case-service-catalog">
+                      Service catalog
+                    </Label>
                     <Select
                       onValueChange={(value) =>
                         setCreateForm((current) => ({
@@ -525,9 +528,7 @@ export function ServiceCasesViewContent({
                           <>
                             {" "}
                             ·{" "}
-                            <span
-                              onClick={(event) => event.stopPropagation()}
-                            >
+                            <span onClick={(event) => event.stopPropagation()}>
                               <WorkflowTraceRouteLink
                                 className="font-medium text-primary"
                                 traceId={serviceCase.workflowTraceId}
@@ -578,8 +579,8 @@ export function ServiceCasesViewContent({
                                 .join(" · ")}
                             </p>
                           </div>
-                          {selectedCaseDetails?.workflowTraceId ??
-                          selectedCaseSummary.workflowTraceId ? (
+                          {(selectedCaseDetails?.workflowTraceId ??
+                          selectedCaseSummary.workflowTraceId) ? (
                             <WorkflowTraceRouteLink
                               className="shrink-0 text-xs font-medium text-primary"
                               traceId={

--- a/packages/athena-webapp/src/components/services/ServiceCatalogView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCatalogView.tsx
@@ -183,6 +183,7 @@ export function ServiceCatalogViewContent({
       <FadeIn className="container mx-auto py-layout-xl">
         <PageWorkspace>
           <PageLevelHeader
+            showBackButton
             eyebrow="Service Ops"
             title="Catalog Management"
             description="Maintain the services staff can book or run, including duration, pricing, deposits, and approval rules."
@@ -493,11 +494,7 @@ export function ServiceCatalogViewContent({
                         <p className="text-sm text-muted-foreground">
                           {`Showing ${visibleServiceCatalogItems.length} of ${items.length} services.`}
                         </p>
-                        <Button
-                          asChild
-                          size="sm"
-                          variant="utility"
-                        >
+                        <Button asChild size="sm" variant="utility">
                           <Link
                             aria-label="Open all services workspace"
                             search={{ o: getOrigin() } as never}

--- a/packages/athena-webapp/src/components/services/ServiceIntakeView.auth.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeView.auth.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import type { Id } from "~/convex/_generated/dataModel";
 
 import { ServiceIntakeView } from "./ServiceIntakeView";
@@ -32,6 +33,22 @@ const mockedToast = vi.hoisted(() => ({
 
 vi.mock("sonner", () => ({
   toast: mockedToast,
+}));
+
+vi.mock("../common/PageLevelHeader", () => ({
+  PageLevelHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+  PageWorkspaceGrid: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PageWorkspaceMain: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  PageWorkspaceRail: ({ children }: { children: ReactNode }) => (
+    <aside>{children}</aside>
+  ),
+  PageWorkspace: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 const readyProtectedState = {

--- a/packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import { toast } from "sonner";
 import { Id } from "~/convex/_generated/dataModel";
 import { ServiceIntakeViewContent } from "./ServiceIntakeView";
@@ -10,6 +11,22 @@ vi.mock("sonner", () => ({
     error: vi.fn(),
     success: vi.fn(),
   },
+}));
+
+vi.mock("../common/PageLevelHeader", () => ({
+  PageLevelHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+  PageWorkspaceGrid: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PageWorkspaceMain: ({ children }: { children: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  PageWorkspaceRail: ({ children }: { children: ReactNode }) => (
+    <aside>{children}</aside>
+  ),
+  PageWorkspace: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 const baseProps = {

--- a/packages/athena-webapp/src/components/services/ServiceIntakeView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeView.tsx
@@ -195,6 +195,7 @@ export function ServiceIntakeViewContent({
       <FadeIn className="container mx-auto py-layout-xl">
         <PageWorkspace>
           <PageLevelHeader
+            showBackButton
             eyebrow="Service Ops"
             title="Service Intake"
             description="Capture walk-in or booked service work with the customer, staff owner, priority, and deposit details ready for operations."

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -856,11 +856,11 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
 
     await waitFor(() =>
-      expect(result.current).toEqual(
+      expect(result.current?.runtimeStatus?.sync).toEqual(
         expect.objectContaining({
-          runtimeStatus: expect.objectContaining({
-            sync: expect.objectContaining({ status: "idle" }),
-          }),
+          reviewEventCount: 1,
+          status: "idle",
+          uploadableEventCount: 1,
         }),
       ),
     );
@@ -1130,7 +1130,11 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       expect(result.current).toEqual(
         expect.objectContaining({
           runtimeStatus: expect.objectContaining({
-            sync: expect.objectContaining({ status: "idle" }),
+            sync: expect.objectContaining({
+              reviewEventCount: 1,
+              status: "idle",
+              uploadableEventCount: 0,
+            }),
           }),
         }),
       ),
@@ -1202,6 +1206,188 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(
       collectLocallySettledSkippedReviewEventIds(events, uploadEvents),
     ).toEqual(["event-clear"]);
+  });
+
+  it("settles inventory-review sale conflicts and their local precursor rows during manual retry", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-checkout",
+            sequence: 5,
+            status: "conflicted",
+          },
+        ],
+        held: [],
+        mappings: [
+          {
+            _id: "mapping-transaction",
+            storeId: "store-1",
+            terminalId: "terminal-cloud-1",
+            localRegisterSessionId: "register-1",
+            localEventId: "event-checkout",
+            localIdKind: "transaction",
+            localId: "local-txn-1",
+            cloudTable: "posTransaction",
+            cloudId: "transaction-1",
+            createdAt: 12,
+          },
+          {
+            _id: "mapping-inventory-review",
+            storeId: "store-1",
+            terminalId: "terminal-cloud-1",
+            localRegisterSessionId: "register-1",
+            localEventId: "event-checkout",
+            localIdKind: "inventoryReviewWorkItem",
+            localId: "local-txn-1:inventory-review",
+            cloudTable: "operationalWorkItem",
+            cloudId: "work-item-1",
+            createdAt: 12,
+          },
+        ],
+        conflicts: [
+          {
+            _id: "conflict-inventory",
+            storeId: "store-1",
+            terminalId: "terminal-cloud-1",
+            localRegisterSessionId: "register-1",
+            localEventId: "event-checkout",
+            sequence: 5,
+            conflictType: "inventory",
+            status: "needs_review",
+            summary:
+              "Inventory needs manager review for a synced offline sale.",
+            details: {},
+            createdAt: 12,
+          },
+        ],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 5,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-session",
+            localPosSessionId: "local-sale-1",
+            sequence: 1,
+            sync: { status: "needs_review", uploaded: true },
+            type: "session.started",
+            uploadSequence: undefined,
+          }),
+          buildLocalEvent({
+            localEventId: "event-cart",
+            localPosSessionId: "local-sale-1",
+            sequence: 2,
+            sync: { status: "needs_review", uploaded: true },
+            type: "cart.item_added",
+            uploadSequence: undefined,
+          }),
+          buildLocalEvent({
+            localEventId: "event-payment",
+            localPosSessionId: "local-sale-1",
+            sequence: 3,
+            sync: { status: "needs_review", uploaded: true },
+            type: "session.payments_updated",
+            uploadSequence: undefined,
+          }),
+          buildLocalEvent({
+            localEventId: "event-checkout",
+            localPosSessionId: "local-sale-1",
+            localTransactionId: "local-txn-1",
+            payload: {
+              localPosSessionId: "local-sale-1",
+              localTransactionId: "local-txn-1",
+              receiptNumber: "LOCAL-1-000001",
+              subtotal: 25,
+              tax: 0,
+              total: 25,
+              payments: [{ method: "cash", amount: 25, timestamp: 2 }],
+            },
+            sequence: 5,
+            sync: { status: "needs_review", uploaded: true },
+            type: "transaction.completed",
+            uploadSequence: 5,
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+    };
+    const storeFactory = () => store as never;
+
+    const { result } = renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          runtimeStatus: expect.objectContaining({
+            sync: expect.objectContaining({
+              reviewEventCount: 4,
+              status: "needs_review",
+              uploadableEventCount: 1,
+            }),
+          }),
+        }),
+      ),
+    );
+    act(() => {
+      result.current?.onRetrySync?.();
+    });
+
+    await waitFor(() =>
+      expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              eventType: "sale_completed",
+              localEventId: "event-checkout",
+            }),
+          ],
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(store.markEventsSynced).toHaveBeenCalledWith(
+        ["event-checkout", "event-session", "event-cart", "event-payment"],
+        { uploaded: true },
+      ),
+    );
+    expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
   });
 
   it("marks uploaded events for review when the server rejects the batch", async () => {
@@ -4640,8 +4826,9 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(
       collectServerSettledLocalEventIds(accepted, mappings, conflicts),
     ).toEqual(["event-sale"]);
-    expect(collectServerReviewLocalEventIds(accepted, mappings, conflicts))
-      .toEqual(["event-payment"]);
+    expect(
+      collectServerReviewLocalEventIds(accepted, mappings, conflicts),
+    ).toEqual(["event-payment"]);
   });
 
   it("marks cleared-sale local precursors synced when the clear event uploads", () => {
@@ -4874,7 +5061,11 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         kind: "ok",
         data: {
           accepted: [
-            { localEventId: "event-expense-1", sequence: 1, status: "projected" },
+            {
+              localEventId: "event-expense-1",
+              sequence: 1,
+              status: "projected",
+            },
           ],
           held: [],
           mappings: [],
@@ -4892,7 +5083,11 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         kind: "ok",
         data: {
           accepted: [
-            { localEventId: "event-expense-2", sequence: 1, status: "projected" },
+            {
+              localEventId: "event-expense-2",
+              sequence: 1,
+              status: "projected",
+            },
           ],
           held: [],
           mappings: [],
@@ -4917,7 +5112,9 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
 
     await waitFor(() =>
-      expect(mocks.ingestLocalEvents.mock.calls.length).toBeGreaterThanOrEqual(2),
+      expect(mocks.ingestLocalEvents.mock.calls.length).toBeGreaterThanOrEqual(
+        2,
+      ),
     );
     expect(mocks.ingestLocalEvents.mock.calls[0]?.[0].events).toEqual([
       expect.objectContaining({
@@ -5699,7 +5896,8 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       kind: "ok",
       data: command,
     });
-    const initialReportCount = mocks.reportTerminalRuntimeStatus.mock.calls.length;
+    const initialReportCount =
+      mocks.reportTerminalRuntimeStatus.mock.calls.length;
 
     renderHook(() =>
       usePosLocalSyncRuntimeStatus({
@@ -5717,8 +5915,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         .slice(initialReportCount)
         .map((call) => call[0]?.status?.appUpdate)
         .find(
-          (appUpdate) =>
-            appUpdate?.commandExecutionId === "command-1:2000100",
+          (appUpdate) => appUpdate?.commandExecutionId === "command-1:2000100",
         );
 
       expect(publishedAppUpdate).toEqual(


### PR DESCRIPTION
## Summary
- finalize POS pending checkout review from the product page into trusted catalog inventory with sale/SKU freshness checks
- let Operations resolve synced-sale inventory review work after stock repair proof exists, while local POS settlement treats those sale conflicts as server-owned inventory work
- update Open Work, Daily Operations, product, service, and terminal surfaces/tests around the new review state and back-navigation headers
- add the compound solution note for the pending-checkout inventory-resolution boundary and refresh Graphify artifacts

## Validation
- `bun run test -- convex/operations/openWorkInventoryReviews.test.ts convex/operations/operationalWorkItems.test.ts convex/pos/application/sync/ingestLocalEvents.test.ts convex/pos/public/catalog.test.ts src/components/add-product/ProductStock.test.ts src/components/add-product/ProductView.test.tsx src/components/operations/DailyOperationsView.test.tsx src/components/operations/OperationsQueueView.test.tsx src/components/pos/terminals/POSTerminalDetailView.test.tsx src/components/products/ProductsListView.test.ts src/components/products/ProductsListView.test.tsx src/components/products/UnresolvedProducts.test.tsx src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
- `bun run test -- src/components/services/ServiceAppointmentsView.test.tsx src/components/services/ServiceCasesView.test.tsx src/components/services/ServiceIntakeView.auth.test.tsx src/components/services/ServiceIntakeView.test.tsx`
- `python3 .agents/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/architecture-patterns/athena-pending-checkout-inventory-resolution-2026-07-03.md`
- `bun run graphify:rebuild`
- `bun run pr:athena`