### PR TITLE
fix(auth): stabilize OTP auth sync handoff

### DIFF
--- a/docs/plans/2026-07-03-002-fix-login-otp-auth-sync-plan.html
+++ b/docs/plans/2026-07-03-002-fix-login-otp-auth-sync-plan.html
@@ -1,0 +1,252 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>fix: Stabilize login OTP auth-sync handoff</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8f5;
+      --panel: #ffffff;
+      --ink: #1d2525;
+      --muted: #61706c;
+      --line: #d9dfd8;
+      --accent: #27736b;
+      --soft: #e8f1ed;
+      --warn: #8a5a13;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1040px;
+      margin: 0 auto;
+      padding: 40px 24px 64px;
+    }
+    header {
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 28px;
+      padding-bottom: 20px;
+    }
+    h1 {
+      font-size: 32px;
+      line-height: 1.15;
+      margin: 0 0 12px;
+      letter-spacing: 0;
+    }
+    h2 {
+      font-size: 20px;
+      margin: 32px 0 12px;
+    }
+    h3 {
+      font-size: 16px;
+      margin: 20px 0 8px;
+    }
+    p {
+      margin: 0 0 12px;
+    }
+    a {
+      color: var(--accent);
+    }
+    code {
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }
+    nav {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px 18px;
+      margin: 22px 0;
+    }
+    nav ul, section ul {
+      margin: 8px 0 0 20px;
+      padding: 0;
+    }
+    li {
+      margin: 6px 0;
+    }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 16px;
+    }
+    .callout {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--accent);
+      border-radius: 8px;
+      padding: 16px 18px;
+      margin: 16px 0;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 12px;
+    }
+    article {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    th, td {
+      border-bottom: 1px solid var(--line);
+      padding: 10px 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: var(--soft);
+    }
+    tr:last-child td {
+      border-bottom: 0;
+    }
+    .tag {
+      display: inline-block;
+      background: var(--soft);
+      color: var(--accent);
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .warning {
+      color: var(--warn);
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>fix: Stabilize login OTP auth-sync handoff</h1>
+      <div class="meta">
+        <span>Type: fix</span>
+        <span>Status: active</span>
+        <span>Date: 2026-07-03</span>
+        <span>Deepened: 2026-07-03</span>
+        <span>Source: <a href="./2026-07-03-002-fix-login-otp-auth-sync-plan.md">markdown plan</a></span>
+      </div>
+    </header>
+
+    <nav aria-label="Plan sections">
+      <strong>Review Map</strong>
+      <ul>
+        <li><a href="#summary">Summary</a></li>
+        <li><a href="#decisions">Key Decisions</a></li>
+        <li><a href="#units">Implementation Units</a></li>
+        <li><a href="#verification">Verification Strategy</a></li>
+        <li><a href="#risks">Risks</a></li>
+      </ul>
+    </nav>
+
+    <section id="summary">
+      <h2>Summary</h2>
+      <div class="callout">
+        <p>After a valid OTP, Athena can briefly route through guards before Convex Auth and the Athena-user sync have settled. The plan keeps the handoff on <code>/login</code> until sync writes the local account ids, then sends the user into the authenticated app.</p>
+      </div>
+      <p>The scope preserves the existing Convex Auth OTP provider, POS recovery-code handoff, and server-owned Athena user sync. Pending handoff state is bounded metadata only; it does not change staff, terminal, drawer, POS, remote-assist, or manager authority.</p>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Decisions</h2>
+      <ul>
+        <li><strong>Keep sync ownership in <code>LoginLayout</code>.</strong> The login route already owns retries, local id storage, and safe sync failures.</li>
+        <li><strong>Stop premature root navigation.</strong> The OTP form should start pending auth sync, then let the login layout navigate only after sync succeeds.</li>
+        <li><strong>Apply the same rule to POS recovery.</strong> POS recovery should store a safe redirect target in handoff metadata and let <code>LoginLayout</code> navigate after sync.</li>
+        <li><strong>Use pending auth sync as a recovery signal.</strong> Guards should not treat an explicit login handoff as final sign-out.</li>
+        <li><strong>Fail closed.</strong> Pending state must carry bounded metadata, expire or clear on no-session settlement, and never act as auth proof.</li>
+        <li><strong>Keep server authority.</strong> <code>syncAuthenticatedAthenaUser</code> remains the only sync/create boundary for Athena users.</li>
+      </ul>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <div class="grid">
+        <article>
+          <span class="tag">U1</span>
+          <h3>Characterize The Race</h3>
+          <p>Add failing tests for OTP success with delayed Convex Auth/Athena sync, bounded stale pending metadata, and route guards that must not bounce users back to login.</p>
+          <p><strong>Files:</strong> <code>InputOTP.test.tsx</code>, <code>login/_layout.test.tsx</code>, <code>useAuth.test.tsx</code>, route guard tests if practical.</p>
+        </article>
+        <article>
+          <span class="tag">U2</span>
+          <h3>Stabilize Login Handoff</h3>
+          <p>Remove or defer OTP and POS recovery submit navigation so <code>LoginLayout</code> finishes sync, writes account ids, clears pending state, and navigates once to <code>/</code> or the stored POS redirect.</p>
+          <p><strong>Files:</strong> <code>InputOTP.tsx</code>, <code>PosRecoveryCodeForm.tsx</code>, <code>authSyncHandoff.ts</code>, <code>login/-login-layout.tsx</code>.</p>
+        </article>
+        <article>
+          <span class="tag">U3</span>
+          <h3>Guard Pending Sync</h3>
+          <p>Teach auth loading/guard logic that pending auth sync is a bounded recovery window, not intentional sign-out or POS/staff/manager authority.</p>
+          <p><strong>Files:</strong> <code>useAuth.ts</code>, root/auth shell routes only if needed.</p>
+        </article>
+        <article>
+          <span class="tag">U4</span>
+          <h3>Browser Proof And Delivery</h3>
+          <p>Use the in-app browser and Gmail OTPs for <code>knownothing955@gmail.com</code> to prove repeated no-reload login, then merge and deploy the touched Athena surface.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="verification">
+      <h2>Verification Strategy</h2>
+      <ul>
+        <li>Focused Vitest slice for <code>InputOTP</code>, <code>LoginLayout</code>, <code>useAuth</code>, and route guards.</li>
+        <li>POS recovery tests proving the shared handoff waits for sync and keeps existing POS recovery gates authoritative.</li>
+        <li>Security tests for stale/tampered pending metadata, no-session settlement, and no rendering of sale-capable POS or elevated authority from pending state alone.</li>
+        <li>TypeScript/build checks plus frontend/architecture lint where touched.</li>
+        <li><code>bun run graphify:rebuild</code> after code edits.</li>
+        <li>Repeated live login attempts at <code>http://localhost:5173/login</code> using real Gmail OTP messages.</li>
+        <li>Post-merge local production deploy: <code>scripts/deploy-vps.sh athena-local</code> unless the merged diff also touches Convex runtime code.</li>
+      </ul>
+    </section>
+
+    <section id="risks">
+      <h2>Risks</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Stale pending flag suppresses real sign-out</td><td>Store bounded metadata, expire or clear stale entries, dispatch auth-sync failure on no-session settlement, and do not write user ids until server sync succeeds.</td></tr>
+          <tr><td>User gets stuck on disabled OTP form</td><td>Preserve auth-sync-failed event and inline login-layout errors.</td></tr>
+          <tr><td>POS recovery login regresses</td><td>Store POS redirect target in handoff metadata and let <code>LoginLayout</code> navigate only after sync.</td></tr>
+          <tr><td>Pending sync mistaken for POS authority</td><td>Negative route tests must prove pending sync alone does not render POS terminal shell, remote assist runtime, staff-authenticated state, manager-elevated state, or sale-capable POS surfaces.</td></tr>
+          <tr><td>Unit tests miss real timing</td><td>Require repeated in-app browser proof with real server-generated OTP codes.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Primary References</h2>
+      <ul>
+        <li><code>packages/athena-webapp/src/components/auth/Login/InputOTP.tsx</code></li>
+        <li><code>packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx</code></li>
+        <li><code>packages/athena-webapp/src/routes/login/-login-layout.tsx</code></li>
+        <li><code>packages/athena-webapp/src/hooks/useAuth.ts</code></li>
+        <li><code>docs/solutions/architecture/athena-pos-recovery-code-login-2026-06-03.md</code></li>
+        <li><code>docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md</code></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-07-03-002-fix-login-otp-auth-sync-plan.md
+++ b/docs/plans/2026-07-03-002-fix-login-otp-auth-sync-plan.md
@@ -1,0 +1,330 @@
+---
+title: fix: Stabilize login OTP auth-sync handoff
+type: fix
+status: active
+date: 2026-07-03
+deepened: 2026-07-03
+---
+
+# fix: Stabilize login OTP auth-sync handoff
+
+## Summary
+
+Make email OTP login complete the Convex Auth -> Athena user sync before the app routes through authenticated guards. The implementation should keep the existing Convex Auth OTP provider, preserve the pending-auth-sync handoff used by POS recovery login, and add regression coverage for the no-reload path that currently fails after OTP entry.
+
+---
+
+## Problem Frame
+
+After a valid server-generated OTP is entered at `/login`, users can be sent back to the login page and must manually reload before the authenticated app appears. Research points to a route timing race: the OTP form navigates to `/` immediately after Convex Auth accepts the OTP, but `LoginLayout` is the component that owns the Athena-user sync and route guards can still observe a transient signed-out state.
+
+---
+
+## Requirements
+
+- R1. A successful email OTP submission must lead to the authenticated Athena app without requiring a manual reload.
+- R2. Athena user sync must finish before the flow depends on authenticated route guards.
+- R3. Existing retry behavior for retryable auth-sync failures must remain intact.
+- R4. Invalid, expired, or reused OTPs must not set pending auth state, store local user ids, or navigate away from the OTP form.
+- R5. POS recovery-code login must continue to use the same pending-auth-sync handoff without broadening POS/staff/manager authority semantics.
+- R6. Auth route guards must treat a pending OTP sync as a loading/recovery window, not a deliberate sign-out.
+- R7. The fix must be proven by focused unit/component tests and repeated live browser login attempts with `knownothing955@gmail.com`.
+- R8. Pending auth-sync state is never auth proof and must fail closed through bounded metadata, expiry, and cleanup when no authenticated Convex session/token arrives.
+
+---
+
+## Scope Boundaries
+
+- Do not replace Convex Auth, change the email OTP provider id, or introduce a custom session store.
+- Do not store OTP codes, raw JWTs, recovery codes, staff proof, or manager proof in browser storage.
+- Do not change POS local authority, staff PIN authentication, drawer/register authority, manager approval proof semantics, or offline POS sale policy.
+- Do not redesign the login UI beyond small state/copy adjustments needed to reflect auth-sync progress.
+
+### Deferred to Follow-Up Work
+
+- Email OTP `redirectTo` parity with POS recovery login: useful if protected-route deep links need exact return destinations, but not required to fix the root reload race.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/components/auth/Login/InputOTP.tsx` currently calls Convex Auth `signIn`, starts pending auth sync, and immediately `navigate({ to: "/" })`.
+- `packages/athena-webapp/src/components/auth/Login/authSyncHandoff.ts` centralizes the `pending_athena_auth_sync` storage flag and `athena:pending-auth-sync` event.
+- `packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx` also starts pending auth sync and currently navigates to the POS redirect target immediately after provider success.
+- `packages/athena-webapp/src/routes/login/-login-layout.tsx` waits for `useConvexAuth()` plus `useAuthToken()`, calls `api.inventory.auth.syncAuthenticatedAthenaUser`, writes `logged_in_user_id` and `athena.pos.app_account_id`, clears the pending flag, and navigates to `/`.
+- `packages/athena-webapp/src/hooks/useAuth.ts` resolves the app-level Athena user from Convex Auth state and `api.inventory.athenaUser.getAuthenticatedUser`.
+- `packages/athena-webapp/src/routes/-index-route-view.tsx` redirects signed-out users from `/` to `/login`.
+- `packages/athena-webapp/src/routes/-authed-layout.tsx` protects the authenticated shell and redirects signed-out users to `/login`.
+- `packages/athena-webapp/convex/auth.ts`, `packages/athena-webapp/convex/otp/EmailOTP.ts`, and `packages/athena-webapp/convex/lib/athenaUserAuth.ts` are the current Convex Auth and Athena-user mapping boundary.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-recovery-code-login-2026-06-03.md`: POS recovery login must create a real Convex Auth session and reuse the pending Athena auth-sync handoff; do not fake app auth state in local storage.
+- `docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md`: delayed Convex/Auth rehydration is a recovery window, not intentional logout, especially on POS routes.
+- `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md`: app login and staff authority are separate credentials; OTP success must not become operational staff proof.
+- `docs/solutions/harness/convex-query-write-boundary-proof-2026-06-18.md`: query/read paths should not perform auth/session repair writes; sync mutations own inserts and patches.
+
+### External References
+
+- None. Local Convex Auth patterns and repo-specific login recovery code are sufficient for this bug fix.
+
+---
+
+## Key Technical Decisions
+
+- Keep sync ownership in `LoginLayout`: The login route already owns retryable sync, local id storage, and safe inline failures. The OTP form should start the handoff and remain in the login route until that owner completes.
+- Treat pending sync as loading/recovery state: Route guards should not classify a user as signed out while the explicit pending handoff flag says the app is still completing login.
+- Bound pending sync fail-closed: The pending flag must carry metadata such as `startedAt` and optional redirect target, must expire, and must be cleared on auth-sync failure, sign-out/no-session settlement, invalid handoff metadata, or timeout.
+- Preserve server authority: `syncAuthenticatedAthenaUser` remains the only place that creates or resolves the Athena user from the authenticated Convex session.
+- Keep browser storage minimal: The pending flag is a control flag only; durable account ids are written only after the server sync returns an Athena user id.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the OTP submitter keep navigating immediately to `/`? No. That is the likely race trigger because it can unmount the sync owner before the Convex Auth state is observable to the app.
+- Should this change touch Convex OTP generation or MailerSend? No. The bug is in the post-OTP client handoff, not code generation or delivery.
+
+### Deferred to Implementation
+
+- Exact helper shape for checking pending auth sync: implementation should reuse `authSyncHandoff.ts` or a small adjacent helper if tests show multiple route surfaces need the same read logic.
+- Whether a route-level integration test is practical with the current TanStack Router test harness: if too expensive, add focused component/hook tests that simulate the same state transition.
+- Exact TTL value for pending auth-sync metadata: choose a short window long enough for normal Convex Auth session propagation but short enough to prevent stale client-controlled loading state from persisting.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant OTP as InputOTPForm
+  participant Login as LoginLayout
+  participant Convex as Convex Auth
+  participant Sync as syncAuthenticatedAthenaUser
+  participant App as Root/Auth Guards
+
+  User->>OTP: Enter valid OTP
+  OTP->>Convex: signIn(email, code)
+  Convex-->>OTP: signingIn true
+  OTP->>Login: mark pending auth sync with startedAt
+  Note over OTP,Login: Stay on /login while sync owner waits for token/session
+  Login->>Sync: sync authenticated Athena user
+  Sync-->>Login: Athena user id
+  Login->>Login: write local account ids, clear pending flag
+  Login->>App: navigate to /
+  App->>App: resolve authenticated user/orgs
+```
+
+---
+
+## Implementation Units
+
+- U1. **Characterize the OTP handoff race**
+
+**Goal:** Add focused failing coverage that captures OTP success followed by delayed Convex Auth/Athena sync without requiring reload.
+
+**Requirements:** R1, R2, R6, R7, R8
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx`
+- Modify: `packages/athena-webapp/src/routes/login/_layout.test.tsx`
+- Modify: `packages/athena-webapp/src/hooks/useAuth.test.tsx`
+- Modify if practical: `packages/athena-webapp/src/routes/-index-route-view.test.tsx` or nearest existing route-guard test
+
+**Approach:**
+- Start test-first with the current race: OTP success marks pending auth sync, Convex Auth/token state is not ready yet, and the flow must not depend on root guard redirecting back to login.
+- Add or adjust assertions so the OTP form remains in handoff-pending state until `LoginLayout` completes sync.
+- Add guard-level coverage that a pending auth-sync flag prevents signed-out redirect decisions from being treated as final.
+
+**Execution note:** Test-first. Confirm at least one focused test fails before implementation.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/routes/login/_layout.test.tsx` for mocked Convex Auth transitions and retryable sync assertions.
+- `packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx` for OTP submit, pending flag, and auth-sync-failed event behavior.
+- `packages/athena-webapp/src/hooks/useAuth.test.tsx` for loading/recovery state modeling.
+
+**Test scenarios:**
+- Happy path: OTP submit returns `signingIn: true` -> pending flag is set, the OTP form enters handoff-pending state, and it does not navigate away before sync completion.
+- Edge case: Convex Auth is initially loading or unauthenticated with pending sync -> login layout does not call sync until token/session is ready.
+- Integration: pending sync flag exists while app auth is transiently null -> route guard remains loading or returns null without navigating to `/login`.
+- Error path: auth-sync failure re-enables OTP entry, clears or expires the pending flag, and does not write `LOGGED_IN_USER_ID_KEY` or `POS_APP_ACCOUNT_ID_KEY`.
+- Security edge case: stale or tampered pending metadata plus no Convex token/session resolves signed out, clears the flag, does not call sync, and redirects normally.
+- Security edge case: pre-existing local account ids are not treated as authority for a new OTP handoff until `syncAuthenticatedAthenaUser` returns the server-confirmed Athena user.
+- Security edge case: invalid, expired, or reused OTP leaves pending auth-sync absent and leaves durable auth/POS account storage unchanged except for explicit stale-state cleanup.
+
+**Verification:**
+- The focused tests fail against the current behavior and pass once the handoff is stabilized.
+
+---
+
+- U2. **Stabilize the login-route auth-sync handoff**
+
+**Goal:** Keep successful OTP and POS recovery login inside the login route until Athena user sync writes local account ids, then route to the authenticated app or stored POS redirect.
+
+**Requirements:** R1, R2, R3, R4, R5, R7, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/auth/Login/InputOTP.tsx`
+- Modify: `packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx`
+- Modify: `packages/athena-webapp/src/components/auth/Login/authSyncHandoff.ts`
+- Modify: `packages/athena-webapp/src/routes/login/-login-layout.tsx`
+- Test: `packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx`
+- Test: `packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx`
+- Test: `packages/athena-webapp/src/routes/login/_layout.test.tsx`
+
+**Approach:**
+- Remove or defer the OTP form's immediate `/` navigation after `signIn`.
+- Remove or defer POS recovery's immediate redirect navigation after `signIn`; store the normalized redirect target in handoff metadata and let `LoginLayout` navigate there only after sync succeeds.
+- Let `LoginLayout` remain responsible for observing Convex Auth readiness, retrying sync, writing `LOGGED_IN_USER_ID_KEY` and `POS_APP_ACCOUNT_ID_KEY`, clearing the pending flag, and navigating to the stored safe redirect or `/`.
+- Add a bounded pre-sync session-settle rule: if Convex Auth settles unauthenticated with no token, or pending metadata is expired/tampered, clear the pending flag, dispatch `ATHENA_AUTH_SYNC_FAILED_EVENT`, and let guards resolve signed out.
+- Keep the OTP form disabled while the handoff is pending and let `ATHENA_AUTH_SYNC_FAILED_EVENT` re-enable it on safe failure.
+- Preserve invalid-code behavior so failed `signIn` responses do not set pending sync or navigate.
+
+**Patterns to follow:**
+- Existing `AUTH_SYNC_RETRY_DELAY_MS` / `AUTH_SYNC_MAX_ATTEMPTS` retry loop in `packages/athena-webapp/src/routes/login/-login-layout.tsx`.
+- Existing `startAthenaAuthSyncHandoff` storage/event boundary in `packages/athena-webapp/src/components/auth/Login/authSyncHandoff.ts`.
+
+**Test scenarios:**
+- Happy path: valid OTP starts pending handoff and waits on login layout, then sync writes both local account ids and navigates to `/`.
+- Happy path: valid POS recovery code starts pending handoff with a safe redirect target and waits on login layout, then sync writes both local account ids and navigates to the stored POS route.
+- Edge case: pending flag exists but Convex Auth token is delayed -> no premature sync call, no redirect loop, eventual sync succeeds.
+- Edge case: pending flag exists but Convex Auth settles unauthenticated with no token/session -> pending state is cleared, auth-sync-failed event fires, and the user is treated as signed out instead of hanging.
+- Error path: non-retryable sync user error renders safe inline login-layout copy and OTP form can be re-enabled.
+- Error path: OTP `signIn` returns `signingIn: false` -> no pending flag, no sync attempt, inline invalid-code copy.
+
+**Verification:**
+- The login flow has a single post-OTP route transition: `/login` -> `/` after Athena sync succeeds.
+
+---
+
+- U3. **Make pending auth sync visible to auth guards**
+
+**Goal:** Prevent `/` and authenticated shell guards from treating an explicit pending auth-sync handoff as a completed sign-out.
+
+**Requirements:** R1, R2, R5, R6, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/hooks/useAuth.ts`
+- Modify if needed: `packages/athena-webapp/src/routes/-index-route-view.tsx`
+- Modify if needed: `packages/athena-webapp/src/routes/-authed-layout.tsx`
+- Test: `packages/athena-webapp/src/hooks/useAuth.test.tsx`
+- Test if touched: `packages/athena-webapp/src/routes/_authed.test.tsx`
+
+**Approach:**
+- Reuse the pending handoff flag as a recovery/loading signal when Convex Auth state is still settling.
+- Treat pending auth-sync as a redirect-suppression/loading signal only. It must not satisfy POS app-session recovery, staff PIN proof, drawer/register authority, manager approval proof, remote assist authority, or any sale-capable POS authorization gate.
+- Honor the same TTL/tamper cleanup rule from U2 so stale client-controlled pending state cannot hold the app in loading indefinitely.
+- Avoid write-side repair in query hooks; continue to let `syncAuthenticatedAthenaUser` own user creation and sync writes.
+- Keep normal signed-out redirects unchanged when there is no pending handoff.
+- Ensure POS recovery-code login still has the same protection because it uses the same pending sync flag.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/hooks/useAuth.test.tsx` already models Safari token rehydration and Convex-user loading states.
+- `docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md` distinguishes recovery windows from deliberate logout.
+
+**Test scenarios:**
+- Happy path: pending sync flag plus unsettled Convex user returns `isLoading: true` and `user: undefined`.
+- Edge case: pending sync flag plus no token/session after the recovery window settles clears the pending flag, does not call sync, and resolves signed out through existing login-layout failure handling.
+- Security edge case: pending auth-sync flag alone must not render POS terminal shell, POS outlet, remote assist runtime, staff-authenticated state, manager-elevated state, or sale-capable POS surfaces in `packages/athena-webapp/src/routes/_authed.test.tsx`.
+- Security edge case: stale `LOGGED_IN_USER_ID_KEY` / `POS_APP_ACCOUNT_ID_KEY` plus pending flag and no Convex session still leaves existing POS recovery gates in charge of access.
+- Regression: no pending flag and no Convex session still returns signed-out behavior so normal logout redirects work.
+- Integration: authenticated shell does not redirect to `/login` solely because auth is in pending sync.
+
+**Verification:**
+- Route guards no longer create a login loop during OTP handoff, while ordinary signed-out users still reach `/login`.
+
+---
+
+- U4. **Live browser proof and deployment delivery**
+
+**Goal:** Prove the fixed behavior in the running app with the Gmail-backed server OTP flow, then ship and deploy the relevant surfaces.
+
+**Requirements:** R1, R7
+
+**Dependencies:** U2, U3
+
+**Files:**
+- No expected source edits beyond tests/handoff artifacts unless implementation reveals a missing runtime scenario.
+
+**Approach:**
+- Use the in-app browser at `http://localhost:5173/login`.
+- Request OTP for `knownothing955@gmail.com`, read the server-generated code from Gmail, and complete login.
+- Repeat the full logout/login or fresh-session login path multiple times in the same browser environment, verifying that authenticated app navigation happens without manual reload every time.
+- After code changes, run the repo's auth-focused test slice, TypeScript/build checks, Graphify rebuild, PR gate, code review loop, merge, root checkout fast-forward, and narrow local production deploy based on the merged diff.
+
+**Patterns to follow:**
+- `packages/athena-webapp/docs/agent/testing.md` login auth-sync validation slice.
+- `docs/solutions/harness/worktree-safe-pr-merge-2026-05-02.md` and the delivery kernel's post-merge local CD rules.
+
+**Test scenarios:**
+- Runtime happy path: entering a fresh OTP redirects to the authenticated app without pressing reload.
+- Runtime repeatability: the same flow succeeds multiple times after logout or session reset.
+- Runtime regression: invalid OTP still stays on login with safe error copy.
+
+**Verification:**
+- Browser evidence shows repeated no-reload login success.
+- PR is merged, local root `main` is fast-forwarded to `origin/main`, and the relevant production deploy command succeeds from a clean root checkout.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** OTP form, login layout, `useAuth`, root route, and authenticated shell all participate in the handoff.
+- **Error propagation:** OTP errors stay in the OTP form; Athena sync errors surface through `LoginLayout` safe inline copy and `ATHENA_AUTH_SYNC_FAILED_EVENT`.
+- **State lifecycle risks:** Pending sync must clear only after successful Athena user sync; stale pending flags must not become permanent authenticated state.
+- **API surface parity:** Convex Auth providers and server sync API remain unchanged.
+- **Integration coverage:** Browser testing is required because the bug depends on real Convex Auth/Gmail/session timing.
+- **Unchanged invariants:** App auth does not grant staff authority, terminal authority, drawer/register authority, or manager proof.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A stale pending flag could suppress a legitimate signed-out redirect | Store bounded handoff metadata, expire or clear stale/tampered entries, dispatch auth-sync failure when session settlement fails, and do not store account ids until server sync succeeds. |
+| Removing OTP submit navigation could leave the user on a disabled form if sync never runs | Preserve `ATHENA_AUTH_SYNC_FAILED_EVENT` and inline login-layout errors; test delayed token/session and failure paths. |
+| Fixing email OTP could regress POS recovery login | Apply the same login-layout-owned sync rule to `PosRecoveryCodeForm`, store its safe redirect target in handoff metadata, and include POS recovery tests. |
+| Pending sync becomes mistaken for POS or staff authority | Add POS/auth-shell negative tests proving pending sync suppresses only premature login redirects and never renders sale-capable POS, staff-authenticated, manager-elevated, or remote-assist authority. |
+| Runtime issue only appears with real Convex/Gmail timing | Validate repeatedly in the in-app browser using `knownothing955@gmail.com` and real server OTP emails. |
+
+---
+
+## Documentation / Operational Notes
+
+- If the implementation creates a reusable pattern for auth handoff guards, add a `docs/solutions/` learning after merge.
+- After modifying code, run `bun run graphify:rebuild`.
+- Because the expected diff is under `packages/athena-webapp/src/**`, the post-merge local deploy should include `scripts/deploy-vps.sh athena-local`; include Convex deploy only if Convex runtime files change.
+
+---
+
+## Sources & References
+
+- Related code: `packages/athena-webapp/src/components/auth/Login/InputOTP.tsx`
+- Related code: `packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx`
+- Related code: `packages/athena-webapp/src/components/auth/Login/authSyncHandoff.ts`
+- Related code: `packages/athena-webapp/src/routes/login/-login-layout.tsx`
+- Related code: `packages/athena-webapp/src/hooks/useAuth.ts`
+- Related code: `packages/athena-webapp/src/routes/-index-route-view.tsx`
+- Related code: `packages/athena-webapp/src/routes/-authed-layout.tsx`
+- Related tests: `packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx`
+- Related tests: `packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx`
+- Related tests: `packages/athena-webapp/src/routes/login/_layout.test.tsx`
+- Related tests: `packages/athena-webapp/src/hooks/useAuth.test.tsx`
+- Related learning: `docs/solutions/architecture/athena-pos-recovery-code-login-2026-06-03.md`
+- Related learning: `docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md`
+- Related learning: `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md`
+- Related learning: `docs/solutions/harness/convex-query-write-boundary-proof-2026-06-18.md`

--- a/docs/solutions/logic-errors/athena-login-otp-auth-sync-handoff-2026-07-03.md
+++ b/docs/solutions/logic-errors/athena-login-otp-auth-sync-handoff-2026-07-03.md
@@ -1,0 +1,126 @@
+---
+title: Athena Login OTP Auth Sync Handoff Waits For App User Sync
+date: 2026-07-03
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: authentication
+symptoms:
+  - "OTP login can redirect back to /login after a valid server-generated code"
+  - "Reloading /login after the bounce can enter the authenticated app"
+  - "POS recovery login can share the same redirect race when it navigates before app-user sync"
+root_cause: async_timing
+resolution_type: code_fix
+severity: high
+related_components:
+  - "convex-auth"
+  - "tanstack-router"
+  - "pos-recovery-login"
+tags:
+  - auth-sync
+  - otp-login
+  - convex-auth
+  - session-storage
+  - pos-recovery
+---
+
+# Athena Login OTP Auth Sync Handoff Waits For App User Sync
+
+## Problem
+
+Athena has two auth states after OTP success: Convex Auth knows the browser is
+signed in, and Athena still needs `syncAuthenticatedAthenaUser` to create or
+load the application user, persist the local app-user id, and then send the
+operator into the authenticated app. If the OTP form navigates immediately
+after `signIn`, route guards can observe the gap between those states and send
+the browser back to `/login`.
+
+## Symptoms
+
+- A valid server-generated OTP returns the user to `/login`.
+- Manually reloading `/login` finishes the authenticated redirect because
+  Convex Auth has settled by then.
+- POS recovery-code login can regress the same way if it navigates to the POS
+  redirect before the Athena app-user sync is complete.
+
+## What Didn't Work
+
+- Navigating from `InputOTPForm` or `PosRecoveryCodeForm` immediately after
+  provider success. That moved the browser before the login layout had durable
+  app-user evidence.
+- Using a bare session-storage sentinel such as `"1"`. It could keep the UI in
+  a pending state without a bounded lifetime or a trusted redirect payload.
+- Treating stale locally persisted app-user ids as enough authority while a new
+  auth-sync handoff is pending. That can let the authed shell make POS recovery
+  decisions from stale account evidence.
+
+## Solution
+
+Keep the OTP and POS recovery forms responsible only for starting an auth-sync
+handoff. The login layout owns the durable completion step:
+
+1. Store bounded handoff metadata in session storage:
+   `redirectTo` and `startedAt`.
+2. Let `LoginLayout` wait until Convex Auth is authenticated and an auth token
+   exists.
+3. Run `syncAuthenticatedAthenaUser`.
+4. Clear the handoff, persist `LOGGED_IN_USER_ID_KEY` and
+   `POS_APP_ACCOUNT_ID_KEY`, then navigate to the stored safe redirect.
+
+The forms should not call `navigate` after successful `signIn`:
+
+```ts
+const result = await signIn(ATHENA_EMAIL_OTP_PROVIDER_ID, {
+  code: data.pin,
+  email: email.trim().toLowerCase(),
+});
+
+if (result.signingIn) {
+  startAthenaAuthSyncHandoff();
+  setIsAuthHandoffPending(true);
+}
+```
+
+The handoff reader should fail closed on missing, invalid, or expired metadata:
+
+```ts
+const handoffStatus = getAthenaAuthSyncHandoffStatus();
+
+if (handoffStatus.kind === "expired" || handoffStatus.kind === "invalid") {
+  failAthenaAuthSyncHandoff();
+  return;
+}
+```
+
+`useAuth` should also treat a fresh pending handoff as loading. That prevents
+the authenticated shell from clearing or trusting stale local user ids while
+Convex Auth and Athena app-user sync are converging.
+
+## Why This Works
+
+The user-visible redirect now happens only after the same component that owns
+`syncAuthenticatedAthenaUser` has durable evidence that Athena has an app user
+for the Convex Auth session. The handoff metadata lets POS recovery preserve its
+intended route, but the redirect is still delayed until the app-user sync
+finishes. The TTL keeps a failed or tampered handoff from pinning the login UI
+forever.
+
+## Prevention
+
+- Keep provider forms side-effect-light: they may start the handoff, but they
+  should not navigate to authenticated routes.
+- Include a TTL and normalized same-origin path in any client-side auth handoff
+  metadata. Do not store OTPs, auth tokens, or raw backend errors there.
+- Add tests that prove valid OTP and POS recovery sign-in do not navigate from
+  the form, stale handoff metadata clears, and stored POS redirects with query
+  params are used only after app-user sync succeeds.
+- Add an authed-route regression proving pending auth-sync loading is not
+  treated as POS terminal authority or a ready app user.
+- Prove the behavior in a browser with repeated real OTP cycles, because this
+  class of bug depends on auth-provider timing, router redirects, and local
+  storage state.
+
+## Related Issues
+
+- [Athena POS Recovery-Code Login Keeps App Account And Staff Authority Separate](../architecture/athena-pos-recovery-code-login-2026-06-03.md)
+- Linear V26-940: Stabilize login OTP auth-sync handoff

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8542 nodes · 10331 edges · 2092 communities detected
+- 8549 nodes · 10342 edges · 2092 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2730,52 +2730,52 @@ Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 150 - "Community 150"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 151 - "Community 151"
 Cohesion: 0.38
 Nodes (10): conflictError(), findPostReviewStockUpdateWithCtx(), idMetadataValue(), inventoryReviewLocalId(), optionalMetadataMatches(), readPositiveCurrentInventoryProofWithCtx(), resolveSyncedSaleInventoryReviewWithCtx(), stringMetadataValue() (+2 more)
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 153 - "Community 153"
+### Community 152 - "Community 152"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 154 - "Community 154"
+### Community 153 - "Community 153"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 155 - "Community 155"
+### Community 154 - "Community 154"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 156 - "Community 156"
+### Community 155 - "Community 155"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 157 - "Community 157"
+### Community 156 - "Community 156"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 158 - "Community 158"
+### Community 157 - "Community 157"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 159 - "Community 159"
+### Community 158 - "Community 158"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 160 - "Community 160"
+### Community 159 - "Community 159"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 161 - "Community 161"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 162 - "Community 162"
 Cohesion: 0.18
@@ -2942,24 +2942,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 203 - "Community 203"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 204 - "Community 204"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 205 - "Community 205"
+### Community 204 - "Community 204"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 206 - "Community 206"
+### Community 205 - "Community 205"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 207 - "Community 207"
+### Community 206 - "Community 206"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 207 - "Community 207"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.39
@@ -3038,256 +3038,256 @@ Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
 ### Community 227 - "Community 227"
+Cohesion: 0.43
+Nodes (7): clearAthenaAuthSyncHandoff(), failAthenaAuthSyncHandoff(), getAthenaAuthSyncHandoffStatus(), normalizeAuthSyncRedirect(), parseHandoff(), readRawHandoff(), startAthenaAuthSyncHandoff()
+
+### Community 228 - "Community 228"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 232 - "Community 232"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 234 - "Community 234"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 236 - "Community 236"
-Cohesion: 0.29
-Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
-
-### Community 237 - "Community 237"
-Cohesion: 0.46
-Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
-
-### Community 238 - "Community 238"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 239 - "Community 239"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 240 - "Community 240"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 237 - "Community 237"
+Cohesion: 0.29
+Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
+
+### Community 238 - "Community 238"
+Cohesion: 0.46
+Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
+
+### Community 239 - "Community 239"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 240 - "Community 240"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 241 - "Community 241"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 242 - "Community 242"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.43
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.52
 Nodes (5): getBlockingRegisterSessionIdFromConflict(), isRegisterSessionConflict(), resolveScopedRegisterSession(), resolveTerminalRegisterConflict(), resolveTerminalRegisterSessionConflict()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 264 - "Community 264"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 265 - "Community 265"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 266 - "Community 266"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 267 - "Community 267"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
-
-### Community 268 - "Community 268"
-Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 269 - "Community 269"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 270 - "Community 270"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 271 - "Community 271"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 272 - "Community 272"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 274 - "Community 274"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 276 - "Community 276"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 277 - "Community 277"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 278 - "Community 278"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 280 - "Community 280"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 281 - "Community 281"
 Cohesion: 0.52
-Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 282 - "Community 282"
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+
+### Community 283 - "Community 283"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
-
-### Community 289 - "Community 289"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 290 - "Community 290"
 Cohesion: 0.33
@@ -3298,120 +3298,120 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 292 - "Community 292"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 293 - "Community 293"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 297 - "Community 297"
+### Community 298 - "Community 298"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 298 - "Community 298"
+### Community 299 - "Community 299"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 305 - "Community 305"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 306 - "Community 306"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 307 - "Community 307"
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
+
+### Community 308 - "Community 308"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 309 - "Community 309"
-Cohesion: 0.4
-Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
+Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.4
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 312 - "Community 312"
-Cohesion: 0.47
-Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
 ### Community 313 - "Community 313"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
 ### Community 314 - "Community 314"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 315 - "Community 315"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 316 - "Community 316"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 319 - "Community 319"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 320 - "Community 320"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 321 - "Community 321"
 Cohesion: 0.33
@@ -3422,116 +3422,116 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 323 - "Community 323"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 324 - "Community 324"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 325 - "Community 325"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 324 - "Community 324"
+### Community 326 - "Community 326"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 325 - "Community 325"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 326 - "Community 326"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 327 - "Community 327"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 328 - "Community 328"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 329 - "Community 329"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 328 - "Community 328"
+### Community 330 - "Community 330"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 329 - "Community 329"
+### Community 331 - "Community 331"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 330 - "Community 330"
+### Community 332 - "Community 332"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 331 - "Community 331"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 332 - "Community 332"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 333 - "Community 333"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 334 - "Community 334"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 335 - "Community 335"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 336 - "Community 336"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 337 - "Community 337"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 338 - "Community 338"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 340 - "Community 340"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 341 - "Community 341"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 342 - "Community 342"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 343 - "Community 343"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 344 - "Community 344"
-Cohesion: 0.67
-Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
 ### Community 345 - "Community 345"
 Cohesion: 0.53
-Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
 ### Community 346 - "Community 346"
+Cohesion: 0.67
+Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
+
+### Community 347 - "Community 347"
+Cohesion: 0.53
+Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
+
+### Community 348 - "Community 348"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 347 - "Community 347"
+### Community 349 - "Community 349"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 348 - "Community 348"
+### Community 350 - "Community 350"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
-
-### Community 349 - "Community 349"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 350 - "Community 350"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.4
@@ -3539,123 +3539,123 @@ Nodes (0):
 
 ### Community 352 - "Community 352"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 353 - "Community 353"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 354 - "Community 354"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
 ### Community 355 - "Community 355"
-Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
-
-### Community 356 - "Community 356"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 356 - "Community 356"
+Cohesion: 0.5
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
+
 ### Community 357 - "Community 357"
 Cohesion: 0.5
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 358 - "Community 358"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 359 - "Community 359"
+Cohesion: 0.5
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+
+### Community 360 - "Community 360"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 361 - "Community 361"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+
+### Community 362 - "Community 362"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 360 - "Community 360"
+### Community 363 - "Community 363"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 361 - "Community 361"
+### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 362 - "Community 362"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 363 - "Community 363"
-Cohesion: 0.6
-Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
-
-### Community 364 - "Community 364"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 365 - "Community 365"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 366 - "Community 366"
-Cohesion: 0.5
-Nodes (2): baseInput(), buildRuntimeStatus()
+Cohesion: 0.6
+Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
 ### Community 367 - "Community 367"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 368 - "Community 368"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.5
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Nodes (2): baseInput(), buildRuntimeStatus()
 
 ### Community 370 - "Community 370"
-Cohesion: 0.6
-Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 371 - "Community 371"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 372 - "Community 372"
-Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Cohesion: 0.5
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 373 - "Community 373"
 Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
 ### Community 374 - "Community 374"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 375 - "Community 375"
 Cohesion: 0.7
-Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 376 - "Community 376"
-Cohesion: 0.5
-Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 377 - "Community 377"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 378 - "Community 378"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
 ### Community 379 - "Community 379"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
 ### Community 380 - "Community 380"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 381 - "Community 381"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 382 - "Community 382"
 Cohesion: 0.4
@@ -3666,32 +3666,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 384 - "Community 384"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 386 - "Community 386"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 387 - "Community 387"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 388 - "Community 388"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 388 - "Community 388"
+Cohesion: 0.5
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 389 - "Community 389"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 390 - "Community 390"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.4
@@ -3706,120 +3706,120 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 394 - "Community 394"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 396 - "Community 396"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 397 - "Community 397"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 398 - "Community 398"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 399 - "Community 399"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 397 - "Community 397"
+### Community 400 - "Community 400"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 398 - "Community 398"
+### Community 401 - "Community 401"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 399 - "Community 399"
+### Community 402 - "Community 402"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 400 - "Community 400"
+### Community 403 - "Community 403"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 401 - "Community 401"
+### Community 404 - "Community 404"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 402 - "Community 402"
+### Community 405 - "Community 405"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 403 - "Community 403"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 404 - "Community 404"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 405 - "Community 405"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 406 - "Community 406"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 408 - "Community 408"
-Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
-
-### Community 409 - "Community 409"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 409 - "Community 409"
+Cohesion: 0.6
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+
 ### Community 410 - "Community 410"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 411 - "Community 411"
-Cohesion: 0.5
-Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
 ### Community 412 - "Community 412"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 414 - "Community 414"
+Cohesion: 0.5
+Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 415 - "Community 415"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 415 - "Community 415"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
-
 ### Community 416 - "Community 416"
-Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 417 - "Community 417"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 418 - "Community 418"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 419 - "Community 419"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
-
-### Community 420 - "Community 420"
-Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
-
-### Community 421 - "Community 421"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 420 - "Community 420"
+Cohesion: 0.7
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+
+### Community 421 - "Community 421"
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+
 ### Community 422 - "Community 422"
-Cohesion: 0.6
-Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.4
@@ -3827,15 +3827,15 @@ Nodes (0):
 
 ### Community 424 - "Community 424"
 Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
 ### Community 425 - "Community 425"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 426 - "Community 426"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 426 - "Community 426"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.4
@@ -3846,72 +3846,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 429 - "Community 429"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 430 - "Community 430"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 430 - "Community 430"
+### Community 431 - "Community 431"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 431 - "Community 431"
+### Community 432 - "Community 432"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 434 - "Community 434"
+### Community 435 - "Community 435"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 437 - "Community 437"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 438 - "Community 438"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 440 - "Community 440"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 440 - "Community 440"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 442 - "Community 442"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 443 - "Community 443"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 444 - "Community 444"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.5
@@ -3930,76 +3930,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 450 - "Community 450"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 451 - "Community 451"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.83
 Nodes (3): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), formatOnlineOrderLabel()
 
-### Community 455 - "Community 455"
+### Community 456 - "Community 456"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 456 - "Community 456"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 458 - "Community 458"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 459 - "Community 459"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 459 - "Community 459"
+### Community 460 - "Community 460"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 460 - "Community 460"
+### Community 461 - "Community 461"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 461 - "Community 461"
+### Community 462 - "Community 462"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 462 - "Community 462"
+### Community 463 - "Community 463"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 463 - "Community 463"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 464 - "Community 464"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 465 - "Community 465"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 466 - "Community 466"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 467 - "Community 467"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 467 - "Community 467"
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 468 - "Community 468"
 Cohesion: 0.5
@@ -4010,24 +4010,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 470 - "Community 470"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 471 - "Community 471"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 472 - "Community 472"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 474 - "Community 474"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.5
@@ -4046,36 +4046,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 479 - "Community 479"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 480 - "Community 480"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 480 - "Community 480"
+### Community 481 - "Community 481"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 481 - "Community 481"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 483 - "Community 483"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 484 - "Community 484"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 485 - "Community 485"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 486 - "Community 486"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 487 - "Community 487"
 Cohesion: 0.5
@@ -4086,24 +4086,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 489 - "Community 489"
-Cohesion: 0.83
-Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
-
-### Community 490 - "Community 490"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 490 - "Community 490"
+Cohesion: 0.83
+Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
+
 ### Community 491 - "Community 491"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 492 - "Community 492"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
@@ -4622,8 +4622,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 623 - "Community 623"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 624 - "Community 624"
 Cohesion: 0.67
@@ -6283,11 +6283,11 @@ Nodes (0):
 
 ### Community 1038 - "Community 1038"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1039 - "Community 1039"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1040 - "Community 1040"
 Cohesion: 1.0
@@ -10756,107 +10756,109 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 885`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 886`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 887`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 888`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 889`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 890`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 891`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 892`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 893`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 894`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 895`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 896`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 897`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 898`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 899`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 900`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 901`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 902`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 903`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
+- **Thin community `Community 904`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 905`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 906`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 907`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 908`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 909`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 910`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 911`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 912`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 913`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 914`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 915`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 916`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 917`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 918`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 919`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 920`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 921`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 922`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 923`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 924`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 925`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 926`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 927`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 928`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 929`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 930`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 931`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 932`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 933`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 934`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 935`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 936`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 937`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10892,1983 +10894,1981 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 938`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 939`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 940`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 941`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 942`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 943`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 944`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 945`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 946`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 947`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 948`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 949`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 950`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 951`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
+- **Thin community `Community 952`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 953`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 954`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 955`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 956`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 957`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 958`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 959`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 960`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 961`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 962`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 963`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 964`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 965`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 966`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 967`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 968`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 969`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 970`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 971`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 972`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 973`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 974`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 975`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 976`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 977`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 978`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 979`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 980`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 981`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 982`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 983`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 984`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 985`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 986`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 987`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 988`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 989`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 990`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 991`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 992`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 993`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 994`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 995`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 996`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 997`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 998`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 999`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1000`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1001`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1002`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1003`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1004`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1005`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1006`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1007`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1008`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1009`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1010`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1011`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1012`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1013`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1014`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1015`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1016`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1017`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1018`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1019`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1020`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1021`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1022`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1023`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1024`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1025`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1026`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1027`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1028`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1029`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1030`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1031`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1032`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1033`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1034`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1035`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1036`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1037`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1038`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1039`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1040`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1041`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1042`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1043`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1044`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1045`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1046`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1047`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1048`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1049`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1050`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1051`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1052`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1053`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1054`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1055`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1056`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1057`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1058`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1059`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1060`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1061`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1062`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1063`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1064`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1065`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1066`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1067`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1068`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1069`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1070`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1071`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1072`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1073`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1074`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1075`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1076`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1077`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1078`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1079`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1080`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1081`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1082`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1083`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1084`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1085`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1086`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1087`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1088`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1089`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1090`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1091`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1092`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1093`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1094`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1095`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1096`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1097`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1098`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1099`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1100`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1101`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1102`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1103`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1104`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1105`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1106`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1107`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1108`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1109`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1110`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1111`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1112`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1113`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1114`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1115`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1116`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1117`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1118`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1119`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1120`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1121`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1122`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1123`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1124`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1125`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1126`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1127`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1128`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1129`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1130`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1131`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1132`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1133`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1134`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1135`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1136`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1137`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1138`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1139`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1140`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1141`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1142`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1143`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1144`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1145`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1146`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1147`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1148`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1149`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1150`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1151`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1152`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1153`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1154`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1155`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1156`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1157`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1158`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1159`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1160`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1161`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1162`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1163`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1164`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1165`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1166`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1167`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1168`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1169`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1170`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1171`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1172`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1173`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1174`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1175`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1176`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1177`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1178`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1179`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1180`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1181`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1182`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1183`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1184`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1185`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1186`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1187`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1188`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1189`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1190`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1191`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1192`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1193`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1194`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1195`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1196`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1197`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1198`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1199`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1200`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1201`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1202`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1203`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1204`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1205`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1206`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1207`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1208`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1209`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1210`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1211`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1212`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1213`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1214`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1215`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1216`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1217`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1218`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1219`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1220`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1221`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1222`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1223`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1224`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1225`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1226`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1227`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1228`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1229`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1230`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `api.js`
+- **Thin community `Community 1231`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1232`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1233`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `server.js`
+- **Thin community `Community 1234`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `app.ts`
+- **Thin community `Community 1235`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1237`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1238`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1239`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `auth.ts`
+- **Thin community `Community 1240`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1242`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `countries.ts`
+- **Thin community `Community 1244`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `email.ts`
+- **Thin community `Community 1245`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1246`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `payment.ts`
+- **Thin community `Community 1247`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1248`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1249`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `types.ts`
+- **Thin community `Community 1250`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1251`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `crons.ts`
+- **Thin community `Community 1252`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1253`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `internal.ts`
+- **Thin community `Community 1254`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1255`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1256`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1257`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1258`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1259`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1260`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1261`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1262`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1263`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1264`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1265`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `env.ts`
+- **Thin community `Community 1266`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1267`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `auth.ts`
+- **Thin community `Community 1268`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1269`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `colors.ts`
+- **Thin community `Community 1270`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `index.ts`
+- **Thin community `Community 1271`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1272`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `products.ts`
+- **Thin community `Community 1273`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1274`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `stores.ts`
+- **Thin community `Community 1275`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1276`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `bag.ts`
+- **Thin community `Community 1277`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `guest.ts`
+- **Thin community `Community 1278`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1279`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `index.ts`
+- **Thin community `Community 1280`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `me.ts`
+- **Thin community `Community 1281`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `offers.ts`
+- **Thin community `Community 1282`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1283`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1284`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1285`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1286`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1287`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1288`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1290`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1291`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `user.ts`
+- **Thin community `Community 1292`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1293`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `index.ts`
+- **Thin community `Community 1294`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `http.ts`
+- **Thin community `Community 1296`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `access.ts`
+- **Thin community `Community 1297`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `index.ts`
+- **Thin community `Community 1301`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1302`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `types.ts`
+- **Thin community `Community 1303`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1304`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `categories.ts`
+- **Thin community `Community 1305`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `colors.ts`
+- **Thin community `Community 1306`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1307`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1308`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1309`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1310`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `pos.ts`
+- **Thin community `Community 1311`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1312`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1313`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1314`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1315`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1317`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1318`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1320`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1322`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1323`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1324`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1325`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `types.ts`
+- **Thin community `Community 1329`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1330`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1331`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1333`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1335`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1337`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `dto.ts`
+- **Thin community `Community 1338`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1339`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1340`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `facts.ts`
+- **Thin community `Community 1343`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1344`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `types.ts`
+- **Thin community `Community 1345`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1346`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1347`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `customers.ts`
+- **Thin community `Community 1349`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1350`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `register.ts`
+- **Thin community `Community 1351`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `sync.ts`
+- **Thin community `Community 1352`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1353`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1354`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1355`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `schema.ts`
+- **Thin community `Community 1356`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `automation.ts`
+- **Thin community `Community 1357`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1358`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1359`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `index.ts`
+- **Thin community `Community 1360`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1361`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1362`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1363`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1364`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1365`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1366`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1367`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `category.ts`
+- **Thin community `Community 1368`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `color.ts`
+- **Thin community `Community 1369`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1370`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1371`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `index.ts`
+- **Thin community `Community 1372`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1373`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1374`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1375`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1376`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `organization.ts`
+- **Thin community `Community 1377`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1378`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `product.ts`
+- **Thin community `Community 1379`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1380`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1381`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1382`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `store.ts`
+- **Thin community `Community 1383`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1384`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1385`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `index.ts`
+- **Thin community `Community 1386`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1387`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1388`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1389`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1390`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1391`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1392`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1393`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `index.ts`
+- **Thin community `Community 1394`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1395`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1396`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1397`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1398`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1399`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1400`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1401`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1402`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1403`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1404`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1405`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `customer.ts`
+- **Thin community `Community 1406`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1407`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1408`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1409`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1410`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `index.ts`
+- **Thin community `Community 1411`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1412`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1413`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1414`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1415`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1416`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1417`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1418`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1419`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1420`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1421`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1422`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1423`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1424`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1425`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1426`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1427`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1428`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1429`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1430`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1431`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `index.ts`
+- **Thin community `Community 1432`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1433`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1434`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `index.ts`
+- **Thin community `Community 1435`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1436`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1437`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1438`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1439`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1440`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1441`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `index.ts`
+- **Thin community `Community 1442`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1443`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1444`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1445`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1446`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1447`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1448`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `bag.ts`
+- **Thin community `Community 1449`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1450`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1451`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1452`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `guest.ts`
+- **Thin community `Community 1453`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `index.ts`
+- **Thin community `Community 1454`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `offer.ts`
+- **Thin community `Community 1455`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1456`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1457`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `review.ts`
+- **Thin community `Community 1458`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1459`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1460`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1461`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1462`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1463`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1464`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1465`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1466`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `bag.ts`
+- **Thin community `Community 1467`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1468`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `customer.ts`
+- **Thin community `Community 1469`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `guest.ts`
+- **Thin community `Community 1470`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1472`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1474`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1475`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1476`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `users.ts`
+- **Thin community `Community 1478`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `payment.ts`
+- **Thin community `Community 1479`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1486`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `index.ts`
+- **Thin community `Community 1487`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1488`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1489`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1490`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1491`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `auth.ts`
+- **Thin community `Community 1492`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1493`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1495`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1496`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1497`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1498`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1499`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `index.ts`
+- **Thin community `Community 1500`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1501`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1502`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1503`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1507`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1509`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1510`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1511`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1512`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1513`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1514`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1515`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1516`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1517`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1518`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1519`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1520`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1522`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `constants.ts`
+- **Thin community `Community 1523`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1524`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1525`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `types.ts`
+- **Thin community `Community 1527`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1528`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1529`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1530`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1531`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1532`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1533`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1534`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1536`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1537`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1538`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1539`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1540`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1541`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1542`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1543`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1544`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1545`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1546`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1547`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `constants.ts`
+- **Thin community `Community 1548`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1549`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1550`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1551`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data.ts`
+- **Thin community `Community 1552`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1553`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1554`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1555`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1556`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1557`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1558`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1559`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1560`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1561`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1562`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1563`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `constants.ts`
+- **Thin community `Community 1564`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1565`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1566`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1567`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data.ts`
+- **Thin community `Community 1568`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1569`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1570`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1571`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1572`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1574`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1575`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1576`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1578`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1579`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1580`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `constants.ts`
+- **Thin community `Community 1581`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1582`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1583`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1584`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1585`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1586`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1587`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1588`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1589`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1591`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1592`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1594`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1595`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1596`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1597`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1600`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1601`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1602`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1604`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1605`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1606`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1607`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1608`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1612`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1613`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1614`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1615`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1616`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1617`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `constants.ts`
+- **Thin community `Community 1618`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1619`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1620`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1621`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `data.ts`
+- **Thin community `Community 1622`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `constants.ts`
+- **Thin community `Community 1625`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1626`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1627`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1628`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1629`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `data.ts`
+- **Thin community `Community 1630`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1631`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `constants.ts`
+- **Thin community `Community 1632`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1633`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1634`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1635`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1636`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `data.ts`
+- **Thin community `Community 1637`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1638`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1639`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1640`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1641`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1643`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1644`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1645`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1646`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1647`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1648`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1649`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1650`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1651`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1653`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1654`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1655`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1656`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1657`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1658`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1660`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1661`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1662`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1663`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1664`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1665`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `types.ts`
+- **Thin community `Community 1666`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1667`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1668`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1669`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1670`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 1671`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1672`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 1673`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1674`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1675`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1676`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1677`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1678`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1679`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1680`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1681`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1682`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1683`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1684`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `data.ts`
+- **Thin community `Community 1685`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1686`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1687`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1688`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1689`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1690`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1691`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1692`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1693`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1694`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1695`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1696`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1697`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `constants.ts`
+- **Thin community `Community 1698`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1699`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1700`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1701`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `data.ts`
+- **Thin community `Community 1702`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `types.ts`
+- **Thin community `Community 1703`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1704`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1705`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1706`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1707`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1708`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `index.ts`
+- **Thin community `Community 1709`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1710`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1711`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1712`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1713`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `index.tsx`
+- **Thin community `Community 1714`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1715`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1716`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1717`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1718`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1719`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1720`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1721`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1722`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1723`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1724`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `index.tsx`
+- **Thin community `Community 1725`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1726`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1727`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1728`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `button.tsx`
+- **Thin community `Community 1729`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1730`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `card.tsx`
+- **Thin community `Community 1731`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1732`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1733`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `command.tsx`
+- **Thin community `Community 1734`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1735`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1736`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1737`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `form.tsx`
+- **Thin community `Community 1738`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1739`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1740`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `input.tsx`
+- **Thin community `Community 1741`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1742`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1743`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1744`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1745`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1746`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1747`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `select.tsx`
+- **Thin community `Community 1748`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1749`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1750`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1751`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1752`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `table.tsx`
+- **Thin community `Community 1753`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1754`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1755`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1756`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1757`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1758`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1759`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1760`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1761`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `constants.ts`
+- **Thin community `Community 1762`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1763`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1764`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1765`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `data.ts`
+- **Thin community `Community 1766`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1767`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1768`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1769`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1770`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1771`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1772`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1773`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1774`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1775`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1776`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `index.ts`
+- **Thin community `Community 1777`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1779`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1780`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1781`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1782`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1783`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1787`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 1788`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1789`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1790`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1791`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1792`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `index.ts`
+- **Thin community `Community 1793`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1794`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `index.ts`
+- **Thin community `Community 1795`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1796`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `aws.ts`
+- **Thin community `Community 1798`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `constants.ts`
+- **Thin community `Community 1799`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `countries.ts`
+- **Thin community `Community 1800`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1801`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1803`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1804`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1805`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1806`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `dto.ts`
+- **Thin community `Community 1809`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `ports.ts`
+- **Thin community `Community 1810`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `constants.ts`
+- **Thin community `Community 1811`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `index.ts`
+- **Thin community `Community 1814`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `types.ts`
+- **Thin community `Community 1816`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1821`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1822`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1823`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1826`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1827`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1828`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1829`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1830`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `index.ts`
+- **Thin community `Community 1835`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1836`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `category.ts`
+- **Thin community `Community 1837`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `product.ts`
+- **Thin community `Community 1838`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `store.ts`
+- **Thin community `Community 1839`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1840`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `user.ts`
+- **Thin community `Community 1841`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1842`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1843`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1844`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1845`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1846`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `main.tsx`
+- **Thin community `Community 1847`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1848`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1849`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1850`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1851`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1852`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1853`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `index.tsx`
+- **Thin community `Community 1854`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1855`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1856`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1857`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1858`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 1859`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1861`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1862`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `index.tsx`
+- **Thin community `Community 1863`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1864`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1865`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1866`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `home.tsx`
+- **Thin community `Community 1867`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1868`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1870`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `review.tsx`
+- **Thin community `Community 1872`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1873`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1874`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `index.tsx`
+- **Thin community `Community 1875`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1876`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1877`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1878`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `index.tsx`
+- **Thin community `Community 1879`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1880`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1881`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1882`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1883`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1884`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1885`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1886`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `index.tsx`
+- **Thin community `Community 1887`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1888`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1889`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1890`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1891`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1892`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1893`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1894`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1895`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1896`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `index.tsx`
+- **Thin community `Community 1897`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1898`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `index.tsx`
+- **Thin community `Community 1899`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `new.tsx`
+- **Thin community `Community 1900`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `index.tsx`
+- **Thin community `Community 1901`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `new.tsx`
+- **Thin community `Community 1902`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1903`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1904`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `index.tsx`
+- **Thin community `Community 1905`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `new.tsx`
+- **Thin community `Community 1906`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `index.tsx`
+- **Thin community `Community 1907`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1908`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1909`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1910`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1911`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `index.tsx`
+- **Thin community `Community 1912`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1913`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1914`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1915`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `index.tsx`
+- **Thin community `Community 1916`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1917`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1918`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1919`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `index.tsx`
+- **Thin community `Community 1920`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1921`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1922`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1923`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1924`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1925`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1926`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2165
-- Graph nodes: 8542
-- Graph edges: 10331
+- Graph nodes: 8549
+- Graph edges: 10342
 - Communities: 2092
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx
@@ -74,9 +74,9 @@ describe("InputOTPForm", () => {
     );
     expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
       PENDING_ATHENA_AUTH_SYNC_KEY,
-      "1"
+      expect.stringMatching(/"startedAt":\d+/),
     );
-    expect(mocked.navigate).toHaveBeenCalledWith({ to: "/" });
+    expect(mocked.navigate).not.toHaveBeenCalled();
   });
 
   it("surfaces invalid verification codes to the operator", async () => {
@@ -144,7 +144,7 @@ describe("InputOTPForm", () => {
     await waitFor(() =>
       expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
         PENDING_ATHENA_AUTH_SYNC_KEY,
-        "1"
+        expect.stringMatching(/"startedAt":\d+/),
       )
     );
   });
@@ -163,7 +163,7 @@ describe("InputOTPForm", () => {
     await waitFor(() =>
       expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
         PENDING_ATHENA_AUTH_SYNC_KEY,
-        "1"
+        expect.stringMatching(/"startedAt":\d+/),
       )
     );
 

--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
@@ -24,7 +24,6 @@ import { useForm } from "react-hook-form";
 import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
 import { ArrowLeft, ArrowRight } from "lucide-react";
-import { useNavigate } from "@tanstack/react-router";
 
 const REQUEST_NEW_CODE_DELAY_SECONDS = 59;
 const OTP_SLOT_INDEXES = [0, 1, 2, 3, 4, 5];
@@ -79,7 +78,6 @@ export function InputOTPForm({
   );
   const signInInFlightRef = useRef(false);
   const { signIn } = useAuthActions();
-  const navigate = useNavigate();
 
   useEffect(() => {
     const handleAuthSyncFailed = () => {
@@ -151,7 +149,6 @@ export function InputOTPForm({
       startAthenaAuthSyncHandoff();
       setIsAuthHandoffPending(true);
       setIsSigningIn(false);
-      navigate({ to: "/" });
       return;
     } catch (e) {
       const message = e instanceof Error ? e.message : "Could not verify code";

--- a/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx
@@ -59,11 +59,11 @@ describe("PosRecoveryCodeForm", () => {
     );
     expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
       PENDING_ATHENA_AUTH_SYNC_KEY,
-      "1",
+      expect.stringMatching(
+        /"redirectTo":"\/wigclub\/store\/wigclub\/pos\/register"/,
+      ),
     );
-    expect(mocked.navigate).toHaveBeenCalledWith({
-      to: "/wigclub/store/wigclub/pos/register",
-    });
+    expect(mocked.navigate).not.toHaveBeenCalled();
     expect(window.localStorage.setItem).not.toHaveBeenCalledWith(
       expect.any(String),
       "abc-123",
@@ -137,7 +137,13 @@ describe("PosRecoveryCodeForm", () => {
     await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
     await user.click(screen.getByRole("button", { name: /continue/i }));
 
-    await waitFor(() => expect(mocked.navigate).toHaveBeenCalledWith({ to: "/" }));
+    await waitFor(() =>
+      expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
+        PENDING_ATHENA_AUTH_SYNC_KEY,
+        expect.stringMatching(/"redirectTo":"\/"/),
+      ),
+    );
+    expect(mocked.navigate).not.toHaveBeenCalled();
   });
 
   it("navigates query-bearing recovery redirects with separate search params", async () => {
@@ -157,10 +163,13 @@ describe("PosRecoveryCodeForm", () => {
     await user.click(screen.getByRole("button", { name: /continue/i }));
 
     await waitFor(() =>
-      expect(mocked.navigate).toHaveBeenCalledWith({
-        to: "/wigclub/store/wigclub/pos/register",
-        search: { drawer: "front" },
-      }),
+      expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
+        PENDING_ATHENA_AUTH_SYNC_KEY,
+        expect.stringMatching(
+          /"redirectTo":"\/wigclub\/store\/wigclub\/pos\/register\?drawer=front"/,
+        ),
+      ),
     );
+    expect(mocked.navigate).not.toHaveBeenCalled();
   });
 });

--- a/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
@@ -1,5 +1,4 @@
 import { useAuthActions } from "@convex-dev/auth/react";
-import { useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
@@ -12,18 +11,6 @@ import { startAthenaAuthSyncHandoff } from "./authSyncHandoff";
 const POS_RECOVERY_ACCOUNT_EMAIL = "pos@wigclub.store";
 const RECOVERY_FAILURE_COPY =
   "POS sign-in failed. Check the recovery code or ask an admin to confirm POS-only access.";
-
-function navigationTargetForRedirect(redirectTo: string) {
-  const [pathname, queryString] = redirectTo.split("?", 2);
-  if (!queryString) {
-    return { to: pathname };
-  }
-
-  return {
-    to: pathname,
-    search: Object.fromEntries(new URLSearchParams(queryString)),
-  };
-}
 
 export function PosRecoveryCodeForm({
   onBack,
@@ -44,7 +31,6 @@ export function PosRecoveryCodeForm({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const signInInFlightRef = useRef(false);
   const { signIn } = useAuthActions();
-  const navigate = useNavigate();
 
   useEffect(() => {
     const handleAuthSyncFailed = () => {
@@ -104,10 +90,9 @@ export function PosRecoveryCodeForm({
         return;
       }
 
-      const targetPath = startAthenaAuthSyncHandoff(redirectTo);
+      startAthenaAuthSyncHandoff(redirectTo);
       setIsAuthHandoffPending(true);
       setIsSigningIn(false);
-      navigate(navigationTargetForRedirect(targetPath) as never);
     } catch {
       setErrorMessage(RECOVERY_FAILURE_COPY);
       signInInFlightRef.current = false;

--- a/packages/athena-webapp/src/components/auth/Login/authSyncHandoff.ts
+++ b/packages/athena-webapp/src/components/auth/Login/authSyncHandoff.ts
@@ -1,7 +1,25 @@
 import {
+  ATHENA_AUTH_SYNC_FAILED_EVENT,
   ATHENA_PENDING_AUTH_SYNC_EVENT,
   PENDING_ATHENA_AUTH_SYNC_KEY,
 } from "~/src/lib/constants";
+
+export const ATHENA_AUTH_SYNC_HANDOFF_TTL_MS = 60_000;
+
+export type AthenaAuthSyncHandoff = {
+  redirectTo: string;
+  startedAt: number;
+};
+
+export type AthenaAuthSyncHandoffStatus =
+  | {
+      kind: "active";
+      handoff: AthenaAuthSyncHandoff;
+      expiresAt: number;
+    }
+  | {
+      kind: "expired" | "invalid" | "missing";
+    };
 
 function normalizeAuthSyncRedirect(redirectTo?: string | null) {
   if (!redirectTo?.startsWith("/") || redirectTo.startsWith("//")) {
@@ -11,9 +29,82 @@ function normalizeAuthSyncRedirect(redirectTo?: string | null) {
   return redirectTo;
 }
 
+function readRawHandoff() {
+  try {
+    return sessionStorage.getItem(PENDING_ATHENA_AUTH_SYNC_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function parseHandoff(raw: string): AthenaAuthSyncHandoff | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<AthenaAuthSyncHandoff>;
+    if (
+      !parsed ||
+      typeof parsed.startedAt !== "number" ||
+      !Number.isFinite(parsed.startedAt) ||
+      typeof parsed.redirectTo !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      startedAt: parsed.startedAt,
+      redirectTo: normalizeAuthSyncRedirect(parsed.redirectTo),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getAthenaAuthSyncHandoffStatus(
+  now = Date.now(),
+): AthenaAuthSyncHandoffStatus {
+  const raw = readRawHandoff();
+  if (!raw) {
+    return { kind: "missing" };
+  }
+
+  const handoff = parseHandoff(raw);
+  if (!handoff) {
+    return { kind: "invalid" };
+  }
+
+  const expiresAt = handoff.startedAt + ATHENA_AUTH_SYNC_HANDOFF_TTL_MS;
+  if (expiresAt <= now) {
+    return { kind: "expired" };
+  }
+
+  return {
+    kind: "active",
+    handoff,
+    expiresAt,
+  };
+}
+
+export function clearAthenaAuthSyncHandoff() {
+  try {
+    sessionStorage.removeItem(PENDING_ATHENA_AUTH_SYNC_KEY);
+  } catch {
+    // Storage can be unavailable in private or locked-down browser contexts.
+  }
+}
+
+export function failAthenaAuthSyncHandoff() {
+  clearAthenaAuthSyncHandoff();
+  window.dispatchEvent(new Event(ATHENA_AUTH_SYNC_FAILED_EVENT));
+}
+
 export function startAthenaAuthSyncHandoff(redirectTo?: string | null) {
-  sessionStorage.setItem(PENDING_ATHENA_AUTH_SYNC_KEY, "1");
+  const normalizedRedirect = normalizeAuthSyncRedirect(redirectTo);
+  const handoff: AthenaAuthSyncHandoff = {
+    redirectTo: normalizedRedirect,
+    startedAt: Date.now(),
+  };
+
+  sessionStorage.setItem(PENDING_ATHENA_AUTH_SYNC_KEY, JSON.stringify(handoff));
   window.dispatchEvent(new Event(ATHENA_PENDING_AUTH_SYNC_EVENT));
 
-  return normalizeAuthSyncRedirect(redirectTo);
+  return normalizedRedirect;
 }

--- a/packages/athena-webapp/src/components/auth/Login/index.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/index.test.tsx
@@ -4,6 +4,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ATHENA_POS_RECOVERY_CODE_PROVIDER_ID } from "../../../../shared/auth";
 import { Login } from "./index";
+import { PENDING_ATHENA_AUTH_SYNC_KEY } from "~/src/lib/constants";
+
+function expectPendingAuthSyncRedirect(redirectTo: string) {
+  const handoffCall = vi
+    .mocked(window.sessionStorage.setItem)
+    .mock.calls.find(([key]) => key === PENDING_ATHENA_AUTH_SYNC_KEY);
+  expect(handoffCall).toBeDefined();
+  const handoff = JSON.parse(String(handoffCall?.[1])) as {
+    redirectTo?: string;
+    startedAt?: unknown;
+  };
+
+  expect(handoff.redirectTo).toBe(redirectTo);
+  expect(typeof handoff.startedAt).toBe("number");
+}
 
 const mocked = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -37,6 +52,7 @@ describe("Login", () => {
     mocked.useSearch.mockReset();
     vi.stubGlobal("indexedDB", {});
     window.sessionStorage.clear();
+    vi.mocked(window.sessionStorage.setItem).mockReset();
   });
 
   it("passes POS route scope from redirectTo into recovery-code sign-in", async () => {
@@ -65,9 +81,8 @@ describe("Login", () => {
         },
       ),
     );
-    expect(mocked.navigate).toHaveBeenCalledWith({
-      to: "/wigclub/store/wigclub/pos/register",
-    });
+    expectPendingAuthSyncRedirect("/wigclub/store/wigclub/pos/register");
+    expect(mocked.navigate).not.toHaveBeenCalled();
   });
 
   it("uses the provisioned local terminal seed for generic login recovery", async () => {
@@ -114,9 +129,8 @@ describe("Login", () => {
         },
       ),
     );
-    expect(mocked.navigate).toHaveBeenCalledWith({
-      to: "/wigclub/store/wigclub/pos",
-    });
+    expectPendingAuthSyncRedirect("/wigclub/store/wigclub/pos");
+    expect(mocked.navigate).not.toHaveBeenCalled();
   });
 
   it("defaults POS-only provisioned terminals to POS recovery while keeping email secondary", async () => {
@@ -186,7 +200,8 @@ describe("Login", () => {
         },
       ),
     );
-    expect(mocked.navigate).toHaveBeenCalledWith({ to: "/" });
+    expectPendingAuthSyncRedirect("/");
+    expect(mocked.navigate).not.toHaveBeenCalled();
   });
 
   it("disables recovery-code submission when neither url nor local browser state identifies a store", async () => {

--- a/packages/athena-webapp/src/hooks/useAuth.test.tsx
+++ b/packages/athena-webapp/src/hooks/useAuth.test.tsx
@@ -1,7 +1,10 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { LOGGED_IN_USER_ID_KEY } from "../lib/constants";
+import {
+  LOGGED_IN_USER_ID_KEY,
+  PENDING_ATHENA_AUTH_SYNC_KEY,
+} from "../lib/constants";
 import { useAuth } from "./useAuth";
 
 const mocked = vi.hoisted(() => ({
@@ -29,6 +32,9 @@ describe("useAuth", () => {
     vi.mocked(window.localStorage.getItem).mockReset();
     vi.mocked(window.localStorage.setItem).mockReset();
     vi.mocked(window.localStorage.removeItem).mockReset();
+    window.sessionStorage.clear();
+    vi.mocked(window.sessionStorage.getItem).mockReset();
+    vi.mocked(window.sessionStorage.removeItem).mockReset();
   });
 
   it("stays loading until the authenticated Convex user settles", () => {
@@ -223,5 +229,47 @@ describe("useAuth", () => {
       email: "manager@example.com",
     });
     expect(mocked.useQuery.mock.calls.at(-1)?.[1]).toEqual({});
+  });
+
+  it("treats fresh pending auth sync as loading while the Convex session is settling", () => {
+    vi.mocked(window.sessionStorage.getItem).mockImplementation((key) =>
+      key === PENDING_ATHENA_AUTH_SYNC_KEY
+        ? JSON.stringify({ startedAt: Date.now(), redirectTo: "/" })
+        : null,
+    );
+    mocked.useAuthToken.mockReturnValue(null);
+    mocked.useConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    mocked.useQuery.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAuth());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.user).toBeUndefined();
+    expect(window.sessionStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for stale pending auth sync metadata", async () => {
+    vi.mocked(window.sessionStorage.getItem).mockImplementation((key) =>
+      key === PENDING_ATHENA_AUTH_SYNC_KEY
+        ? JSON.stringify({ startedAt: 1, redirectTo: "/" })
+        : null,
+    );
+    mocked.useAuthToken.mockReturnValue(null);
+    mocked.useConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    mocked.useQuery.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.user).toBeNull();
+    expect(window.sessionStorage.removeItem).toHaveBeenCalledWith(
+      PENDING_ATHENA_AUTH_SYNC_KEY,
+    );
   });
 });

--- a/packages/athena-webapp/src/hooks/useAuth.ts
+++ b/packages/athena-webapp/src/hooks/useAuth.ts
@@ -1,14 +1,24 @@
 import { useConvexAuth, useQuery } from "convex/react";
 import { useAuthToken } from "@convex-dev/auth/react";
-import { LOGGED_IN_USER_ID_KEY } from "../lib/constants";
+import {
+  ATHENA_PENDING_AUTH_SYNC_EVENT,
+  LOGGED_IN_USER_ID_KEY,
+} from "../lib/constants";
 import { api } from "~/convex/_generated/api";
 import { useEffect, useState } from "react";
+import {
+  failAthenaAuthSyncHandoff,
+  getAthenaAuthSyncHandoffStatus,
+} from "../components/auth/Login/authSyncHandoff";
 
 export const useAuth = () => {
   const [loggedInUserId, setLoggedInUserId] = useState<string | null>(null);
   const [isStorageLoaded, setIsStorageLoaded] = useState(false);
+  const [pendingAuthSyncTick, setPendingAuthSyncTick] = useState(0);
   const authToken = useAuthToken();
   const { isAuthenticated, isLoading: isLoadingConvexAuth } = useConvexAuth();
+  const pendingAuthSyncStatus = getAthenaAuthSyncHandoffStatus();
+  const isPendingAuthSync = pendingAuthSyncStatus.kind === "active";
   const currentConvexUser = useQuery(api.app.getCurrentUser);
   const isRecoveringConvexSession =
     Boolean(authToken) && !isAuthenticated && currentConvexUser === undefined;
@@ -30,9 +40,49 @@ export const useAuth = () => {
   }, []);
 
   useEffect(() => {
+    const handlePendingAuthSync = () => {
+      setPendingAuthSyncTick((tick) => tick + 1);
+    };
+
+    window.addEventListener(ATHENA_PENDING_AUTH_SYNC_EVENT, handlePendingAuthSync);
+    window.addEventListener("storage", handlePendingAuthSync);
+
+    return () => {
+      window.removeEventListener(
+        ATHENA_PENDING_AUTH_SYNC_EVENT,
+        handlePendingAuthSync,
+      );
+      window.removeEventListener("storage", handlePendingAuthSync);
+    };
+  }, []);
+
+  useEffect(() => {
+    const status = getAthenaAuthSyncHandoffStatus();
+    if (status.kind === "expired" || status.kind === "invalid") {
+      failAthenaAuthSyncHandoff();
+      return;
+    }
+
+    if (status.kind !== "active") {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      const latestStatus = getAthenaAuthSyncHandoffStatus();
+      if (latestStatus.kind === "active") {
+        failAthenaAuthSyncHandoff();
+        setPendingAuthSyncTick((tick) => tick + 1);
+      }
+    }, Math.max(status.expiresAt - Date.now(), 0));
+
+    return () => window.clearTimeout(timeoutId);
+  }, [authToken, isAuthenticated, isLoadingConvexAuth, pendingAuthSyncTick]);
+
+  useEffect(() => {
     if (
       !isStorageLoaded ||
       isLoadingConvexAuth ||
+      isPendingAuthSync ||
       isRecoveringConvexSession ||
       isLoadingConvexUser ||
       isLoadingAthenaUser
@@ -57,6 +107,7 @@ export const useAuth = () => {
   }, [
     authenticatedAthenaUser,
     isLoadingConvexAuth,
+    isPendingAuthSync,
     isRecoveringConvexSession,
     isLoadingConvexUser,
     isLoadingAthenaUser,
@@ -66,6 +117,7 @@ export const useAuth = () => {
   const isLoading =
     !isStorageLoaded ||
     isLoadingConvexAuth ||
+    isPendingAuthSync ||
     isRecoveringConvexSession ||
     isLoadingConvexUser ||
     isLoadingAthenaUser;

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -395,6 +395,40 @@ describe("Authed layout", () => {
     expect(mocked.navigate).not.toHaveBeenCalled();
   });
 
+  it("does not treat pending auth-sync loading as POS terminal authority", () => {
+    vi.mocked(window.localStorage.getItem).mockImplementation((key) =>
+      key === LOGGED_IN_USER_ID_KEY || key === POS_APP_ACCOUNT_ID_KEY
+        ? "stale-user-1"
+        : null,
+    );
+    mocked.useAuth.mockReturnValue({
+      user: undefined,
+      isLoading: true,
+    });
+    mocked.useLocalPosEntryContext.mockReturnValue(readyLocalPosEntryContext());
+    mocked.readStoredPosAppAccountId.mockReturnValue("stale-user-1");
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({ location: { pathname: "/wigclub/store/wigclub/pos/register" } }),
+    );
+
+    const { container } = render(<Layout />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByTestId("authed-outlet")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("pos-remote-assist-host")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /pos terminal/i }),
+    ).not.toBeInTheDocument();
+    expect(mocked.usePosTerminalAppSessionRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isAppUserMissing: false,
+        storedAppAccountId: "stale-user-1",
+      }),
+    );
+    expect(mocked.navigate).not.toHaveBeenCalled();
+  });
+
   it("keeps non-POS routes blocked while offline auth is still loading", () => {
     Object.defineProperty(window.navigator, "onLine", {
       configurable: true,

--- a/packages/athena-webapp/src/routes/login/-login-layout.tsx
+++ b/packages/athena-webapp/src/routes/login/-login-layout.tsx
@@ -7,14 +7,17 @@ import { useConvexAuth, useMutation } from "convex/react";
 import { useEffect, useRef, useState } from "react";
 import { useAuthToken } from "@convex-dev/auth/react";
 import {
-  ATHENA_AUTH_SYNC_FAILED_EVENT,
   ATHENA_PENDING_AUTH_SYNC_EVENT,
   LOGGED_IN_USER_ID_KEY,
   POS_APP_ACCOUNT_ID_KEY,
-  PENDING_ATHENA_AUTH_SYNC_KEY,
 } from "~/src/lib/constants";
 import { api } from "~/convex/_generated/api";
 import { runCommand } from "~/src/lib/errors/runCommand";
+import {
+  clearAthenaAuthSyncHandoff,
+  failAthenaAuthSyncHandoff,
+  getAthenaAuthSyncHandoffStatus,
+} from "~/src/components/auth/Login/authSyncHandoff";
 
 const HOME_PATH = "/";
 
@@ -23,6 +26,18 @@ const AUTH_SYNC_MAX_ATTEMPTS = 60;
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function navigationTargetForRedirect(redirectTo: string) {
+  const url = new URL(redirectTo, window.location.origin);
+  const pathname = url.pathname || "/";
+  const search = Object.fromEntries(url.searchParams.entries());
+
+  if (Object.keys(search).length === 0) {
+    return { to: pathname };
+  }
+
+  return { to: pathname, search };
 }
 
 function useDocumentScrollLock() {
@@ -90,8 +105,8 @@ export function LoginLayout() {
   }, []);
 
   useEffect(() => {
-    const pendingAuthSync =
-      sessionStorage.getItem(PENDING_ATHENA_AUTH_SYNC_KEY) === "1";
+    const handoffStatus = getAthenaAuthSyncHandoffStatus();
+    const pendingAuthSync = handoffStatus.kind === "active";
     const hasLoggedInUserId = Boolean(
       localStorage.getItem(LOGGED_IN_USER_ID_KEY)
     );
@@ -100,11 +115,28 @@ export function LoginLayout() {
     const shouldCompletePendingAuthSync =
       pendingAuthSync || shouldRecoverAuthenticatedSession;
 
+    if (handoffStatus.kind === "expired" || handoffStatus.kind === "invalid") {
+      failAthenaAuthSyncHandoff();
+      return;
+    }
+
     if (isSyncingRef.current || !shouldCompletePendingAuthSync) {
       return;
     }
 
     if (isLoading || !isAuthenticated || !authToken) {
+      if (pendingAuthSync) {
+        const timeoutId = window.setTimeout(() => {
+          const latestStatus = getAthenaAuthSyncHandoffStatus();
+          if (latestStatus.kind === "active") {
+            failAthenaAuthSyncHandoff();
+            setPendingAuthSyncTick((tick) => tick + 1);
+          }
+        }, Math.max(handoffStatus.expiresAt - Date.now(), 0));
+
+        return () => window.clearTimeout(timeoutId);
+      }
+
       return;
     }
 
@@ -156,10 +188,12 @@ export function LoginLayout() {
           return;
         }
 
-        sessionStorage.removeItem(PENDING_ATHENA_AUTH_SYNC_KEY);
+        const redirectTo =
+          handoffStatus.kind === "active" ? handoffStatus.handoff.redirectTo : "/";
+        clearAthenaAuthSyncHandoff();
         localStorage.setItem(LOGGED_IN_USER_ID_KEY, userId);
         localStorage.setItem(POS_APP_ACCOUNT_ID_KEY, userId);
-        navigate({ to: "/" });
+        navigate(navigationTargetForRedirect(redirectTo) as never);
       } catch (error) {
         if (!isMountedRef.current) {
           return;
@@ -171,7 +205,7 @@ export function LoginLayout() {
             : "Could not finish loading your Athena profile";
 
         setAuthSyncError(message);
-        window.dispatchEvent(new Event(ATHENA_AUTH_SYNC_FAILED_EVENT));
+        failAthenaAuthSyncHandoff();
         isSyncingRef.current = false;
       }
     };

--- a/packages/athena-webapp/src/routes/login/_layout.test.tsx
+++ b/packages/athena-webapp/src/routes/login/_layout.test.tsx
@@ -4,11 +4,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LoginLayout } from "./-login-layout";
 import {
+  ATHENA_AUTH_SYNC_FAILED_EVENT,
   LOGGED_IN_USER_ID_KEY,
   POS_APP_ACCOUNT_ID_KEY,
   PENDING_ATHENA_AUTH_SYNC_KEY,
 } from "~/src/lib/constants";
 import { ok, userError } from "~/shared/commandResult";
+
+function activeHandoff(redirectTo = "/") {
+  return JSON.stringify({ startedAt: Date.now(), redirectTo });
+}
 
 const mocked = vi.hoisted(() => ({
   useConvexAuth: vi.fn(),
@@ -86,8 +91,7 @@ describe("LoginLayout", () => {
         })
       )
       .mockResolvedValue(ok({ _id: "user-1" }));
-    window.sessionStorage.setItem(PENDING_ATHENA_AUTH_SYNC_KEY, "1");
-    vi.mocked(window.sessionStorage.getItem).mockReturnValue("1");
+    vi.mocked(window.sessionStorage.getItem).mockReturnValue(activeHandoff());
 
     const view = render(<LoginLayout />);
 
@@ -108,6 +112,7 @@ describe("LoginLayout", () => {
       POS_APP_ACCOUNT_ID_KEY,
       "user-1"
     );
+    expect(mocked.navigate).toHaveBeenCalledWith({ to: "/" });
   });
 
   it("recovers an authenticated Convex session even when the pending sync flag is missing", async () => {
@@ -135,6 +140,31 @@ describe("LoginLayout", () => {
     expect(mocked.navigate).toHaveBeenCalledWith({ to: "/" });
   });
 
+  it("uses the pending auth-sync redirect after the Athena user sync succeeds", async () => {
+    mocked.useConvexAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+    mocked.useAuthToken.mockReturnValue("jwt-123");
+    mocked.syncAuthenticatedAthenaUser.mockResolvedValue(ok({ _id: "user-pos" }));
+    vi.mocked(window.sessionStorage.getItem).mockReturnValue(
+      activeHandoff("/wigclub/store/wigclub/pos/register?drawer=front")
+    );
+
+    render(<LoginLayout />);
+
+    await waitFor(() =>
+      expect(mocked.syncAuthenticatedAthenaUser).toHaveBeenCalledTimes(1)
+    );
+    expect(window.sessionStorage.removeItem).toHaveBeenCalledWith(
+      PENDING_ATHENA_AUTH_SYNC_KEY
+    );
+    expect(mocked.navigate).toHaveBeenCalledWith({
+      to: "/wigclub/store/wigclub/pos/register",
+      search: { drawer: "front" },
+    });
+  });
+
   it("surfaces safe auth-sync user errors without storing a bogus Athena user id", async () => {
     mocked.useConvexAuth.mockReturnValue({
       isAuthenticated: true,
@@ -147,7 +177,7 @@ describe("LoginLayout", () => {
         message: "Sign in again to continue",
       })
     );
-    vi.mocked(window.sessionStorage.getItem).mockReturnValue("1");
+    vi.mocked(window.sessionStorage.getItem).mockReturnValue(activeHandoff());
 
     render(<LoginLayout />);
 
@@ -160,6 +190,30 @@ describe("LoginLayout", () => {
       LOGGED_IN_USER_ID_KEY,
       undefined
     );
+  });
+
+  it("clears stale pending auth sync when Convex Auth settles without a session", async () => {
+    const authSyncFailed = vi.fn();
+    window.addEventListener(ATHENA_AUTH_SYNC_FAILED_EVENT, authSyncFailed);
+    mocked.useConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    mocked.useAuthToken.mockReturnValue(null);
+    vi.mocked(window.sessionStorage.getItem).mockReturnValue(
+      JSON.stringify({ startedAt: 1, redirectTo: "/" }),
+    );
+
+    render(<LoginLayout />);
+
+    await waitFor(() =>
+      expect(window.sessionStorage.removeItem).toHaveBeenCalledWith(
+        PENDING_ATHENA_AUTH_SYNC_KEY,
+      ),
+    );
+    expect(authSyncFailed).toHaveBeenCalledTimes(1);
+    expect(mocked.syncAuthenticatedAthenaUser).not.toHaveBeenCalled();
+    window.removeEventListener(ATHENA_AUTH_SYNC_FAILED_EVENT, authSyncFailed);
   });
 
   it("completes auth recovery after the Convex identity settles during an in-flight sync", async () => {


### PR DESCRIPTION
## Summary
- Keep OTP and POS recovery forms on `/login` after provider success and let `LoginLayout` own the authenticated redirect after `syncAuthenticatedAthenaUser` succeeds.
- Replace the bare pending auth-sync sentinel with bounded JSON handoff metadata containing `redirectTo` and `startedAt`, plus fail-closed cleanup for invalid or expired handoffs.
- Teach `useAuth` and authed route tests to treat fresh pending auth sync as loading, avoiding stale local user/POS authority during the Convex Auth to Athena-user gap.
- Added plan and solution notes for V26-940 and refreshed graphify artifacts.

## Validation
- `bun run test -- src/components/auth/Login/InputOTP.test.tsx src/components/auth/Login/PosRecoveryCodeForm.test.tsx src/components/auth/Login/index.test.tsx src/routes/login/_layout.test.tsx src/hooks/useAuth.test.tsx src/routes/_authed.test.tsx`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run plan-html:check docs/plans/2026-07-03-002-fix-login-otp-auth-sync-plan.html`
- `bun run pr:athena`

## Browser proof
Using the in-app browser at `http://localhost:5173/login` and Gmail OTPs for `knownothing955@gmail.com`, verified three consecutive real login cycles with no manual reload:
- OTP `995824`: `/login` -> `/wigclub/store/wigclub/operations`
- OTP `659738`: `/login` -> `/wigclub/store/wigclub/operations`
- OTP `305469`: `/login` -> `/wigclub/store/wigclub/operations`

Linear: V26-940
