### PR TITLE
Fix archived pending checkout review work lifecycle

### DIFF
--- a/docs/plans/2026-07-04-001-fix-pos-pending-checkout-archive-work-lifecycle-plan.html
+++ b/docs/plans/2026-07-04-001-fix-pos-pending-checkout-archive-work-lifecycle-plan.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Plan: Retire archived pending checkout review work</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f8fb;
+        --panel: #ffffff;
+        --ink: #172033;
+        --muted: #5f6b7c;
+        --line: #d9dfeb;
+        --accent: #3158d4;
+        --soft: #edf2ff;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      main {
+        max-width: 1060px;
+        margin: 0 auto;
+        padding: 48px 24px 72px;
+      }
+      header {
+        margin-bottom: 28px;
+      }
+      .eyebrow {
+        color: var(--accent);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: .08em;
+        text-transform: uppercase;
+      }
+      h1 {
+        margin: 8px 0 12px;
+        font-size: clamp(32px, 5vw, 56px);
+        line-height: 1.02;
+        letter-spacing: 0;
+      }
+      h2 {
+        margin: 34px 0 12px;
+        font-size: 24px;
+        letter-spacing: 0;
+      }
+      h3 {
+        margin: 22px 0 8px;
+        font-size: 17px;
+        letter-spacing: 0;
+      }
+      p {
+        margin: 0 0 14px;
+      }
+      .summary {
+        color: var(--muted);
+        font-size: 18px;
+        max-width: 860px;
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        margin-top: 18px;
+        padding: 24px;
+      }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+        margin: 12px 0 18px;
+      }
+      th, td {
+        border: 1px solid var(--line);
+        padding: 10px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        background: var(--soft);
+      }
+      ul {
+        margin: 0 0 12px 20px;
+        padding: 0;
+      }
+      li {
+        margin: 7px 0;
+      }
+      code {
+        background: #eef1f7;
+        border-radius: 4px;
+        padding: 1px 5px;
+      }
+      .flow {
+        display: grid;
+        gap: 10px;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        margin-top: 14px;
+      }
+      .node {
+        background: var(--soft);
+        border: 1px solid #c9d5ff;
+        border-radius: 8px;
+        padding: 12px;
+        font-weight: 650;
+      }
+      .muted {
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="eyebrow">Fix plan · 2026-07-04</div>
+        <h1>Retire archived pending checkout review work</h1>
+        <p class="summary">Move POS pending checkout review work lifecycle out of read-time hiding and into source-owned archive/unarchive behavior, so Open Work and EOD Review agree on what is still actionable.</p>
+      </header>
+
+      <section>
+        <h2>Problem</h2>
+        <p>Archived provisional POS pending checkout products leave associated <code>pos_pending_checkout_item_review</code> operational work items open. Open Work filters those rows out because the product is archived, while EOD Review reads open operational work directly and still carries them forward.</p>
+        <table>
+          <tr><th>Surface</th><th>Current behavior</th></tr>
+          <tr><td>Open Work</td><td>Shows the synced sale inventory reviews because archived provisional pending checkout rows are hidden at queue projection.</td></tr>
+          <tr><td>EOD Review</td><td>Shows stale pending checkout review rows because their work item status is still open.</td></tr>
+        </table>
+      </section>
+
+      <section>
+        <h2>Direction</h2>
+        <ul>
+          <li>Archive cancels every matching <code>open</code> or <code>in_progress</code> pending checkout review work item and clears the source pointer.</li>
+          <li>The pending checkout item stays <code>pending_review</code> or <code>flagged</code>; archive is not a review decision.</li>
+          <li>Unarchive creates one fresh open review work item when the source still needs review and no current open review exists.</li>
+          <li>Resolved sources do not recreate review work.</li>
+          <li>A mandatory dry-run and bounded production repair retire existing stale open rows with the same helper semantics.</li>
+          <li>Live product availability mutations abort if duplicate-work scans are incomplete, so product state and work lifecycle cannot commit partially.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Implementation Units</h2>
+        <div class="flow">
+          <div class="node">U1 lifecycle helper</div>
+          <div class="node">U2 product mutations</div>
+          <div class="node">U3 Open Work / EOD alignment</div>
+          <div class="node">U4 production repair</div>
+          <div class="node">U5 tests and validation</div>
+        </div>
+        <h3>Primary Files</h3>
+        <ul>
+          <li><code>packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts</code></li>
+          <li><code>packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts</code></li>
+          <li><code>packages/athena-webapp/convex/inventory/products.ts</code></li>
+          <li><code>packages/athena-webapp/convex/operations/operationalWorkItems.ts</code></li>
+          <li><code>packages/athena-webapp/convex/operations/dailyClose.ts</code> tests only unless implementation reveals a status-read bug</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Key Decisions</h2>
+        <table>
+          <tr><th>Decision</th><th>Rationale</th></tr>
+          <tr><td>Use <code>cancelled</code> for archived work</td><td>Archive makes review unactionable; it does not mean manager review completed.</td></tr>
+          <tr><td>Keep source status unchanged</td><td>The product is still a POS pending checkout item and can be reviewed after unarchive.</td></tr>
+          <tr><td>Treat <code>operationalWorkItemId</code> as current pointer</td><td>Archive clears the stale pointer; unarchive points it at the fresh actionable row.</td></tr>
+          <tr><td>Create a fresh work item on unarchive</td><td>Preserves retired history and avoids resurrecting stale metadata.</td></tr>
+          <tr><td>Route all availability transitions through the helper</td><td><code>archive</code>, <code>unarchive</code>, and generic <code>update</code> must agree.</td></tr>
+          <tr><td>Abort on incomplete live scans</td><td>If the helper cannot prove the full current work set, the source product mutation does not commit.</td></tr>
+          <tr><td>Repair production data</td><td>Code fixes prevent new drift; existing stale rows still need bounded dry-run and repair.</td></tr>
+        </table>
+      </section>
+
+      <section>
+        <h2>Acceptance</h2>
+        <ul>
+          <li>Archived provisional pending checkout review work is terminal and absent from both Open Work and EOD carry-forward.</li>
+          <li>Unarchived actionable pending checkout sources get exactly one fresh open review work item.</li>
+          <li>Resolved pending checkout sources do not recreate review work.</li>
+          <li>Dry-run and mutating repair paths identify and retire current stale rows safely with candidate ids, skip reasons, cursors, and idempotent retry behavior.</li>
+          <li>Incomplete duplicate scans abort <code>archive</code>, <code>unarchive</code>, and generic <code>update</code> availability transitions.</li>
+          <li>Focused Convex tests pass for product lifecycle, queue projection, and EOD carry-forward.</li>
+        </ul>
+        <p class="muted">The Markdown plan is canonical. This HTML file is a browser-readable review artifact.</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/plans/2026-07-04-001-fix-pos-pending-checkout-archive-work-lifecycle-plan.md
+++ b/docs/plans/2026-07-04-001-fix-pos-pending-checkout-archive-work-lifecycle-plan.md
@@ -1,0 +1,351 @@
+---
+title: "fix: Retire archived pending checkout review work"
+type: fix
+status: active
+date: 2026-07-04
+---
+
+# fix: Retire archived pending checkout review work
+
+## Summary
+
+Archived provisional POS pending checkout products currently leave their associated `pos_pending_checkout_item_review` operational work items open. Open Work hides those rows at read time, but EOD Review reads open operational work directly, so stale hidden work still appears in carry-forward and can block closeout. The clean fix is to move the archive/unarchive behavior into the source lifecycle: archiving a provisional pending checkout product retires the associated review work item, while unarchiving recreates exactly one fresh review item if the source pending checkout item still needs review.
+
+The pending checkout item itself stays pending. Archiving the provisional product is not a manager review decision, so it should not mark the checkout item approved, linked, or rejected. It only makes the current review work unactionable while the provisional product is archived.
+
+---
+
+## Problem Frame
+
+The production symptom is a disagreement between two Operations surfaces:
+
+| Surface | Current behavior |
+| --- | --- |
+| Open Work | Shows only the 15 `synced_sale_inventory_review` rows because `pos_pending_checkout_item_review` rows tied to archived provisional products are filtered out at read time. |
+| EOD Review carry-forward | Shows 29 open work items because it reads every open or `in_progress` operational work item, including 14 POS pending checkout review rows whose provisional products are archived. |
+
+The backend source of the bug is that product archive only patches `product.availability = "archived"`. It does not transition the operational review work item. That leaves an open work row which is invisible in one workspace and live in another.
+
+The desired invariant is:
+
+> If a work item is not actionable because its source product is archived, it must not remain open. Any surface that reads open operational work should agree without needing a UI-only or query-only exception.
+
+---
+
+## Requirements
+
+- R1. Archiving a provisional product linked to a pending checkout item must terminally retire every open or `in_progress` `pos_pending_checkout_item_review` work item for that source identity.
+- R2. Archive retirement must leave `posPendingCheckoutItem.status` unchanged when the item is still `pending_review` or `flagged`; archive is not approval, linking, or rejection.
+- R3. Unarchiving that product must create one fresh open `pos_pending_checkout_item_review` when the linked pending checkout item is still actionable and no current `open` or `in_progress` review exists.
+- R4. Unarchive must not recreate review work for pending checkout items already `approved`, `linked_to_catalog`, or `rejected`.
+- R5. Repeated archive/unarchive and retry behavior must be idempotent; no duplicate open work items may be created for the same `pendingCheckoutItemId`.
+- R6. The explicit `archive`, `unarchive`, and generic product `update` availability paths must all use the same lifecycle helper for availability transitions.
+- R7. Open Work and EOD Review must agree because terminal statuses are correct, not because one surface hides stale open rows.
+- R8. Existing production rows with archived provisional products and open POS pending checkout review work must have a safe repair path.
+- R9. Audit evidence must make the lifecycle understandable: who/what retired the work, why, which product/pending item/work item was affected, and which new work item was created on unarchive.
+- R10. Focused tests must cover archive retirement, unarchive recreation, dedupe, resolved-item no-op behavior, EOD exclusion, Open Work queue consistency, empty/nil source paths, and bounded-scan incomplete behavior.
+
+---
+
+## Scope Boundaries
+
+- This plan does not change POS pending checkout review decisions or product-page trusted inventory finalization.
+- This plan does not mark archived pending checkout items rejected. Operators can still unarchive the provisional product and review the original pending checkout evidence.
+- This plan does not redesign Open Work or EOD UI.
+- This plan does not remove pending checkout sale evidence, provisional product/SKU anchors, or operational event history.
+- This plan does not create trusted inventory movements. Archive/unarchive only changes review work actionability.
+- This plan may adjust the Open Work archived-product filter after lifecycle writes and repair are in place, but the filter is not the source fix.
+
+### Deferred to Follow-Up Work
+
+- A richer product timeline UI for retired/recreated pending checkout review work, if operators need visible explanation beyond existing operational events.
+- A broader operational work item terminal-reason schema if more work types need first-class cancellation reasons later.
+
+---
+
+## Context & Research
+
+### Relevant Code
+
+- `packages/athena-webapp/convex/inventory/products.ts` owns `archive`, `unarchive`, and generic `update`; today these paths patch product availability and refresh search/catalog/cache projections.
+- `packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts` creates pending checkout items, provisional product/SKU anchors, and the initial `pos_pending_checkout_item_review` operational work item with the metadata shape to preserve.
+- `packages/athena-webapp/convex/pos/public/catalog.ts` owns actual pending checkout review resolution and maps review decisions to operational work item status through `updateOperationalWorkItemStatusWithCtx`.
+- `packages/athena-webapp/convex/operations/operationalWorkItems.ts` defines terminal statuses as `completed` and `cancelled`, stable source identity for `pos_pending_checkout_item_review:<pendingCheckoutItemId>`, Open Work queue reads, and the current archived-provisional-product read-time filter.
+- `packages/athena-webapp/convex/operations/dailyClose.ts` reads open operational work items by status for EOD carry-forward; it correctly sees rows that are still open.
+- `packages/athena-webapp/convex/schema.ts` already has `productSku.by_productId`, `posPendingCheckoutItem.by_storeId_provisionalProductSkuId`, `posPendingCheckoutItem.by_operationalWorkItemId`, and `operationalWorkItem.by_storeId_type_status`; it does not have an indexed source-identity or metadata lookup for operational work.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture-patterns/athena-open-work-resolution-ownership-2026-07-02.md`: Open Work owns discovery and routing; source workflows own resolution unless Operations has narrow source identity and stable authority.
+- `docs/solutions/architecture-patterns/athena-pending-checkout-inventory-resolution-2026-07-03.md`: product-page/catalog finalization owns transitions from checkout evidence to trusted catalog inventory; Operations should not mutate catalog/inventory directly.
+- `docs/solutions/architecture/athena-store-ops-catalog-visibility-boundaries-2026-06-24.md`: archived products should be filtered at server composition boundaries for visibility, while archive-management paths must preserve audit/restore access.
+- `docs/solutions/logic-errors/athena-daily-operations-aggregate-read-model-2026-05-08.md`: daily operations surfaces aggregate source workflows and should consume indexed open-status reads rather than broad capped scans filtered later.
+
+### Investigation Findings
+
+- The Open Work discrepancy is not a frontend bug. It comes from `filterArchivedPendingCheckoutWorkItems` hiding archived provisional product rows during queue projection.
+- EOD is not wrong to include open work. The stale rows are still `status: "open"` at the operational work item layer.
+- The pending checkout source rows observed in production remain `pending_review`, have no `reviewedAt`, and point at archived provisional products. That supports leaving the source review state intact while retiring only the operational review work.
+
+---
+
+## Key Technical Decisions
+
+- **Use `cancelled` for archive-retired review work.** `completed` implies the manager review happened. Archive makes the review unactionable, so `cancelled` is the clearer terminal state.
+- **Do not mutate the pending checkout item review decision on archive.** Keep `posPendingCheckoutItem.status` as `pending_review` or `flagged`; update only the operational work pointer and audit metadata needed to explain actionability.
+- **Use `operationalWorkItemId` as the current actionable work pointer.** Archive cancellation clears `posPendingCheckoutItem.operationalWorkItemId` after retiring matching open rows. Unarchive patches it to the fresh open row. Review/finalization paths must not complete or overwrite a cancelled retired row by following a stale pointer.
+- **Create a fresh work item on unarchive.** Do not reopen the old cancelled row. A fresh row keeps the retired history intact, avoids resurrecting stale row metadata, and lets `posPendingCheckoutItem.operationalWorkItemId` point at the current actionable review.
+- **Centralize lifecycle in a POS-owned helper.** Create `packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts`. `inventory/products.ts` imports this helper. The helper must not import `inventory/products.ts` or `pos/public/catalog.ts`; shared work-item title, metadata, and priority builders should live in this helper or a sibling POS application module so product mutations do not depend on public POS catalog code.
+- **Treat product availability changes consistently.** Generic `products.update` remains availability-capable, but it must compare prior and next availability and call the lifecycle helper when crossing the archived boundary: `live`/`draft` -> `archived` retires review work, and `archived` -> `live`/`draft` recreates deduped review work when the source is actionable. Non-availability updates and transitions that do not cross the archived boundary do not run lifecycle work.
+- **Use bounded complete scans for duplicate open work detection.** The first implementation should not add a new schema field. It should query `operationalWorkItem.by_storeId_type_status` for `open` and `in_progress`, scan up to an explicit safe cap for the store/type/status lane, and match metadata `pendingCheckoutItemId`. If the scan is incomplete during `archive`, `unarchive`, or generic `products.update`, the availability mutation must abort so product availability and work-item lifecycle cannot commit partially.
+- **Retain the Open Work archived filter only as a temporary defensive guard.** After lifecycle writes and production repair, correctness should come from terminal work statuses. A follow-up inside this plan can remove or narrow the filter once tests prove no stale open rows are expected.
+- **Repair existing production data with the same helper semantics and bounded batches.** The repair must require dry-run first, use explicit store-scoped batches with cursor/continuation, include candidate ids and skip reasons, and cancel only `pos_pending_checkout_item_review` rows whose source pending checkout item is still actionable and whose provisional product is archived.
+- **Stamp a terminal timestamp for cancellations.** Archive and repair cancellation should set `completedAt` when moving work to `cancelled`, matching the field's practical role as terminal time in existing reports. If implementation updates `updateOperationalWorkItemStatusWithCtx` for this, tests must cover both `completed` and `cancelled` terminal stamping.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should archive close the open work item associated with the pending checkout item?** Yes. It should retire/cancel the operational review work because the source is not currently actionable.
+- **Should archive reject the pending checkout item?** No. The product is still a POS pending checkout item; review evidence remains pending so unarchive can create fresh review work.
+- **What happens when the product gets unarchived?** If the pending checkout source still needs review, unarchive creates a new deduped work item and points the pending checkout item at it.
+- **Should unarchive reopen the old cancelled row?** No. Create a fresh row and preserve the old row as audit history.
+
+### Deferred to Implementation
+
+- Whether to keep the Open Work archived filter as a legacy backstop after repair or remove it to expose future lifecycle bugs earlier.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Product archived"] --> B["Find provisional SKUs"]
+  B --> C["Find pending checkout items by provisionalProductSkuId"]
+  C --> D{"Pending item still actionable?"}
+  D -->|yes| E["Cancel all matching open/in_progress review work"]
+  D -->|no| F["No review-work mutation"]
+  E --> G["Record operational event and retire pointer metadata"]
+
+  H["Product unarchived"] --> I["Find linked pending checkout items"]
+  I --> J{"Still pending_review or flagged?"}
+  J -->|yes| K{"Any open/in_progress review exists?"}
+  K -->|no| L["Create fresh review work item"]
+  K -->|yes| M["No-op idempotently"]
+  L --> N["Patch operationalWorkItemId to fresh row"]
+```
+
+The helper should use source identity, not display text, to decide ownership:
+
+| Input | Required guard |
+| --- | --- |
+| Product id | Product must belong to the requested store. |
+| Product SKU ids | SKUs must belong to the archived/unarchived product. |
+| Pending checkout item | `storeId` must match, `provisionalProductSkuId` or `provisionalProductId` must match the product anchors, and status must be actionable for lifecycle changes. |
+| Operational work item | Type must be `pos_pending_checkout_item_review`, store must match, metadata must point at the same `pendingCheckoutItemId`, and status must be `open` or `in_progress` for archive cancellation. |
+
+Duplicate detection and repair use existing indexes in this slice:
+
+| Operation | Query strategy | Incomplete behavior |
+| --- | --- | --- |
+| Archive cancellation | Follow `posPendingCheckoutItem.operationalWorkItemId`, then also scan `operationalWorkItem.by_storeId_type_status` for `open` and `in_progress` `pos_pending_checkout_item_review` rows and match metadata `pendingCheckoutItemId`. | Abort the source availability mutation before commit; no product archive should persist with a partially cancelled work set. |
+| Unarchive recreation | Scan `operationalWorkItem.by_storeId_type_status` for `open` and `in_progress` rows and match metadata `pendingCheckoutItemId` before creating. | Abort the source availability mutation before commit; no product unarchive should persist if duplicate status cannot be proven. |
+| Production repair | Batch through store/type/status lanes with cursor/continuation and metadata/source validation per candidate. | Stop at batch boundary, return cursor and skip/candidate counts; rerun until complete. |
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 helper"] --> U2["U2 product mutations"]
+  U1 --> U3["U3 queue/EOD alignment"]
+  U2 --> U4["U4 production repair"]
+  U3 --> U5["U5 tests and validation"]
+  U4 --> U5
+```
+
+- U1. **Create the Pending Checkout Review Work Lifecycle Helper**
+
+**Goal:** Add a shared Convex helper that finds pending checkout items for a product, cancels actionable review work on archive, and creates deduped fresh review work on unarchive.
+
+**Requirements:** R1, R2, R3, R4, R5, R9
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts`
+- Modify if needed: `packages/athena-webapp/convex/operations/operationalWorkItems.ts`
+
+**Approach:**
+- Extract reusable work item metadata/title/priority construction into `pendingCheckoutReviewWorkLifecycle.ts` or a sibling POS application helper so recreated work items match current source-owned shape without importing public catalog code.
+- Keep import direction one-way: `inventory/products.ts` may import the POS lifecycle helper; the lifecycle helper must not import `inventory/products.ts` or `pos/public/catalog.ts`.
+- Resolve product SKUs through `productSku.by_productId`, then pending items through `posPendingCheckoutItem.by_storeId_provisionalProductSkuId`.
+- Treat `pending_review` and `flagged` as actionable. Treat `approved`, `linked_to_catalog`, and `rejected` as no-ops.
+- On archive, first prove the duplicate scan is complete, then cancel every matching `open` or `in_progress` work item tied to the same `pendingCheckoutItemId`, not only the current pointer. If the scan is incomplete, throw/abort so no product availability transition commits. Patch metadata with `retiredReason: "provisional_product_archived"`, archived product id, provisional SKU id, prior work status, and terminal timestamp.
+- After archive cancellation, clear `posPendingCheckoutItem.operationalWorkItemId` because it is the current-actionable pointer.
+- On unarchive, scan existing `open` and `in_progress` work rows by `by_storeId_type_status` and metadata `pendingCheckoutItemId` before creating a new work item. If the bounded scan is incomplete, throw/abort so no product availability transition commits.
+- Patch `posPendingCheckoutItem.operationalWorkItemId` to the fresh row on recreation.
+- Record operational events for retirement and recreation using the existing event style in pending checkout command code. Recreation events must include the old retired work id when known and the new work id.
+
+**Test Scenarios:**
+- Archive cancels an open pending checkout review work item and preserves `posPendingCheckoutItem.status = "pending_review"`.
+- Archive cancels an `in_progress` review work item without marking it completed.
+- Archive cancels duplicate `open` / `in_progress` rows for the same `pendingCheckoutItemId` source identity.
+- Archive clears `operationalWorkItemId` after retirement.
+- Archive is idempotent when the product is already archived or the work item is already terminal.
+- Unarchive creates one new open review work item for a still-pending source and patches `operationalWorkItemId`.
+- Unarchive creates one new open review work item for a `flagged` source.
+- Unarchive creates no work for `approved`, `linked_to_catalog`, or `rejected` sources.
+- Repeated unarchive does not create duplicate open rows for the same `pendingCheckoutItemId`.
+- Cross-store or mismatched provisional product/SKU anchors are ignored.
+- Empty paths no-op safely: product has no SKUs, SKUs have no pending checkout items, pending checkout item has no `operationalWorkItemId`, and referenced work item is missing/deleted.
+- Incomplete duplicate scans fail closed and abort the source product availability mutation.
+
+- U2. **Wire Product Availability Mutations Through the Helper**
+
+**Goal:** Ensure every product availability transition to or from archived applies the pending checkout review work lifecycle.
+
+**Requirements:** R1, R3, R5, R6, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/inventory/products.ts`
+- Update tests: `packages/athena-webapp/convex/inventory/products.sku.test.ts`
+
+**Approach:**
+- In `archive`, after store access and product ownership checks, run the lifecycle helper in the same mutation and abort on incomplete scan; only then allow the availability transition to commit with the work-item retirements.
+- In `unarchive`, run the lifecycle helper in the same mutation and abort on incomplete scan; only then allow the availability transition to commit with any recreated current review work.
+- In generic `update`, fetch the current product before patching. If `availability` is provided and crosses into `archived` from `live` or `draft`, run the archive-retirement helper in the same mutation and abort on incomplete scan. If it crosses out of `archived` into `live` or `draft`, run the unarchive-recreation helper in the same mutation and abort on incomplete scan. If availability is unchanged or absent, do not run lifecycle work.
+- Product mutations may patch availability before or after helper effects as long as Convex transaction semantics guarantee a thrown incomplete-scan error rolls back all writes in that mutation. The observable contract is atomic: product availability and lifecycle work commit together or neither commits.
+- Keep existing search projection, catalog summary, and cache invalidation behavior intact.
+- Return the product as today only on successful complete lifecycle application; incomplete duplicate scans throw/abort and do not return a partially updated product.
+
+**Test Scenarios:**
+- Dedicated `archive` retires review work and still refreshes product projections.
+- Dedicated `unarchive` recreates review work and still refreshes product projections.
+- Generic `update` retires work for `live`/`draft` -> `archived`, recreates deduped work for `archived` -> `live`/`draft`, and leaves non-transition updates alone.
+- Incomplete duplicate scans abort `archive`, `unarchive`, and generic `update` availability transitions without committing product availability changes.
+- Mutation returns null/no-ops safely when product id or store id do not match.
+- Products with no SKUs and SKUs with no pending checkout items update availability without lifecycle errors.
+
+- U3. **Align Open Work and EOD Around Terminal Status**
+
+**Goal:** Make Open Work and EOD carry-forward agree because archived pending checkout review work is no longer open.
+
+**Requirements:** R7, R10
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/operationalWorkItems.ts`
+- Modify tests: `packages/athena-webapp/convex/operations/operationalWorkItems.test.ts`
+- Modify tests: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+
+**Approach:**
+- Add regression coverage proving archived provisional pending checkout review work is terminal after archive and therefore absent from both Open Work and EOD open-work reads.
+- Decide whether to remove `filterArchivedPendingCheckoutWorkItems` or keep it as a legacy defensive backstop.
+- If retained, add a focused test that labels it as legacy defense rather than source correctness.
+- Do not add a matching archived-product filter to EOD; that would duplicate the read-time hiding bug instead of fixing lifecycle state.
+
+**Test Scenarios:**
+- After archive lifecycle, Open Work count and EOD carry-forward count both exclude the retired pending checkout review work item.
+- A manually constructed legacy open row tied to an archived product is either hidden only by the legacy guard or exposed intentionally, depending on the filter decision.
+- A non-archived pending checkout review still appears in Open Work and EOD carry-forward as open work.
+
+- U4. **Add a Safe Production Repair Path**
+
+**Goal:** Repair existing stale open `pos_pending_checkout_item_review` rows tied to archived provisional products.
+
+**Requirements:** R8, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Add internal mutation or script near: `packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts`
+- Add tests near: `packages/athena-webapp/convex/operations/operationalWorkItems.test.ts` or `packages/athena-webapp/convex/inventory/products.sku.test.ts`
+- Add runbook notes if repo convention has an operations doc for one-time repair.
+
+**Approach:**
+- Implement the repair with the same helper semantics as archive, not a one-off metadata scan.
+- Scope repair by explicit `storeId` and require dry-run mode before mutating mode. Dry run must report candidate work item ids, product ids, provisional SKU ids, pending checkout item ids, current statuses, and skip reasons, not only counts.
+- Process repair in bounded batches over `operationalWorkItem.by_storeId_type_status` for `pos_pending_checkout_item_review` rows with `open` and `in_progress` status. Each call should accept a cursor/continuation or equivalent batch token, cap rows per mutation, and return whether more work remains.
+- Mutating mode should cancel only rows with explicit store match, work type match, `open` / `in_progress` status, actionable pending checkout status, archived provisional product verification, matching product/SKU anchors, and matching metadata `pendingCheckoutItemId`. Rows with missing or mismatched metadata must be skipped.
+- Repair retry/rollback semantics are idempotent: rerunning the same batch or full repair skips already terminal rows and does not create replacement work.
+- Record operational event or metadata reason `repairReason: "archived_provisional_product_open_work_repair"` with actor/system source, timestamp, repair run identifier, old work item id, pending checkout item id, provisional product id, provisional SKU id, and prior work status.
+- Before rollout, run dry-run verification against production data. After repair, EOD carry-forward for Wigclub should drop the stale POS pending checkout review rows while keeping the 15 synced sale inventory review items.
+
+**Test Scenarios:**
+- Dry run returns candidate rows without mutating work items.
+- Repair cancels only archived-product pending checkout review work.
+- Repair skips already terminal rows, resolved pending checkout sources, cross-store rows, and rows with missing/mismatched metadata.
+- Repair is idempotent when run twice.
+- Repair batches return cursor/continuation and do not exceed the configured per-mutation cap.
+- Repair handles empty paths: no candidates, missing/deleted referenced pending item, missing/deleted product, product with no SKUs, and incomplete scan/page conditions.
+
+- U5. **Validation and Regression Coverage**
+
+**Goal:** Validate Convex correctness, style, and the no-UI-regression contract.
+
+**Requirements:** R10
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- Update: `packages/athena-webapp/convex/inventory/products.sku.test.ts`
+- Update: `packages/athena-webapp/convex/operations/operationalWorkItems.test.ts`
+- Update: `packages/athena-webapp/convex/operations/dailyClose.test.ts`
+- Update only if helper extraction requires it: `packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts`
+
+**Approach:**
+- Keep tests focused on backend lifecycle and read-model agreement. No browser validation is required for this slice.
+- Use package-relative Vitest commands from `packages/athena-webapp`, not direct `bun test`.
+- Run Convex audit/lint commands required by `packages/athena-webapp/docs/agent/testing.md` for changed Convex files.
+- If code files change during implementation, run `bun run graphify:rebuild` from repo root per `AGENTS.md`.
+
+**Suggested Test Commands:**
+- `cd packages/athena-webapp && bun run test -- convex/inventory/products.sku.test.ts -t "archive"`
+- `cd packages/athena-webapp && bun run test -- convex/operations/operationalWorkItems.test.ts -t "pending checkout"`
+- `cd packages/athena-webapp && bun run test -- convex/operations/dailyClose.test.ts -t "carry-forward"`
+- `cd packages/athena-webapp && bun run audit:convex`
+- `cd packages/athena-webapp && bun run lint:convex:changed`
+
+---
+
+## System-Wide Impact
+
+- **POS pending checkout:** Source evidence remains pending. Operational review work becomes explicitly tied to product archive actionability.
+- **Product archive/unarchive:** Availability changes gain side effects for POS pending checkout review work, but only for source-linked provisional products in the same store.
+- **Open Work:** The workspace no longer relies on silently hiding archived-product review rows as the primary correctness mechanism.
+- **EOD Review:** Carry-forward reads remain source-agnostic and status-based; retired rows fall out naturally.
+- **Operations audit:** Archive/unarchive and repair flows should leave enough metadata/events for an operator or developer to explain why a review item disappeared or returned.
+- **Production data:** Existing stale open rows need one-time repair; otherwise code fixes only prevent new drift.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Archive is misinterpreted as review rejection. | Preserve `posPendingCheckoutItem.status`; use `operationalWorkItem.status = "cancelled"` with archive-specific metadata/event reason. |
+| Duplicate review work is created on repeated unarchive. | Dedupe by `pendingCheckoutItemId` source identity and check both the current pointer and `open` / `in_progress` rows; abort source availability mutations if the duplicate scan is incomplete. |
+| Generic product update bypasses lifecycle. | Route all availability transitions that cross the archived boundary through the same helper. |
+| Production repair cancels unrelated work. | Scope by store, work type, source metadata, pending item status, product/SKU anchors, archived product availability, and mandatory dry run with ids and skip reasons. |
+| Open Work filter masks future lifecycle bugs. | Prefer removing or narrowing the filter after repair; if retained, test and label it as legacy defense only. |
+| Cancelled rows lack `completedAt`, affecting reports. | Stamp `completedAt` when this lifecycle cancels work and test terminal timestamp behavior. |
+
+---
+
+## Acceptance Criteria
+
+- Archiving an actionable provisional pending checkout product cancels all matching current POS pending checkout review work items, clears the source pointer, and leaves the pending checkout source status unchanged.
+- Unarchiving the same product creates exactly one fresh open POS pending checkout review work item if the source still needs review.
+- Resolved pending checkout sources do not produce new work on unarchive.
+- Open Work and EOD Review report the same actionable open work set for archived provisional pending checkout products.
+- A mandatory dry-run and mutating production repair path can identify and retire the current stale open work rows with candidate ids, skip reasons, bounded batches, and idempotent retry behavior.
+- Focused Convex tests pass for product lifecycle, Open Work queue, and EOD carry-forward behavior.

--- a/docs/solutions/logic-errors/athena-pending-checkout-archive-work-lifecycle-2026-07-04.md
+++ b/docs/solutions/logic-errors/athena-pending-checkout-archive-work-lifecycle-2026-07-04.md
@@ -1,0 +1,107 @@
+---
+title: Athena Pending Checkout Archive Work Lifecycle
+date: 2026-07-04
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "Archived POS pending checkout products still appeared as open review work in EOD carry-forward."
+  - "The Open Work workspace and EOD review could disagree because one read model filtered archived products while another consumed stale operational work snapshots."
+  - "Completed or archived pending checkout review subjects left `posPendingCheckoutItem.operationalWorkItemId` pointing at open work."
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: high
+tags: [athena-webapp, pending-checkout, open-work, eod-review, convex]
+---
+
+# Athena Pending Checkout Archive Work Lifecycle
+
+## Problem
+POS pending checkout review work is source-owned by the pending checkout item and
+its provisional product/SKU anchors. When a provisional product is archived, the
+review subject is no longer actionable, but the product archive path only patched
+catalog availability and refreshed projections. It did not terminally update the
+associated `operationalWorkItem` rows or clear the pending item work pointer.
+
+That allowed EOD Review carry-forward to preserve stale open work for archived
+pending checkout products even after the operator-facing Open Work workspace no
+longer showed the same items.
+
+## Symptoms
+- EOD Review showed many `pos_pending_checkout_item_review` carry-forward rows
+  for provisional products that had already been archived.
+- Open Work returned only the currently actionable synced-sale inventory review
+  rows, making EOD look stale by comparison.
+- `posPendingCheckoutItem.operationalWorkItemId` could continue pointing at an
+  open or in-progress work row after the provisional product was archived.
+
+## What Didn't Work
+- Filtering archived provisional products out of a read model by itself. That
+  hides stale work in one workspace but leaves the underlying operational work
+  open for other consumers such as Daily Close.
+- Treating work item metadata as the only source identity. Metadata can be stale
+  or malformed; the pending checkout row's current `operationalWorkItemId`
+  pointer is also part of the lifecycle contract.
+- Running a mutating repair over whatever appears on a paginated query page at
+  execution time. The reviewed dry-run candidates can drift before the live
+  repair runs.
+
+## Solution
+Make product availability changes own the pending checkout review work lifecycle.
+When a provisional pending checkout product crosses into `archived`, cancel every
+matching open or in-progress `pos_pending_checkout_item_review` row and clear the
+pending item pointer. When the product is unarchived, reattach existing review
+work or create a fresh open review row.
+
+The lifecycle helper should use both source anchors:
+
+- Follow `posPendingCheckoutItem.operationalWorkItemId` first, validating store,
+  type, and open/in-progress status before cancellation or reattachment.
+- Also scan open/in-progress pending checkout review work by metadata to catch
+  duplicate rows.
+- Discover pending checkout items through targeted indexes:
+  `by_storeId_provisionalProductSkuId` for SKU anchors and
+  `by_storeId_provisionalProductId` for product-only anchors.
+- Refresh title, priority, and metadata when reattaching an existing work row so
+  Open Work and EOD see the same normalized row context.
+
+The repair path should be dry-run first:
+
+1. Dry run pages open or in-progress pending checkout review work and returns
+   candidate work item ids plus skip reasons.
+2. Mutating repair requires a `repairRunId` and explicit `workItemIds` from the
+   reviewed dry run.
+3. Each explicit id is revalidated for store, type, status, actionable pending
+   item, valid ids, and archived provisional product before cancellation.
+4. Malformed metadata is reported as a skip reason instead of aborting the batch.
+
+## Why This Works
+Open Work is an aggregate read surface, not the owner of every source workflow.
+The source workflow must terminally update its own work item when the underlying
+subject stops being actionable. Product archive is the transition that makes a
+pending checkout provisional product non-actionable, so that transition is the
+right place to cancel review work and clear the source pointer.
+
+Following the pointer first handles the row the source currently believes is its
+review work even when metadata drifted. Scanning duplicate metadata afterward
+keeps older duplicate rows from surviving. Requiring explicit repair candidates
+keeps production cleanup aligned with the reviewed dry-run output.
+
+## Prevention
+- Whenever a source subject becomes non-actionable, patch its current work item
+  to a terminal status instead of relying on read-model filters.
+- Treat `operationalWorkItemId` pointers and stable metadata identities as
+  complementary; use the pointer for the current row and metadata scans for
+  duplicates.
+- Add lifecycle tests for both `open` and `in_progress` work statuses.
+- Add repair tests for dry-run candidates, explicit mutating candidate ids,
+  malformed metadata skip reasons, stale candidate scope revalidation, and
+  pointer clearing.
+- Keep EOD and Open Work agreement tests near source lifecycle changes so stale
+  snapshots do not reappear in carry-forward workflows.
+
+## Related Issues
+- [Athena Open Work Resolution Ownership](../architecture-patterns/athena-open-work-resolution-ownership-2026-07-02.md)
+- [Athena Pending Checkout Inventory Resolution](../architecture-patterns/athena-pending-checkout-inventory-resolution-2026-07-03.md)
+- [Athena POS Pending Checkout Item Recovery](../architecture/athena-pos-pending-checkout-item-recovery-2026-06-06.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2169 files · ~0 words
+- 2170 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8585 nodes · 10397 edges · 2096 communities detected
+- 8605 nodes · 10439 edges · 2097 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2106,6 +2106,7 @@
 - [[_COMMUNITY_Community 2093|Community 2093]]
 - [[_COMMUNITY_Community 2094|Community 2094]]
 - [[_COMMUNITY_Community 2095|Community 2095]]
+- [[_COMMUNITY_Community 2096|Community 2096]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2350,16 +2351,16 @@ Cohesion: 0.2
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.18
-Nodes (23): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+15 more)
-
-### Community 55 - "Community 55"
 Cohesion: 0.14
 Nodes (18): findCurrentStoreDayOpening(), findLatestStoreDayOpening(), getTodaySummary(), getTransactionById(), isActivePosSummaryOpeningAt(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames() (+10 more)
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
+
+### Community 56 - "Community 56"
+Cohesion: 0.19
+Nodes (22): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem(), findOrCreatePendingCheckoutCategory() (+14 more)
 
 ### Community 57 - "Community 57"
 Cohesion: 0.17
@@ -2462,1092 +2463,1092 @@ Cohesion: 0.16
 Nodes (10): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), requireProductSkuSearchAccess(), requireProductSkuSearchAdmin() (+2 more)
 
 ### Community 82 - "Community 82"
+Cohesion: 0.27
+Nodes (16): assertCompleteScan(), buildPendingCheckoutReviewWorkItemMetadata(), buildPendingCheckoutReviewWorkItemPriority(), buildPendingCheckoutReviewWorkItemTitle(), cancelPendingCheckoutReviewWorkItem(), ensurePendingCheckoutReviewWorkForUnarchivedProduct(), getOpenReviewWorkItemFromPointer(), getOpenReviewWorkItemsForStore() (+8 more)
+
+### Community 83 - "Community 83"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.22
 Nodes (15): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+7 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.25
 Nodes (15): applyTheme(), emitThemeChange(), getStorage(), getStoredDarkThemeVariant(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme() (+7 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.25
 Nodes (16): buildStorefrontContextEvent(), buildStorefrontIdempotencyKey(), compactScalarPayload(), createStorefrontContextTrackingEnvelope(), createStorefrontRouteViewedContextEvent(), getCartChange(), getCartContextEventInput(), getCheckoutBlocker() (+8 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.22
 Nodes (14): assertActorMatchesStore(), buildCompiledContextBundle(), buildStoreInsightsContextBundleFromContextEvents(), buildUserInsightsContextBundleFromContextEvents(), compileContextEvent(), compileContextEventsWithReport(), getDataWindow(), getStoreFrontActorById() (+6 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.19
 Nodes (10): canListRegisterSessionSyncConflicts(), filterPendingCompletedSaleVoidApprovals(), filterPendingTransactionItemAdjustmentApprovals(), getNumberMetadata(), getPendingItemAdjustmentCashDelta(), getStringMetadata(), listPendingCompletedSaleVoidApprovals(), listPendingRegisterSessionApprovalRequests() (+2 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.15
 Nodes (7): getBlockedPosTerminalShellCopy(), getBrowserPathWithSearch(), getLoginHref(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.23
 Nodes (13): buildAbusePartitionKey(), buildServerContextTrackingEnvelope(), deriveBrowserFamily(), deriveContextEnvironment(), deriveOsFamily(), derivePrimarySubject(), isAcceptedSyntheticContext(), isRecord() (+5 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.19
 Nodes (10): buildLatestRunDebugPayload(), getBoundedDebugRunsByCapability(), getLatestDebugRunByCapability(), getLatestDebugRunBySubject(), isActiveRunStale(), isActiveRunStatus(), selectLatestDebugRunFromCandidates(), shouldRecoverActiveRun() (+2 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.3
 Nodes (15): buildPosOperatorSnapshot(), buildRecentDayBuckets(), buildSummaryTrendBucket(), buildTransactionDateBuckets(), calculateDeltaPercent(), formatHourLabel(), formatPaymentMethodLabel(), formatShortDate() (+7 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.17
 Nodes (8): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterCatalogState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.22
 Nodes (11): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), getInvalidationNodes(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline() (+3 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.23
 Nodes (13): collectConvexReturnValidatorContractFindings(), escapeRegExp(), extractConvexPublicFunctionsWithReturns(), fileExists(), findMatchingDefinitionEnd(), hasConvexReturnContractProofForExport(), isConvexReturnContractSourcePath(), isRelevantConvexContractProofPath() (+5 more)
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.18
 Nodes (5): buildPendingCheckoutFinalizationPayloadHash(), buildPendingCheckoutSaleEvidenceFingerprint(), buildTrustedSkuFingerprint(), listPendingCheckoutProductPageBindingWithCtx(), stableStringify()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.2
 Nodes (9): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), drawerAuthorityMatchesActiveRegisterSession(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable() (+1 more)
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.3
 Nodes (13): assertApprovalDecisionCanApply(), buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError() (+5 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (10): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), getRepairRegisterSessionCloseoutBoundaryAt(), isDuplicateRegisterOpenConflict() (+2 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getStatusesToOrdered() (+5 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.2
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.14
 Nodes (0):
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.18
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.22
 Nodes (7): getConversionRequestId(), handleClick(), handleFinalize(), if(), normalizeCommandMessage(), restock(), updateProductVariants()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.18
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.17
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.18
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.29
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.18
 Nodes (2): expenseItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.38
 Nodes (10): conflictError(), findPostReviewStockUpdateWithCtx(), idMetadataValue(), inventoryReviewLocalId(), optionalMetadataMatches(), readPositiveCurrentInventoryProofWithCtx(), resolveSyncedSaleInventoryReviewWithCtx(), stringMetadataValue() (+2 more)
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.25
 Nodes (6): buildGitProcessEnv(), clearRecordedProof(), parseProviderSkippedEvents(), runGitStdout(), runProcess(), writePrAthenaProviderEvidence()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.33
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.27
 Nodes (5): getLocalOperatingDate(), getLocalOperatingDateRange(), getReadinessDiagnosticRows(), getReadinessLoadingBlockers(), POSReadinessLoadingState()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.31
 Nodes (7): architectureSolutionNote(), createFixtureRepo(), gitEnv(), nonFoundationalArchitectureSolutionNote(), runGit(), solutionNote(), write()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.39
 Nodes (7): findActivePendingCheckoutLookupAliasByCode(), firstEvidenceTime(), normalizePendingCheckoutLookupCode(), resolvePendingCheckoutSku(), resolvePendingCheckoutSkuFromItem(), retirePendingCheckoutLookupAliasForItem(), upsertPendingCheckoutLookupAlias()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.47
 Nodes (8): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isPendingCheckoutLookupAliasVisible(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.28
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 204 - "Community 204"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
 ### Community 205 - "Community 205"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 206 - "Community 206"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 207 - "Community 207"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 208 - "Community 208"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
+### Community 206 - "Community 206"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 207 - "Community 207"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 208 - "Community 208"
+Cohesion: 0.22
+Nodes (0):
+
 ### Community 209 - "Community 209"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 210 - "Community 210"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
+Cohesion: 0.32
+Nodes (4): createProductsQueryCtx(), createSkuMutationCtx(), pendingCheckoutEvidence(), pendingCheckoutItem()
+
+### Community 216 - "Community 216"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 215 - "Community 215"
+### Community 217 - "Community 217"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 216 - "Community 216"
+### Community 218 - "Community 218"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 217 - "Community 217"
+### Community 219 - "Community 219"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 218 - "Community 218"
+### Community 220 - "Community 220"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 219 - "Community 219"
+### Community 221 - "Community 221"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 220 - "Community 220"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 221 - "Community 221"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 223 - "Community 223"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
-
-### Community 224 - "Community 224"
-Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
-
-### Community 225 - "Community 225"
-Cohesion: 0.39
-Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
-
-### Community 226 - "Community 226"
-Cohesion: 0.29
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
-
-### Community 227 - "Community 227"
-Cohesion: 0.25
-Nodes (1): DataTableRowActions()
-
-### Community 228 - "Community 228"
-Cohesion: 0.43
-Nodes (7): clearAthenaAuthSyncHandoff(), failAthenaAuthSyncHandoff(), getAthenaAuthSyncHandoffStatus(), normalizeAuthSyncRedirect(), parseHandoff(), readRawHandoff(), startAthenaAuthSyncHandoff()
-
-### Community 229 - "Community 229"
-Cohesion: 0.32
-Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
-
-### Community 230 - "Community 230"
-Cohesion: 0.25
-Nodes (1): ResizeObserverStub
-
-### Community 231 - "Community 231"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 232 - "Community 232"
+### Community 224 - "Community 224"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 225 - "Community 225"
+Cohesion: 0.36
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+
+### Community 226 - "Community 226"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 227 - "Community 227"
+Cohesion: 0.39
+Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
+
+### Community 228 - "Community 228"
 Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+
+### Community 229 - "Community 229"
+Cohesion: 0.25
+Nodes (1): DataTableRowActions()
+
+### Community 230 - "Community 230"
+Cohesion: 0.43
+Nodes (7): clearAthenaAuthSyncHandoff(), failAthenaAuthSyncHandoff(), getAthenaAuthSyncHandoffStatus(), normalizeAuthSyncRedirect(), parseHandoff(), readRawHandoff(), startAthenaAuthSyncHandoff()
+
+### Community 231 - "Community 231"
+Cohesion: 0.32
+Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
+
+### Community 232 - "Community 232"
+Cohesion: 0.25
+Nodes (1): ResizeObserverStub
 
 ### Community 233 - "Community 233"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 234 - "Community 234"
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
+
+### Community 235 - "Community 235"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 236 - "Community 236"
 Cohesion: 0.39
 Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
-### Community 235 - "Community 235"
+### Community 237 - "Community 237"
 Cohesion: 0.39
 Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
-### Community 236 - "Community 236"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 237 - "Community 237"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 238 - "Community 238"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 239 - "Community 239"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 240 - "Community 240"
 Cohesion: 0.29
 Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
 
-### Community 239 - "Community 239"
+### Community 241 - "Community 241"
 Cohesion: 0.46
 Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
-### Community 240 - "Community 240"
+### Community 242 - "Community 242"
 Cohesion: 0.46
 Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
 
-### Community 241 - "Community 241"
+### Community 243 - "Community 243"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 242 - "Community 242"
+### Community 244 - "Community 244"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 243 - "Community 243"
+### Community 245 - "Community 245"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 244 - "Community 244"
+### Community 246 - "Community 246"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 245 - "Community 245"
+### Community 247 - "Community 247"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 246 - "Community 246"
+### Community 248 - "Community 248"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 247 - "Community 247"
+### Community 249 - "Community 249"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 248 - "Community 248"
+### Community 250 - "Community 250"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 249 - "Community 249"
+### Community 251 - "Community 251"
 Cohesion: 0.43
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 250 - "Community 250"
+### Community 252 - "Community 252"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 251 - "Community 251"
+### Community 253 - "Community 253"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 252 - "Community 252"
+### Community 254 - "Community 254"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 253 - "Community 253"
+### Community 255 - "Community 255"
 Cohesion: 0.52
 Nodes (5): getBlockingRegisterSessionIdFromConflict(), isRegisterSessionConflict(), resolveScopedRegisterSession(), resolveTerminalRegisterConflict(), resolveTerminalRegisterSessionConflict()
 
-### Community 254 - "Community 254"
+### Community 256 - "Community 256"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 255 - "Community 255"
+### Community 257 - "Community 257"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 256 - "Community 256"
+### Community 258 - "Community 258"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 257 - "Community 257"
+### Community 259 - "Community 259"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 258 - "Community 258"
+### Community 260 - "Community 260"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 259 - "Community 259"
+### Community 261 - "Community 261"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 262 - "Community 262"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 261 - "Community 261"
+### Community 263 - "Community 263"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 262 - "Community 262"
+### Community 264 - "Community 264"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 263 - "Community 263"
+### Community 265 - "Community 265"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 264 - "Community 264"
+### Community 266 - "Community 266"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 265 - "Community 265"
+### Community 267 - "Community 267"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 266 - "Community 266"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 267 - "Community 267"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 268 - "Community 268"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 269 - "Community 269"
 Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 272 - "Community 272"
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
+
+### Community 273 - "Community 273"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 275 - "Community 275"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 274 - "Community 274"
+### Community 276 - "Community 276"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 275 - "Community 275"
+### Community 277 - "Community 277"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 276 - "Community 276"
+### Community 278 - "Community 278"
 Cohesion: 0.52
 Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
-### Community 277 - "Community 277"
+### Community 279 - "Community 279"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 278 - "Community 278"
+### Community 280 - "Community 280"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 279 - "Community 279"
+### Community 281 - "Community 281"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 280 - "Community 280"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 281 - "Community 281"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 282 - "Community 282"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 283 - "Community 283"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 284 - "Community 284"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 283 - "Community 283"
+### Community 285 - "Community 285"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 284 - "Community 284"
+### Community 286 - "Community 286"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 285 - "Community 285"
+### Community 287 - "Community 287"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 286 - "Community 286"
+### Community 288 - "Community 288"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 287 - "Community 287"
+### Community 289 - "Community 289"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 288 - "Community 288"
+### Community 290 - "Community 290"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 289 - "Community 289"
+### Community 291 - "Community 291"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 290 - "Community 290"
+### Community 292 - "Community 292"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
-
-### Community 291 - "Community 291"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 292 - "Community 292"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 294 - "Community 294"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.6
-Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
 ### Community 297 - "Community 297"
-Cohesion: 0.53
-Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 298 - "Community 298"
 Cohesion: 0.6
-Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
 ### Community 299 - "Community 299"
+Cohesion: 0.53
+Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
+
+### Community 300 - "Community 300"
+Cohesion: 0.6
+Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 301 - "Community 301"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 300 - "Community 300"
+### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 301 - "Community 301"
+### Community 303 - "Community 303"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 302 - "Community 302"
+### Community 304 - "Community 304"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 303 - "Community 303"
+### Community 305 - "Community 305"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 304 - "Community 304"
+### Community 306 - "Community 306"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 305 - "Community 305"
+### Community 307 - "Community 307"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 306 - "Community 306"
+### Community 308 - "Community 308"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 307 - "Community 307"
+### Community 309 - "Community 309"
 Cohesion: 0.4
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 308 - "Community 308"
+### Community 310 - "Community 310"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 309 - "Community 309"
+### Community 311 - "Community 311"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 310 - "Community 310"
+### Community 312 - "Community 312"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 311 - "Community 311"
-Cohesion: 0.4
-Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
-
-### Community 312 - "Community 312"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.4
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
 ### Community 314 - "Community 314"
+Cohesion: 0.4
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
+
+### Community 315 - "Community 315"
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+
+### Community 316 - "Community 316"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 315 - "Community 315"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 316 - "Community 316"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 317 - "Community 317"
-Cohesion: 0.47
-Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 319 - "Community 319"
+Cohesion: 0.47
+Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
+
+### Community 320 - "Community 320"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 321 - "Community 321"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 320 - "Community 320"
+### Community 322 - "Community 322"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 321 - "Community 321"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 322 - "Community 322"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 323 - "Community 323"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.53
-Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 326 - "Community 326"
-Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 327 - "Community 327"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 328 - "Community 328"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
 ### Community 329 - "Community 329"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 330 - "Community 330"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 331 - "Community 331"
 Cohesion: 0.33
-Nodes (1): MemoryCache
+Nodes (0):
 
 ### Community 332 - "Community 332"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 333 - "Community 333"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 334 - "Community 334"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
+### Community 335 - "Community 335"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 333 - "Community 333"
+### Community 336 - "Community 336"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
-### Community 334 - "Community 334"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 335 - "Community 335"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 336 - "Community 336"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 337 - "Community 337"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 338 - "Community 338"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 340 - "Community 340"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 341 - "Community 341"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 342 - "Community 342"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 343 - "Community 343"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 344 - "Community 344"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 345 - "Community 345"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 346 - "Community 346"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 347 - "Community 347"
-Cohesion: 0.67
-Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
 ### Community 348 - "Community 348"
 Cohesion: 0.53
-Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
 ### Community 349 - "Community 349"
+Cohesion: 0.67
+Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
+
+### Community 350 - "Community 350"
+Cohesion: 0.53
+Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
+
+### Community 351 - "Community 351"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 350 - "Community 350"
+### Community 352 - "Community 352"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 351 - "Community 351"
+### Community 353 - "Community 353"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
-
-### Community 352 - "Community 352"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 353 - "Community 353"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 354 - "Community 354"
 Cohesion: 0.4
@@ -3555,111 +3556,111 @@ Nodes (0):
 
 ### Community 355 - "Community 355"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 357 - "Community 357"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
-
-### Community 359 - "Community 359"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 359 - "Community 359"
+Cohesion: 0.5
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
+
 ### Community 360 - "Community 360"
 Cohesion: 0.5
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 362 - "Community 362"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 363 - "Community 363"
 Cohesion: 0.6
-Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 364 - "Community 364"
+Cohesion: 0.6
+Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+
+### Community 365 - "Community 365"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 366 - "Community 366"
+### Community 367 - "Community 367"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
-
-### Community 371 - "Community 371"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 372 - "Community 372"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 373 - "Community 373"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 381 - "Community 381"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 382 - "Community 382"
 Cohesion: 0.4
@@ -3674,12 +3675,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 386 - "Community 386"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 386 - "Community 386"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.4
@@ -3690,20 +3691,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 389 - "Community 389"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 390 - "Community 390"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 391 - "Community 391"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 392 - "Community 392"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 393 - "Community 393"
 Cohesion: 0.4
@@ -3726,80 +3727,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 398 - "Community 398"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 399 - "Community 399"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 399 - "Community 399"
+### Community 400 - "Community 400"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 400 - "Community 400"
+### Community 401 - "Community 401"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 401 - "Community 401"
+### Community 402 - "Community 402"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 402 - "Community 402"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 404 - "Community 404"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 405 - "Community 405"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 406 - "Community 406"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 406 - "Community 406"
+### Community 407 - "Community 407"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 407 - "Community 407"
+### Community 408 - "Community 408"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 410 - "Community 410"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 411 - "Community 411"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 412 - "Community 412"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 413 - "Community 413"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 414 - "Community 414"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 416 - "Community 416"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 417 - "Community 417"
 Cohesion: 0.4
@@ -3810,44 +3811,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 419 - "Community 419"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 420 - "Community 420"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 421 - "Community 421"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 422 - "Community 422"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 424 - "Community 424"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 425 - "Community 425"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 427 - "Community 427"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 428 - "Community 428"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 429 - "Community 429"
 Cohesion: 0.4
@@ -3858,72 +3859,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 431 - "Community 431"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 432 - "Community 432"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 434 - "Community 434"
+### Community 435 - "Community 435"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 438 - "Community 438"
+### Community 439 - "Community 439"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 439 - "Community 439"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 440 - "Community 440"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 441 - "Community 441"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 442 - "Community 442"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 442 - "Community 442"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 444 - "Community 444"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 445 - "Community 445"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 445 - "Community 445"
+### Community 446 - "Community 446"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 446 - "Community 446"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 447 - "Community 447"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.5
@@ -3942,76 +3943,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 452 - "Community 452"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 453 - "Community 453"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 455 - "Community 455"
+### Community 456 - "Community 456"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 456 - "Community 456"
+### Community 457 - "Community 457"
 Cohesion: 0.83
 Nodes (3): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), formatOnlineOrderLabel()
 
-### Community 457 - "Community 457"
+### Community 458 - "Community 458"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 458 - "Community 458"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 459 - "Community 459"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 460 - "Community 460"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 461 - "Community 461"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 461 - "Community 461"
+### Community 462 - "Community 462"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 462 - "Community 462"
+### Community 463 - "Community 463"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 463 - "Community 463"
+### Community 464 - "Community 464"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 464 - "Community 464"
+### Community 465 - "Community 465"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 465 - "Community 465"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 466 - "Community 466"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 467 - "Community 467"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 468 - "Community 468"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 469 - "Community 469"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 469 - "Community 469"
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.5
@@ -4022,24 +4023,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 472 - "Community 472"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 473 - "Community 473"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 473 - "Community 473"
+### Community 474 - "Community 474"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 474 - "Community 474"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 476 - "Community 476"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.5
@@ -4058,36 +4059,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 481 - "Community 481"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 482 - "Community 482"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 482 - "Community 482"
+### Community 483 - "Community 483"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 483 - "Community 483"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 484 - "Community 484"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 485 - "Community 485"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 486 - "Community 486"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 487 - "Community 487"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 488 - "Community 488"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.5
@@ -4098,28 +4099,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 491 - "Community 491"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 492 - "Community 492"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 492 - "Community 492"
+### Community 493 - "Community 493"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 493 - "Community 493"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 496 - "Community 496"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.5
@@ -4150,12 +4151,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 504 - "Community 504"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 505 - "Community 505"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 505 - "Community 505"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 506 - "Community 506"
 Cohesion: 0.5
@@ -4166,12 +4167,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 509 - "Community 509"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 509 - "Community 509"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.5
@@ -4182,120 +4183,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 512 - "Community 512"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 513 - "Community 513"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 513 - "Community 513"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 514 - "Community 514"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 515 - "Community 515"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 518 - "Community 518"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 519 - "Community 519"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 520 - "Community 520"
+### Community 521 - "Community 521"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 521 - "Community 521"
+### Community 522 - "Community 522"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 522 - "Community 522"
+### Community 523 - "Community 523"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 523 - "Community 523"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 525 - "Community 525"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 527 - "Community 527"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 528 - "Community 528"
+### Community 529 - "Community 529"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 529 - "Community 529"
+### Community 530 - "Community 530"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 530 - "Community 530"
+### Community 531 - "Community 531"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 531 - "Community 531"
+### Community 532 - "Community 532"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 532 - "Community 532"
+### Community 533 - "Community 533"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 533 - "Community 533"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 534 - "Community 534"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 535 - "Community 535"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 536 - "Community 536"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 536 - "Community 536"
+### Community 537 - "Community 537"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 537 - "Community 537"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 538 - "Community 538"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 539 - "Community 539"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 540 - "Community 540"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 541 - "Community 541"
 Cohesion: 0.5
@@ -4326,63 +4327,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 548 - "Community 548"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 549 - "Community 549"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 550 - "Community 550"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 551 - "Community 551"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 551 - "Community 551"
+### Community 552 - "Community 552"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 552 - "Community 552"
+### Community 553 - "Community 553"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 553 - "Community 553"
+### Community 554 - "Community 554"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 554 - "Community 554"
+### Community 555 - "Community 555"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 555 - "Community 555"
+### Community 556 - "Community 556"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 556 - "Community 556"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 557 - "Community 557"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 558 - "Community 558"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 559 - "Community 559"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 559 - "Community 559"
+### Community 560 - "Community 560"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 560 - "Community 560"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 561 - "Community 561"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 562 - "Community 562"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 563 - "Community 563"
@@ -4390,12 +4391,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 564 - "Community 564"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 565 - "Community 565"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 565 - "Community 565"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 566 - "Community 566"
 Cohesion: 0.67
@@ -4454,32 +4455,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 580 - "Community 580"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 581 - "Community 581"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 582 - "Community 582"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 583 - "Community 583"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 584 - "Community 584"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 585 - "Community 585"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 586 - "Community 586"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 587 - "Community 587"
 Cohesion: 0.67
@@ -4494,12 +4495,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 590 - "Community 590"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 591 - "Community 591"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 591 - "Community 591"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
@@ -4518,12 +4519,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 596 - "Community 596"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 597 - "Community 597"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 597 - "Community 597"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 598 - "Community 598"
 Cohesion: 0.67
@@ -4538,16 +4539,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 601 - "Community 601"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 602 - "Community 602"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 603 - "Community 603"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 604 - "Community 604"
 Cohesion: 0.67
@@ -4558,28 +4559,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 606 - "Community 606"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 607 - "Community 607"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 608 - "Community 608"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 609 - "Community 609"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 610 - "Community 610"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 611 - "Community 611"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 611 - "Community 611"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 612 - "Community 612"
 Cohesion: 0.67
@@ -4587,11 +4588,11 @@ Nodes (0):
 
 ### Community 613 - "Community 613"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 614 - "Community 614"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 615 - "Community 615"
 Cohesion: 0.67
@@ -4606,12 +4607,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 618 - "Community 618"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 619 - "Community 619"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 619 - "Community 619"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 620 - "Community 620"
 Cohesion: 0.67
@@ -4635,23 +4636,23 @@ Nodes (0):
 
 ### Community 625 - "Community 625"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 628 - "Community 628"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 629 - "Community 629"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 629 - "Community 629"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
@@ -4659,15 +4660,15 @@ Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 632 - "Community 632"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 633 - "Community 633"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
@@ -4678,16 +4679,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 636 - "Community 636"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 637 - "Community 637"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 638 - "Community 638"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
@@ -4722,12 +4723,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 647 - "Community 647"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 648 - "Community 648"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 648 - "Community 648"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
@@ -4747,79 +4748,79 @@ Nodes (0):
 
 ### Community 653 - "Community 653"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 654 - "Community 654"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 655 - "Community 655"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 657 - "Community 657"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 660 - "Community 660"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 661 - "Community 661"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 661 - "Community 661"
+### Community 662 - "Community 662"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 662 - "Community 662"
+### Community 663 - "Community 663"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 663 - "Community 663"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 664 - "Community 664"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 665 - "Community 665"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 666 - "Community 666"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 667 - "Community 667"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 668 - "Community 668"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 669 - "Community 669"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 670 - "Community 670"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 672 - "Community 672"
 Cohesion: 0.67
@@ -4851,11 +4852,11 @@ Nodes (0):
 
 ### Community 679 - "Community 679"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 680 - "Community 680"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 681 - "Community 681"
 Cohesion: 0.67
@@ -4886,52 +4887,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 688 - "Community 688"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 689 - "Community 689"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 689 - "Community 689"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 690 - "Community 690"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 691 - "Community 691"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 692 - "Community 692"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 693 - "Community 693"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 693 - "Community 693"
+### Community 694 - "Community 694"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 694 - "Community 694"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 695 - "Community 695"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 696 - "Community 696"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 697 - "Community 697"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 698 - "Community 698"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 699 - "Community 699"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 699 - "Community 699"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 700 - "Community 700"
 Cohesion: 0.67
@@ -4958,76 +4959,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 706 - "Community 706"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 707 - "Community 707"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 708 - "Community 708"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 709 - "Community 709"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 710 - "Community 710"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 711 - "Community 711"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 712 - "Community 712"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 713 - "Community 713"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 714 - "Community 714"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 715 - "Community 715"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 716 - "Community 716"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 717 - "Community 717"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 718 - "Community 718"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 719 - "Community 719"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 720 - "Community 720"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 721 - "Community 721"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 722 - "Community 722"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 723 - "Community 723"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 724 - "Community 724"
 Cohesion: 0.67
@@ -5042,12 +5043,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 727 - "Community 727"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 728 - "Community 728"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 728 - "Community 728"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 729 - "Community 729"
 Cohesion: 0.67
@@ -5058,12 +5059,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 731 - "Community 731"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 732 - "Community 732"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 732 - "Community 732"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 733 - "Community 733"
 Cohesion: 0.67
@@ -5130,16 +5131,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 749 - "Community 749"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 750 - "Community 750"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 751 - "Community 751"
+### Community 750 - "Community 750"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 751 - "Community 751"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
@@ -5154,24 +5155,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 755 - "Community 755"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 756 - "Community 756"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 756 - "Community 756"
+### Community 757 - "Community 757"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 757 - "Community 757"
+### Community 758 - "Community 758"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 758 - "Community 758"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 759 - "Community 759"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 760 - "Community 760"
 Cohesion: 1.0
@@ -6299,11 +6300,11 @@ Nodes (0):
 
 ### Community 1041 - "Community 1041"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1042 - "Community 1042"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1043 - "Community 1043"
 Cohesion: 1.0
@@ -10517,370 +10518,374 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2096 - "Community 2096"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 759`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 760`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 761`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 762`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 763`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 764`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 765`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 766`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 767`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 768`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 769`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 770`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 771`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 772`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 773`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 774`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 775`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 776`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 777`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 778`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 779`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 780`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 781`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 782`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 783`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 784`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 785`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 786`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 787`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 788`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 789`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 790`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 791`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 792`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 793`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 794`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 795`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 796`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 797`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 798`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 799`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 800`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 801`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 802`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 803`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 804`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 805`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 806`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 807`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 808`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 809`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 810`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 811`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 812`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 813`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 814`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 815`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 816`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 817`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 818`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 819`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 820`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 821`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 822`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 823`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 824`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 825`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 826`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 827`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 828`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 829`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 830`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 831`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 832`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 833`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 834`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 835`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 836`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 837`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 838`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 839`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 840`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 841`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 842`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 843`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 844`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 845`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 846`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 847`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 848`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 849`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 850`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 851`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 852`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 853`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 854`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 855`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 856`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 857`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 858`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 859`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 860`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 861`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 862`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 863`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 864`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 865`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 866`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 867`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 868`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 869`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 870`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 871`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 872`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 873`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 874`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 875`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 876`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 877`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 878`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 879`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 880`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 881`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 882`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 883`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 884`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 885`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 886`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 887`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 888`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 889`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 890`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 891`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 892`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 893`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 894`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 895`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 896`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 897`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 898`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 899`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 900`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 901`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 902`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 903`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 904`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 905`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 906`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 907`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
+- **Thin community `Community 908`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 909`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 910`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 911`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 912`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 913`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 914`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 915`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 916`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 917`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 918`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 919`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 920`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 921`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 922`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 923`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 924`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 925`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 926`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 927`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 928`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 929`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 930`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 931`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 932`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 933`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 934`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 935`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 936`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 937`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 938`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 939`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 940`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10916,2317 +10921,2317 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 941`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 942`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 943`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 944`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 945`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 946`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 947`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 948`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 949`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 950`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 951`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 952`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 953`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 954`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
+- **Thin community `Community 955`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 956`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 957`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 958`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 959`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 960`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 961`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 962`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 963`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 964`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 965`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 966`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 967`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 968`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 969`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 970`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 971`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 972`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 973`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 974`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 975`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 976`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 977`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 978`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 979`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 980`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 981`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 982`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 983`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 984`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 985`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 986`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 987`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 988`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 989`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 990`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 991`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 992`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 993`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 994`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 995`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 996`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 997`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 998`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 999`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1000`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1001`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1002`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1003`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1004`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1005`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1006`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1007`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1008`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1009`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1010`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1011`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1012`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1013`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1014`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1015`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1016`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1017`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1018`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1019`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1020`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1021`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1022`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1023`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1024`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1025`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1026`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1027`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1028`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1029`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1030`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1031`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1032`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1033`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1034`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1035`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1036`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1037`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1038`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1039`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1040`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1041`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1042`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1043`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1044`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1045`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1046`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1047`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1048`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1049`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1050`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1051`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1052`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1053`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1054`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1055`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1056`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1057`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1058`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1059`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1060`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1061`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1062`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1063`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1064`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1065`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1066`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1067`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1068`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1069`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1070`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1071`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1072`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1073`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1074`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1075`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1076`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1077`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1078`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1079`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1080`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1081`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1082`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1083`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1084`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1085`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1086`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1087`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1088`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1089`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1090`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1091`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1092`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1093`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1094`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1095`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1096`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1097`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1098`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1099`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1100`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1101`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1102`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1103`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1104`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1105`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1106`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1107`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1108`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1109`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1110`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1111`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1112`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1113`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1114`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1115`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1116`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1117`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1118`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1119`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1120`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1121`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1122`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1123`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1124`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1125`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1126`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1127`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1128`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1129`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1130`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1131`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1132`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1133`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1134`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1135`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1136`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1137`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1138`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1139`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1140`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1141`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1142`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1143`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1144`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1145`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1146`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1147`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1148`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1149`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1150`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1151`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1152`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1153`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1154`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1155`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1156`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1157`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1158`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1159`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1160`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1161`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1162`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1163`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1164`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1165`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1166`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1167`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1168`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1169`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1170`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1171`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1172`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1173`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1174`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1175`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1176`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1177`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1178`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1179`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1180`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1181`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1182`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1183`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1184`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1185`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1186`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1187`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1188`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1189`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1190`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1191`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1192`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1193`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1194`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1195`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1196`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1197`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1198`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1199`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1200`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1201`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1202`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1203`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1204`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1205`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1206`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1207`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1208`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1209`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1210`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1211`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1212`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1213`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1214`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1215`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1216`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1217`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1218`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1219`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1220`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1221`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1222`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1223`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1224`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1225`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1226`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1227`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1228`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1229`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1230`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1231`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1232`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1233`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1234`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `api.js`
+- **Thin community `Community 1235`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1236`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1237`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `server.js`
+- **Thin community `Community 1238`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `app.ts`
+- **Thin community `Community 1239`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1240`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1241`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1242`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `auth.ts`
+- **Thin community `Community 1244`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1246`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1247`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `countries.ts`
+- **Thin community `Community 1248`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `email.ts`
+- **Thin community `Community 1249`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1250`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `payment.ts`
+- **Thin community `Community 1251`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1252`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1253`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `types.ts`
+- **Thin community `Community 1254`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1255`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `crons.ts`
+- **Thin community `Community 1256`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1257`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `internal.ts`
+- **Thin community `Community 1258`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1259`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1260`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1262`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1263`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1264`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `DailyManagerReport.tsx`
+- **Thin community `Community 1265`** (1 nodes): `DailyManagerReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1266`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1267`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1268`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1269`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1270`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1271`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `env.ts`
+- **Thin community `Community 1272`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1273`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `auth.ts`
+- **Thin community `Community 1274`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1275`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `colors.ts`
+- **Thin community `Community 1276`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `index.ts`
+- **Thin community `Community 1277`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1278`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `products.ts`
+- **Thin community `Community 1279`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `stores.ts`
+- **Thin community `Community 1281`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `bag.ts`
+- **Thin community `Community 1283`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `guest.ts`
+- **Thin community `Community 1284`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `index.ts`
+- **Thin community `Community 1286`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `me.ts`
+- **Thin community `Community 1287`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `offers.ts`
+- **Thin community `Community 1288`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1289`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1290`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1291`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1292`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1293`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1294`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1296`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1297`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `user.ts`
+- **Thin community `Community 1298`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1299`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `index.ts`
+- **Thin community `Community 1300`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1301`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `http.ts`
+- **Thin community `Community 1302`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `access.ts`
+- **Thin community `Community 1303`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1304`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `index.ts`
+- **Thin community `Community 1307`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `types.ts`
+- **Thin community `Community 1309`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1310`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `categories.ts`
+- **Thin community `Community 1311`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `colors.ts`
+- **Thin community `Community 1312`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1313`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1314`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1315`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1316`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `pos.ts`
+- **Thin community `Community 1317`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1318`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1319`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1321`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1322`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1324`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1325`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1326`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1329`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1330`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1331`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1333`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `types.ts`
+- **Thin community `Community 1335`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1337`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1338`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1339`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1340`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `dto.ts`
+- **Thin community `Community 1344`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1345`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1346`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1347`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `types.ts`
+- **Thin community `Community 1349`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `facts.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `types.ts`
+- **Thin community `Community 1350`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1351`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1352`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `types.ts`
+- **Thin community `Community 1353`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1354`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `customers.ts`
+- **Thin community `Community 1355`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `register.ts`
+- **Thin community `Community 1357`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `sync.ts`
+- **Thin community `Community 1358`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1359`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1360`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1361`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `schema.ts`
+- **Thin community `Community 1362`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `automation.ts`
+- **Thin community `Community 1363`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1364`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1365`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `index.ts`
+- **Thin community `Community 1366`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1367`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1368`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1369`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1370`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1371`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1372`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1373`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `category.ts`
+- **Thin community `Community 1374`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `color.ts`
+- **Thin community `Community 1375`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1376`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1377`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `index.ts`
+- **Thin community `Community 1378`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1379`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1380`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1381`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1382`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `organization.ts`
+- **Thin community `Community 1383`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1384`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `product.ts`
+- **Thin community `Community 1385`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1386`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1387`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1388`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `store.ts`
+- **Thin community `Community 1389`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1390`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1391`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `index.ts`
+- **Thin community `Community 1392`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1393`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1394`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1395`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1396`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1397`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1398`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1399`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `index.ts`
+- **Thin community `Community 1400`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1401`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1402`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1403`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1404`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1405`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1406`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1407`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1408`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1409`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1410`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1411`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `customer.ts`
+- **Thin community `Community 1412`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1413`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1414`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1415`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1416`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `index.ts`
+- **Thin community `Community 1417`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1418`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1419`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1420`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1421`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1422`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1423`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1424`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1425`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1426`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1427`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1428`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1429`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1430`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1431`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1432`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1433`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1434`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1435`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1436`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1437`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `index.ts`
+- **Thin community `Community 1438`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1439`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1440`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `index.ts`
+- **Thin community `Community 1441`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1442`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1443`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1444`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1445`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1446`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1447`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `index.ts`
+- **Thin community `Community 1448`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1449`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1450`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1451`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1452`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1453`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1454`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `bag.ts`
+- **Thin community `Community 1455`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1456`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1457`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1458`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `guest.ts`
+- **Thin community `Community 1459`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `index.ts`
+- **Thin community `Community 1460`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `offer.ts`
+- **Thin community `Community 1461`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1462`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1463`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `review.ts`
+- **Thin community `Community 1464`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1465`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1466`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1467`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1468`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1469`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1470`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1471`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `bag.ts`
+- **Thin community `Community 1473`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1474`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `customer.ts`
+- **Thin community `Community 1475`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `guest.ts`
+- **Thin community `Community 1476`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1478`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1480`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1481`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1482`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `users.ts`
+- **Thin community `Community 1484`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `payment.ts`
+- **Thin community `Community 1485`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1486`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1487`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1488`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1492`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `index.ts`
+- **Thin community `Community 1493`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1494`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1495`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1496`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1497`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `auth.ts`
+- **Thin community `Community 1498`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1499`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1501`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1502`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1503`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1505`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `index.ts`
+- **Thin community `Community 1506`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1507`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1508`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1509`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1513`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1514`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1515`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1516`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1517`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1518`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1519`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1520`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1521`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1522`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1524`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1525`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1526`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1527`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1528`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `constants.ts`
+- **Thin community `Community 1529`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1530`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1532`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `types.ts`
+- **Thin community `Community 1533`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1534`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1535`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1536`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1537`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1538`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1539`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1540`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1541`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1542`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1543`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1544`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1545`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1546`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1547`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1548`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1549`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1550`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1551`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1552`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1553`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `constants.ts`
+- **Thin community `Community 1554`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1555`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1556`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1557`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `data.ts`
+- **Thin community `Community 1558`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1559`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1560`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1561`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1562`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1563`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1564`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1565`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1566`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1567`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1568`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1569`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `constants.ts`
+- **Thin community `Community 1570`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1571`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1572`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1573`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `data.ts`
+- **Thin community `Community 1574`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1576`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1577`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1578`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1580`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1581`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1582`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1583`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1584`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1585`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `constants.ts`
+- **Thin community `Community 1586`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1587`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1588`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1589`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1590`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1591`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1592`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1593`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1594`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1597`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1599`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1600`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1601`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1602`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1603`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1604`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1605`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1606`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1607`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1611`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1612`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1613`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1614`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1615`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1617`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1618`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1619`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1620`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1622`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `constants.ts`
+- **Thin community `Community 1623`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1624`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1625`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1626`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `data.ts`
+- **Thin community `Community 1627`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1628`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1629`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `constants.ts`
+- **Thin community `Community 1630`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1631`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1632`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1633`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1634`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `data.ts`
+- **Thin community `Community 1635`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1636`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `constants.ts`
+- **Thin community `Community 1637`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1638`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1639`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1640`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1641`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `data.ts`
+- **Thin community `Community 1642`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1643`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1645`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1646`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1647`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1648`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1649`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1650`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1651`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1652`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1653`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1654`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1655`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1656`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1657`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1658`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1660`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1661`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1662`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1663`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1664`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1665`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1666`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1667`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1669`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1670`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `types.ts`
+- **Thin community `Community 1671`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1672`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1673`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1674`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1675`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 1676`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1677`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 1678`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1679`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1680`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1681`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1682`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1683`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1684`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1685`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1686`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1687`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1688`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1689`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `data.ts`
+- **Thin community `Community 1690`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1691`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1692`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1693`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1694`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1695`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1696`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1697`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1698`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1699`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1700`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1701`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1702`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `constants.ts`
+- **Thin community `Community 1703`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1704`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1705`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1706`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `data.ts`
+- **Thin community `Community 1707`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `types.ts`
+- **Thin community `Community 1708`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1709`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1710`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1711`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1712`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1713`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `index.ts`
+- **Thin community `Community 1714`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1715`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1716`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1717`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1718`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `index.tsx`
+- **Thin community `Community 1719`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1720`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1721`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1722`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1723`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1724`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1725`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1726`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1727`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1728`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1729`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `index.tsx`
+- **Thin community `Community 1730`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1731`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1732`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1733`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `button.tsx`
+- **Thin community `Community 1734`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1735`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `card.tsx`
+- **Thin community `Community 1736`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1737`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1738`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `command.tsx`
+- **Thin community `Community 1739`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1740`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1741`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1742`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `form.tsx`
+- **Thin community `Community 1743`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1744`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1745`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `input.tsx`
+- **Thin community `Community 1746`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1747`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1748`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1749`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1750`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1751`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1752`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `select.tsx`
+- **Thin community `Community 1753`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1754`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1755`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1756`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1757`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `table.tsx`
+- **Thin community `Community 1758`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1759`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1760`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1761`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1762`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1763`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1764`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1765`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1766`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `constants.ts`
+- **Thin community `Community 1767`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1768`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1769`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1770`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `data.ts`
+- **Thin community `Community 1771`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1772`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1773`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1774`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1775`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1776`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1777`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1778`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1779`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1780`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1781`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `index.ts`
+- **Thin community `Community 1782`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1784`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1787`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1788`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1789`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1790`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1791`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1792`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1794`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1795`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1796`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1797`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `index.ts`
+- **Thin community `Community 1798`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1799`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `index.ts`
+- **Thin community `Community 1800`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1801`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `aws.ts`
+- **Thin community `Community 1803`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `constants.ts`
+- **Thin community `Community 1804`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `countries.ts`
+- **Thin community `Community 1805`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1806`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1810`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1811`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `dto.ts`
+- **Thin community `Community 1814`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `ports.ts`
+- **Thin community `Community 1815`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `constants.ts`
+- **Thin community `Community 1816`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `index.ts`
+- **Thin community `Community 1819`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `types.ts`
+- **Thin community `Community 1821`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1822`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1826`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1827`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1828`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1829`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1830`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1835`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1836`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1837`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1838`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1839`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `index.ts`
+- **Thin community `Community 1840`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1841`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `category.ts`
+- **Thin community `Community 1842`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `product.ts`
+- **Thin community `Community 1843`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `store.ts`
+- **Thin community `Community 1844`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1845`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `user.ts`
+- **Thin community `Community 1846`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1847`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1848`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1849`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1850`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1851`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `main.tsx`
+- **Thin community `Community 1852`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1853`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1854`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1855`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1857`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1858`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `index.tsx`
+- **Thin community `Community 1859`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1860`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1861`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1862`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1863`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 1864`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1865`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1866`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1867`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `index.tsx`
+- **Thin community `Community 1868`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1870`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `home.tsx`
+- **Thin community `Community 1872`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1873`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1874`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1875`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `index.tsx`
+- **Thin community `Community 1876`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `review.tsx`
+- **Thin community `Community 1877`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1878`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1879`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `index.tsx`
+- **Thin community `Community 1880`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1881`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1882`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1883`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `index.tsx`
+- **Thin community `Community 1884`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1885`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1886`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1887`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1888`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1889`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1890`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1891`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `index.tsx`
+- **Thin community `Community 1892`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1893`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1894`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1895`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1896`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1897`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1898`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1899`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1900`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1901`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `index.tsx`
+- **Thin community `Community 1902`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1903`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `index.tsx`
+- **Thin community `Community 1904`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `new.tsx`
+- **Thin community `Community 1905`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `index.tsx`
+- **Thin community `Community 1906`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `new.tsx`
+- **Thin community `Community 1907`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1908`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1909`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `index.tsx`
+- **Thin community `Community 1910`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `new.tsx`
+- **Thin community `Community 1911`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `index.tsx`
+- **Thin community `Community 1912`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1913`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1914`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1915`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1916`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `index.tsx`
+- **Thin community `Community 1917`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1918`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1919`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1920`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `index.tsx`
+- **Thin community `Community 1921`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1922`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1923`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1924`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `index.tsx`
+- **Thin community `Community 1925`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1926`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1927`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1928`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1929`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1930`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1931`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1932`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1933`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1934`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1935`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1936`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1937`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1938`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1939`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1940`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1941`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1942`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1943`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1944`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1945`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1946`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1947`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1948`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `setup.ts`
+- **Thin community `Community 1949`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1950`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `types.ts`
+- **Thin community `Community 1951`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1952`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1953`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1954`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1955`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1956`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1957`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1958`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `types.ts`
+- **Thin community `Community 1959`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1960`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1961`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1962`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1963`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1964`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1965`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1966`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1967`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `schema.ts`
+- **Thin community `Community 1968`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1969`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1970`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1971`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1972`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1973`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1974`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1975`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1976`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1977`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `types.ts`
+- **Thin community `Community 1978`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1979`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1980`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1981`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1982`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1983`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1984`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1985`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `constants.ts`
+- **Thin community `Community 1986`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1987`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `About.tsx`
+- **Thin community `Community 1988`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1989`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1990`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1991`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1992`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1993`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1994`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1995`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1996`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1997`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1998`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `types.ts`
+- **Thin community `Community 1999`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2000`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2001`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2002`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2003`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2004`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2005`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2006`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2007`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2008`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2009`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2010`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `button.tsx`
+- **Thin community `Community 2011`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `card.tsx`
+- **Thin community `Community 2012`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2013`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `command.tsx`
+- **Thin community `Community 2014`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2015`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2016`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2017`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `form.tsx`
+- **Thin community `Community 2018`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2019`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2020`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2021`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2022`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `input.tsx`
+- **Thin community `Community 2023`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `label.tsx`
+- **Thin community `Community 2024`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2025`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2026`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2027`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `index.ts`
+- **Thin community `Community 2028`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `types.ts`
+- **Thin community `Community 2029`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2030`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2031`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2032`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2033`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `select.tsx`
+- **Thin community `Community 2034`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2035`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2036`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `table.tsx`
+- **Thin community `Community 2037`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2038`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2039`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2040`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2041`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2042`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `config.ts`
+- **Thin community `Community 2043`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2044`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2045`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2046`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2047`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2048`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `constants.ts`
+- **Thin community `Community 2049`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `countries.ts`
+- **Thin community `Community 2050`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2051`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2052`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2053`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2054`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `index.ts`
+- **Thin community `Community 2055`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2056`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `store.ts`
+- **Thin community `Community 2057`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `bag.ts`
+- **Thin community `Community 2058`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2059`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `category.ts`
+- **Thin community `Community 2060`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `organization.ts`
+- **Thin community `Community 2061`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `product.ts`
+- **Thin community `Community 2062`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `store.ts`
+- **Thin community `Community 2063`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2064`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `user.ts`
+- **Thin community `Community 2065`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `states.ts`
+- **Thin community `Community 2066`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2067`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2068`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2069`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2070`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2071`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2072`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2073`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2074`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `index.tsx`
+- **Thin community `Community 2075`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2076`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `index.tsx`
+- **Thin community `Community 2077`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2078`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2079`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2080`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2081`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2082`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `index.tsx`
+- **Thin community `Community 2083`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2084`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2085`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2086`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2087`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2088`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `index.js`
+- **Thin community `Community 2089`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2090`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2091`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2092`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2093`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2094`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2095`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2096`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2169
-- Graph nodes: 8585
-- Graph edges: 10397
-- Communities: 2096
+- Code files discovered: 2170
+- Graph nodes: 8605
+- Graph edges: 10439
+- Communities: 2097
 
 ## Graph Hotspots
 - `dailyClose.ts` (102 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,8 +20,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 13) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 13) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 67) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `storefrontContextEvents.ts` (17 edges, Community 85) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
-- `checkoutSession.ts` (14 edges, Community 101) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storefrontContextEvents.ts` (17 edges, Community 86) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
+- `checkoutSession.ts` (14 edges, Community 102) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (15 edges, Community 102) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 210) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 102) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossCluster()` (4 edges, Community 102) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 102) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (15 edges, Community 103) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.test.js` (6 edges, Community 211) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `createRedisClient()` (4 edges, Community 103) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossCluster()` (4 edges, Community 103) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `invalidateAcrossClusterWithPipeline()` (4 edges, Community 103) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -193,6 +193,7 @@ import type * as pos_application_commands_correctTransaction from "../pos/applic
 import type * as pos_application_commands_createOrReusePendingCheckoutItem from "../pos/application/commands/createOrReusePendingCheckoutItem.js";
 import type * as pos_application_commands_expenseSessionCommands from "../pos/application/commands/expenseSessionCommands.js";
 import type * as pos_application_commands_expenseSessionTracing from "../pos/application/commands/expenseSessionTracing.js";
+import type * as pos_application_commands_pendingCheckoutReviewWorkLifecycle from "../pos/application/commands/pendingCheckoutReviewWorkLifecycle.js";
 import type * as pos_application_commands_posSessionTracing from "../pos/application/commands/posSessionTracing.js";
 import type * as pos_application_commands_quickAddCatalogItem from "../pos/application/commands/quickAddCatalogItem.js";
 import type * as pos_application_commands_register from "../pos/application/commands/register.js";
@@ -624,6 +625,7 @@ declare const fullApi: ApiFromModules<{
   "pos/application/commands/createOrReusePendingCheckoutItem": typeof pos_application_commands_createOrReusePendingCheckoutItem;
   "pos/application/commands/expenseSessionCommands": typeof pos_application_commands_expenseSessionCommands;
   "pos/application/commands/expenseSessionTracing": typeof pos_application_commands_expenseSessionTracing;
+  "pos/application/commands/pendingCheckoutReviewWorkLifecycle": typeof pos_application_commands_pendingCheckoutReviewWorkLifecycle;
   "pos/application/commands/posSessionTracing": typeof pos_application_commands_posSessionTracing;
   "pos/application/commands/quickAddCatalogItem": typeof pos_application_commands_quickAddCatalogItem;
   "pos/application/commands/register": typeof pos_application_commands_register;

--- a/packages/athena-webapp/convex/inventory/products.sku.test.ts
+++ b/packages/athena-webapp/convex/inventory/products.sku.test.ts
@@ -20,6 +20,7 @@ import {
   update,
   updateSku,
 } from "./products";
+import { repairArchivedPendingCheckoutReviewWork } from "../pos/application/commands/pendingCheckoutReviewWorkLifecycle";
 
 const mocks = vi.hoisted(() => ({
   refreshProductSkuSearchForProduct: vi.fn(),
@@ -44,6 +45,9 @@ type TableName =
   | "catalogSummary"
   | "category"
   | "inventoryHold"
+  | "operationalEvent"
+  | "operationalWorkItem"
+  | "posPendingCheckoutItem"
   | "product"
   | "productSku"
   | "subcategory";
@@ -63,6 +67,66 @@ function getTestScheduler(ctx: QueryCtx | MutationCtx) {
     .scheduler;
 }
 
+function pendingCheckoutEvidence() {
+  return {
+    firstSeenAt: 1,
+    lastSeenAt: 1,
+    observedLookupCodes: ["123456789012"],
+    observedPrices: [125000],
+    offlineSaleCount: 0,
+    totalQuantitySold: 1,
+    transactionCount: 1,
+  };
+}
+
+function pendingCheckoutItem(overrides: Partial<Row> = {}) {
+  const { _id = "pending001", ...rest } = overrides;
+
+  return {
+    _id,
+    createdAt: 1,
+    createdFrom: "offline_sync",
+    currency: "GHS",
+    evidence: pendingCheckoutEvidence(),
+    lookupCode: "123456789012",
+    name: "Protein Brazilian Hair Repair Mask",
+    normalizedLookupCode: "123456789012",
+    normalizedName: "protein brazilian hair repair mask",
+    operationalWorkItemId: "work001",
+    organizationId: "org0001",
+    provisionalPrice: 125000,
+    provisionalProductId: "product001",
+    provisionalProductSkuId: "sku001",
+    reviewPriority: "normal",
+    status: "pending_review",
+    storeId: "storezzzz",
+    updatedAt: 1,
+    ...rest,
+  };
+}
+
+function pendingCheckoutReviewWorkItem(overrides: Partial<Row> = {}) {
+  const { _id = "work001", ...rest } = overrides;
+
+  return {
+    _id,
+    approvalState: "not_required",
+    createdAt: 1,
+    metadata: {
+      pendingCheckoutItemId: "pending001",
+      provisionalProductId: "product001",
+      provisionalProductSkuId: "sku001",
+    },
+    organizationId: "org0001",
+    priority: "normal",
+    status: "open",
+    storeId: "storezzzz",
+    title: "Review pending checkout item: Protein Brazilian Hair Repair Mask",
+    type: "pos_pending_checkout_item_review",
+    ...rest,
+  };
+}
+
 function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
   const tables: Record<TableName, Map<string, Row>> = {
     catalogSummary: new Map(
@@ -72,6 +136,15 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
     inventoryHold: new Map(
       (seed.inventoryHold ?? []).map((row) => [row._id, row]),
     ),
+    operationalEvent: new Map(
+      (seed.operationalEvent ?? []).map((row) => [row._id, row]),
+    ),
+    operationalWorkItem: new Map(
+      (seed.operationalWorkItem ?? []).map((row) => [row._id, row]),
+    ),
+    posPendingCheckoutItem: new Map(
+      (seed.posPendingCheckoutItem ?? []).map((row) => [row._id, row]),
+    ),
     product: new Map((seed.product ?? []).map((row) => [row._id, row])),
     productSku: new Map((seed.productSku ?? []).map((row) => [row._id, row])),
     subcategory: new Map((seed.subcategory ?? []).map((row) => [row._id, row])),
@@ -80,6 +153,9 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
     catalogSummary: seed.catalogSummary?.length ?? 0,
     category: 0,
     inventoryHold: seed.inventoryHold?.length ?? 0,
+    operationalEvent: seed.operationalEvent?.length ?? 0,
+    operationalWorkItem: seed.operationalWorkItem?.length ?? 0,
+    posPendingCheckoutItem: seed.posPendingCheckoutItem?.length ?? 0,
     product: 0,
     productSku: seed.productSku?.length ?? 0,
     subcategory: 0,
@@ -100,6 +176,17 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
       first: async () => matches[0] ?? null,
       collect: async () => matches,
       take: async (count: number) => matches.slice(0, count),
+      paginate: async (paginationOpts: { cursor: string | null; numItems: number }) => {
+        const start = paginationOpts.cursor ? Number(paginationOpts.cursor) : 0;
+        const page = matches.slice(start, start + paginationOpts.numItems);
+        const next = start + paginationOpts.numItems;
+
+        return {
+          continueCursor: String(next),
+          isDone: next >= matches.length,
+          page,
+        };
+      },
     };
   }
 
@@ -107,6 +194,9 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
     db: {
       async get(table: TableName, id: string) {
         return tables[table].get(id) ?? null;
+      },
+      normalizeId(_table: TableName, id: string) {
+        return id.includes("invalid") ? null : id;
       },
       async insert(table: TableName, value: Record<string, unknown>) {
         counters[table] += 1;
@@ -474,6 +564,102 @@ describe("product archiving", () => {
     });
   });
 
+  it("cancels pending checkout review work when archiving its provisional product", async () => {
+    mocks.requireStoreFullAdminAccess.mockResolvedValue({});
+
+    const { ctx, tables } = createSkuMutationCtx({
+      operationalWorkItem: [
+        pendingCheckoutReviewWorkItem({
+          metadata: { pendingCheckoutItemId: "pending001" },
+          priority: "high",
+          title: "Stale title",
+        }),
+      ],
+      posPendingCheckoutItem: [pendingCheckoutItem()],
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          storeId: "storezzzz",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(archive)(ctx, {
+      id: "product001" as Id<"product">,
+      storeId: "storezzzz" as Id<"store">,
+    });
+
+    expect(tables.operationalWorkItem.get("work001")).toMatchObject({
+      completedAt: expect.any(Number),
+      metadata: expect.objectContaining({
+        pendingCheckoutItemId: "pending001",
+        retiredReason: "provisional_product_archived",
+      }),
+      status: "cancelled",
+    });
+    expect(tables.posPendingCheckoutItem.get("pending001")).toMatchObject({
+      operationalWorkItemId: undefined,
+    });
+    expect(Array.from(tables.operationalEvent.values())).toEqual([
+      expect.objectContaining({
+        eventType: "pos_pending_checkout_item_review_work_cancelled",
+        subjectId: "pending001",
+        workItemId: "work001",
+      }),
+    ]);
+  });
+
+  it("cancels in-progress pending checkout review work through the product anchor when the SKU anchor is missing", async () => {
+    mocks.requireStoreFullAdminAccess.mockResolvedValue({});
+
+    const { ctx, tables } = createSkuMutationCtx({
+      operationalWorkItem: [
+        pendingCheckoutReviewWorkItem({
+          metadata: {},
+          status: "in_progress",
+        }),
+      ],
+      posPendingCheckoutItem: [
+        pendingCheckoutItem({
+          provisionalProductSkuId: undefined,
+        }),
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(archive)(ctx, {
+      id: "product001" as Id<"product">,
+      storeId: "storezzzz" as Id<"store">,
+    });
+
+    expect(tables.operationalWorkItem.get("work001")).toMatchObject({
+      completedAt: expect.any(Number),
+      metadata: expect.objectContaining({
+        pendingCheckoutItemId: "pending001",
+        provisionalProductId: "product001",
+        retiredReason: "provisional_product_archived",
+      }),
+      status: "cancelled",
+    });
+    expect(tables.posPendingCheckoutItem.get("pending001")).toMatchObject({
+      operationalWorkItemId: undefined,
+    });
+  });
+
   it("unarchives a product with store admin access", async () => {
     mocks.requireStoreFullAdminAccess.mockResolvedValue({});
 
@@ -511,6 +697,498 @@ describe("product archiving", () => {
       needsRefresh: false,
       productCount: 1,
       storeId: "storezzzz",
+    });
+  });
+
+  it("creates fresh pending checkout review work when unarchiving its provisional product", async () => {
+    mocks.requireStoreFullAdminAccess.mockResolvedValue({});
+
+    const { ctx, tables } = createSkuMutationCtx({
+      posPendingCheckoutItem: [
+        pendingCheckoutItem({
+          operationalWorkItemId: undefined,
+          reviewPriority: "elevated",
+        }),
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "archived",
+          storeId: "storezzzz",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(unarchive)(ctx, {
+      id: "product001" as Id<"product">,
+      storeId: "storezzzz" as Id<"store">,
+    });
+
+    const workItem = Array.from(tables.operationalWorkItem.values())[0];
+    expect(workItem).toMatchObject({
+      priority: "medium",
+      status: "open",
+      title: "Review pending checkout item: Protein Brazilian Hair Repair Mask",
+      type: "pos_pending_checkout_item_review",
+    });
+    expect(tables.posPendingCheckoutItem.get("pending001")).toMatchObject({
+      operationalWorkItemId: workItem._id,
+    });
+  });
+
+  it("reattaches existing pending checkout review work when unarchiving without duplicating it", async () => {
+    mocks.requireStoreFullAdminAccess.mockResolvedValue({});
+
+    const { ctx, tables } = createSkuMutationCtx({
+      operationalWorkItem: [pendingCheckoutReviewWorkItem()],
+      posPendingCheckoutItem: [
+        pendingCheckoutItem({
+          operationalWorkItemId: undefined,
+        }),
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "archived",
+          storeId: "storezzzz",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(unarchive)(ctx, {
+      id: "product001" as Id<"product">,
+      storeId: "storezzzz" as Id<"store">,
+    });
+
+    expect(Array.from(tables.operationalWorkItem.values())).toHaveLength(1);
+    expect(tables.operationalWorkItem.get("work001")).toMatchObject({
+      metadata: expect.objectContaining({
+        pendingCheckoutItemId: "pending001",
+        provisionalProductId: "product001",
+        provisionalProductSkuId: "sku001",
+        restoredReason: "provisional_product_unarchived",
+      }),
+      priority: "normal",
+      title: "Review pending checkout item: Protein Brazilian Hair Repair Mask",
+    });
+    expect(tables.posPendingCheckoutItem.get("pending001")).toMatchObject({
+      operationalWorkItemId: "work001",
+    });
+  });
+
+  it("repairs stale pending checkout review work for archived provisional products after a dry run", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      operationalWorkItem: [pendingCheckoutReviewWorkItem()],
+      posPendingCheckoutItem: [pendingCheckoutItem()],
+      product: [
+        {
+          _id: "product001",
+          availability: "archived",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    const dryRun = await getHandler(repairArchivedPendingCheckoutReviewWork)(
+      ctx,
+      {
+        dryRun: true,
+        paginationOpts: { cursor: null, numItems: 10 },
+        status: "open",
+        storeId: "storezzzz" as Id<"store">,
+      },
+    );
+
+    expect(dryRun).toMatchObject({
+      candidates: ["work001"],
+      repaired: [],
+    });
+    expect(tables.operationalWorkItem.get("work001")).toMatchObject({
+      status: "open",
+    });
+
+    const repaired = await getHandler(repairArchivedPendingCheckoutReviewWork)(
+      ctx,
+      {
+        dryRun: false,
+        repairRunId: "repair-2026-07-04",
+        status: "open",
+        storeId: "storezzzz" as Id<"store">,
+        workItemIds: dryRun.candidates,
+      },
+    );
+
+    expect(repaired).toMatchObject({
+      candidates: ["work001"],
+      repaired: ["work001"],
+    });
+    expect(tables.operationalWorkItem.get("work001")).toMatchObject({
+      completedAt: expect.any(Number),
+      metadata: expect.objectContaining({
+        repairRunId: "repair-2026-07-04",
+        retiredReason: "archived_provisional_product_repair",
+      }),
+      status: "cancelled",
+    });
+    expect(tables.posPendingCheckoutItem.get("pending001")).toMatchObject({
+      operationalWorkItemId: undefined,
+    });
+  });
+
+  it("repairs stale in-progress pending checkout review work for archived provisional products", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      operationalWorkItem: [
+        pendingCheckoutReviewWorkItem({
+          status: "in_progress",
+        }),
+      ],
+      posPendingCheckoutItem: [pendingCheckoutItem()],
+      product: [
+        {
+          _id: "product001",
+          availability: "archived",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    const dryRun = await getHandler(repairArchivedPendingCheckoutReviewWork)(
+      ctx,
+      {
+        dryRun: true,
+        paginationOpts: { cursor: null, numItems: 10 },
+        status: "in_progress",
+        storeId: "storezzzz" as Id<"store">,
+      },
+    );
+
+    expect(dryRun).toMatchObject({
+      candidates: ["work001"],
+      repaired: [],
+    });
+
+    const repaired = await getHandler(repairArchivedPendingCheckoutReviewWork)(
+      ctx,
+      {
+        dryRun: false,
+        repairRunId: "repair-2026-07-04",
+        status: "in_progress",
+        storeId: "storezzzz" as Id<"store">,
+        workItemIds: dryRun.candidates,
+      },
+    );
+
+    expect(repaired).toMatchObject({
+      candidates: ["work001"],
+      repaired: ["work001"],
+    });
+    expect(tables.operationalWorkItem.get("work001")).toMatchObject({
+      completedAt: expect.any(Number),
+      metadata: expect.objectContaining({
+        repairRunId: "repair-2026-07-04",
+        retiredReason: "archived_provisional_product_repair",
+      }),
+      status: "cancelled",
+    });
+    expect(tables.posPendingCheckoutItem.get("pending001")).toMatchObject({
+      operationalWorkItemId: undefined,
+    });
+  });
+
+  it("skips unsafe repair rows without mutating unrelated work", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      operationalWorkItem: [
+        pendingCheckoutReviewWorkItem({
+          _id: "work-missing-metadata",
+          metadata: {},
+        }),
+        pendingCheckoutReviewWorkItem({
+          _id: "work-invalid-pending",
+          metadata: { pendingCheckoutItemId: "invalid-pending" },
+        }),
+        pendingCheckoutReviewWorkItem({
+          _id: "work-approved",
+          metadata: { pendingCheckoutItemId: "pending-approved" },
+        }),
+        pendingCheckoutReviewWorkItem({
+          _id: "work-missing-product",
+          metadata: { pendingCheckoutItemId: "pending-missing-product" },
+        }),
+        pendingCheckoutReviewWorkItem({
+          _id: "work-live-product",
+          metadata: { pendingCheckoutItemId: "pending-live-product" },
+        }),
+      ],
+      posPendingCheckoutItem: [
+        pendingCheckoutItem({
+          _id: "pending-approved",
+          operationalWorkItemId: "work-approved",
+          status: "approved",
+        }),
+        pendingCheckoutItem({
+          _id: "pending-missing-product",
+          operationalWorkItemId: "work-missing-product",
+          provisionalProductId: undefined,
+          provisionalProductSkuId: undefined,
+        }),
+        pendingCheckoutItem({
+          _id: "pending-live-product",
+          operationalWorkItemId: "work-live-product",
+          provisionalProductId: "product-live",
+          provisionalProductSkuId: undefined,
+        }),
+      ],
+      product: [
+        {
+          _id: "product-live",
+          availability: "live",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    const result = await getHandler(repairArchivedPendingCheckoutReviewWork)(
+      ctx,
+      {
+        dryRun: true,
+        paginationOpts: { cursor: null, numItems: 10 },
+        status: "open",
+        storeId: "storezzzz" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      candidates: [],
+      repaired: [],
+      skipped: [
+        { reason: "missing_pending_checkout_item_id", workItemId: "work-missing-metadata" },
+        { reason: "invalid_pending_checkout_item_id", workItemId: "work-invalid-pending" },
+        { reason: "pending_checkout_item_not_actionable", workItemId: "work-approved" },
+        { reason: "missing_provisional_product", workItemId: "work-missing-product" },
+        { reason: "provisional_product_not_archived", workItemId: "work-live-product" },
+      ],
+    });
+    expect(
+      Array.from(tables.operationalWorkItem.values()).map((workItem) => workItem.status),
+    ).toEqual(["open", "open", "open", "open", "open"]);
+  });
+
+  it("requires explicit dry-run candidate ids before mutating repair rows", async () => {
+    const { ctx } = createSkuMutationCtx({
+      operationalWorkItem: [pendingCheckoutReviewWorkItem()],
+      posPendingCheckoutItem: [pendingCheckoutItem()],
+      product: [
+        {
+          _id: "product001",
+          availability: "archived",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(repairArchivedPendingCheckoutReviewWork)(ctx, {
+        dryRun: false,
+        paginationOpts: { cursor: null, numItems: 10 },
+        status: "open",
+        storeId: "storezzzz" as Id<"store">,
+      }),
+    ).rejects.toThrow(
+      "Provide a repair run id and explicit dry-run candidate work item ids to repair.",
+    );
+  });
+
+  it("revalidates explicit repair candidate ids before mutating stale rows", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      operationalWorkItem: [
+        pendingCheckoutReviewWorkItem({
+          _id: "work-wrong-status",
+          status: "in_progress",
+        }),
+        pendingCheckoutReviewWorkItem({
+          _id: "work-wrong-store",
+          storeId: "other-store",
+        }),
+        pendingCheckoutReviewWorkItem({
+          _id: "work-wrong-type",
+          type: "service_case",
+        }),
+        pendingCheckoutReviewWorkItem({
+          _id: "work-pending-wrong-store",
+          metadata: { pendingCheckoutItemId: "pending-wrong-store" },
+        }),
+        pendingCheckoutReviewWorkItem({
+          _id: "work-invalid-product",
+          metadata: {
+            pendingCheckoutItemId: "pending-bad-product",
+            provisionalProductId: "invalid-product",
+          },
+        }),
+      ],
+      posPendingCheckoutItem: [
+        pendingCheckoutItem({
+          _id: "pending-wrong-store",
+          operationalWorkItemId: "work-pending-wrong-store",
+          storeId: "other-store",
+        }),
+        pendingCheckoutItem({
+          _id: "pending-bad-product",
+          operationalWorkItemId: "work-invalid-product",
+          provisionalProductId: undefined,
+          provisionalProductSkuId: undefined,
+        }),
+      ],
+    });
+
+    const result = await getHandler(repairArchivedPendingCheckoutReviewWork)(
+      ctx,
+      {
+        dryRun: false,
+        repairRunId: "repair-2026-07-04",
+        status: "open",
+        storeId: "storezzzz" as Id<"store">,
+        workItemIds: [
+          "work-wrong-status",
+          "work-wrong-store",
+          "work-wrong-type",
+          "work-pending-wrong-store",
+          "work-invalid-product",
+        ],
+      },
+    );
+
+    expect(result).toMatchObject({
+      candidates: [],
+      repaired: [],
+      skipped: [
+        {
+          reason: "work_item_no_longer_matches_repair_scope",
+          workItemId: "work-wrong-status",
+        },
+        {
+          reason: "work_item_no_longer_matches_repair_scope",
+          workItemId: "work-wrong-store",
+        },
+        {
+          reason: "work_item_no_longer_matches_repair_scope",
+          workItemId: "work-wrong-type",
+        },
+        {
+          reason: "pending_checkout_item_wrong_store",
+          workItemId: "work-pending-wrong-store",
+        },
+        {
+          reason: "invalid_provisional_product",
+          workItemId: "work-invalid-product",
+        },
+      ],
+    });
+    expect(
+      Array.from(tables.operationalWorkItem.values()).map((workItem) => workItem.status),
+    ).toEqual(["in_progress", "open", "open", "open", "open"]);
+  });
+
+  it("reconciles pending checkout review work when a generic product update archives the provisional product", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      operationalWorkItem: [pendingCheckoutReviewWorkItem()],
+      posPendingCheckoutItem: [pendingCheckoutItem()],
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          storeId: "storezzzz",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(update)(ctx, {
+      availability: "archived",
+      id: "product001" as Id<"product">,
+    });
+
+    expect(tables.operationalWorkItem.get("work001")).toMatchObject({
+      completedAt: expect.any(Number),
+      metadata: expect.objectContaining({
+        pendingCheckoutItemId: "pending001",
+        retiredReason: "provisional_product_archived",
+      }),
+      status: "cancelled",
+    });
+    expect(tables.posPendingCheckoutItem.get("pending001")).toMatchObject({
+      operationalWorkItemId: undefined,
+    });
+    expect(Array.from(tables.operationalEvent.values())).toEqual([
+      expect.objectContaining({
+        eventType: "pos_pending_checkout_item_review_work_cancelled",
+        subjectId: "pending001",
+        workItemId: "work001",
+      }),
+    ]);
+  });
+
+  it("reconciles pending checkout review work when a generic product update unarchives the provisional product", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      posPendingCheckoutItem: [
+        pendingCheckoutItem({
+          operationalWorkItemId: undefined,
+          reviewPriority: "elevated",
+        }),
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "archived",
+          storeId: "storezzzz",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(update)(ctx, {
+      availability: "live",
+      id: "product001" as Id<"product">,
+    });
+
+    const workItem = Array.from(tables.operationalWorkItem.values())[0];
+    expect(workItem).toMatchObject({
+      metadata: expect.objectContaining({
+        pendingCheckoutItemId: "pending001",
+        restoredReason: "provisional_product_unarchived",
+      }),
+      priority: "medium",
+      status: "open",
+      title: "Review pending checkout item: Protein Brazilian Hair Repair Mask",
+      type: "pos_pending_checkout_item_review",
+    });
+    expect(tables.posPendingCheckoutItem.get("pending001")).toMatchObject({
+      operationalWorkItemId: workItem._id,
     });
   });
 

--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -25,6 +25,10 @@ import {
   EMPTY_CATALOG_SUMMARY,
   refreshCatalogSummaryWithCtx,
 } from "./catalogSummary";
+import {
+  ensurePendingCheckoutReviewWorkForUnarchivedProduct,
+  retirePendingCheckoutReviewWorkForArchivedProduct,
+} from "../pos/application/commands/pendingCheckoutReviewWorkLifecycle";
 
 const entity = "product";
 
@@ -988,6 +992,7 @@ export const update = mutation({
   },
   handler: async (ctx, args) => {
     const { id, ...rest } = args;
+    const productBefore = await ctx.db.get("product", args.id);
 
     if (args.name) {
       const allSkus = await ctx.db
@@ -1008,6 +1013,25 @@ export const update = mutation({
     const product = await ctx.db.get("product", args.id);
 
     if (product) {
+      if (
+        args.availability === "archived" &&
+        productBefore?.availability !== "archived"
+      ) {
+        await retirePendingCheckoutReviewWorkForArchivedProduct(ctx, {
+          productId: product._id,
+          storeId: product.storeId,
+        });
+      } else if (
+        args.availability !== undefined &&
+        args.availability !== "archived" &&
+        productBefore?.availability === "archived"
+      ) {
+        await ensurePendingCheckoutReviewWorkForUnarchivedProduct(ctx, {
+          productId: product._id,
+          storeId: product.storeId,
+        });
+      }
+
       await ctx.scheduler.runAfter(
         0,
         internal.inventory.productUtil.invalidateProductCache,
@@ -1037,6 +1061,10 @@ export const archive = mutation({
     }
 
     await ctx.db.patch("product", args.id, { availability: "archived" });
+    await retirePendingCheckoutReviewWorkForArchivedProduct(ctx, {
+      productId: product._id,
+      storeId: product.storeId,
+    });
     await refreshProductSkuSearchForProduct(ctx, args.id);
     await refreshCatalogSummaryWithCtx(ctx, product.storeId);
 
@@ -1067,6 +1095,10 @@ export const unarchive = mutation({
     }
 
     await ctx.db.patch("product", args.id, { availability: "live" });
+    await ensurePendingCheckoutReviewWorkForUnarchivedProduct(ctx, {
+      productId: product._id,
+      storeId: product.storeId,
+    });
     await refreshProductSkuSearchForProduct(ctx, args.id);
     await refreshCatalogSummaryWithCtx(ctx, product.storeId);
 

--- a/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts
@@ -5,6 +5,10 @@ import { upsertProductSkuSearchProjection } from "../../../inventory/skuSearch";
 import { recordOperationalEventWithCtx } from "../../../operations/operationalEvents";
 import { createOperationalWorkItemWithCtx } from "../../../operations/operationalWorkItems";
 import { toSlug } from "../../../utils";
+import {
+  buildPendingCheckoutReviewWorkItemPriority,
+  buildPendingCheckoutReviewWorkItemTitle,
+} from "./pendingCheckoutReviewWorkLifecycle";
 
 export type PendingCheckoutResult = {
   id: Id<"posPendingCheckoutItem">;
@@ -442,14 +446,6 @@ function buildEventMessage(args: {
   return `${args.actorLabel} ${action} pending checkout item ${args.itemName}. Quantity entered: ${args.quantitySold}.`;
 }
 
-function buildWorkItemPriority(
-  reviewPriority: Doc<"posPendingCheckoutItem">["reviewPriority"],
-) {
-  if (reviewPriority === "high") return "high";
-  if (reviewPriority === "elevated") return "medium";
-  return "normal";
-}
-
 async function syncPendingCheckoutWorkItem(
   ctx: MutationCtx,
   item: Doc<"posPendingCheckoutItem">,
@@ -478,7 +474,8 @@ async function syncPendingCheckoutWorkItem(
       totalQuantitySold: item.evidence.totalQuantitySold,
       transactionCount: item.evidence.transactionCount,
     },
-    priority: buildWorkItemPriority(item.reviewPriority),
+    priority: buildPendingCheckoutReviewWorkItemPriority(item.reviewPriority),
+    title: buildPendingCheckoutReviewWorkItemTitle(item),
   });
 }
 
@@ -896,10 +893,12 @@ export async function createOrReusePendingCheckoutItem(
       totalQuantitySold: itemWithAnchors.evidence.totalQuantitySold,
     },
     organizationId: itemWithAnchors.organizationId,
-    priority: buildWorkItemPriority(itemWithAnchors.reviewPriority),
+    priority: buildPendingCheckoutReviewWorkItemPriority(
+      itemWithAnchors.reviewPriority,
+    ),
     status: "open",
     storeId: itemWithAnchors.storeId,
-    title: `Review pending checkout item: ${itemWithAnchors.name}`,
+    title: buildPendingCheckoutReviewWorkItemTitle(itemWithAnchors),
     type: "pos_pending_checkout_item_review",
   });
 

--- a/packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/pendingCheckoutReviewWorkLifecycle.ts
@@ -1,0 +1,582 @@
+import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+
+import { internalMutation, type MutationCtx } from "../../../_generated/server";
+import type { Doc, Id } from "../../../_generated/dataModel";
+import { createOperationalWorkItemWithCtx } from "../../../operations/operationalWorkItems";
+import { recordOperationalEventWithCtx } from "../../../operations/operationalEvents";
+
+const REVIEW_WORK_TYPE = "pos_pending_checkout_item_review";
+const OPEN_REVIEW_WORK_STATUSES = ["open", "in_progress"] as const;
+const ACTIONABLE_PENDING_CHECKOUT_STATUSES = new Set(["pending_review", "flagged"]);
+const OPEN_WORK_SCAN_LIMIT = 1_000;
+const PRODUCT_SKU_SCAN_LIMIT = 500;
+const PENDING_CHECKOUT_SCAN_LIMIT = 500;
+const REPAIR_WORK_ITEM_BATCH_LIMIT = 100;
+
+type OpenReviewWorkStatus = (typeof OPEN_REVIEW_WORK_STATUSES)[number];
+type PendingCheckoutReviewItem = Doc<"posPendingCheckoutItem">;
+
+function now() {
+  return Date.now();
+}
+
+function metadataString(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+) {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function matchesPendingCheckoutSource(
+  workItem: Doc<"operationalWorkItem">,
+  item: PendingCheckoutReviewItem,
+) {
+  const pendingCheckoutItemId =
+    metadataString(workItem.metadata, "pendingCheckoutItemId") ??
+    metadataString(workItem.metadata, "posPendingCheckoutItemId");
+
+  return pendingCheckoutItemId === String(item._id);
+}
+
+function assertCompleteScan<T>(rows: T[], limit: number, label: string) {
+  if (rows.length > limit) {
+    throw new Error(
+      `Too many ${label} to safely reconcile in one mutation. Run the repair path in smaller batches.`,
+    );
+  }
+}
+
+export function buildPendingCheckoutReviewWorkItemPriority(
+  reviewPriority: PendingCheckoutReviewItem["reviewPriority"],
+) {
+  if (reviewPriority === "high") return "high";
+  if (reviewPriority === "elevated") return "medium";
+  return "normal";
+}
+
+export function buildPendingCheckoutReviewWorkItemTitle(
+  item: PendingCheckoutReviewItem,
+) {
+  return `Review pending checkout item: ${item.name}`;
+}
+
+function buildPendingCheckoutReviewWorkItemMetadata(
+  item: PendingCheckoutReviewItem,
+  extra?: Record<string, unknown>,
+) {
+  return {
+    lookupCode: item.lookupCode,
+    pendingCheckoutItemId: item._id,
+    price: item.provisionalPrice,
+    provisionalProductId: item.provisionalProductId,
+    provisionalProductSkuId: item.provisionalProductSkuId,
+    reviewPriority: item.reviewPriority,
+    totalQuantitySold: item.evidence.totalQuantitySold,
+    transactionCount: item.evidence.transactionCount,
+    ...extra,
+  };
+}
+
+async function getProductSkusForProduct(
+  ctx: MutationCtx,
+  productId: Id<"product">,
+) {
+  const rows = await ctx.db
+    .query("productSku")
+    .withIndex("by_productId", (q) => q.eq("productId", productId))
+    .take(PRODUCT_SKU_SCAN_LIMIT + 1);
+
+  assertCompleteScan(rows, PRODUCT_SKU_SCAN_LIMIT, "product SKUs");
+  return rows;
+}
+
+async function getPendingCheckoutItemsForProduct(
+  ctx: MutationCtx,
+  args: {
+    productId: Id<"product">;
+    storeId: Id<"store">;
+  },
+) {
+  const skus = await getProductSkusForProduct(ctx, args.productId);
+  const itemById = new Map<Id<"posPendingCheckoutItem">, PendingCheckoutReviewItem>();
+
+  for (const sku of skus) {
+    const items = await ctx.db
+      .query("posPendingCheckoutItem")
+      .withIndex("by_storeId_provisionalProductSkuId", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("provisionalProductSkuId", sku._id),
+      )
+      .take(PENDING_CHECKOUT_SCAN_LIMIT + 1);
+
+    assertCompleteScan(items, PENDING_CHECKOUT_SCAN_LIMIT, "pending checkout items");
+
+    for (const item of items) {
+      if (item.provisionalProductId === args.productId) {
+        itemById.set(item._id, item);
+      }
+    }
+  }
+
+  const productAnchoredItems = await ctx.db
+    .query("posPendingCheckoutItem")
+    .withIndex("by_storeId_provisionalProductId", (q) =>
+      q.eq("storeId", args.storeId).eq("provisionalProductId", args.productId),
+    )
+    .take(PENDING_CHECKOUT_SCAN_LIMIT + 1);
+
+  assertCompleteScan(
+    productAnchoredItems,
+    PENDING_CHECKOUT_SCAN_LIMIT,
+    "pending checkout items",
+  );
+
+  for (const item of productAnchoredItems) {
+    itemById.set(item._id, item);
+  }
+
+  return Array.from(itemById.values());
+}
+
+async function getOpenReviewWorkItemsForStore(
+  ctx: MutationCtx,
+  storeId: Id<"store">,
+) {
+  const rows: Array<Doc<"operationalWorkItem">> = [];
+
+  for (const status of OPEN_REVIEW_WORK_STATUSES) {
+    const workItems = await ctx.db
+      .query("operationalWorkItem")
+      .withIndex("by_storeId_type_status", (q) =>
+        q.eq("storeId", storeId).eq("type", REVIEW_WORK_TYPE).eq("status", status),
+      )
+      .take(OPEN_WORK_SCAN_LIMIT + 1);
+
+    assertCompleteScan(workItems, OPEN_WORK_SCAN_LIMIT, "open pending checkout review work items");
+    rows.push(...workItems);
+  }
+
+  return rows;
+}
+
+function groupOpenReviewWorkByPendingCheckoutItem(
+  workItems: Array<Doc<"operationalWorkItem">>,
+) {
+  const grouped = new Map<string, Array<Doc<"operationalWorkItem">>>();
+
+  for (const workItem of workItems) {
+    const pendingCheckoutItemId =
+      metadataString(workItem.metadata, "pendingCheckoutItemId") ??
+      metadataString(workItem.metadata, "posPendingCheckoutItemId");
+
+    if (!pendingCheckoutItemId) continue;
+
+    const existing = grouped.get(pendingCheckoutItemId) ?? [];
+    existing.push(workItem);
+    grouped.set(pendingCheckoutItemId, existing);
+  }
+
+  return grouped;
+}
+
+async function getOpenReviewWorkItemFromPointer(
+  ctx: MutationCtx,
+  item: PendingCheckoutReviewItem,
+) {
+  if (!item.operationalWorkItemId) return null;
+
+  const workItem = await ctx.db.get(
+    "operationalWorkItem",
+    item.operationalWorkItemId,
+  );
+  if (
+    !workItem ||
+    workItem.storeId !== item.storeId ||
+    workItem.type !== REVIEW_WORK_TYPE ||
+    !OPEN_REVIEW_WORK_STATUSES.includes(workItem.status as OpenReviewWorkStatus)
+  ) {
+    return null;
+  }
+
+  return workItem;
+}
+
+async function recordLifecycleEvent(
+  ctx: MutationCtx,
+  args: {
+    actorUserId?: Id<"athenaUser">;
+    eventType: string;
+    item: PendingCheckoutReviewItem;
+    message: string;
+    metadata: Record<string, unknown>;
+    workItemId?: Id<"operationalWorkItem">;
+  },
+) {
+  await recordOperationalEventWithCtx(ctx, {
+    actorType: args.actorUserId ? "human" : "automation",
+    actorUserId: args.actorUserId,
+    eventType: args.eventType,
+    message: args.message,
+    metadata: {
+      lookupCode: args.item.lookupCode,
+      pendingCheckoutItemId: args.item._id,
+      provisionalProductId: args.item.provisionalProductId,
+      provisionalProductSkuId: args.item.provisionalProductSkuId,
+      status: args.item.status,
+      ...args.metadata,
+    },
+    metadataDedupeKeys: ["pendingCheckoutItemId", "workItemId", "reason"],
+    organizationId: args.item.organizationId,
+    storeId: args.item.storeId,
+    subjectId: String(args.item._id),
+    subjectLabel: args.item.name,
+    subjectType: "pos_pending_checkout_item",
+    workItemId: args.workItemId,
+  });
+}
+
+async function cancelPendingCheckoutReviewWorkItem(
+  ctx: MutationCtx,
+  args: {
+    actorUserId?: Id<"athenaUser">;
+    item: PendingCheckoutReviewItem;
+    reason: string;
+    repairRunId?: string;
+    workItem: Doc<"operationalWorkItem">;
+  },
+) {
+  const completedAt = now();
+
+  await ctx.db.patch("operationalWorkItem", args.workItem._id, {
+    completedAt,
+    metadata: {
+      ...(args.workItem.metadata ?? {}),
+      pendingCheckoutItemId: args.item._id,
+      provisionalProductId: args.item.provisionalProductId,
+      provisionalProductSkuId: args.item.provisionalProductSkuId,
+      retiredAt: completedAt,
+      retiredByUserId: args.actorUserId,
+      retiredReason: args.reason,
+      ...(args.repairRunId ? { repairRunId: args.repairRunId } : {}),
+    },
+    status: "cancelled",
+  });
+
+  await recordLifecycleEvent(ctx, {
+    actorUserId: args.actorUserId,
+    eventType: "pos_pending_checkout_item_review_work_cancelled",
+    item: args.item,
+    message: `Cancelled pending checkout review work for ${args.item.name}.`,
+    metadata: {
+      reason: args.reason,
+      workItemId: args.workItem._id,
+      ...(args.repairRunId ? { repairRunId: args.repairRunId } : {}),
+    },
+    workItemId: args.workItem._id,
+  });
+}
+
+export async function retirePendingCheckoutReviewWorkForArchivedProduct(
+  ctx: MutationCtx,
+  args: {
+    actorUserId?: Id<"athenaUser">;
+    productId: Id<"product">;
+    reason?: string;
+    repairRunId?: string;
+    storeId: Id<"store">;
+  },
+) {
+  const [items, openWorkItems] = await Promise.all([
+    getPendingCheckoutItemsForProduct(ctx, args),
+    getOpenReviewWorkItemsForStore(ctx, args.storeId),
+  ]);
+  const openWorkByItemId = groupOpenReviewWorkByPendingCheckoutItem(openWorkItems);
+  const reason = args.reason ?? "provisional_product_archived";
+  const retiredWorkItemIds: Array<Id<"operationalWorkItem">> = [];
+  const clearedPendingCheckoutItemIds: Array<Id<"posPendingCheckoutItem">> = [];
+
+  for (const item of items) {
+    if (!ACTIONABLE_PENDING_CHECKOUT_STATUSES.has(item.status)) continue;
+
+    const matchingWorkItemsById = new Map<Id<"operationalWorkItem">, Doc<"operationalWorkItem">>();
+    const pointerWorkItem = await getOpenReviewWorkItemFromPointer(ctx, item);
+
+    if (pointerWorkItem) {
+      matchingWorkItemsById.set(pointerWorkItem._id, pointerWorkItem);
+    }
+
+    for (const workItem of openWorkByItemId.get(String(item._id)) ?? []) {
+      if (matchesPendingCheckoutSource(workItem, item)) {
+        matchingWorkItemsById.set(workItem._id, workItem);
+      }
+    }
+
+    const matchingWorkItems = Array.from(matchingWorkItemsById.values());
+    const retiredWorkItemIdsForItem: Array<Id<"operationalWorkItem">> = [];
+
+    for (const workItem of matchingWorkItems) {
+      await cancelPendingCheckoutReviewWorkItem(ctx, {
+        actorUserId: args.actorUserId,
+        item,
+        reason,
+        repairRunId: args.repairRunId,
+        workItem,
+      });
+      retiredWorkItemIds.push(workItem._id);
+      retiredWorkItemIdsForItem.push(workItem._id);
+    }
+
+    if (
+      item.operationalWorkItemId &&
+      retiredWorkItemIdsForItem.includes(item.operationalWorkItemId)
+    ) {
+      await ctx.db.patch("posPendingCheckoutItem", item._id, {
+        operationalWorkItemId: undefined,
+        updatedAt: now(),
+      });
+      clearedPendingCheckoutItemIds.push(item._id);
+    }
+  }
+
+  return {
+    clearedPendingCheckoutItemIds,
+    pendingCheckoutItemCount: items.length,
+    retiredWorkItemIds,
+  };
+}
+
+export async function ensurePendingCheckoutReviewWorkForUnarchivedProduct(
+  ctx: MutationCtx,
+  args: {
+    actorUserId?: Id<"athenaUser">;
+    productId: Id<"product">;
+    storeId: Id<"store">;
+  },
+) {
+  const [items, openWorkItems] = await Promise.all([
+    getPendingCheckoutItemsForProduct(ctx, args),
+    getOpenReviewWorkItemsForStore(ctx, args.storeId),
+  ]);
+  const openWorkByItemId = groupOpenReviewWorkByPendingCheckoutItem(openWorkItems);
+  const createdWorkItemIds: Array<Id<"operationalWorkItem">> = [];
+  const restoredPendingCheckoutItemIds: Array<Id<"posPendingCheckoutItem">> = [];
+
+  for (const item of items) {
+    if (!ACTIONABLE_PENDING_CHECKOUT_STATUSES.has(item.status)) continue;
+
+    const existingWorkItem =
+      (await getOpenReviewWorkItemFromPointer(ctx, item)) ??
+      (openWorkByItemId.get(String(item._id)) ?? [])[0];
+    if (existingWorkItem) {
+      await ctx.db.patch("operationalWorkItem", existingWorkItem._id, {
+        metadata: buildPendingCheckoutReviewWorkItemMetadata(item, {
+          restoredReason: "provisional_product_unarchived",
+        }),
+        priority: buildPendingCheckoutReviewWorkItemPriority(item.reviewPriority),
+        title: buildPendingCheckoutReviewWorkItemTitle(item),
+      });
+
+      if (item.operationalWorkItemId !== existingWorkItem._id) {
+        await ctx.db.patch("posPendingCheckoutItem", item._id, {
+          operationalWorkItemId: existingWorkItem._id,
+          updatedAt: now(),
+        });
+        restoredPendingCheckoutItemIds.push(item._id);
+      }
+      continue;
+    }
+
+    const workItem = await createOperationalWorkItemWithCtx(ctx, {
+      createdByUserId: args.actorUserId,
+      metadata: buildPendingCheckoutReviewWorkItemMetadata(item, {
+        restoredReason: "provisional_product_unarchived",
+      }),
+      organizationId: item.organizationId,
+      priority: buildPendingCheckoutReviewWorkItemPriority(item.reviewPriority),
+      status: "open",
+      storeId: item.storeId,
+      title: buildPendingCheckoutReviewWorkItemTitle(item),
+      type: REVIEW_WORK_TYPE,
+    });
+
+    if (!workItem) continue;
+
+    await ctx.db.patch("posPendingCheckoutItem", item._id, {
+      operationalWorkItemId: workItem._id,
+      updatedAt: now(),
+    });
+    createdWorkItemIds.push(workItem._id);
+    restoredPendingCheckoutItemIds.push(item._id);
+
+    await recordLifecycleEvent(ctx, {
+      actorUserId: args.actorUserId,
+      eventType: "pos_pending_checkout_item_review_work_reopened",
+      item,
+      message: `Opened pending checkout review work for ${item.name}.`,
+      metadata: {
+        reason: "provisional_product_unarchived",
+        workItemId: workItem._id,
+      },
+      workItemId: workItem._id,
+    });
+  }
+
+  return {
+    createdWorkItemIds,
+    pendingCheckoutItemCount: items.length,
+    restoredPendingCheckoutItemIds,
+  };
+}
+
+function isActionablePendingCheckoutItem(
+  item: Doc<"posPendingCheckoutItem"> | null,
+): item is Doc<"posPendingCheckoutItem"> {
+  return item !== null && ACTIONABLE_PENDING_CHECKOUT_STATUSES.has(item.status);
+}
+
+export const repairArchivedPendingCheckoutReviewWork = internalMutation({
+  args: {
+    dryRun: v.boolean(),
+    paginationOpts: v.optional(paginationOptsValidator),
+    repairRunId: v.optional(v.string()),
+    status: v.union(v.literal("open"), v.literal("in_progress")),
+    storeId: v.id("store"),
+    workItemIds: v.optional(v.array(v.id("operationalWorkItem"))),
+  },
+  handler: async (ctx, args) => {
+    if (args.workItemIds && args.workItemIds.length > REPAIR_WORK_ITEM_BATCH_LIMIT) {
+      throw new Error(
+        `Repair batches are limited to ${REPAIR_WORK_ITEM_BATCH_LIMIT} work items.`,
+      );
+    }
+
+    if (args.dryRun && !args.paginationOpts) {
+      throw new Error("Provide pagination options for repair dry runs.");
+    }
+
+    if (!args.dryRun && (!args.repairRunId || !args.workItemIds?.length)) {
+      throw new Error("Provide a repair run id and explicit dry-run candidate work item ids to repair.");
+    }
+
+    const page = args.workItemIds
+      ? {
+          continueCursor: null,
+          isDone: true,
+          page: (
+            await Promise.all(args.workItemIds.map((id) => ctx.db.get("operationalWorkItem", id)))
+          ).filter((row): row is Doc<"operationalWorkItem"> => row !== null),
+        }
+      : await ctx.db
+          .query("operationalWorkItem")
+          .withIndex("by_storeId_type_status", (q) =>
+            q
+              .eq("storeId", args.storeId)
+              .eq("type", REVIEW_WORK_TYPE)
+              .eq("status", args.status),
+          )
+          .paginate(args.paginationOpts!);
+    const repaired: Array<Id<"operationalWorkItem">> = [];
+    const candidates: Array<Id<"operationalWorkItem">> = [];
+    const skipped: Array<{ workItemId: Id<"operationalWorkItem">; reason: string }> = [];
+
+    for (const workItem of page.page) {
+      if (
+        workItem.storeId !== args.storeId ||
+        workItem.type !== REVIEW_WORK_TYPE ||
+        workItem.status !== args.status
+      ) {
+        skipped.push({ workItemId: workItem._id, reason: "work_item_no_longer_matches_repair_scope" });
+        continue;
+      }
+
+      const pendingCheckoutItemId =
+        metadataString(workItem.metadata, "pendingCheckoutItemId") ??
+        metadataString(workItem.metadata, "posPendingCheckoutItemId");
+
+      if (!pendingCheckoutItemId) {
+        skipped.push({ workItemId: workItem._id, reason: "missing_pending_checkout_item_id" });
+        continue;
+      }
+
+      const normalizedPendingCheckoutItemId = ctx.db.normalizeId(
+        "posPendingCheckoutItem",
+        pendingCheckoutItemId,
+      );
+      if (!normalizedPendingCheckoutItemId) {
+        skipped.push({ workItemId: workItem._id, reason: "invalid_pending_checkout_item_id" });
+        continue;
+      }
+
+      const item = await ctx.db.get(
+        "posPendingCheckoutItem",
+        normalizedPendingCheckoutItemId,
+      );
+      if (!isActionablePendingCheckoutItem(item)) {
+        skipped.push({ workItemId: workItem._id, reason: "pending_checkout_item_not_actionable" });
+        continue;
+      }
+
+      if (item.storeId !== args.storeId) {
+        skipped.push({ workItemId: workItem._id, reason: "pending_checkout_item_wrong_store" });
+        continue;
+      }
+
+      const productId =
+        item.provisionalProductId ??
+        (metadataString(workItem.metadata, "provisionalProductId") as Id<"product"> | null);
+      if (!productId) {
+        skipped.push({ workItemId: workItem._id, reason: "missing_provisional_product" });
+        continue;
+      }
+
+      const normalizedProductId = ctx.db.normalizeId("product", productId);
+      if (!normalizedProductId) {
+        skipped.push({ workItemId: workItem._id, reason: "invalid_provisional_product" });
+        continue;
+      }
+
+      const product = await ctx.db.get("product", normalizedProductId);
+      if (!product || product.storeId !== args.storeId) {
+        skipped.push({ workItemId: workItem._id, reason: "provisional_product_missing" });
+        continue;
+      }
+
+      if (product.availability !== "archived") {
+        skipped.push({ workItemId: workItem._id, reason: "provisional_product_not_archived" });
+        continue;
+      }
+
+      candidates.push(workItem._id);
+
+      if (!args.dryRun) {
+        await cancelPendingCheckoutReviewWorkItem(ctx, {
+          item,
+          reason: "archived_provisional_product_repair",
+          repairRunId: args.repairRunId,
+          workItem,
+        });
+
+        if (item.operationalWorkItemId === workItem._id) {
+          await ctx.db.patch("posPendingCheckoutItem", item._id, {
+            operationalWorkItemId: undefined,
+            updatedAt: now(),
+          });
+        }
+
+        repaired.push(workItem._id);
+      }
+    }
+
+    return {
+      candidates,
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+      repaired,
+      skipped,
+      status: args.status,
+    };
+  },
+});

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -671,6 +671,10 @@ const schema = defineSchema({
       "storeId",
       "provisionalProductSkuId",
     ])
+    .index("by_storeId_provisionalProductId", [
+      "storeId",
+      "provisionalProductId",
+    ])
     .index("by_operationalWorkItemId", ["operationalWorkItemId"]),
   posPendingCheckoutLookupAlias: defineTable(posPendingCheckoutLookupAliasSchema)
     .index("by_storeId_normalizedLookupCode_status", [

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 626 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 627 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 


### PR DESCRIPTION
## Summary

- cancel open/in-progress pending checkout review work when a provisional pending-checkout product is archived
- clear and restore `posPendingCheckoutItem.operationalWorkItemId` across archive/unarchive and generic product availability updates
- add a targeted `by_storeId_provisionalProductId` index plus a dry-run-first repair mutation for stale archived-product review work
- document the implementation plan and compound solution learning

## Validation

Focused/local:
- `bun run test -- convex/inventory/products.sku.test.ts` (28 tests)
- `bun run test -- convex/operations/operationalWorkItems.test.ts` (18 tests)
- `bun run test -- convex/operations/dailyClose.test.ts` (61 tests)
- `bun run typecheck`
- `bun run lint:convex:changed`
- `bun run lint:architecture`
- `bun run audit:convex`
- `bun run graphify:check`
- `python3 .agents/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/logic-errors/athena-pending-checkout-archive-work-lifecycle-2026-07-04.md`
- `bun run compound:check`

Pre-push gate:
- `graphify:check`
- `compound:check`
- `harness:self-review`
- `architecture:check`
- `harness:review`
- `workflow:check`
- `harness:test`
- `test:coverage`
- full `@athena/webapp test` (428 files, 4708 tests)
- `@athena/webapp audit:convex`
- `@athena/webapp lint:convex:changed`
- selected Athena operation/POS/cash-control suites (12 files, 507 tests)
- `@athena/webapp build`
- selected auth/staff/store/POS suites (22 files, 648 tests)
- harness behavior scenarios: `athena-convex-storefront-composition`, `athena-convex-storefront-failure-visibility`, `athena-admin-shell-boot`

## Linear

- V26-941
- V26-942
- V26-943
