### PR TITLE
fix(operations): polish carry-forward work item copy

### DIFF
--- a/docs/solutions/design-patterns/athena-daily-operations-carry-forward-copy-2026-07-04.md
+++ b/docs/solutions/design-patterns/athena-daily-operations-carry-forward-copy-2026-07-04.md
@@ -1,0 +1,105 @@
+---
+title: Daily operations carry-forward rows need operator-facing copy
+date: 2026-07-04
+category: design-patterns
+module: athena-webapp
+problem_type: design_pattern
+component: rails_view
+resolution_type: code_fix
+severity: medium
+applies_when:
+  - "Daily opening or close surfaces render operational work items"
+  - "Backend work item titles or metadata may contain raw identifiers"
+  - "A review card is reused across queue, opening, and close contexts"
+tags: [daily-operations, carry-forward, product-copy, operations]
+---
+
+# Daily operations carry-forward rows need operator-facing copy
+
+## Problem
+Daily opening and end-of-day close views can render carry-forward operational
+work items that originated in Open Work. Those items often carry backend-shaped
+titles and metadata such as `service_case`, `normal`, or
+`pos_pending_checkout_item_review`, which are accurate but not calm
+operator-facing copy.
+
+## Solution
+Normalize carry-forward item presentation at the daily operations boundary,
+even when the underlying work item remains generic. The card should:
+
+- Capitalize plain lower-case titles without changing intentionally cased copy.
+- Preserve meaningful title prefixes such as `Review inventory for` and
+  `Review pending checkout item:` while title-casing the product or subject.
+- Convert work item type, status, and priority metadata into operator-facing
+  labels before rendering.
+- Keep operational work item metadata visible in the collapsed card instead of
+  requiring an extra details disclosure.
+- Put the source action in the card header so the operator sees the next action
+  next to the row identity.
+
+For example, render `service_case` as `Service case`, `normal` as `Normal`,
+and `Review pending checkout item: protein Brazilian hair repair mask` as
+`Review pending checkout item: Protein Brazilian Hair Repair Mask`.
+
+## Why This Matters
+Daily opening and close are handoff surfaces. Operators scan them to decide
+whether the store can open, whether the day can close, or what work must carry
+forward. Raw identifiers make that scan feel like backend inspection instead of
+operations work, and hiding key work-item metadata behind a disclosure adds an
+avoidable step when the row itself is already the work summary.
+
+The same shared review card can still be reused, but each caller should decide
+which fields are primary for that workflow. For ordinary review evidence, a
+compact row plus details disclosure is helpful. For carry-forward operational
+work, the type/status/priority triplet is the compact summary.
+
+## Prevention
+- Add component tests that assert the rendered copy, not only the raw snapshot
+  shape.
+- Include representative work item types such as service cases, synced-sale
+  inventory reviews, and POS pending checkout reviews in daily opening and close
+  fixtures.
+- Keep product-copy normalization close to the surface that owns the operator
+  decision, instead of mutating durable work item records for one view.
+- When reusing `OperationReviewItemCard`, choose `headerActionSlot`,
+  `collapsedMetadataEntries`, and `metadataEntries` deliberately for each
+  workflow.
+
+## Examples
+Before:
+
+```text
+tokin
+type: service_case
+priority: normal
+status: open
+```
+
+After:
+
+```text
+Tokin
+Type: Service case
+Priority: Normal
+Status: Open
+```
+
+Before:
+
+```text
+Review inventory for slides
+```
+
+After:
+
+```text
+Review inventory for Slides
+```
+
+## Related
+- `docs/product-copy-tone.md`
+- `docs/solutions/design-patterns/athena-open-work-row-context-metadata-2026-06-29.md`
+- `docs/solutions/architecture-patterns/athena-open-work-resolution-ownership-2026-07-02.md`
+- `packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`
+- `packages/athena-webapp/src/components/operations/DailyCloseView.tsx`
+- `packages/athena-webapp/src/components/operations/OperationReviewItemCard.tsx`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8578 nodes · 10384 edges · 2096 communities detected
+- 8585 nodes · 10397 edges · 2096 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2151,7 +2151,7 @@ Nodes (66): attentionSeverity(), automationRunClassification(), automationStatus
 
 ### Community 4 - "Community 4"
 Cohesion: 0.04
-Nodes (32): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), getBucketCountClassName(), getDailyCloseSalesMetricLabels(), getDailyCloseStatus(), getDisplayMetadataLabel() (+24 more)
+Nodes (34): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatOperationalWorkTypeLabel(), getBucketCountClassName(), getDailyCloseSalesMetricLabels(), getDailyCloseStatus() (+26 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.09
@@ -2178,16 +2178,16 @@ Cohesion: 0.08
 Nodes (42): addDaysToOperatingDate(), automationErrorMessage(), automationIdempotencyKey(), configuredEodAutoCompleteStoreDayContext(), configuredOpeningOperatingDate(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming() (+34 more)
 
 ### Community 11 - "Community 11"
+Cohesion: 0.06
+Nodes (27): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatOperationalWorkTypeLabel(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue() (+19 more)
+
+### Community 12 - "Community 12"
 Cohesion: 0.11
 Nodes (42): completed(), executeCallbackCommand(), executeClearLocalReviewItems(), executeClearStaleDrawerAuthority(), executeCollectLocalReview(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand() (+34 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
-
-### Community 13 - "Community 13"
-Cohesion: 0.06
-Nodes (24): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+16 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.07

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2169
-- Graph nodes: 8578
-- Graph edges: 10384
+- Graph nodes: 8585
+- Graph edges: 10397
 - Communities: 2096
 
 ## Graph Hotspots
@@ -17,7 +17,7 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `harness-inferential-review.ts` (86 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (69 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `ingestLocalEvents.ts` (56 edges, Community 7) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `posLocalStore.ts` (56 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `dailyClose.ts` (102 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (66 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (69 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 12) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 13) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 13) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 67) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 85) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 101) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -385,6 +385,21 @@ describe("DailyCloseViewContent", () => {
 
     renderContent(blockedSnapshot);
 
+    const blockerCard = screen
+      .getByText("Register session is still open")
+      .closest("article");
+    expect(blockerCard).not.toBeNull();
+
+    const viewSessionLink = within(blockerCard as HTMLElement).getByRole(
+      "link",
+      { name: /view session/i },
+    );
+    const showDetailsButton = within(blockerCard as HTMLElement).getByRole(
+      "button",
+      { name: /show details/i },
+    );
+    expect(viewSessionLink.parentElement).toBe(showDetailsButton.parentElement);
+
     for (const detailsButton of screen.getAllByRole("button", {
       name: /show details/i,
     })) {
@@ -1559,6 +1574,107 @@ describe("DailyCloseViewContent", () => {
         startAt: readySnapshot.startAt,
       });
     });
+  });
+
+  it("formats carry-forward work item copy and shows all work details", () => {
+    const snapshot: DailyCloseSnapshot = {
+      ...readySnapshot,
+      carryForwardItems: [
+        {
+          description:
+            "Open operational work will carry forward after the end of day review.",
+          id: "carry-service-case-1",
+          metadata: {
+            priority: "normal",
+            status: "open",
+            type: "service_case",
+          },
+          statusLabel: "Carry forward",
+          subject: {
+            id: "carry-service-case-1",
+            label: "fuccin it up some more",
+            type: "operational_work_item",
+          },
+          title: "fuccin it up some more",
+        },
+        {
+          description:
+            "Open operational work will carry forward after the end of day review.",
+          id: "carry-inventory-review-1",
+          metadata: {
+            priority: "normal",
+            status: "open",
+            type: "synced_sale_inventory_review",
+          },
+          statusLabel: "Carry forward",
+          subject: {
+            id: "carry-inventory-review-1",
+            label: "Review inventory for clogs",
+            type: "operational_work_item",
+          },
+          title: "Review inventory for clogs",
+        },
+        {
+          description:
+            "Open operational work will carry forward after the end of day review.",
+          id: "carry-pending-checkout-1",
+          metadata: {
+            priority: "normal",
+            status: "open",
+            type: "pos_pending_checkout_item_review",
+          },
+          statusLabel: "Carry forward",
+          subject: {
+            id: "carry-pending-checkout-1",
+            label:
+              "Review pending checkout item: protein Brazilian hair repair mask",
+            type: "operational_work_item",
+          },
+          title:
+            "Review pending checkout item: protein Brazilian hair repair mask",
+        },
+      ],
+      status: "carry_forward",
+      summary: {
+        ...baseSummary,
+        carryForwardCount: 3,
+      },
+    };
+
+    renderContent(snapshot);
+
+    expect(screen.getByText("Fuccin it up some more")).toBeInTheDocument();
+    expect(screen.getByText("Review inventory for Clogs")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Review pending checkout item: Protein Brazilian Hair Repair Mask",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("fuccin it up some more"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Review inventory for clogs"),
+    ).not.toBeInTheDocument();
+
+    const firstCard = screen
+      .getByText("Fuccin it up some more")
+      .closest("article");
+    expect(firstCard).not.toBeNull();
+    expect(within(firstCard as HTMLElement).getByText("Type")).toBeInTheDocument();
+    expect(
+      within(firstCard as HTMLElement).getByText("Service case"),
+    ).toBeInTheDocument();
+    expect(
+      within(firstCard as HTMLElement).queryByText("service_case"),
+    ).not.toBeInTheDocument();
+    expect(within(firstCard as HTMLElement).getByText("Priority")).toBeInTheDocument();
+    expect(within(firstCard as HTMLElement).getByText("Normal")).toBeInTheDocument();
+    expect(
+      within(firstCard as HTMLElement).queryByRole("button", {
+        name: /show details/i,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("routes carry-forward item completion through the resolver action", async () => {

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -25,7 +25,7 @@ import {
 
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { formatReviewReason } from "@/components/cash-controls/formatReviewReason";
-import { cn } from "@/lib/utils";
+import { capitalizeFirstLetter, capitalizeWords, cn } from "@/lib/utils";
 import { toOperatorMessage } from "@/lib/errors/operatorMessages";
 import {
   runCommand,
@@ -59,6 +59,7 @@ import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSig
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Calendar } from "../ui/calendar";
+import { Checkbox } from "../ui/checkbox";
 import { LoadingButton } from "../ui/loading-button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
@@ -937,6 +938,31 @@ function normalizeDailyCloseItemCopy(value?: string | null) {
   return value?.replace(/\bEnd-of-Day Review\b/g, "end of day review");
 }
 
+function formatDailyCloseItemTitle(title: string) {
+  const trimmedTitle = title.trim();
+
+  if (!trimmedTitle) return title;
+
+  const inventoryReviewMatch = trimmedTitle.match(
+    /^(Review inventory for )(.+)$/i,
+  );
+  const pendingCheckoutReviewMatch = trimmedTitle.match(
+    /^(Review pending checkout item: )(.+)$/i,
+  );
+
+  if (inventoryReviewMatch) {
+    return `${inventoryReviewMatch[1]}${capitalizeWords(inventoryReviewMatch[2])}`;
+  }
+
+  if (pendingCheckoutReviewMatch) {
+    return `${pendingCheckoutReviewMatch[1]}${capitalizeWords(pendingCheckoutReviewMatch[2])}`;
+  }
+
+  return trimmedTitle === trimmedTitle.toLowerCase()
+    ? capitalizeFirstLetter(trimmedTitle)
+    : title;
+}
+
 function shouldShowCollapsedDescription(description?: string | null) {
   if (!description) return false;
 
@@ -953,11 +979,43 @@ function getItemContextLabel(item: DailyCloseItem) {
       : "Close item";
 }
 
+function isOperationalWorkItem(item: DailyCloseItem) {
+  return (
+    normalizeMetadataLabel(item.category ?? "") === "operationalworkitem" ||
+    normalizeMetadataLabel(item.subject?.type ?? "") === "operationalworkitem"
+  );
+}
+
 function humanizeMetadataLabel(label: string) {
   return label
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
     .replace(/[_-]+/g, " ")
     .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function formatOperationalWorkTypeLabel(type: string) {
+  switch (type) {
+    case "pos_pending_checkout_item_review":
+      return "POS pending checkout";
+    case "synced_sale_inventory_review":
+      return "Synced sale inventory";
+    case "service_case":
+      return "Service case";
+    case "service_appointment":
+      return "Service appointment";
+    case "service_intake":
+      return "Service intake";
+    case "purchase_order":
+      return "Purchase order";
+    case "stock_adjustment_review":
+      return "Stock adjustment approval";
+    case "daily_close_carry_forward":
+      return "Daily close follow-up";
+    case "service_deposit_review":
+      return "Unsupported work type";
+    default:
+      return humanizeMetadataLabel(type);
+  }
 }
 
 const moneyMetadataLabels = new Set([
@@ -1319,6 +1377,14 @@ function formatMetadataValue(label: string, value: unknown, currency: string) {
 
     if (normalizedLabel === "status") {
       return humanizeMetadataLabel(value);
+    }
+
+    if (normalizedLabel === "priority") {
+      return capitalizeFirstLetter(value);
+    }
+
+    if (normalizedLabel === "type") {
+      return formatOperationalWorkTypeLabel(value);
     }
 
     if (normalizedLabel === "reason") {
@@ -2243,6 +2309,7 @@ function DailyCloseItemCard({
   const itemId = getItemId(item);
   const contextLabel = getItemContextLabel(item);
   const description = getItemDescription(item);
+  const title = formatDailyCloseItemTitle(item.title);
   const showCollapsedDescription = shouldShowCollapsedDescription(description);
   const metadataEntries = getMetadataEntries(
     canViewFinancialDetails,
@@ -2251,7 +2318,10 @@ function DailyCloseItemCard({
     orgUrlSlug,
     storeUrlSlug,
   );
-  const collapsedMetadataEntries = getCollapsedMetadataEntries(metadataEntries);
+  const showMetadataDetails = !isOperationalWorkItem(item);
+  const collapsedMetadataEntries = showMetadataDetails
+    ? getCollapsedMetadataEntries(metadataEntries)
+    : metadataEntries;
   const hasSourceLink = Boolean(item.link);
   const sourceAction = hasSourceLink ? (
     <ItemLink
@@ -2269,32 +2339,31 @@ function DailyCloseItemCard({
   return (
     <OperationReviewItemCard
       actionSlot={
-        actionSlot || sourceAction ? (
+        actionSlot ? (
           <div className="flex flex-wrap items-center gap-2">
             {actionSlot}
-            {sourceAction}
           </div>
         ) : null
       }
       collapsedMetadataEntries={collapsedMetadataEntries}
       contextLabel={contextLabel}
       description={description}
+      headerActionSlot={sourceAction}
       itemId={itemId}
-      metadataEntries={metadataEntries}
+      metadataEntries={showMetadataDetails ? metadataEntries : []}
       selectionSlot={
         selectable ? (
-          <input
-            aria-label={`Carry forward ${item.title}`}
+          <Checkbox
+            aria-label={`Carry forward ${title}`}
             checked={Boolean(selected)}
-            className="mt-1 h-4 w-4 rounded border-border text-signal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            onChange={(event) => onSelectedChange?.(event.target.checked)}
-            type="checkbox"
+            className="mt-1"
+            onCheckedChange={(checked) => onSelectedChange?.(checked === true)}
           />
         ) : null
       }
       badgeSlot={badgeSlot}
       showCollapsedDescription={showCollapsedDescription}
-      title={item.title}
+      title={title}
     />
   );
 }

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -968,6 +968,102 @@ describe("DailyOpeningViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("formats carry-forward work item copy and groups source action with details", () => {
+    const snapshot: DailyOpeningSnapshot = {
+      ...readySnapshot,
+      carryForwardItems: [
+        {
+          category: "operational_work_item",
+          description:
+            "Open operational work will carry forward after the opening handoff.",
+          id: "carry-service-case-1",
+          key: "carry-service-case-1",
+          link: {
+            label: "View open work",
+            to: "/$orgUrlSlug/store/$storeUrlSlug/operations/open-work",
+          },
+          metadata: {
+            priority: "normal",
+            status: "open",
+            type: "service_case",
+          },
+          title: "tokin",
+        },
+        {
+          category: "operational_work_item",
+          description:
+            "Open operational work will carry forward after the opening handoff.",
+          id: "carry-inventory-review-1",
+          key: "carry-inventory-review-1",
+          link: {
+            label: "View open work",
+            to: "/$orgUrlSlug/store/$storeUrlSlug/operations/open-work",
+          },
+          metadata: {
+            priority: "high",
+            status: "open",
+            type: "synced_sale_inventory_review",
+          },
+          title: "Review inventory for slides",
+        },
+        {
+          category: "operational_work_item",
+          description:
+            "Open operational work will carry forward after the opening handoff.",
+          id: "carry-pending-checkout-1",
+          key: "carry-pending-checkout-1",
+          link: {
+            label: "View open work",
+            to: "/$orgUrlSlug/store/$storeUrlSlug/operations/open-work",
+          },
+          metadata: {
+            priority: "normal",
+            status: "open",
+            type: "pos_pending_checkout_item_review",
+          },
+          title:
+            "Review pending checkout item: protein Brazilian hair repair mask",
+        },
+      ],
+      status: "needs_attention",
+      summary: {
+        blockerCount: 0,
+        carryForwardCount: 3,
+        readyCount: 1,
+        reviewCount: 0,
+      },
+    };
+
+    renderContent(snapshot);
+
+    expect(screen.getByText("Tokin")).toBeInTheDocument();
+    expect(screen.getByText("Review inventory for Slides")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Review pending checkout item: Protein Brazilian Hair Repair Mask",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Service case")).toBeInTheDocument();
+    expect(screen.getAllByText("Normal")).toHaveLength(2);
+    expect(screen.getAllByText("Open")).toHaveLength(3);
+    expect(screen.queryByText("service_case")).not.toBeInTheDocument();
+    expect(screen.queryByText("normal")).not.toBeInTheDocument();
+    expect(screen.queryByText("open")).not.toBeInTheDocument();
+
+    const firstCard = screen.getByText("Tokin").closest("article");
+    expect(firstCard).not.toBeNull();
+
+    const viewOpenWorkLink = within(firstCard as HTMLElement).getByRole("link", {
+      name: /view open work/i,
+    });
+    expect(viewOpenWorkLink).toBeInTheDocument();
+    expect(
+      within(firstCard as HTMLElement).queryByRole("button", {
+        name: /show details/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps started Opening Handoff primary over stale skipped automation decisions", () => {
     renderContent({
       ...readySnapshot,

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
-import { cn } from "@/lib/utils";
+import { capitalizeFirstLetter, capitalizeWords, cn } from "@/lib/utils";
 import { toOperatorMessage } from "@/lib/errors/operatorMessages";
 import {
   runCommand,
@@ -361,6 +361,60 @@ function humanizeMetadataLabel(label: string) {
     .replace(/\b\w/g, (character) => character.toUpperCase());
 }
 
+function normalizeMetadataLabel(label: string) {
+  return label.replace(/[_\s-]+/g, "").toLowerCase();
+}
+
+function formatOpeningItemTitle(title: string) {
+  const trimmedTitle = title.trim();
+
+  if (!trimmedTitle) return title;
+
+  const inventoryReviewMatch = trimmedTitle.match(
+    /^(Review inventory for )(.+)$/i,
+  );
+  const pendingCheckoutReviewMatch = trimmedTitle.match(
+    /^(Review pending checkout item: )(.+)$/i,
+  );
+
+  if (inventoryReviewMatch) {
+    return `${inventoryReviewMatch[1]}${capitalizeWords(inventoryReviewMatch[2])}`;
+  }
+
+  if (pendingCheckoutReviewMatch) {
+    return `${pendingCheckoutReviewMatch[1]}${capitalizeWords(pendingCheckoutReviewMatch[2])}`;
+  }
+
+  return trimmedTitle === trimmedTitle.toLowerCase()
+    ? capitalizeFirstLetter(trimmedTitle)
+    : title;
+}
+
+function formatOperationalWorkTypeLabel(type: string) {
+  switch (type) {
+    case "pos_pending_checkout_item_review":
+      return "POS pending checkout";
+    case "synced_sale_inventory_review":
+      return "Synced sale inventory";
+    case "service_case":
+      return "Service case";
+    case "service_appointment":
+      return "Service appointment";
+    case "service_intake":
+      return "Service intake";
+    case "purchase_order":
+      return "Purchase order";
+    case "stock_adjustment_review":
+      return "Stock adjustment approval";
+    case "daily_close_carry_forward":
+      return "Daily close follow-up";
+    case "service_deposit_review":
+      return "Unsupported work type";
+    default:
+      return humanizeMetadataLabel(type);
+  }
+}
+
 function getOpeningStatus(snapshot: DailyOpeningSnapshot): DailyOpeningStatus {
   if (snapshot.startedOpening) return "started";
   if (snapshot.status) return snapshot.status;
@@ -406,6 +460,13 @@ function getItemContextLabel(item: DailyOpeningItem) {
       : "Opening item";
 }
 
+function isOperationalWorkItem(item: DailyOpeningItem) {
+  return (
+    normalizeMetadataLabel(item.category ?? "") === "operationalworkitem" ||
+    normalizeMetadataLabel(item.subject?.type ?? "") === "operationalworkitem"
+  );
+}
+
 function formatMetadataValue(value: ReactNode, currency: string) {
   if (typeof value === "number") {
     return new Intl.NumberFormat([], {
@@ -432,8 +493,21 @@ function getMetadataLabel(item: DailyOpeningItem, label: string) {
 }
 
 function getMetadataValue(label: string, value: ReactNode, currency: string) {
+  const normalizedLabel = normalizeMetadataLabel(label);
+
   if (label === "operatingDate" && typeof value === "string") {
     return formatOperatingDate(value);
+  }
+
+  if (normalizedLabel === "type" && typeof value === "string") {
+    return formatOperationalWorkTypeLabel(value);
+  }
+
+  if (
+    (normalizedLabel === "status" || normalizedLabel === "priority") &&
+    typeof value === "string"
+  ) {
+    return capitalizeFirstLetter(value);
   }
 
   if (label.endsWith("At") && typeof value === "number") {
@@ -1020,16 +1094,18 @@ function OpeningItemCard({
   const itemId = getItemId(item);
   const contextLabel = getItemContextLabel(item);
   const description = getItemDescription(item);
+  const title = formatOpeningItemTitle(item.title);
   const metadataEntries = getMetadataEntries(
     item,
     currency,
     orgUrlSlug,
     storeUrlSlug,
   );
+  const showMetadataDetails = !isOperationalWorkItem(item);
 
   return (
     <OperationReviewItemCard
-      actionSlot={
+      headerActionSlot={
         <ItemLink
           link={item.link}
           orgUrlSlug={orgUrlSlug}
@@ -1044,13 +1120,16 @@ function OpeningItemCard({
         ) : null
       }
       contextLabel={contextLabel}
+      collapsedMetadataEntries={
+        showMetadataDetails ? undefined : metadataEntries
+      }
       description={description}
       itemId={itemId}
-      metadataEntries={metadataEntries}
+      metadataEntries={showMetadataDetails ? metadataEntries : []}
       selectionSlot={
         requiresAcknowledgement ? (
           <input
-            aria-label={`Acknowledge ${item.title}`}
+            aria-label={`Acknowledge ${title}`}
             checked={Boolean(selected)}
             className="mt-1 h-4 w-4 rounded border-border text-signal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             onChange={(event) => onSelectedChange?.(event.target.checked)}
@@ -1059,7 +1138,7 @@ function OpeningItemCard({
         ) : null
       }
       showCollapsedDescription={showCollapsedDescription}
-      title={item.title}
+      title={title}
     />
   );
 }


### PR DESCRIPTION
## Summary
Daily opening and EOD carry-forward cards now translate operational work item titles and metadata into operator-facing copy before rendering. Work item type, status, and priority stay visible in the collapsed row, while source actions move into the card header so operators can scan the handoff without opening a details disclosure.

This also adds focused coverage for service case, synced-sale inventory review, and POS pending-checkout carry-forward rows, plus a solution note for the reusable copy pattern.

## Validation
- `bun run test -- src/components/operations/DailyCloseView.test.tsx src/components/operations/DailyOpeningView.test.tsx`
- Pre-push validation passed, including graphify check, compound check, architecture checks, `@athena/webapp:test` (428 files, 4,699 tests), focused daily operations tests (8 files, 293 tests), TypeScript, production build, and `athena-admin-shell-boot` behavior scenario.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-10a37f?logo=openai&logoColor=white)