### PR TITLE
fix(operations): polish EOD reporting flow

### DIFF
--- a/docs/solutions/architecture-patterns/athena-eod-automation-manager-report-emails-2026-07-04.md
+++ b/docs/solutions/architecture-patterns/athena-eod-automation-manager-report-emails-2026-07-04.md
@@ -23,9 +23,11 @@ tags:
 ## Problem
 
 Athena needed to send a manager-facing daily report after the EOD automation
-successfully completed a store day. The report depends on the completed
-`dailyClose.reportSnapshot`, live register-session cash-position corrections,
-store currency formatting, and the admin-recipient list in `ADMIN_EMAILS`.
+successfully completed a store day or prepared the EOD Review for manager
+review. Completed reports depend on the completed `dailyClose.reportSnapshot`,
+while prepared reports are assembled from the live EOD Review snapshot. Both
+paths use live register-session cash-position corrections, store currency
+formatting, and the admin-recipient list in `ADMIN_EMAILS`.
 
 The tempting implementation is to send directly from the daily close mutation,
 but email delivery is network I/O. In Convex, that belongs in an action, while
@@ -39,7 +41,7 @@ scheduled automation entrypoint:
 - `runConfiguredDailyOperationsAutomationMutation` performs the existing
   automation mutations and returns EOD auto-complete results.
 - `runConfiguredDailyOperationsAutomation` is an internal action that calls the
-  mutation, filters for fresh `applied` EOD auto-complete results, then sends
+  mutation, filters for fresh reportable EOD auto-complete results, then sends
   manager reports.
 - `sendDailyManagerReportToAdminsForDate` is an internal action that assembles
   the report payload for one completed operating date and sends it to every
@@ -50,12 +52,16 @@ scheduled automation entrypoint:
 The important guard is filtering only fresh action results:
 
 ```ts
-function isAppliedEodAutoCompleteResult(result) {
-  return result?.action === "applied" && result.run.outcome === "applied";
+function isReportableEodAutoCompleteResult(result) {
+  return (
+    (result?.action === "applied" && result.run.outcome === "applied") ||
+    (result?.action === "recorded" && result.run.outcome === "prepared")
+  );
 }
 ```
 
-That excludes dry runs, disabled policies, skipped outcomes, and
+That includes fresh completed reports and fresh prepared-for-review reports,
+while excluding dry runs, disabled policies, skipped outcomes, and
 `already_recorded` idempotency returns so scheduled retries do not resend old
 reports.
 
@@ -66,17 +72,19 @@ letting the automation mutation remain deterministic and testable. It also
 makes the recipient source explicit: scheduled automation sends to
 `ADMIN_EMAILS`, while one-off testing actions can still target a single address.
 
-Report payload construction should happen after completion, not before. The
-completed snapshot is the source of truth for status, notes, readiness, and
-operating date, while live register-session reads can correct cash position for
-historical days with multiple sessions.
+Report payload construction should happen from the state that owns the message.
+Completed reports should use the completed snapshot as the source of truth for
+status, notes, readiness, and operating date. Prepared reports should use the
+live EOD Review snapshot and link managers back to EOD Review as the CTA. Live
+register-session reads can correct cash position for historical days with
+multiple sessions in both paths.
 
 ## Prevention
 
 - Keep network delivery out of Convex mutations. Use an internal action wrapper
   when an automation mutation needs to trigger email, webhooks, or other
   external side effects.
-- Filter notification sends by fresh `applied` automation results, not by the
+- Filter notification sends by fresh reportable automation results, not by the
   presence of any applied automation run.
 - Preserve explicit manual-send actions for development or support workflows so
   scheduled manager notifications do not reuse ad hoc recipient arguments.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2170 files · ~0 words
+- 2172 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8605 nodes · 10439 edges · 2097 communities detected
+- 8612 nodes · 10456 edges · 2099 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2107,6 +2107,8 @@
 - [[_COMMUNITY_Community 2094|Community 2094]]
 - [[_COMMUNITY_Community 2095|Community 2095]]
 - [[_COMMUNITY_Community 2096|Community 2096]]
+- [[_COMMUNITY_Community 2097|Community 2097]]
+- [[_COMMUNITY_Community 2098|Community 2098]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2207,12 +2209,12 @@ Cohesion: 0.07
 Nodes (19): Boolean(), buildMissingDraftResult(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemNumberDetail(), getQueueWorkItemStockAdjustmentSkuId(), getQueueWorkItemStringDetail() (+11 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.08
-Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
-
-### Community 19 - "Community 19"
 Cohesion: 0.09
 Nodes (25): applyTodayRefreshSnapshot(), buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatOnlineOrderTimelineFallbackMessage(), formatPendingApprovalsLabel(), formatTimelineMessage() (+17 more)
+
+### Community 19 - "Community 19"
+Cohesion: 0.08
+Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.14
@@ -2307,80 +2309,80 @@ Cohesion: 0.16
 Nodes (25): acknowledgeTerminalRecoveryCommand(), arraysEqualAsSets(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), hasRuntimeLocalReviewDetails(), isActiveCommand() (+17 more)
 
 ### Community 43 - "Community 43"
+Cohesion: 0.17
+Nodes (19): buildBlockers(), buildCarryForwardItems(), buildDailyManagerReportPayload(), buildPaymentTotals(), buildPreparedBlockers(), buildPreparedCarryForwardItems(), buildPreparedDailyManagerReportPayload(), buildPreparedReviewItems() (+11 more)
+
+### Community 44 - "Community 44"
 Cohesion: 0.15
 Nodes (20): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), linkedPendingCheckoutItemMatchesTrustedLine(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity() (+12 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.17
 Nodes (25): getRegisterCatalogPrice(), getRegisterCatalogProjectionPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isLinkedPendingCheckoutAliasVisible(), isLinkedPendingCheckoutApprovedSkuVisible(), isPendingCheckoutItemVisible(), isTrustedRegisterCatalogProjection() (+17 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.12
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.09
 Nodes (5): buildPersistedRuntimeStatus(), buildQueryCtx(), buildRegisterSession(), buildRuntimeStatus(), buildTrackedQueryCtx()
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.09
 Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.16
 Nodes (20): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getRuntimeReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady() (+12 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.2
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.14
 Nodes (18): findCurrentStoreDayOpening(), findLatestStoreDayOpening(), getTodaySummary(), getTransactionById(), isActivePosSummaryOpeningAt(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames() (+10 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.19
 Nodes (22): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem(), findOrCreatePendingCheckoutCategory() (+14 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.17
 Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.17
 Nodes (19): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+11 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
-
-### Community 61 - "Community 61"
-Cohesion: 0.16
-Nodes (15): buildBlockers(), buildCarryForwardItems(), buildDailyManagerReportPayload(), buildPaymentTotals(), buildReviewedItems(), buildSummaryMetrics(), countLabel(), formatCompletedAt() (+7 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.16
@@ -2743,52 +2745,52 @@ Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 152 - "Community 152"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 153 - "Community 153"
 Cohesion: 0.38
 Nodes (10): conflictError(), findPostReviewStockUpdateWithCtx(), idMetadataValue(), inventoryReviewLocalId(), optionalMetadataMatches(), readPositiveCurrentInventoryProofWithCtx(), resolveSyncedSaleInventoryReviewWithCtx(), stringMetadataValue() (+2 more)
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.25
 Nodes (5): getRuntimeStatusPublishMaterialSignature(), getRuntimeStatusPublishSignature(), getRuntimeStatusSignature(), normalizeRuntimeStatusPublishMaterial(), normalizeRuntimeStatusSignature()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 163 - "Community 163"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.18
@@ -2816,15 +2818,15 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 171 - "Community 171"
-Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 172 - "Community 172"
+### Community 171 - "Community 171"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
+
+### Community 172 - "Community 172"
+Cohesion: 0.33
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.29
@@ -2955,24 +2957,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 205 - "Community 205"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 206 - "Community 206"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 207 - "Community 207"
+### Community 206 - "Community 206"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 208 - "Community 208"
+### Community 207 - "Community 207"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 209 - "Community 209"
+### Community 208 - "Community 208"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 209 - "Community 209"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.39
@@ -4099,28 +4101,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 491 - "Community 491"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 492 - "Community 492"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 493 - "Community 493"
+### Community 492 - "Community 492"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 494 - "Community 494"
+### Community 493 - "Community 493"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 495 - "Community 495"
+### Community 494 - "Community 494"
 Cohesion: 0.67
 Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
-### Community 496 - "Community 496"
+### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (2): getPosRouteScope(), Login()
+
+### Community 496 - "Community 496"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 0.5
@@ -4151,12 +4153,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 504 - "Community 504"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 505 - "Community 505"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+
+### Community 505 - "Community 505"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 506 - "Community 506"
 Cohesion: 0.5
@@ -4167,12 +4169,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 509 - "Community 509"
 Cohesion: 1.0
 Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+
+### Community 509 - "Community 509"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 510 - "Community 510"
 Cohesion: 0.5
@@ -4183,120 +4185,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 512 - "Community 512"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 513 - "Community 513"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 513 - "Community 513"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 514 - "Community 514"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 515 - "Community 515"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 516 - "Community 516"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 517 - "Community 517"
+### Community 516 - "Community 516"
 Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
-### Community 518 - "Community 518"
+### Community 517 - "Community 517"
 Cohesion: 0.67
 Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
-### Community 519 - "Community 519"
+### Community 518 - "Community 518"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 520 - "Community 520"
+### Community 519 - "Community 519"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 521 - "Community 521"
+### Community 520 - "Community 520"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 522 - "Community 522"
+### Community 521 - "Community 521"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 523 - "Community 523"
+### Community 522 - "Community 522"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 524 - "Community 524"
+### Community 523 - "Community 523"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 525 - "Community 525"
+### Community 524 - "Community 524"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+
+### Community 525 - "Community 525"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 526 - "Community 526"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 527 - "Community 527"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 529 - "Community 529"
+### Community 528 - "Community 528"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 530 - "Community 530"
+### Community 529 - "Community 529"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 531 - "Community 531"
+### Community 530 - "Community 530"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 532 - "Community 532"
+### Community 531 - "Community 531"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 533 - "Community 533"
+### Community 532 - "Community 532"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+
+### Community 533 - "Community 533"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 534 - "Community 534"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 535 - "Community 535"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 536 - "Community 536"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 537 - "Community 537"
+### Community 536 - "Community 536"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 538 - "Community 538"
+### Community 537 - "Community 537"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 539 - "Community 539"
+### Community 538 - "Community 538"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 540 - "Community 540"
+### Community 539 - "Community 539"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 540 - "Community 540"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 541 - "Community 541"
 Cohesion: 0.5
@@ -4327,63 +4329,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 548 - "Community 548"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 549 - "Community 549"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 550 - "Community 550"
+### Community 549 - "Community 549"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 551 - "Community 551"
+### Community 550 - "Community 550"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 552 - "Community 552"
+### Community 551 - "Community 551"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 553 - "Community 553"
+### Community 552 - "Community 552"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 554 - "Community 554"
+### Community 553 - "Community 553"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 555 - "Community 555"
+### Community 554 - "Community 554"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 556 - "Community 556"
+### Community 555 - "Community 555"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 557 - "Community 557"
+### Community 556 - "Community 556"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 558 - "Community 558"
+### Community 557 - "Community 557"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 559 - "Community 559"
+### Community 558 - "Community 558"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 560 - "Community 560"
+### Community 559 - "Community 559"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+
+### Community 560 - "Community 560"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 561 - "Community 561"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 562 - "Community 562"
-Cohesion: 0.5
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 563 - "Community 563"
@@ -4391,12 +4393,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 564 - "Community 564"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 565 - "Community 565"
 Cohesion: 1.0
 Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+
+### Community 565 - "Community 565"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 566 - "Community 566"
 Cohesion: 0.67
@@ -4455,32 +4457,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 580 - "Community 580"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 581 - "Community 581"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 582 - "Community 582"
+### Community 581 - "Community 581"
 Cohesion: 1.0
 Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
-### Community 583 - "Community 583"
+### Community 582 - "Community 582"
 Cohesion: 1.0
 Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
-### Community 584 - "Community 584"
+### Community 583 - "Community 583"
 Cohesion: 1.0
 Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
-### Community 585 - "Community 585"
+### Community 584 - "Community 584"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 586 - "Community 586"
+### Community 585 - "Community 585"
 Cohesion: 0.67
 Nodes (1): PosServerError
+
+### Community 586 - "Community 586"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 587 - "Community 587"
 Cohesion: 0.67
@@ -4495,12 +4497,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 590 - "Community 590"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 591 - "Community 591"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+
+### Community 591 - "Community 591"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
@@ -4519,12 +4521,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 596 - "Community 596"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 597 - "Community 597"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 597 - "Community 597"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 598 - "Community 598"
 Cohesion: 0.67
@@ -4539,16 +4541,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 601 - "Community 601"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 602 - "Community 602"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 603 - "Community 603"
+### Community 602 - "Community 602"
 Cohesion: 1.0
 Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+
+### Community 603 - "Community 603"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 604 - "Community 604"
 Cohesion: 0.67
@@ -4559,28 +4561,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 606 - "Community 606"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 607 - "Community 607"
 Cohesion: 1.0
 Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
-### Community 608 - "Community 608"
+### Community 607 - "Community 607"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 609 - "Community 609"
+### Community 608 - "Community 608"
 Cohesion: 1.0
 Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
-### Community 610 - "Community 610"
+### Community 609 - "Community 609"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 611 - "Community 611"
+### Community 610 - "Community 610"
 Cohesion: 1.0
 Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+
+### Community 611 - "Community 611"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 612 - "Community 612"
 Cohesion: 0.67
@@ -4588,11 +4590,11 @@ Nodes (0):
 
 ### Community 613 - "Community 613"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 614 - "Community 614"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 615 - "Community 615"
 Cohesion: 0.67
@@ -4607,12 +4609,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 618 - "Community 618"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 619 - "Community 619"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+
+### Community 619 - "Community 619"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 620 - "Community 620"
 Cohesion: 0.67
@@ -4636,23 +4638,23 @@ Nodes (0):
 
 ### Community 625 - "Community 625"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 626 - "Community 626"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 628 - "Community 628"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 629 - "Community 629"
 Cohesion: 1.0
 Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
+
+### Community 629 - "Community 629"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
@@ -4660,11 +4662,11 @@ Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 632 - "Community 632"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 633 - "Community 633"
 Cohesion: 1.0
@@ -6304,11 +6306,11 @@ Nodes (0):
 
 ### Community 1042 - "Community 1042"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1043 - "Community 1043"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1044 - "Community 1044"
 Cohesion: 1.0
@@ -10522,6 +10524,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2097 - "Community 2097"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2098 - "Community 2098"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -10549,343 +10559,345 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 771`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 772`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 773`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 774`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 775`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 776`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 777`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 778`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 779`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 780`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 781`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 782`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 783`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 784`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 785`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 786`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 787`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 788`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 789`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 790`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 791`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 792`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 793`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 794`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 795`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 796`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 797`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 798`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 799`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 800`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 801`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 802`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 803`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 804`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 805`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 806`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 807`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 808`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 809`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 810`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 811`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 812`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 813`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 814`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 815`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 816`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 817`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 818`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 819`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 820`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 821`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 822`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 823`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 824`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 825`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 826`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 827`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 828`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 829`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 830`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 831`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 832`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 833`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 834`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 835`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 836`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 837`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 838`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 839`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 840`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 841`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 842`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 843`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 844`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 845`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 846`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 847`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 848`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 849`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 850`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 851`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 852`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 853`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 854`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 855`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 856`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 857`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 858`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 859`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 860`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 861`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 862`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 863`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 864`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 865`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 866`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 867`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 868`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 869`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 870`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 871`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 872`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 873`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 874`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 875`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 876`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 877`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 878`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 879`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 880`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 881`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 882`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 883`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 884`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 885`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 886`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 887`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 888`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 889`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 890`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 891`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 892`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 893`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 894`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 895`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 896`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 897`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 898`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 899`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 900`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 901`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 902`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 903`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 904`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 905`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 906`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 907`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `getTodayRefreshCalls()`, `DailyOperationsView.test.tsx`
+- **Thin community `Community 908`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 909`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 910`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 911`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 912`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 913`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 914`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 915`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 916`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 917`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 918`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 919`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 920`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 921`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 922`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 923`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 924`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 925`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 926`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 927`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 928`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 929`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 930`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 931`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 932`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 933`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 934`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 935`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 936`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 937`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 938`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 939`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 940`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 941`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10921,2317 +10933,2319 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 942`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 943`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 944`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 945`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 946`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 947`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 948`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 949`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 950`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 951`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 952`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 953`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 954`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 955`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
+- **Thin community `Community 956`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 957`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 958`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 959`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 960`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 961`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 962`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 963`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 964`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 965`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 966`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 967`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 968`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 969`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 970`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 971`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 972`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 973`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 974`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 975`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 976`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 977`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 978`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 979`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 980`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 981`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 982`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 983`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 984`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 985`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 986`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 987`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 988`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 989`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 990`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 991`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 992`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 993`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 994`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 995`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 996`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 997`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 998`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 999`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1000`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1001`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1002`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1003`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1004`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1005`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1006`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1007`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1008`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1009`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1010`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1011`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1012`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1013`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1014`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1015`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1016`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1017`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1018`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1019`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1020`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1021`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1022`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1023`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1024`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1025`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1026`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1027`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1028`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1029`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1030`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1031`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1032`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1033`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1034`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1035`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1036`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1037`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1038`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1039`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1040`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1041`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1042`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1043`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1044`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1045`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1046`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1047`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1048`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1049`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1050`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1051`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1052`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1053`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1054`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1055`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1056`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1057`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1058`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1059`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1060`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1061`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1062`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1063`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1064`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1065`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1066`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1067`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1068`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1069`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1070`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1071`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1072`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1073`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1074`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1075`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1076`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1077`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1078`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1079`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1080`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1081`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1082`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1083`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1084`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1085`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1086`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1087`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1088`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
+- **Thin community `Community 1089`** (2 nodes): `sku-activity.tsx`, `handleSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1090`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1091`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1092`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1093`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1094`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1095`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1096`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1097`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1098`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1099`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1100`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1101`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1102`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1103`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1104`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1105`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1106`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1107`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1108`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1109`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1110`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1111`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1112`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1113`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1114`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1115`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1116`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1117`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1118`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1119`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1120`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1121`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1122`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1123`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1124`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1125`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1126`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1127`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1128`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1129`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1130`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1131`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1132`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1133`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1134`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1135`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1136`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1137`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1138`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1139`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1140`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1141`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1142`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1143`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1144`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1145`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1146`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1147`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1148`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1149`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1150`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1151`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1152`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1153`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1154`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1155`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1156`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1157`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1158`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1159`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1160`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1161`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1162`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1163`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1164`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1165`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1166`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1167`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1168`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1169`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1170`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1171`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1172`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1173`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1174`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1175`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1176`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1177`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1178`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1179`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1180`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1181`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1182`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1183`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1184`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1185`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1186`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1187`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1188`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1189`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1190`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1191`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1192`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1193`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1194`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1195`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1196`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1197`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1198`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1199`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1200`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1201`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1202`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1203`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1204`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1205`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1206`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1207`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1208`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1209`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1210`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1211`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1212`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1213`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1214`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1215`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1216`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1217`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1218`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1219`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1220`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1221`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1222`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1223`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1224`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1225`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1226`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1227`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1228`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1229`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1230`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1231`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1232`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1233`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1234`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1235`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `api.js`
+- **Thin community `Community 1236`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1237`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1238`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `server.js`
+- **Thin community `Community 1239`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `app.ts`
+- **Thin community `Community 1240`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1242`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1243`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1244`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `auth.ts`
+- **Thin community `Community 1245`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1246`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1247`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1248`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `countries.ts`
+- **Thin community `Community 1249`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `email.ts`
+- **Thin community `Community 1250`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1251`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `payment.ts`
+- **Thin community `Community 1252`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1253`** (1 nodes): `contextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1254`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `types.ts`
+- **Thin community `Community 1255`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1256`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `crons.ts`
+- **Thin community `Community 1257`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1258`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `internal.ts`
+- **Thin community `Community 1259`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1260`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1262`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1263`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1264`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1265`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `DailyManagerReport.tsx`
+- **Thin community `Community 1266`** (1 nodes): `DailyManagerReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1267`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1268`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1269`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1270`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1271`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1272`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `env.ts`
+- **Thin community `Community 1273`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1274`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `auth.ts`
+- **Thin community `Community 1275`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1276`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `colors.ts`
+- **Thin community `Community 1277`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `index.ts`
+- **Thin community `Community 1278`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1279`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `products.ts`
+- **Thin community `Community 1280`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `stores.ts`
+- **Thin community `Community 1282`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `bag.ts`
+- **Thin community `Community 1284`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `guest.ts`
+- **Thin community `Community 1285`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `index.ts`
+- **Thin community `Community 1287`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `me.ts`
+- **Thin community `Community 1288`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `offers.ts`
+- **Thin community `Community 1289`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1290`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1291`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1292`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1293`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1294`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1295`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1297`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1298`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `user.ts`
+- **Thin community `Community 1299`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1300`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `index.ts`
+- **Thin community `Community 1301`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1302`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `http.ts`
+- **Thin community `Community 1303`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `access.ts`
+- **Thin community `Community 1304`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1307`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `index.ts`
+- **Thin community `Community 1308`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `types.ts`
+- **Thin community `Community 1310`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1311`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `categories.ts`
+- **Thin community `Community 1312`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `colors.ts`
+- **Thin community `Community 1313`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1314`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1315`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1316`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1317`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `pos.ts`
+- **Thin community `Community 1318`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1319`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1320`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1322`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1324`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1325`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1327`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1330`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1331`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1332`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1333`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1335`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `types.ts`
+- **Thin community `Community 1336`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1337`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1338`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1339`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1340`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1344`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `dto.ts`
+- **Thin community `Community 1345`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1346`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1347`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1349`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `types.ts`
+- **Thin community `Community 1350`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `facts.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `types.ts`
+- **Thin community `Community 1351`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1352`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1353`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `types.ts`
+- **Thin community `Community 1354`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1355`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `customers.ts`
+- **Thin community `Community 1356`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1357`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `register.ts`
+- **Thin community `Community 1358`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `sync.ts`
+- **Thin community `Community 1359`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1360`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1361`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `schema.ts`
+- **Thin community `Community 1363`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `automation.ts`
+- **Thin community `Community 1364`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1365`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1366`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `index.ts`
+- **Thin community `Community 1367`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1368`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1369`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1370`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1371`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1372`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1373`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1374`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `category.ts`
+- **Thin community `Community 1375`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `color.ts`
+- **Thin community `Community 1376`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1377`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1378`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `index.ts`
+- **Thin community `Community 1379`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1380`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1381`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1382`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1383`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `organization.ts`
+- **Thin community `Community 1384`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1385`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `product.ts`
+- **Thin community `Community 1386`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1387`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1388`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1389`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `store.ts`
+- **Thin community `Community 1390`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1391`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1392`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `index.ts`
+- **Thin community `Community 1393`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1394`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1395`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1396`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1397`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1398`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1399`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1400`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `index.ts`
+- **Thin community `Community 1401`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1402`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1403`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1404`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1405`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1406`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1407`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1408`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1409`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1410`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1411`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1412`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `customer.ts`
+- **Thin community `Community 1413`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1414`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1415`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1416`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1417`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `index.ts`
+- **Thin community `Community 1418`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1419`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1420`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1421`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1422`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1423`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1424`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1425`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1426`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1427`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1428`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1429`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1430`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1431`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1432`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1433`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1434`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1435`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1436`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1437`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1438`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `index.ts`
+- **Thin community `Community 1439`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1440`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1441`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `index.ts`
+- **Thin community `Community 1442`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1443`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1444`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1445`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1446`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1447`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1448`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `index.ts`
+- **Thin community `Community 1449`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1450`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1451`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1452`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1453`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1454`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1455`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `bag.ts`
+- **Thin community `Community 1456`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1457`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1458`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1459`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `guest.ts`
+- **Thin community `Community 1460`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `index.ts`
+- **Thin community `Community 1461`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `offer.ts`
+- **Thin community `Community 1462`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1463`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1464`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `review.ts`
+- **Thin community `Community 1465`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1466`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1467`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1468`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1469`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1470`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1471`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1472`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `bag.ts`
+- **Thin community `Community 1474`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1475`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `customer.ts`
+- **Thin community `Community 1476`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `guest.ts`
+- **Thin community `Community 1477`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1478`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1479`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1481`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1482`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1483`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `users.ts`
+- **Thin community `Community 1485`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `payment.ts`
+- **Thin community `Community 1486`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1487`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1488`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1493`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `index.ts`
+- **Thin community `Community 1494`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1495`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1496`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1497`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1498`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `auth.ts`
+- **Thin community `Community 1499`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1501`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1503`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1504`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1506`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `index.ts`
+- **Thin community `Community 1507`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1508`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1509`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1513`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1514`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1515`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1516`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1517`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1518`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1519`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1520`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1521`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1522`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1523`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1525`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1526`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1527`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1528`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1529`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `constants.ts`
+- **Thin community `Community 1530`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1531`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1532`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1533`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `types.ts`
+- **Thin community `Community 1534`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1536`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1537`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1538`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1539`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1540`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1541`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1542`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1543`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1544`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1545`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1546`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1547`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1548`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1549`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1550`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1551`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1552`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1553`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1554`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `constants.ts`
+- **Thin community `Community 1555`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1556`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1557`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1558`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `data.ts`
+- **Thin community `Community 1559`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1560`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1561`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1562`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1563`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1564`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1565`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1566`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1567`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1568`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1569`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1570`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `constants.ts`
+- **Thin community `Community 1571`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1572`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1573`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1574`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `data.ts`
+- **Thin community `Community 1575`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1576`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1578`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1579`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1581`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1582`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1583`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1584`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1585`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1586`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `constants.ts`
+- **Thin community `Community 1587`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1588`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1589`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1591`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1592`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1593`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1595`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1597`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1600`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1601`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1602`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1603`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1604`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1605`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1606`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1607`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1608`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1611`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1612`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1613`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1614`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1615`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1616`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1617`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1618`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1619`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1620`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1621`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1622`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1623`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `constants.ts`
+- **Thin community `Community 1624`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1625`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1626`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1627`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `data.ts`
+- **Thin community `Community 1628`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1629`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1630`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `constants.ts`
+- **Thin community `Community 1631`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1632`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1633`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1634`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1635`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `data.ts`
+- **Thin community `Community 1636`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1637`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `constants.ts`
+- **Thin community `Community 1638`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1639`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1640`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1641`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1642`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `data.ts`
+- **Thin community `Community 1643`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1644`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1645`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1646`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1647`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1648`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1649`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1650`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1651`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1653`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1654`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1655`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1656`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1657`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1658`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1659`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1660`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1661`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1662`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1663`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1664`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1665`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1666`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1667`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1668`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1669`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1670`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1671`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `types.ts`
+- **Thin community `Community 1672`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1673`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1674`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1675`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1676`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 1677`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1678`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 1679`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1680`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1682`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1683`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1684`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1685`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1686`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1687`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1688`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1689`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1690`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `data.ts`
+- **Thin community `Community 1691`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1692`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1693`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1694`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1695`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1696`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1697`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1698`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1699`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1700`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1701`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1702`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1703`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `constants.ts`
+- **Thin community `Community 1704`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1705`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1706`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1707`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `data.ts`
+- **Thin community `Community 1708`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `types.ts`
+- **Thin community `Community 1709`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1710`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1711`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1712`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1713`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1714`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `index.ts`
+- **Thin community `Community 1715`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1716`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1717`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1718`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1719`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `index.tsx`
+- **Thin community `Community 1720`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1721`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1722`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1723`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1724`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1725`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1726`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1727`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1728`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1729`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1730`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `index.tsx`
+- **Thin community `Community 1731`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1732`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1733`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1734`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `button.tsx`
+- **Thin community `Community 1735`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1736`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `card.tsx`
+- **Thin community `Community 1737`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1738`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1739`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `command.tsx`
+- **Thin community `Community 1740`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1741`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1742`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1743`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `form.tsx`
+- **Thin community `Community 1744`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1745`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1746`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `input.tsx`
+- **Thin community `Community 1747`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1748`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1749`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1750`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1751`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1752`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1753`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `select.tsx`
+- **Thin community `Community 1754`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1755`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1756`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1757`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1758`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `table.tsx`
+- **Thin community `Community 1759`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1760`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1761`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1762`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1763`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1764`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1765`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1766`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1767`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `constants.ts`
+- **Thin community `Community 1768`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1769`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1770`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1771`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `data.ts`
+- **Thin community `Community 1772`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1773`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1774`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1775`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1776`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1777`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1778`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1779`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1780`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1781`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1782`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `index.ts`
+- **Thin community `Community 1783`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1785`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1787`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1788`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1789`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1790`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1791`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1792`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1793`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1795`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1796`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1797`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1798`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `index.ts`
+- **Thin community `Community 1799`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1800`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1801`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1802`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1803`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `aws.ts`
+- **Thin community `Community 1804`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `constants.ts`
+- **Thin community `Community 1805`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `countries.ts`
+- **Thin community `Community 1806`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1807`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1808`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1809`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1811`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1812`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `dto.ts`
+- **Thin community `Community 1815`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `ports.ts`
+- **Thin community `Community 1816`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `constants.ts`
+- **Thin community `Community 1817`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `index.ts`
+- **Thin community `Community 1820`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1821`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `types.ts`
+- **Thin community `Community 1822`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1826`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1827`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1828`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1829`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1830`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1835`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1836`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1837`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1838`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1839`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1840`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `index.ts`
+- **Thin community `Community 1841`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1842`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `category.ts`
+- **Thin community `Community 1843`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `product.ts`
+- **Thin community `Community 1844`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `store.ts`
+- **Thin community `Community 1845`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1846`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `user.ts`
+- **Thin community `Community 1847`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1848`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1849`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1850`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1851`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1852`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `main.tsx`
+- **Thin community `Community 1853`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1854`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1855`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1857`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1858`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1859`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `index.tsx`
+- **Thin community `Community 1860`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `index.tsx`
+- **Thin community `Community 1861`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1862`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1863`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1864`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 1865`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1866`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1867`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1868`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `index.tsx`
+- **Thin community `Community 1869`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1870`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1871`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1872`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `home.tsx`
+- **Thin community `Community 1873`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1874`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1875`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1876`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `index.tsx`
+- **Thin community `Community 1877`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `review.tsx`
+- **Thin community `Community 1878`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1879`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1880`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `index.tsx`
+- **Thin community `Community 1881`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1882`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1883`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1884`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `index.tsx`
+- **Thin community `Community 1885`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1886`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1887`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1888`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1889`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1890`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1891`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1892`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `index.tsx`
+- **Thin community `Community 1893`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1894`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1895`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1896`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1897`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1898`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1899`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1900`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1901`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1902`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `index.tsx`
+- **Thin community `Community 1903`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1904`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1905`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `new.tsx`
+- **Thin community `Community 1906`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1907`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1908`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1909`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1910`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `index.tsx`
+- **Thin community `Community 1911`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `new.tsx`
+- **Thin community `Community 1912`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1913`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1914`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1915`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1916`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1917`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `index.tsx`
+- **Thin community `Community 1918`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1919`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1920`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1921`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `index.tsx`
+- **Thin community `Community 1922`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1923`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1924`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1925`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `index.tsx`
+- **Thin community `Community 1926`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1927`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1928`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1929`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1930`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1931`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1932`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1933`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1934`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1935`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1936`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1937`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1938`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1939`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1940`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1941`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1942`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1943`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1944`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1945`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1946`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1947`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1948`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1949`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `setup.ts`
+- **Thin community `Community 1950`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1951`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `types.ts`
+- **Thin community `Community 1952`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1953`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1954`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1955`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1956`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1957`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1958`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1959`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `types.ts`
+- **Thin community `Community 1960`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1961`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1962`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1963`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1964`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1965`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1966`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1967`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1968`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `schema.ts`
+- **Thin community `Community 1969`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1970`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1971`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1972`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1973`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1974`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1975`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1976`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1977`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1978`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `types.ts`
+- **Thin community `Community 1979`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1980`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1981`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1982`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1983`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1984`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1985`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1986`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `constants.ts`
+- **Thin community `Community 1987`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1988`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `About.tsx`
+- **Thin community `Community 1989`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1990`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1991`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1992`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1993`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1994`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1995`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1996`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1997`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1998`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1999`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `types.ts`
+- **Thin community `Community 2000`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2001`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2002`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2003`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2004`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2005`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2006`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2007`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2008`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2009`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2010`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2011`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `button.tsx`
+- **Thin community `Community 2012`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `card.tsx`
+- **Thin community `Community 2013`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2014`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `command.tsx`
+- **Thin community `Community 2015`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2016`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2017`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2018`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `form.tsx`
+- **Thin community `Community 2019`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2020`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2021`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2022`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2023`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `input.tsx`
+- **Thin community `Community 2024`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `label.tsx`
+- **Thin community `Community 2025`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2026`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2027`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2028`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `index.ts`
+- **Thin community `Community 2029`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `types.ts`
+- **Thin community `Community 2030`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2031`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2032`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2033`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2034`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `select.tsx`
+- **Thin community `Community 2035`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2036`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2037`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `table.tsx`
+- **Thin community `Community 2038`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2039`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2040`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2041`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2042`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2043`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `config.ts`
+- **Thin community `Community 2044`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2045`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2046`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2047`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2048`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2049`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `constants.ts`
+- **Thin community `Community 2050`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `countries.ts`
+- **Thin community `Community 2051`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2052`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2053`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2054`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2055`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `index.ts`
+- **Thin community `Community 2056`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2057`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `store.ts`
+- **Thin community `Community 2058`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `bag.ts`
+- **Thin community `Community 2059`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2060`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `category.ts`
+- **Thin community `Community 2061`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `organization.ts`
+- **Thin community `Community 2062`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `product.ts`
+- **Thin community `Community 2063`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `store.ts`
+- **Thin community `Community 2064`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2065`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `user.ts`
+- **Thin community `Community 2066`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `states.ts`
+- **Thin community `Community 2067`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2068`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2069`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2070`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2071`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2072`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2073`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2074`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2075`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `index.tsx`
+- **Thin community `Community 2076`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2077`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2078`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2079`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2080`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2081`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2082`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2083`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `index.tsx`
+- **Thin community `Community 2084`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2085`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2086`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2087`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2088`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2089`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `index.js`
+- **Thin community `Community 2090`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2091`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2092`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2093`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2094`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2095`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2096`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2097`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2098`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2170
-- Graph nodes: 8605
-- Graph edges: 10439
-- Communities: 2097
+- Code files discovered: 2172
+- Graph nodes: 8612
+- Graph edges: 10456
+- Communities: 2099
 
 ## Graph Hotspots
 - `dailyClose.ts` (102 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -45,6 +45,8 @@ import type * as customerMessaging_whatsappClient from "../customerMessaging/wha
 import type * as customerMessaging_whatsappConfig from "../customerMessaging/whatsappConfig.js";
 import type * as devPatchBadTransaction from "../devPatchBadTransaction.js";
 import type * as emails_DailyManagerReport from "../emails/DailyManagerReport.js";
+import type * as emails_DailyManagerReportBordered from "../emails/DailyManagerReportBordered.js";
+import type * as emails_DailyManagerReportUnbordered from "../emails/DailyManagerReportUnbordered.js";
 import type * as emails_DiscountCode from "../emails/DiscountCode.js";
 import type * as emails_DiscountReminder from "../emails/DiscountReminder.js";
 import type * as emails_ExpenseReceiptEmail from "../emails/ExpenseReceiptEmail.js";
@@ -477,6 +479,8 @@ declare const fullApi: ApiFromModules<{
   "customerMessaging/whatsappConfig": typeof customerMessaging_whatsappConfig;
   devPatchBadTransaction: typeof devPatchBadTransaction;
   "emails/DailyManagerReport": typeof emails_DailyManagerReport;
+  "emails/DailyManagerReportBordered": typeof emails_DailyManagerReportBordered;
+  "emails/DailyManagerReportUnbordered": typeof emails_DailyManagerReportUnbordered;
   "emails/DiscountCode": typeof emails_DiscountCode;
   "emails/DiscountReminder": typeof emails_DiscountReminder;
   "emails/ExpenseReceiptEmail": typeof emails_ExpenseReceiptEmail;

--- a/packages/athena-webapp/convex/emails/DailyManagerReport.test.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReport.test.tsx
@@ -38,6 +38,10 @@ describe("DailyManagerReport", () => {
     const html = await render(<DailyManagerReport {...baseProps} />);
 
     expect(html).toContain("Athena daily report");
+    expect(html).toContain("max-width:620px;background-color:#ffffff");
+    expect(html).not.toContain(
+      "max-width:620px;background-color:#ffffff;border:1px solid #dde0e5;border-radius:8px",
+    );
     expect(html).toContain("Completed under policy");
     expect(html).toContain("Athena completed EOD Review under store policy.");
     expect(html).toContain("No follow-up needed for this operating day.");
@@ -48,6 +52,17 @@ describe("DailyManagerReport", () => {
     expect(html).toContain("View EOD Review");
     expect(html).toContain("lucide-arrow-up-right");
     expect(html).not.toContain("Athena keeps the full close record");
+  });
+
+  it("supports a bordered report frame", async () => {
+    const html = await render(
+      <DailyManagerReport {...baseProps} frameVariant="bordered" />,
+    );
+
+    expect(html).toContain("Athena daily report");
+    expect(html).toContain(
+      "max-width:620px;background-color:#ffffff;border:1px solid #dde0e5;border-radius:8px",
+    );
   });
 
   it("uses the cedi display symbol for GHS preview defaults", async () => {
@@ -63,14 +78,21 @@ describe("DailyManagerReport", () => {
       />,
     );
 
-    expect(html).toContain("Opening handoff");
-    expect(html).toContain("1 carry-forward item");
+    expect(html).toContain("Ready for manager review");
+    expect(html).not.toContain("Review the close when you are ready.");
+    expect(html).toContain("Before close");
+    expect(html).toContain("Register session is still open");
+    expect(html).toContain("Front Counter is still open.");
+    expect(html).toContain(
+      "Final cash count and variance will be available after the register is closed.",
+    );
+    expect(html).not.toContain("opening team");
     expect(html).not.toContain("Cash variance");
     expect(html).toContain("GH₵1,201.82");
     expect(html).toContain("Expected cash");
-    expect(html).toContain("Counted cash");
+    expect(html).not.toContain("Counted cash");
     expect(html).not.toContain("Cash deposit");
-    expect(html).toContain("GH₵-42.18");
+    expect(html).not.toContain("Net variance");
     expect(html).not.toContain("TXN-1048 | GH₵220");
     expect(html).not.toContain("GHS 1,244");
   });
@@ -151,16 +173,18 @@ describe("DailyManagerReport", () => {
     expect(html).toContain("Completed under policy");
     expect(html).not.toContain("Cash variance");
     expect(html).toContain("Opening handoff");
-    expect(html).toContain("1 carry-forward item");
+    expect(html).toContain("1 item for the next opening");
+    expect(html).not.toContain("opening team");
+    expect(html).not.toContain("1 follow-up");
     expect(html).not.toContain("1 carry-forward</p>");
-    expect(html).toContain(
-      "Visible in the next operating day&#x27;s opening workflow",
-    );
+    expect(html).toContain("Review before the next store day starts.");
     expect(html).not.toContain(
       "1 carry-forward item | Visible in the next operating day&#x27;s opening workflow",
     );
     expect(html).not.toContain("Review register cash handoff before trading.");
-    expect(html.indexOf("Attention")).toBeLessThan(
+    expect(html).toContain("Next opening");
+    expect(html).not.toContain(">Attention<");
+    expect(html.indexOf("Next opening")).toBeLessThan(
       html.indexOf("Operating summary"),
     );
   });
@@ -180,8 +204,18 @@ describe("DailyManagerReport", () => {
     );
 
     expect(html).toContain("Automation failed");
-    expect(html).toContain("Athena could not finish the EOD Review automation check.");
-    expect(html).not.toContain("Register session open");
+    expect(html).toContain(
+      "Athena could not finish the EOD Review automation check.",
+    );
+    expect(html).toContain("Before close");
+    expect(html).toContain("Register session open");
+    expect(html).toContain("Front Counter is still open.");
+    expect(html).toContain(
+      "Final cash count and variance will be available after the register is closed.",
+    );
+    expect(html).toContain("Expected cash");
+    expect(html).not.toContain("Counted cash");
+    expect(html).not.toContain("Net variance");
     expect(html).toContain("1 blocker");
   });
 });

--- a/packages/athena-webapp/convex/emails/DailyManagerReport.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReport.tsx
@@ -11,9 +11,7 @@ import {
   Section,
   Text,
 } from "@react-email/components";
-import {
-  ArrowUpRight,
-} from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import { currencyFormatter } from "../utils";
 
 type DailyReportStatus =
@@ -52,6 +50,7 @@ export interface DailyManagerReportProps {
   operatingDate: string;
   completedAt: string;
   completedBy: string;
+  frameVariant?: "bordered" | "unbordered";
   storeCurrency?: string;
   status: DailyReportStatus;
   statusLabel?: string;
@@ -66,12 +65,22 @@ export interface DailyManagerReportProps {
   notes?: string;
 }
 
-const sampleCarryForwardItems: DailyManagerReportItem[] = [
+export const dailyManagerReportPreviewProps = {
+  completedAt: "8:42 PM",
+  completedBy: "Athena",
+  operatingDate: "Friday, July 3",
+  reportUrl:
+    "https://athena.wigclub.store/wigclub/store/wigclub/operations/daily-close",
+  status: "prepared",
+  storeName: "Wigclub",
+} satisfies DailyManagerReportProps;
+
+const sampleBlockers: DailyManagerReportItem[] = [
   {
-    title: "Opening handoff",
-    message: "Opening team should review the register cash handoff.",
-    meta: "Visible in the next operating day's opening workflow",
-    tone: "warning",
+    title: "Register session is still open",
+    message: "Front Counter is still open.",
+    meta: "Resolve before completing EOD Review.",
+    tone: "danger",
   },
 ];
 
@@ -86,9 +95,9 @@ const statusCopy: Record<
     tone: "success",
   },
   prepared: {
-    label: "Prepared for review",
+    label: "Ready for manager review",
     preview: "EOD Review is ready for manager review.",
-    summary: "Athena prepared EOD Review for manager review.",
+    summary: "",
     tone: "warning",
   },
   skipped: {
@@ -107,7 +116,8 @@ const statusCopy: Record<
   dry_run: {
     label: "Dry run",
     preview: "EOD automation checked the workflow in dry run.",
-    summary: "Athena checked EOD Review in dry run. No workflow changes were made.",
+    summary:
+      "Athena checked EOD Review in dry run. No workflow changes were made.",
     tone: "neutral",
   },
   disabled: {
@@ -119,7 +129,8 @@ const statusCopy: Record<
   eligible: {
     label: "Eligible",
     preview: "EOD Review is ready for automation.",
-    summary: "Athena found EOD Review ready for automation. No workflow changes were made.",
+    summary:
+      "Athena found EOD Review ready for automation. No workflow changes were made.",
     tone: "neutral",
   },
 };
@@ -129,34 +140,41 @@ export default function DailyManagerReport({
   operatingDate = "Friday, July 3",
   completedAt = "8:42 PM",
   completedBy = "Athena",
+  frameVariant = "unbordered",
   storeCurrency = "GHS",
   status = "prepared",
   statusLabel,
   statusSummary,
   reportUrl = "https://athena.wigclub.store/wigclub/store/wigclub/operations/daily-close",
   reviewedItems,
-  carryForwardItems = sampleCarryForwardItems,
-  blockers = [],
+  carryForwardItems = [],
+  blockers = sampleBlockers,
   summaryMetrics,
   cashMetrics,
   paymentTotals,
   notes = "No additional manager notes were added.",
 }: DailyManagerReportProps) {
   const money = formatReportAmount(storeCurrency);
-  const resolvedReviewedItems =
-    reviewedItems ?? sampleReviewedItemsFor(money);
+  const resolvedReviewedItems = reviewedItems ?? sampleReviewedItemsFor(money);
   const resolvedSummaryMetrics =
     summaryMetrics ?? sampleSummaryMetricsFor(money);
   const resolvedCashMetrics = cashMetrics ?? sampleCashMetricsFor(money);
-  const resolvedPaymentTotals =
-    paymentTotals ?? samplePaymentTotalsFor(money);
+  const resolvedPaymentTotals = paymentTotals ?? samplePaymentTotalsFor(money);
   const copy = statusCopy[status];
   const resolvedStatusLabel = statusLabel ?? copy.label;
   const resolvedStatusSummary = statusSummary ?? copy.summary;
   const previewText = `${storeName} EOD: ${resolvedStatusLabel}. ${copy.preview}`;
+  const timestampLabel = status === "applied" ? "Closed" : "Prepared";
   const attentionItems = buildAttentionItems({
+    blockers,
     carryForwardItems,
   });
+  const hasRegisterSessionBlocker = blockers.some(isRegisterSessionBlocker);
+  const expectedCashMetrics = resolvedCashMetrics.filter((metric) =>
+    /expected cash/i.test(metric.label),
+  );
+  const handoffSectionTitle =
+    blockers.length > 0 ? "Before close" : "Next opening";
   const attentionSummary = buildAttentionSummary({
     blockers: blockers.length,
     carryForward: carryForwardItems.length,
@@ -170,12 +188,19 @@ export default function DailyManagerReport({
       <Head />
       <Preview>{previewText}</Preview>
       <Body style={styles.body}>
-        <Container style={styles.shell}>
+        <Container
+          style={
+            frameVariant === "unbordered"
+              ? styles.unborderedShell
+              : styles.shell
+          }
+        >
           <Section style={styles.header}>
             <Text style={styles.eyebrow}>Athena daily report</Text>
             <Text style={styles.title}>{storeName}</Text>
             <Text style={styles.subtitle}>
-              {operatingDate} | Closed at {completedAt} by {completedBy}
+              {operatingDate} | {timestampLabel} at {completedAt} by{" "}
+              {completedBy}
             </Text>
           </Section>
 
@@ -184,32 +209,26 @@ export default function DailyManagerReport({
               <Column style={styles.statusColumn}>
                 <Text style={styles.statusLabel}>Status</Text>
                 <Text style={styles.statusTitle}>{resolvedStatusLabel}</Text>
-                <Text style={styles.statusSummary}>
-                  {resolvedStatusSummary}
-                </Text>
+                {resolvedStatusSummary ? (
+                  <Text style={styles.statusSummary}>
+                    {resolvedStatusSummary}
+                  </Text>
+                ) : null}
               </Column>
               {showStatusBadge && (
                 <Column style={styles.badgeColumn}>
-                  <StatusBadge tone={copy.tone}>{attentionSummary}</StatusBadge>
+                  <StatusBadge>{attentionSummary}</StatusBadge>
                 </Column>
               )}
             </Row>
           </Section>
 
           <Section style={styles.section}>
-            <SectionHeading
-              title="Attention"
-              quietTitle
-              detail={
-                attentionItems.length === 0
-                  ? "No reviewed, blocked, or carry-forward items."
-                  : `${attentionItems.length} item${
-                      attentionItems.length === 1 ? "" : "s"
-                    } surfaced`
-              }
-            />
+            <SectionHeading title={handoffSectionTitle} quietTitle />
             {attentionItems.length === 0 ? (
-              <EmptyState>No follow-up needed for this operating day.</EmptyState>
+              <EmptyState>
+                No follow-up needed for this operating day.
+              </EmptyState>
             ) : (
               <Section style={styles.attentionList}>
                 {attentionItems.slice(0, 4).map((item) => (
@@ -223,22 +242,32 @@ export default function DailyManagerReport({
             {attentionItems.length > 4 && (
               <Text style={styles.mutedLine}>
                 {attentionItems.length - 4} more item
-                {attentionItems.length - 4 === 1 ? "" : "s"} available in Athena.
+                {attentionItems.length - 4 === 1 ? "" : "s"} available in
+                Athena.
               </Text>
             )}
           </Section>
 
           <Section style={styles.separatedSection}>
-            <SectionHeading
-              title="Operating summary"
-              quietTitle
-            />
+            <SectionHeading title="Operating summary" quietTitle />
             <OperatingSummaryGrid metrics={resolvedSummaryMetrics} />
           </Section>
 
           <Section style={styles.separatedSection}>
             <SectionHeading title="Cash position" quietTitle />
-            <SummaryMetricGrid metrics={resolvedCashMetrics} />
+            {hasRegisterSessionBlocker ? (
+              <>
+                {expectedCashMetrics.length > 0 ? (
+                  <SummaryMetricGrid metrics={expectedCashMetrics} />
+                ) : null}
+                <EmptyState>
+                  Final cash count and variance will be available after the
+                  register is closed.
+                </EmptyState>
+              </>
+            ) : (
+              <SummaryMetricGrid metrics={resolvedCashMetrics} />
+            )}
           </Section>
 
           {resolvedPaymentTotals.length > 0 && (
@@ -293,30 +322,40 @@ function buildAttentionSummary(args: {
 }
 
 function buildAttentionItems({
+  blockers,
   carryForwardItems,
 }: {
+  blockers: DailyManagerReportItem[];
   carryForwardItems: DailyManagerReportItem[];
 }) {
+  const visibleBlockers = blockers.map((item) => ({
+    ...item,
+    meta: item.meta ?? "Resolve before completing EOD Review.",
+  }));
   const carryForwardMessage = carryForwardItems.length
-    ? `${carryForwardItems.length} carry-forward item${
+    ? `${carryForwardItems.length} item${
         carryForwardItems.length === 1 ? "" : "s"
-      }`
+      } for the next opening`
     : undefined;
   const carryForwardMeta = carryForwardItems.length
-    ? "Visible in the next operating day's opening workflow"
+    ? "Review before the next store day starts."
     : undefined;
   const visibleCarryForwardItems = carryForwardItems.length
     ? [
         {
           title: "Opening handoff",
-          message: carryForwardMessage ?? "Carry-forward items available.",
+          message: carryForwardMessage ?? "Items for the next opening.",
           meta: carryForwardMeta,
           tone: "warning" as AttentionTone,
         },
       ]
     : [];
 
-  return visibleCarryForwardItems;
+  return [...visibleBlockers, ...visibleCarryForwardItems];
+}
+
+function isRegisterSessionBlocker(item: DailyManagerReportItem) {
+  return /register/i.test(`${item.title} ${item.message}`);
 }
 
 function formatReportAmount(currency: string) {
@@ -405,18 +444,8 @@ function SectionHeading({
   );
 }
 
-function StatusBadge({
-  children,
-  tone,
-}: {
-  children: ReactNode;
-  tone: AttentionTone;
-}) {
-  return (
-    <Text style={{ ...styles.statusBadge, ...toneStyles[tone] }}>
-      {children}
-    </Text>
-  );
+function StatusBadge({ children }: { children: ReactNode }) {
+  return <Text style={styles.statusIndicator}>{children}</Text>;
 }
 
 function EmptyState({ children }: { children: ReactNode }) {
@@ -430,12 +459,8 @@ function AttentionItem({ item }: { item: DailyManagerReportItem }) {
     <Section style={styles.attentionItem}>
       <Row>
         <Column>
-          <Text style={styles.itemTitle}>
-            {item.title}
-            {item.meta ? (
-              <span style={styles.itemTitleMeta}> {item.meta}</span>
-            ) : null}
-          </Text>
+          <Text style={styles.itemTitle}>{item.title}</Text>
+          {item.meta ? <Text style={styles.itemMeta}>{item.meta}</Text> : null}
           {hasMetrics ? (
             <AttentionMetricGrid metrics={item.metrics ?? []} />
           ) : (
@@ -486,7 +511,11 @@ function OperatingSummaryGrid({
   );
 }
 
-function SummaryMetricGrid({ metrics }: { metrics: DailyManagerReportMetric[] }) {
+function SummaryMetricGrid({
+  metrics,
+}: {
+  metrics: DailyManagerReportMetric[];
+}) {
   const rows: DailyManagerReportMetric[][] = [];
 
   for (let index = 0; index < metrics.length; index += 2) {
@@ -577,11 +606,7 @@ function PaymentMeta({ payment }: { payment: DailyManagerReportPaymentTotal }) {
         }`
       : `${payment.method} transactions`;
 
-  return (
-    <Text style={styles.paymentDetail}>
-      {count}
-    </Text>
-  );
+  return <Text style={styles.paymentDetail}>{count}</Text>;
 }
 
 const fontSans =
@@ -712,13 +737,12 @@ const styles: Record<string, CSSProperties> = {
     lineHeight: "20px",
     margin: 0,
   },
-  itemTitleMeta: {
+  itemMeta: {
     color: colors.muted,
-    display: "inline-block",
     fontSize: "12px",
     fontWeight: 400,
     lineHeight: "18px",
-    margin: "0 0 0 8px",
+    margin: "6px 0 0",
   },
   mutedLine: {
     color: colors.muted,
@@ -840,15 +864,19 @@ const styles: Record<string, CSSProperties> = {
     maxWidth: "620px",
     overflow: "hidden",
   },
-  statusBadge: {
-    borderRadius: "999px",
-    display: "inline-block",
+  unborderedShell: {
+    backgroundColor: colors.raised,
+    margin: "0 auto",
+    maxWidth: "620px",
+    overflow: "hidden",
+  },
+  statusIndicator: {
+    color: colors.foreground,
     fontSize: "12px",
     fontWeight: 500,
     lineHeight: "18px",
     margin: "1px 0 0",
-    padding: "5px 10px",
-    textAlign: "center",
+    textAlign: "right",
   },
   statusColumn: {
     verticalAlign: "top",

--- a/packages/athena-webapp/convex/emails/DailyManagerReportBordered.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReportBordered.tsx
@@ -1,0 +1,12 @@
+import DailyManagerReport, {
+  dailyManagerReportPreviewProps,
+} from "./DailyManagerReport";
+
+export default function DailyManagerReportBordered() {
+  return (
+    <DailyManagerReport
+      {...dailyManagerReportPreviewProps}
+      frameVariant="bordered"
+    />
+  );
+}

--- a/packages/athena-webapp/convex/emails/DailyManagerReportUnbordered.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReportUnbordered.tsx
@@ -1,0 +1,12 @@
+import DailyManagerReport, {
+  dailyManagerReportPreviewProps,
+} from "./DailyManagerReport";
+
+export default function DailyManagerReportUnbordered() {
+  return (
+    <DailyManagerReport
+      {...dailyManagerReportPreviewProps}
+      frameVariant="unbordered"
+    />
+  );
+}

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
@@ -135,4 +135,62 @@ describe("daily manager report email URLs", () => {
       })),
     );
   });
+
+  it("sends prepared EOD reports with an EOD Review CTA", async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(null, { status: 202 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const report = {
+      blockers: [],
+      carryForwardItems: [],
+      cashMetrics: [],
+      completedAt: "8:42 PM",
+      completedBy: "Athena",
+      operatingDate: "Monday, June 8",
+      operatingDateValue: "2026-06-08",
+      paymentTotals: [],
+      reportUrl:
+        "https://athena.wigclub.store/accra/store/accra/operations/daily-close?operatingDate=2026-06-08",
+      reviewedItems: [
+        {
+          message: "Manager should review the close before completion.",
+          title: "Manager review",
+          tone: "warning" as const,
+        },
+      ],
+      status: "prepared",
+      storeCurrency: "GHS",
+      storeName: "Accra",
+      summaryMetrics: [],
+    };
+    const runQuery = vi.fn(async () => report);
+
+    const result = await sendDailyManagerReportToAdminsForDateWithCtx(
+      { runQuery } as never,
+      {
+        operatingDate: "2026-06-08",
+        status: "prepared",
+        storeId: "store-1" as never,
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(ADMIN_EMAILS.length);
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    );
+    expect(body.html).toContain("Ready for manager review");
+    expect(body.html).toContain("Prepared");
+    expect(body.html).toContain("8:42 PM");
+    expect(body.html).toContain(
+      "https://athena.wigclub.store/accra/store/accra/operations/daily-close?operatingDate=2026-06-08",
+    );
+    expect(result[0]).toEqual({
+      operatingDate: "2026-06-08",
+      recipientEmail: ADMIN_EMAILS[0].email,
+      status: 202,
+      storeName: "Accra",
+    });
+  });
 });

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
@@ -12,6 +12,7 @@ import { toDisplayAmount } from "../lib/currency";
 import { currencyFormatter } from "../utils";
 import { sendDailyManagerReportEmail } from "../mailersend";
 import { ADMIN_EMAILS } from "../constants/email";
+import { buildDailyCloseSnapshotWithCtx } from "./dailyClose";
 import type {
   DailyManagerReportItem,
   DailyManagerReportMetric,
@@ -50,12 +51,12 @@ type DailyCloseReportSnapshot = {
 };
 
 type DailyManagerReportPayload = DailyManagerReportProps & {
-  dailyCloseId: Id<"dailyClose">;
+  dailyCloseId?: Id<"dailyClose">;
   operatingDateValue: string;
 };
 
 type SentDailyManagerReport = {
-  dailyCloseId: Id<"dailyClose">;
+  dailyCloseId?: Id<"dailyClose">;
   operatingDate: string;
   recipientEmail: string;
   status: number;
@@ -70,6 +71,11 @@ type RegisterCashPositionSummary = {
   registerCount: number;
   registerVarianceCount: number;
 };
+
+type DailyManagerReportSendStatus = "applied" | "prepared";
+type PreparedDailyCloseSnapshot = Awaited<
+  ReturnType<typeof buildDailyCloseSnapshotWithCtx>
+>;
 
 const REGISTER_SESSION_EMAIL_SOURCE_LIMIT = 1000;
 
@@ -148,8 +154,7 @@ export const getDailyManagerReportPayloadsForDateRange = internalQuery({
     );
     const cashPositionSummaries = await Promise.all(
       dailyClosesWithSnapshots.map((dailyClose) => {
-        const snapshot =
-          dailyClose.reportSnapshot as DailyCloseReportSnapshot;
+        const snapshot = dailyClose.reportSnapshot as DailyCloseReportSnapshot;
 
         return buildRegisterCashPositionSummary(ctx, {
           endAt: snapshot.closeMetadata.endAt,
@@ -171,6 +176,34 @@ export const getDailyManagerReportPayloadsForDateRange = internalQuery({
   },
 });
 
+export const getPreparedDailyManagerReportPayloadForDate = internalQuery({
+  args: {
+    operatingDate: v.string(),
+    preparedAt: v.optional(v.number()),
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args): Promise<DailyManagerReportPayload> => {
+    const store = await resolveStore(ctx, { storeId: args.storeId });
+    const snapshot = await buildDailyCloseSnapshotWithCtx(ctx, {
+      operatingDate: args.operatingDate,
+      storeId: args.storeId,
+    });
+    const cashPositionSummary = await buildRegisterCashPositionSummary(ctx, {
+      endAt: snapshot.endAt,
+      operatingDate: snapshot.operatingDate,
+      startAt: snapshot.startAt,
+      storeId: store._id,
+    });
+
+    return buildPreparedDailyManagerReportPayload({
+      cashPositionSummary,
+      preparedAt: args.preparedAt,
+      snapshot,
+      store,
+    });
+  },
+});
+
 export const sendMostRecentDailyManagerReport = action({
   args: {
     recipientEmail: v.string(),
@@ -178,10 +211,7 @@ export const sendMostRecentDailyManagerReport = action({
     storeId: v.optional(v.id("store")),
     storeSlug: v.optional(v.string()),
   },
-  handler: async (
-    ctx,
-    args,
-  ): Promise<SentDailyManagerReport> => {
+  handler: async (ctx, args): Promise<SentDailyManagerReport> => {
     const report: DailyManagerReportPayload = await ctx.runQuery(
       internal.operations.dailyManagerReportEmail
         .getMostRecentDailyManagerReportPayload,
@@ -262,19 +292,34 @@ export async function sendDailyManagerReportToAdminsForDateWithCtx(
   ctx: Pick<ActionCtx, "runQuery">,
   args: {
     operatingDate: string;
+    preparedAt?: number;
+    status?: DailyManagerReportSendStatus;
     storeId: Id<"store">;
   },
 ): Promise<SentDailyManagerReport[]> {
-  const reports: DailyManagerReportPayload[] = await ctx.runQuery(
-    internal.operations.dailyManagerReportEmail
-      .getDailyManagerReportPayloadsForDateRange,
-    {
-      endOperatingDate: args.operatingDate,
-      startOperatingDate: args.operatingDate,
-      storeId: args.storeId,
-    },
-  );
-  const report = reports[0];
+  const status = args.status ?? "applied";
+  const report =
+    status === "prepared"
+      ? await ctx.runQuery(
+          internal.operations.dailyManagerReportEmail
+            .getPreparedDailyManagerReportPayloadForDate,
+          {
+            operatingDate: args.operatingDate,
+            preparedAt: args.preparedAt,
+            storeId: args.storeId,
+          },
+        )
+      : (
+          await ctx.runQuery(
+            internal.operations.dailyManagerReportEmail
+              .getDailyManagerReportPayloadsForDateRange,
+            {
+              endOperatingDate: args.operatingDate,
+              startOperatingDate: args.operatingDate,
+              storeId: args.storeId,
+            },
+          )
+        )[0];
 
   if (!report) return [];
 
@@ -307,6 +352,8 @@ export async function sendDailyManagerReportToAdminsForDateWithCtx(
 export const sendDailyManagerReportToAdminsForDate = internalAction({
   args: {
     operatingDate: v.string(),
+    preparedAt: v.optional(v.number()),
+    status: v.optional(v.union(v.literal("applied"), v.literal("prepared"))),
     storeId: v.id("store"),
   },
   handler: (ctx, args) =>
@@ -405,6 +452,59 @@ function buildDailyManagerReportPayload(args: {
   };
 }
 
+function buildPreparedDailyManagerReportPayload(args: {
+  cashPositionSummary?: RegisterCashPositionSummary;
+  preparedAt?: number;
+  snapshot: PreparedDailyCloseSnapshot;
+  store: Doc<"store">;
+}): DailyManagerReportPayload {
+  const storeCurrency = normalizeCurrency(args.store.currency);
+  const money = moneyFormatter(storeCurrency);
+  const summary = {
+    ...args.snapshot.summary,
+    ...(args.cashPositionSummary ?? {}),
+  };
+  const expectedCash = numberFromSummaryWithFallback(
+    summary,
+    "currentDayCashTotal",
+    numberFromSummary(summary, "expectedCashTotal"),
+  );
+  const netCashVariance = numberFromSummary(summary, "netCashVariance");
+  const countedCash = expectedCash + netCashVariance;
+  const reportUrl = `${resolveAppUrl()}/${args.store.slug}/store/${args.store.slug}/operations/daily-close?operatingDate=${encodeURIComponent(args.snapshot.operatingDate)}`;
+
+  return {
+    operatingDateValue: args.snapshot.operatingDate,
+    storeName: args.store.name,
+    operatingDate: formatOperatingDate(args.snapshot.operatingDate),
+    completedAt: formatCompletedAt(args.preparedAt ?? Date.now()),
+    completedBy: "Athena",
+    storeCurrency,
+    status: "prepared",
+    reportUrl,
+    reviewedItems: buildPreparedReviewItems(args.snapshot),
+    carryForwardItems: buildPreparedCarryForwardItems(args.snapshot),
+    blockers: buildPreparedBlockers(args.snapshot),
+    summaryMetrics: buildSummaryMetrics(summary, money),
+    cashMetrics: [
+      {
+        label: "Expected cash",
+        value: money(expectedCash),
+      },
+      {
+        label: "Counted cash",
+        value: money(countedCash),
+      },
+      {
+        label: "Net variance",
+        value: money(netCashVariance),
+      },
+    ],
+    paymentTotals: buildPaymentTotals(summary, money),
+    notes: "EOD Review is waiting for manager review.",
+  };
+}
+
 async function buildRegisterCashPositionSummary(
   ctx: QueryCtx,
   args: {
@@ -414,36 +514,39 @@ async function buildRegisterCashPositionSummary(
     storeId: Id<"store">;
   },
 ): Promise<RegisterCashPositionSummary> {
-  const [openedDateSessions, closeoutDateSessions, missingCloseoutDateSessions] =
-    await Promise.all([
-      ctx.db
-        .query("registerSession")
-        .withIndex("by_storeId_status_openedOperatingDate", (q) =>
-          q
-            .eq("storeId", args.storeId)
-            .eq("status", "closed")
-            .eq("openedOperatingDate", args.operatingDate),
-        )
-        .take(REGISTER_SESSION_EMAIL_SOURCE_LIMIT),
-      ctx.db
-        .query("registerSession")
-        .withIndex("by_storeId_status_closeoutOperatingDate", (q) =>
-          q
-            .eq("storeId", args.storeId)
-            .eq("status", "closed")
-            .eq("closeoutOperatingDate", args.operatingDate),
-        )
-        .take(REGISTER_SESSION_EMAIL_SOURCE_LIMIT),
-      ctx.db
-        .query("registerSession")
-        .withIndex("by_storeId_status_closeoutOperatingDate", (q) =>
-          q
-            .eq("storeId", args.storeId)
-            .eq("status", "closed")
-            .eq("closeoutOperatingDate", undefined),
-        )
-        .take(REGISTER_SESSION_EMAIL_SOURCE_LIMIT),
-    ]);
+  const [
+    openedDateSessions,
+    closeoutDateSessions,
+    missingCloseoutDateSessions,
+  ] = await Promise.all([
+    ctx.db
+      .query("registerSession")
+      .withIndex("by_storeId_status_openedOperatingDate", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("status", "closed")
+          .eq("openedOperatingDate", args.operatingDate),
+      )
+      .take(REGISTER_SESSION_EMAIL_SOURCE_LIMIT),
+    ctx.db
+      .query("registerSession")
+      .withIndex("by_storeId_status_closeoutOperatingDate", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("status", "closed")
+          .eq("closeoutOperatingDate", args.operatingDate),
+      )
+      .take(REGISTER_SESSION_EMAIL_SOURCE_LIMIT),
+    ctx.db
+      .query("registerSession")
+      .withIndex("by_storeId_status_closeoutOperatingDate", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("status", "closed")
+          .eq("closeoutOperatingDate", undefined),
+      )
+      .take(REGISTER_SESSION_EMAIL_SOURCE_LIMIT),
+  ]);
   const sessionsById = new Map<Id<"registerSession">, Doc<"registerSession">>();
 
   [...openedDateSessions, ...closeoutDateSessions].forEach((session) =>
@@ -539,6 +642,17 @@ function buildReviewedItems(
   ];
 }
 
+function buildPreparedReviewItems(
+  snapshot: PreparedDailyCloseSnapshot,
+): DailyManagerReportItem[] {
+  return snapshot.reviewItems.map((item) => ({
+    title: item.title,
+    message: item.message,
+    meta: "Needs manager review",
+    tone: "warning" as const,
+  }));
+}
+
 function buildCarryForwardItems(
   snapshot: DailyCloseReportSnapshot,
 ): DailyManagerReportItem[] {
@@ -548,6 +662,17 @@ function buildCarryForwardItems(
   return Array.from({ length: count }, (_, index) => ({
     title: index === 0 ? "Opening handoff" : `Carry-forward ${index + 1}`,
     message: `${count} carry-forward item${count === 1 ? "" : "s"}`,
+    tone: "warning" as const,
+  }));
+}
+
+function buildPreparedCarryForwardItems(
+  snapshot: PreparedDailyCloseSnapshot,
+): DailyManagerReportItem[] {
+  return snapshot.carryForwardItems.map((item) => ({
+    title: item.title,
+    message: item.message,
+    meta: "Carries forward after review",
     tone: "warning" as const,
   }));
 }
@@ -566,6 +691,16 @@ function buildBlockers(
     }));
 }
 
+function buildPreparedBlockers(
+  snapshot: PreparedDailyCloseSnapshot,
+): DailyManagerReportItem[] {
+  return snapshot.blockers.map((item) => ({
+    title: item.title,
+    message: item.message,
+    tone: "danger" as const,
+  }));
+}
+
 function buildPaymentTotals(
   summary: Record<string, unknown>,
   money: (amount: number) => string,
@@ -574,13 +709,11 @@ function buildPaymentTotals(
 
   if (!Array.isArray(paymentTotals)) return [];
 
-  return paymentTotals
-    .filter(isPaymentTotal)
-    .map((paymentTotal) => ({
-      method: formatPaymentMethod(paymentTotal.method),
-      amount: money(paymentTotal.amount),
-      transactionCount: paymentTotal.transactionCount,
-    }));
+  return paymentTotals.filter(isPaymentTotal).map((paymentTotal) => ({
+    method: formatPaymentMethod(paymentTotal.method),
+    amount: money(paymentTotal.amount),
+    transactionCount: paymentTotal.transactionCount,
+  }));
 }
 
 export function buildSummaryMetrics(

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -327,9 +327,7 @@ function completedDailyClose(overrides: Partial<Row> = {}): Row {
       reviewCount: 0,
       status: "ready",
     },
-    sourceSubjects: [
-      { type: "pos_transaction", id: "txn-1", label: "TXN-1" },
-    ],
+    sourceSubjects: [{ type: "pos_transaction", id: "txn-1", label: "TXN-1" }],
     status: "completed",
     storeId: "store-1",
     summary: { salesTotal: 12000 },
@@ -364,13 +362,16 @@ describe("daily operations automation adapter", () => {
     );
 
     await expect(
-      getHandler(updateOpeningAutoStartPolicy)({ db } as unknown as MutationCtx, {
-        localStartMinutes: 480,
-        mode: "enabled",
-        openingBlockerHandling: "start_with_manager_review",
-        operatingTimezoneOffsetMinutes: 0,
-        storeId: "store-1" as Id<"store">,
-      }),
+      getHandler(updateOpeningAutoStartPolicy)(
+        { db } as unknown as MutationCtx,
+        {
+          localStartMinutes: 480,
+          mode: "enabled",
+          openingBlockerHandling: "start_with_manager_review",
+          operatingTimezoneOffsetMinutes: 0,
+          storeId: "store-1" as Id<"store">,
+        },
+      ),
     ).rejects.toThrow("Only full admins can access stock operations.");
   });
 
@@ -394,16 +395,19 @@ describe("daily operations automation adapter", () => {
     );
 
     await expect(
-      getHandler(updateEodAutoCompletePolicy)({ db } as unknown as MutationCtx, {
-        cleanDayAutoCompleteEnabled: true,
-        localCompletionWindowMinutes: 1260,
-        maxAbsoluteCashVariance: 5000,
-        maxVoidedSaleCount: 2,
-        maxVoidedSaleTotal: 50000,
-        mode: "enabled",
-        operatingTimezoneOffsetMinutes: 0,
-        storeId: "store-1" as Id<"store">,
-      }),
+      getHandler(updateEodAutoCompletePolicy)(
+        { db } as unknown as MutationCtx,
+        {
+          cleanDayAutoCompleteEnabled: true,
+          localCompletionWindowMinutes: 1260,
+          maxAbsoluteCashVariance: 5000,
+          maxVoidedSaleCount: 2,
+          maxVoidedSaleTotal: 50000,
+          mode: "enabled",
+          operatingTimezoneOffsetMinutes: 0,
+          storeId: "store-1" as Id<"store">,
+        },
+      ),
     ).rejects.toThrow("Only full admins can access stock operations.");
     expect(inserts).toEqual([]);
     expect(patches).toEqual([]);
@@ -484,14 +488,19 @@ describe("daily operations automation adapter", () => {
     });
 
     await expect(
-      getHandler(updateOpeningAutoStartPolicy)({ db } as unknown as MutationCtx, {
-        localStartMinutes: 480,
-        mode: "enabled",
-        openingBlockerHandling: "start_with_manager_review",
-        operatingTimezoneOffsetMinutes: 15 * 60,
-        storeId: "store-1" as Id<"store">,
-      }),
-    ).rejects.toThrow("Operating timezone offset must be within UTC-14 to UTC+14.");
+      getHandler(updateOpeningAutoStartPolicy)(
+        { db } as unknown as MutationCtx,
+        {
+          localStartMinutes: 480,
+          mode: "enabled",
+          openingBlockerHandling: "start_with_manager_review",
+          operatingTimezoneOffsetMinutes: 15 * 60,
+          storeId: "store-1" as Id<"store">,
+        },
+      ),
+    ).rejects.toThrow(
+      "Operating timezone offset must be within UTC-14 to UTC+14.",
+    );
   });
 
   it("auto-starts only clean Opening Handoff snapshots under enabled policy", async () => {
@@ -784,12 +793,9 @@ describe("daily operations automation adapter", () => {
     const { db } = createDb({ store: [store] });
 
     await expect(
-      getEodAutoCompletePolicyConfigWithCtx(
-        { db } as unknown as MutationCtx,
-        {
-          storeId: "store-1" as Id<"store">,
-        },
-      ),
+      getEodAutoCompletePolicyConfigWithCtx({ db } as unknown as MutationCtx, {
+        storeId: "store-1" as Id<"store">,
+      }),
     ).resolves.toMatchObject({
       cleanDayAutoCompleteEnabled: false,
       configured: false,
@@ -820,7 +826,9 @@ describe("daily operations automation adapter", () => {
           storeId: "store-1" as Id<"store">,
         },
       ),
-    ).rejects.toThrow("EOD local completion window must be within one local day.");
+    ).rejects.toThrow(
+      "EOD local completion window must be within one local day.",
+    );
 
     await expect(
       upsertEodAutoCompletePolicyConfigWithCtx(
@@ -931,16 +939,22 @@ describe("daily operations automation adapter", () => {
     });
   });
 
-  it("sends manager reports only for freshly applied EOD automation completions", async () => {
-    const runAction = vi.fn(async (_functionRef: unknown, _args: unknown) => [
-      {
-        dailyCloseId: "daily-close-1",
-        operatingDate: "2026-06-08",
-        recipientEmail: "manager@example.com",
-        status: 202,
-        storeName: "Accra",
-      },
-    ]);
+  it("sends manager reports for freshly applied or prepared EOD automation outcomes", async () => {
+    const runAction = vi.fn(async (_functionRef: unknown, args: unknown) => {
+      const operatingDate = (args as { operatingDate: string }).operatingDate;
+
+      return [
+        {
+          ...(operatingDate === "2026-06-08"
+            ? { dailyCloseId: "daily-close-1" }
+            : {}),
+          operatingDate,
+          recipientEmail: "manager@example.com",
+          status: 202,
+          storeName: "Accra",
+        },
+      ];
+    });
 
     const result = await sendDailyManagerReportsForAppliedEodAutomationWithCtx(
       { runAction } as never,
@@ -973,13 +987,28 @@ describe("daily operations automation adapter", () => {
               storeId: "store-1",
             },
           },
+          {
+            action: "recorded",
+            run: {
+              _id: "automation-run-prepared",
+              operatingDate: "2026-06-05",
+              outcome: "prepared",
+              storeId: "store-1",
+            },
+          },
         ] as never,
       },
     );
 
-    expect(runAction).toHaveBeenCalledTimes(1);
+    expect(runAction).toHaveBeenCalledTimes(2);
     expect(runAction.mock.calls[0]?.[1]).toEqual({
       operatingDate: "2026-06-08",
+      status: "applied",
+      storeId: "store-1",
+    });
+    expect(runAction.mock.calls[1]?.[1]).toEqual({
+      operatingDate: "2026-06-05",
+      status: "prepared",
       storeId: "store-1",
     });
     expect(result).toEqual([
@@ -995,6 +1024,19 @@ describe("daily operations automation adapter", () => {
           },
         ],
         runId: "automation-run-applied",
+        storeId: "store-1",
+      },
+      {
+        operatingDate: "2026-06-05",
+        reports: [
+          {
+            operatingDate: "2026-06-05",
+            recipientEmail: "manager@example.com",
+            status: 202,
+            storeName: "Accra",
+          },
+        ],
+        runId: "automation-run-prepared",
         storeId: "store-1",
       },
     ]);
@@ -1436,9 +1478,9 @@ describe("daily operations automation adapter", () => {
     );
 
     expect(result.eodAutoCompleteResults).toHaveLength(0);
-    expect(inserts.filter((insert) => insert.table === "automationRun")).toEqual(
-      [],
-    );
+    expect(
+      inserts.filter((insert) => insert.table === "automationRun"),
+    ).toEqual([]);
   });
 
   it("derives configured EOD auto-complete operating dates from policy local timezone", async () => {
@@ -1564,9 +1606,7 @@ describe("daily operations automation adapter", () => {
         eligible: true,
         observed: {
           carryForwardCount: 1,
-          carryForwardItemKeys: [
-            "operational_work_item:work-1:carry_forward",
-          ],
+          carryForwardItemKeys: ["operational_work_item:work-1:carry_forward"],
           carryForwardPreserved: true,
         },
       },
@@ -1695,28 +1735,28 @@ describe("daily operations automation adapter", () => {
       "automationRun",
     ]);
     expect(inserts.map((insert) => insert.value)).toEqual([
-        expect.objectContaining({
-          outcome: "dry_run",
-          policyMode: "dry_run",
-          decisionEvidence: expect.objectContaining({
-            classification: "clean_day",
-            observed: expect.objectContaining({
-              scheduleEvidenceSource: "canonical_schedule",
-              storeScheduleId: "storeSchedule-1",
-            }),
+      expect.objectContaining({
+        outcome: "dry_run",
+        policyMode: "dry_run",
+        decisionEvidence: expect.objectContaining({
+          classification: "clean_day",
+          observed: expect.objectContaining({
+            scheduleEvidenceSource: "canonical_schedule",
+            storeScheduleId: "storeSchedule-1",
           }),
         }),
-        expect.objectContaining({
-          outcome: "dry_run",
-          policyMode: "dry_run",
-          decisionEvidence: expect.objectContaining({
-            classification: "clean_day",
-            observed: expect.objectContaining({
-              scheduleEvidenceSource: "canonical_schedule",
-              storeScheduleId: "storeSchedule-1",
-            }),
+      }),
+      expect.objectContaining({
+        outcome: "dry_run",
+        policyMode: "dry_run",
+        decisionEvidence: expect.objectContaining({
+          classification: "clean_day",
+          observed: expect.objectContaining({
+            scheduleEvidenceSource: "canonical_schedule",
+            storeScheduleId: "storeSchedule-1",
           }),
         }),
+      }),
     ]);
     expect(
       inserts.map((insert) => insert.value).map((run) => run.idempotencyKey),
@@ -2406,7 +2446,8 @@ describe("daily operations automation adapter", () => {
 
     const runPatch = patches.find(
       (patch) =>
-        patch.table === "automationRun" && patch.id === "automation-run-applied",
+        patch.table === "automationRun" &&
+        patch.id === "automation-run-applied",
     )?.value;
 
     expect(runPatch).toMatchObject({
@@ -2597,9 +2638,9 @@ describe("daily operations automation adapter", () => {
       store: [store, store2],
     });
 
-    const result = await runConfiguredDailyOperationsAutomationWithCtx(
-      { db } as unknown as MutationCtx,
-    );
+    const result = await runConfiguredDailyOperationsAutomationWithCtx({
+      db,
+    } as unknown as MutationCtx);
 
     expect(result.openingResults).toHaveLength(2);
     expect(result.eodResults).toHaveLength(1);
@@ -2659,9 +2700,9 @@ describe("daily operations automation adapter", () => {
     );
 
     expect(result.openingResults).toEqual([]);
-    expect(inserts.filter((insert) => insert.table === "automationRun")).toEqual(
-      [],
-    );
+    expect(
+      inserts.filter((insert) => insert.table === "automationRun"),
+    ).toEqual([]);
   });
 
   it("skips configured automation policies with invalid persisted timezone offsets", async () => {
@@ -2683,9 +2724,9 @@ describe("daily operations automation adapter", () => {
     );
 
     expect(result.openingResults).toEqual([]);
-    expect(inserts.filter((insert) => insert.table === "automationRun")).toEqual(
-      [],
-    );
+    expect(
+      inserts.filter((insert) => insert.table === "automationRun"),
+    ).toEqual([]);
   });
 
   it("catches up a late-day Opening start when the next hourly tick crosses midnight", async () => {
@@ -2862,9 +2903,9 @@ describe("daily operations automation adapter", () => {
     );
 
     expect(result.openingResults).toEqual([]);
-    expect(inserts.filter((insert) => insert.table === "automationRun")).toEqual(
-      [],
-    );
+    expect(
+      inserts.filter((insert) => insert.table === "automationRun"),
+    ).toEqual([]);
   });
 
   it("continues configured automation when one policy throws", async () => {

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -75,13 +75,7 @@ export const dailyOperationsOpeningAutoStartAction = defineAutomationAction({
 
 export const dailyOperationsEodPrepareAction = defineAutomationAction({
   action: EOD_PREPARE_ACTION,
-  allowedOutcomes: [
-    "disabled",
-    "dry_run",
-    "skipped",
-    "prepared",
-    "failed",
-  ],
+  allowedOutcomes: ["disabled", "dry_run", "skipped", "prepared", "failed"],
   domain: DAILY_OPERATIONS_AUTOMATION_DOMAIN,
   mutationBoundary: "EOD Review preparation ledger only",
   requiresSourceSubjects: true,
@@ -220,7 +214,8 @@ async function getOpeningAutoStartPolicyForApi(
     operatingTimezoneOffsetMinutes:
       config.policy?.operatingTimezoneOffsetMinutes ?? null,
     paused: config.paused,
-    policyVersion: config.policy?.policyVersion ?? DAILY_OPERATIONS_POLICY_VERSION,
+    policyVersion:
+      config.policy?.policyVersion ?? DAILY_OPERATIONS_POLICY_VERSION,
   };
 }
 
@@ -242,7 +237,8 @@ async function getEodAutoCompletePolicyForApi(
     operatingTimezoneOffsetMinutes:
       config.policy?.operatingTimezoneOffsetMinutes ?? null,
     paused: config.paused,
-    policyVersion: config.policy?.policyVersion ?? DAILY_OPERATIONS_POLICY_VERSION,
+    policyVersion:
+      config.policy?.policyVersion ?? DAILY_OPERATIONS_POLICY_VERSION,
   };
 }
 
@@ -551,7 +547,10 @@ function eodAutoCompleteDecision(
     });
   }
 
-  if (snapshot.readiness.blockerCount > 0 || disqualifyingCategories.length > 0) {
+  if (
+    snapshot.readiness.blockerCount > 0 ||
+    disqualifyingCategories.length > 0
+  ) {
     return decision({
       classification: "blocked",
       decisionReason:
@@ -741,7 +740,8 @@ export async function runDailyCloseAutoCompleteEligibilityWithCtx(
     args.completionWindowSatisfied
       ? {
           insideCompletionWindow: true,
-          localCompletionWindowMinutes: policyConfig.localCompletionWindowMinutes,
+          localCompletionWindowMinutes:
+            policyConfig.localCompletionWindowMinutes,
           localMinuteOfDay: policyConfig.localCompletionWindowMinutes,
           scheduleEvidence: scheduleEvidenceForStoreDayContext(
             args.storeDayContext,
@@ -749,12 +749,12 @@ export async function runDailyCloseAutoCompleteEligibilityWithCtx(
           ),
         }
       : args.now
-      ? eodAutoCompleteTiming({
-          now: args.now,
-          policyConfig,
-          storeDayContext: args.storeDayContext,
-        })
-      : null,
+        ? eodAutoCompleteTiming({
+            now: args.now,
+            policyConfig,
+            storeDayContext: args.storeDayContext,
+          })
+        : null,
   );
   const policyReviewedItemKeys =
     adapterDecision.decisionEvidence.classification === "low_risk_review"
@@ -771,8 +771,7 @@ export async function runDailyCloseAutoCompleteEligibilityWithCtx(
         automationPolicyVersion: run.policyVersion,
         automationRunId: run._id,
         eodAutoCompletePolicy: {
-          cleanDayAutoCompleteEnabled:
-            policyConfig.cleanDayAutoCompleteEnabled,
+          cleanDayAutoCompleteEnabled: policyConfig.cleanDayAutoCompleteEnabled,
           maxAbsoluteCashVariance: policyConfig.maxAbsoluteCashVariance,
           maxVoidedSaleCount: policyConfig.maxVoidedSaleCount,
           maxVoidedSaleTotal: policyConfig.maxVoidedSaleTotal,
@@ -857,7 +856,9 @@ function historicEodAutoCloseIdempotencyKey(args: {
   return `${DAILY_OPERATIONS_AUTOMATION_DOMAIN}:${EOD_AUTO_COMPLETE_ACTION}:historic:${args.storeId}:${args.operatingDate}`;
 }
 
-function policyEvidenceForHistoricRun(policyConfig: EodAutoCompletePolicyConfig) {
+function policyEvidenceForHistoricRun(
+  policyConfig: EodAutoCompletePolicyConfig,
+) {
   return {
     cleanDayAutoCompleteEnabled: policyConfig.cleanDayAutoCompleteEnabled,
     localCompletionWindowMinutes: policyConfig.localCompletionWindowMinutes,
@@ -936,11 +937,10 @@ async function recordHistoricEodQuarantineWithCtx(
     operatingDate: args.operatingDate,
     organizationId: args.policyConfig.policy?.organizationId,
     outcome: "skipped",
-    policyMode: args.policyConfig.paused
-      ? "disabled"
-      : args.policyConfig.mode,
+    policyMode: args.policyConfig.paused ? "disabled" : args.policyConfig.mode,
     policyVersion:
-      args.policyConfig.policy?.policyVersion ?? DAILY_OPERATIONS_POLICY_VERSION,
+      args.policyConfig.policy?.policyVersion ??
+      DAILY_OPERATIONS_POLICY_VERSION,
     snapshotCounts: {},
     sourceSubjects: [
       {
@@ -1232,7 +1232,10 @@ export async function runHistoricEodAutoCloseForDateWithCtx(
     };
   }
 
-  if (supportPolicyMode !== "enabled" || adapterDecision.outcome !== "eligible") {
+  if (
+    supportPolicyMode !== "enabled" ||
+    adapterDecision.outcome !== "eligible"
+  ) {
     return {
       action:
         adapterDecision.decisionEvidence.classification === "completed"
@@ -1246,7 +1249,8 @@ export async function runHistoricEodAutoCloseForDateWithCtx(
 
   const result = await completeDailyCloseForAutomationWithCtx(ctx, {
     automationDecisionReason:
-      run.decisionReason ?? "Historic EOD Review completed by automation policy.",
+      run.decisionReason ??
+      "Historic EOD Review completed by automation policy.",
     automationPolicyVersion: run.policyVersion,
     automationRunId: run._id,
     automationScheduleEvidence:
@@ -1327,7 +1331,9 @@ export async function runHistoricEodAutoCloseBatchWithCtx(
     !isValidOperatingDate(args.startOperatingDate) ||
     !isValidOperatingDate(args.endOperatingDate)
   ) {
-    throw new Error("Historic EOD auto-close requires valid date range bounds.");
+    throw new Error(
+      "Historic EOD auto-close requires valid date range bounds.",
+    );
   }
 
   if (
@@ -1347,7 +1353,10 @@ export async function runHistoricEodAutoCloseBatchWithCtx(
   const results: HistoricEodDateResult[] = [];
   let operatingDate = args.startOperatingDate;
 
-  while (operatingDate <= args.endOperatingDate && results.length < args.maxDays) {
+  while (
+    operatingDate <= args.endOperatingDate &&
+    results.length < args.maxDays
+  ) {
     const result = await runHistoricEodAutoCloseForDateWithCtx(ctx, {
       asOfOperatingDate,
       mode: args.mode,
@@ -1445,11 +1454,10 @@ function openingPolicyCronWindow(args: {
   if (localMinuteOfDay < openingLocalStartMinutes) {
     const previousLocalDate = localDateForPolicy({
       now: args.now - CONFIGURED_AUTOMATION_LOOKBACK_MS,
-      operatingTimezoneOffsetMinutes: args.policy.operatingTimezoneOffsetMinutes,
+      operatingTimezoneOffsetMinutes:
+        args.policy.operatingTimezoneOffsetMinutes,
     });
-    const previousOperatingDate = previousLocalDate
-      ?.toISOString()
-      .slice(0, 10);
+    const previousOperatingDate = previousLocalDate?.toISOString().slice(0, 10);
     const currentOperatingDate = localDate.toISOString().slice(0, 10);
     const previousMinuteOfDay = previousLocalDate
       ? previousLocalDate.getUTCHours() * 60 + previousLocalDate.getUTCMinutes()
@@ -1534,7 +1542,9 @@ function eodPolicyCompletionAtForStoreDay(args: {
   }
 
   const offsetMinutes = normalizedPolicyOffsetFromScheduleStart({
-    policyLocalStartMinutes: eodLocalCompletionWindowMinutesForPolicy(args.policy),
+    policyLocalStartMinutes: eodLocalCompletionWindowMinutesForPolicy(
+      args.policy,
+    ),
     scheduleStartMinutes: args.storeDayContext.eodWindowEndMinutes,
   });
 
@@ -1881,10 +1891,14 @@ export async function runScheduledDailyOperationsAutomationWithCtx(
   const now = args.now ?? Date.now();
   const [openingPolicies, eodPolicies, eodAutoCompletePolicies] =
     await Promise.all([
-    listConfiguredAutomationPolicies(ctx, { action: OPENING_AUTO_START_ACTION }),
-    listConfiguredAutomationPolicies(ctx, { action: EOD_PREPARE_ACTION }),
-    listConfiguredAutomationPolicies(ctx, { action: EOD_AUTO_COMPLETE_ACTION }),
-  ]);
+      listConfiguredAutomationPolicies(ctx, {
+        action: OPENING_AUTO_START_ACTION,
+      }),
+      listConfiguredAutomationPolicies(ctx, { action: EOD_PREPARE_ACTION }),
+      listConfiguredAutomationPolicies(ctx, {
+        action: EOD_AUTO_COMPLETE_ACTION,
+      }),
+    ]);
   const openingResults = await Promise.all(
     openingPolicies.map((policy) =>
       runConfiguredPolicySafely(ctx, {
@@ -1945,10 +1959,14 @@ export async function runConfiguredDailyOperationsAutomationWithCtx(
   const now = args.now ?? Date.now();
   const [openingPolicies, eodPolicies, eodAutoCompletePolicies] =
     await Promise.all([
-    listConfiguredAutomationPolicies(ctx, { action: OPENING_AUTO_START_ACTION }),
-    listConfiguredAutomationPolicies(ctx, { action: EOD_PREPARE_ACTION }),
-    listConfiguredAutomationPolicies(ctx, { action: EOD_AUTO_COMPLETE_ACTION }),
-  ]);
+      listConfiguredAutomationPolicies(ctx, {
+        action: OPENING_AUTO_START_ACTION,
+      }),
+      listConfiguredAutomationPolicies(ctx, { action: EOD_PREPARE_ACTION }),
+      listConfiguredAutomationPolicies(ctx, {
+        action: EOD_AUTO_COMPLETE_ACTION,
+      }),
+    ]);
   const openingResults = await Promise.all(
     openingPolicies.map(async (policy) => {
       const scheduleContext = await resolveConfiguredStoreScheduleContext(ctx, {
@@ -2056,7 +2074,7 @@ type DailyOperationsAutomationResult = Awaited<
 type DailyManagerReportAutomationSendResult = {
   operatingDate: string;
   reports: Array<{
-    dailyCloseId: Id<"dailyClose">;
+    dailyCloseId?: Id<"dailyClose">;
     operatingDate: string;
     recipientEmail: string;
     status: number;
@@ -2066,10 +2084,13 @@ type DailyManagerReportAutomationSendResult = {
   storeId: Id<"store">;
 };
 
-function isAppliedEodAutoCompleteResult(
+function isReportableEodAutoCompleteResult(
   result: DailyOperationsAutomationResult["eodAutoCompleteResults"][number],
 ) {
-  return result?.action === "applied" && result.run.outcome === "applied";
+  return (
+    (result?.action === "applied" && result.run.outcome === "applied") ||
+    (result?.action === "recorded" && result.run.outcome === "prepared")
+  );
 }
 
 export async function sendDailyManagerReportsForAppliedEodAutomationWithCtx(
@@ -2078,15 +2099,18 @@ export async function sendDailyManagerReportsForAppliedEodAutomationWithCtx(
     results: DailyOperationsAutomationResult["eodAutoCompleteResults"];
   },
 ): Promise<DailyManagerReportAutomationSendResult[]> {
-  const appliedResults = args.results.filter(isAppliedEodAutoCompleteResult);
+  const reportableResults = args.results.filter(
+    isReportableEodAutoCompleteResult,
+  );
   const sentReports: DailyManagerReportAutomationSendResult[] = [];
 
-  for (const result of appliedResults) {
+  for (const result of reportableResults) {
     const reports = await ctx.runAction(
       internal.operations.dailyManagerReportEmail
         .sendDailyManagerReportToAdminsForDate,
       {
         operatingDate: result.run.operatingDate,
+        status: result.run.outcome === "prepared" ? "prepared" : "applied",
         storeId: result.run.storeId,
       },
     );
@@ -2160,7 +2184,9 @@ async function runHistoricEodAutoCloseBatchActionWithCtx(
     !isValidOperatingDate(args.startOperatingDate) ||
     !isValidOperatingDate(args.endOperatingDate)
   ) {
-    throw new Error("Historic EOD auto-close requires valid date range bounds.");
+    throw new Error(
+      "Historic EOD auto-close requires valid date range bounds.",
+    );
   }
 
   if (
@@ -2180,9 +2206,13 @@ async function runHistoricEodAutoCloseBatchActionWithCtx(
   const results: HistoricEodDateResult[] = [];
   let operatingDate = args.startOperatingDate;
 
-  while (operatingDate <= args.endOperatingDate && results.length < args.maxDays) {
+  while (
+    operatingDate <= args.endOperatingDate &&
+    results.length < args.maxDays
+  ) {
     const result = await ctx.runMutation(
-      internal.operations.dailyOperationsAutomation.runHistoricEodAutoCloseForDate,
+      internal.operations.dailyOperationsAutomation
+        .runHistoricEodAutoCloseForDate,
       {
         asOfOperatingDate,
         mode: args.mode,

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 16 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 627 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 629 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/src/components/Navbar.test.tsx
+++ b/packages/athena-webapp/src/components/Navbar.test.tsx
@@ -45,6 +45,11 @@ describe("AppHeader", () => {
       "min-[430px]:flex",
       "shrink-0",
     );
+    expect(screen.getByLabelText("Development environment")).toHaveClass(
+      "border-action-workflow-border",
+      "bg-action-workflow-soft",
+      "text-action-workflow",
+    );
     expect(screen.getByTestId("organization-switcher")).toHaveClass(
       "max-w-[10.75rem]",
       "min-[430px]:max-w-[14rem]",

--- a/packages/athena-webapp/src/components/Navbar.tsx
+++ b/packages/athena-webapp/src/components/Navbar.tsx
@@ -10,15 +10,22 @@ import { currencyFormatter } from "../lib/utils";
 
 export const AppHeader = () => {
   const organizations = useGetOrganizations();
+  const showDevIndicator = import.meta.env.DEV;
 
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2">
-      <Link
-        to="/"
-        className="hidden shrink-0 items-center min-[430px]:flex"
-      >
+      <Link to="/" className="hidden shrink-0 items-center min-[430px]:flex">
         <p className="font-medium">athena</p>
       </Link>
+      {showDevIndicator ? (
+        <span
+          aria-label="Development environment"
+          className="hidden shrink-0 rounded-full border border-action-workflow-border bg-action-workflow-soft px-1.5 py-px text-[10px] font-medium uppercase leading-none text-action-workflow min-[430px]:inline-flex"
+          title="Development environment"
+        >
+          dev
+        </span>
+      ) : null}
       <p className="hidden text-muted-foreground sm:block">/</p>
       <OrganizationSwitcher
         className="max-w-[10.75rem] min-[430px]:max-w-[14rem]"
@@ -76,7 +83,7 @@ const Navbar = () => {
 
   const newOrder = useQuery(
     api.storeFront.onlineOrder.newOrder,
-    activeStore?._id ? { storeId: activeStore._id } : "skip"
+    activeStore?._id ? { storeId: activeStore._id } : "skip",
   );
 
   const formatter = currencyFormatter(activeStore?.currency || "USD");

--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
@@ -16,9 +16,7 @@ import {
 import { useAuthActions } from "@convex-dev/auth/react";
 import { ATHENA_EMAIL_OTP_PROVIDER_ID } from "../../../../shared/auth";
 import { LoadingButton } from "~/src/components/ui/loading-button";
-import {
-  ATHENA_AUTH_SYNC_FAILED_EVENT,
-} from "~/src/lib/constants";
+import { ATHENA_AUTH_SYNC_FAILED_EVENT } from "~/src/lib/constants";
 import { startAthenaAuthSyncHandoff } from "./authSyncHandoff";
 import { useForm } from "react-hook-form";
 import { useEffect, useRef, useState } from "react";
@@ -86,7 +84,10 @@ export function InputOTPForm({
       setIsAuthHandoffPending(false);
     };
 
-    window.addEventListener(ATHENA_AUTH_SYNC_FAILED_EVENT, handleAuthSyncFailed);
+    window.addEventListener(
+      ATHENA_AUTH_SYNC_FAILED_EVENT,
+      handleAuthSyncFailed,
+    );
 
     return () => {
       window.removeEventListener(
@@ -249,6 +250,7 @@ export function InputOTPForm({
             isLoading={isSigningIn}
             disabled={isSigningIn || isAuthHandoffPending}
             type="submit"
+            variant="workflow"
             className="group relative z-10 h-control-standard w-fit px-layout-lg shadow-[0_16px_34px_-22px_hsl(var(--signal)/0.72)]"
           >
             Continue

--- a/packages/athena-webapp/src/components/auth/Login/LoginForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/LoginForm.tsx
@@ -57,10 +57,7 @@ export function LoginForm({
           <form.Field
             name="email"
             validators={{
-              onSubmit: z
-                .string()
-                .max(256)
-                .email("Email address is not valid"),
+              onSubmit: z.string().max(256).email("Email address is not valid"),
             }}
             children={(field) => (
               <Input
@@ -71,9 +68,10 @@ export function LoginForm({
                 value={field.state.value}
                 onBlur={field.handleBlur}
                 onChange={(e) => field.handleChange(e.target.value)}
-                className={`h-control-standard border-border/80 bg-background shadow-[inset_0_1px_0_hsl(var(--background)/0.85)] ${field.state.meta?.errors.length > 0 &&
+                className={`h-control-standard border-border/80 bg-background shadow-[inset_0_1px_0_hsl(var(--background)/0.85)] ${
+                  field.state.meta?.errors.length > 0 &&
                   "border-destructive focus-visible:ring-destructive"
-                  }`}
+                }`}
               />
             )}
           />
@@ -90,6 +88,7 @@ export function LoginForm({
         <LoadingButton
           isLoading={isSubmitting}
           type="submit"
+          variant="workflow"
           className="group relative z-10 h-control-standard w-fit shadow-[0_16px_34px_-22px_hsl(var(--signal)/0.72)]"
         >
           Continue

--- a/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
@@ -39,7 +39,10 @@ export function PosRecoveryCodeForm({
       setIsAuthHandoffPending(false);
     };
 
-    window.addEventListener(ATHENA_AUTH_SYNC_FAILED_EVENT, handleAuthSyncFailed);
+    window.addEventListener(
+      ATHENA_AUTH_SYNC_FAILED_EVENT,
+      handleAuthSyncFailed,
+    );
     return () =>
       window.removeEventListener(
         ATHENA_AUTH_SYNC_FAILED_EVENT,
@@ -80,7 +83,10 @@ export function PosRecoveryCodeForm({
         payload.storeUrlSlug = storeUrlSlug;
       }
 
-      const result = await signIn(ATHENA_POS_RECOVERY_CODE_PROVIDER_ID, payload);
+      const result = await signIn(
+        ATHENA_POS_RECOVERY_CODE_PROVIDER_ID,
+        payload,
+      );
 
       if (!result.signingIn) {
         setErrorMessage(RECOVERY_FAILURE_COPY);
@@ -125,7 +131,10 @@ export function PosRecoveryCodeForm({
         onSubmit={handleSubmit}
       >
         <div className="relative z-10 flex w-full flex-col gap-layout-sm">
-          <label className="text-sm font-medium text-foreground" htmlFor="pos-recovery-account">
+          <label
+            className="text-sm font-medium text-foreground"
+            htmlFor="pos-recovery-account"
+          >
             POS account
           </label>
           <Input
@@ -137,7 +146,10 @@ export function PosRecoveryCodeForm({
         </div>
 
         <div className="relative z-10 flex w-full flex-col gap-layout-sm">
-          <label className="text-sm font-medium text-foreground" htmlFor="pos-recovery-code">
+          <label
+            className="text-sm font-medium text-foreground"
+            htmlFor="pos-recovery-code"
+          >
             Recovery code
           </label>
           <Input
@@ -166,6 +178,7 @@ export function PosRecoveryCodeForm({
           isLoading={isSigningIn}
           disabled={!canSubmit}
           type="submit"
+          variant="workflow"
           className="group relative z-10 h-control-standard w-fit shadow-[0_16px_34px_-22px_hsl(var(--signal)/0.72)]"
         >
           Continue

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -129,9 +129,7 @@ vi.mock("recharts", () => ({
       data-display-dates={data.map((day) => day.displayDate).join("|")}
       data-display-labels={data.map((day) => day.displayLabel).join("|")}
       data-known-item-counts={data
-        .map((day) =>
-          day.hasKnownItemCount === false ? "unknown" : "known",
-        )
+        .map((day) => (day.hasKnownItemCount === false ? "unknown" : "known"))
         .join("|")}
       data-margin-right={margin?.right ?? ""}
       data-testid="store-pulse-chart"
@@ -1136,13 +1134,18 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.getByRole("heading", { name: "Historical store-day view" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", {
-        name: "Review EOD Review for Friday, May 8, 2026",
-      }),
-    ).toHaveAttribute(
+    const historicalEodReviewLink = screen.getByRole("link", {
+      name: "Review EOD Review for Friday, May 8, 2026",
+    });
+    expect(historicalEodReviewLink).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
+    );
+    expect(historicalEodReviewLink).toHaveClass(
+      "border-success/35",
+      "bg-success/10",
+      "text-success",
+      "hover:text-success",
     );
     expect(screen.queryByText("Workflow status")).not.toBeInTheDocument();
     expect(screen.queryByText("Current day only")).not.toBeInTheDocument();
@@ -1156,6 +1159,29 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.queryByRole("link", { name: "Open Open work" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("opens the operating date picker to the selected operating date month", () => {
+    vi.setSystemTime(new Date(2026, 6, 4, 12));
+
+    renderContent(
+      {
+        ...operatingSnapshot,
+        operatingDate: "2026-06-21",
+      },
+      {
+        onOperatingDateChange: vi.fn(),
+      },
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Change operating date, currently Sunday, June 21, 2026",
+      }),
+    );
+
+    expect(screen.getByText("June 2026")).toBeInTheDocument();
+    expect(screen.queryByText("July 2026")).not.toBeInTheDocument();
   });
 
   it("redacts financial metrics when a POS-only user has no manager elevation", () => {
@@ -1209,11 +1235,19 @@ describe("DailyOperationsViewContent", () => {
       "href",
       "/wigclub/store/osu/pos/expense-reports?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
     );
-    expect(
-      screen.getByRole("link", { name: "Start EOD Review" }),
-    ).toHaveAttribute(
+    const startEodReviewLink = screen.getByRole("link", {
+      name: "Start EOD Review",
+    });
+    expect(startEodReviewLink).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
+    );
+    expect(startEodReviewLink).toHaveClass(
+      "border-success/35",
+      "bg-success/10",
+      "text-success",
+      "hover:text-success",
+      "active:scale-[0.98]",
     );
     expect(screen.queryByText("Current day only")).not.toBeInTheDocument();
     expect(screen.getByText("No active workflow blockers")).toBeInTheDocument();
@@ -1884,13 +1918,18 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.getByRole("heading", { name: "Historical store-day view" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", {
-        name: "Review EOD Review for Friday, May 8, 2026",
-      }),
-    ).toHaveAttribute(
+    const historicalEodReviewLink = screen.getByRole("link", {
+      name: "Review EOD Review for Friday, May 8, 2026",
+    });
+    expect(historicalEodReviewLink).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
+    );
+    expect(historicalEodReviewLink).toHaveClass(
+      "border-success/35",
+      "bg-success/10",
+      "text-success",
+      "hover:text-success",
     );
     expect(
       screen.queryByRole("link", { name: "Review EOD Review" }),
@@ -1913,6 +1952,134 @@ describe("DailyOperationsViewContent", () => {
     ).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/opening?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
+    );
+  });
+
+  it("tones current-day primary actions across daily operations lifecycle states", () => {
+    const operatingDate = getCurrentLocalOperatingDate();
+    const renderCurrentState = (snapshot: DailyOperationsSnapshot) =>
+      renderContent({
+        ...snapshot,
+        operatingDate,
+      });
+
+    let view = renderCurrentState(notOpenedSnapshot);
+    expect(
+      screen.getByRole("link", { name: "Start Opening Handoff" }),
+    ).toHaveClass(
+      "border-border",
+      "text-muted-foreground",
+      "hover:text-foreground",
+      "active:scale-[0.98]",
+    );
+    view.unmount();
+
+    view = renderCurrentState({
+      ...operatingSnapshot,
+      lifecycle: {
+        description: "The store day is open and operating.",
+        label: "Operating",
+        status: "operating",
+      },
+    });
+    expect(screen.getByRole("link", { name: "Start EOD Review" })).toHaveClass(
+      "border-action-workflow-border",
+      "bg-action-workflow-soft",
+      "text-action-workflow",
+      "hover:text-action-workflow",
+      "active:scale-[0.98]",
+    );
+    view.unmount();
+
+    view = renderCurrentState(blockedSnapshot);
+    expect(
+      screen.getByRole("link", { name: "Review close blockers" }),
+    ).toHaveClass(
+      "border-danger/30",
+      "bg-danger/10",
+      "text-danger",
+      "hover:text-danger",
+      "active:scale-[0.98]",
+    );
+    view.unmount();
+
+    view = renderCurrentState(operatingSnapshot);
+    expect(screen.getByRole("link", { name: "Start EOD Review" })).toHaveClass(
+      "border-success/35",
+      "bg-success/10",
+      "text-success",
+      "hover:text-success",
+      "active:scale-[0.98]",
+    );
+    view.unmount();
+
+    renderCurrentState(closedSnapshot);
+    expect(screen.getByRole("link", { name: "Review EOD Review" })).toHaveClass(
+      "border-success/25",
+      "bg-success/10",
+      "text-success",
+      "hover:text-success",
+      "active:scale-[0.98]",
+    );
+  });
+
+  it("tones historical EOD Review links across reviewable lifecycle states", () => {
+    let view = renderContent({
+      ...operatingSnapshot,
+      lifecycle: {
+        description: "The store day is open and operating.",
+        label: "Operating",
+        status: "operating",
+      },
+    });
+    expect(
+      screen.getByRole("link", {
+        name: "Review EOD Review for Friday, May 8, 2026",
+      }),
+    ).toHaveClass(
+      "border-warning/30",
+      "bg-warning/10",
+      "text-warning-foreground",
+      "hover:text-warning-foreground",
+    );
+    expect(
+      screen.getByRole("heading", { name: "Incomplete store-day close" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This historical store day does not have a completed close.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Review EOD before treating this date as a closed store-day record.",
+      ),
+    ).toBeInTheDocument();
+    view.unmount();
+
+    view = renderContent(blockedSnapshot);
+    expect(
+      screen.getByRole("link", {
+        name: "Review EOD Review for Friday, May 8, 2026",
+      }),
+    ).toHaveClass(
+      "border-danger/30",
+      "bg-danger/10",
+      "text-danger",
+      "hover:text-danger",
+    );
+    view.unmount();
+
+    renderContent(closedSnapshot);
+    expect(
+      screen.getByRole("link", {
+        name: "Review EOD Review for Friday, May 8, 2026",
+      }),
+    ).toHaveClass(
+      "border-success/25",
+      "bg-success/10",
+      "text-success",
+      "hover:text-success",
     );
   });
 
@@ -1968,9 +2135,7 @@ describe("DailyOperationsViewContent", () => {
     renderContent(
       {
         ...blockedSnapshot,
-        lanes: blockedSnapshot.lanes.filter(
-          (lane) => lane.key !== "approvals",
-        ),
+        lanes: blockedSnapshot.lanes.filter((lane) => lane.key !== "approvals"),
         operatingDate,
       },
       {
@@ -1995,10 +2160,7 @@ describe("DailyOperationsViewContent", () => {
       "href",
       "/wigclub/store/osu/operations/approvals?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
     );
-    expect(screen.getByText("3")).toHaveClass(
-      "font-semibold",
-      "tabular-nums",
-    );
+    expect(screen.getByText("3")).toHaveClass("font-semibold", "tabular-nums");
   });
 
   it("passes origin context to current-day blocker review actions", () => {
@@ -2007,11 +2169,19 @@ describe("DailyOperationsViewContent", () => {
       operatingDate: getCurrentLocalOperatingDate(),
     });
 
-    expect(
-      screen.getByRole("link", { name: "Review close blockers" }),
-    ).toHaveAttribute(
+    const blockerReviewLink = screen.getByRole("link", {
+      name: "Review close blockers",
+    });
+    expect(blockerReviewLink).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
+    );
+    expect(blockerReviewLink).toHaveClass(
+      "border-danger/30",
+      "bg-danger/10",
+      "text-danger",
+      "hover:text-danger",
+      "active:scale-[0.98]",
     );
     expect(
       screen.getByRole("link", { name: "Open Registers" }),
@@ -2230,7 +2400,9 @@ describe("DailyOperationsViewContent", () => {
       screen.getByRole("link", { name: "Got2b Gel Black" }),
     ).toHaveAttribute(
       "href",
-      expect.stringContaining("/wigclub/store/osu/products/product-approved?o="),
+      expect.stringContaining(
+        "/wigclub/store/osu/products/product-approved?o=",
+      ),
     );
     expect(
       screen.getByRole("link", { name: "Got2b Gel Black" }),

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -131,6 +131,10 @@ export type DailyOperationsLaneStatus =
   | "closed"
   | "unknown";
 
+type PrimaryActionEmphasisStatus =
+  | DailyOperationsLifecycleStatus
+  | "historical_operating";
+
 type DailyOperationsAutomationOutcome =
   | "applied"
   | "prepared"
@@ -795,9 +799,11 @@ const ONLINE_ORDER_TIMELINE_MESSAGE_TEMPLATES: Record<
   string,
   (orderLabel: string) => string
 > = {
-  online_order_cancelled: (orderLabel) => `Online order ${orderLabel} cancelled.`,
+  online_order_cancelled: (orderLabel) =>
+    `Online order ${orderLabel} cancelled.`,
   online_order_created: (orderLabel) => `Online order ${orderLabel} created.`,
-  online_order_delivered: (orderLabel) => `Online order ${orderLabel} delivered.`,
+  online_order_delivered: (orderLabel) =>
+    `Online order ${orderLabel} delivered.`,
   online_order_exchange_balance_collection: (orderLabel) =>
     `Exchange balance collected for online order ${orderLabel}.`,
   online_order_exchange_processed: (orderLabel) =>
@@ -810,7 +816,8 @@ const ONLINE_ORDER_TIMELINE_MESSAGE_TEMPLATES: Record<
     `Payment collected for online order ${orderLabel}.`,
   online_order_payment_verified: (orderLabel) =>
     `Payment verified for online order ${orderLabel}.`,
-  online_order_picked_up: (orderLabel) => `Online order ${orderLabel} picked up.`,
+  online_order_picked_up: (orderLabel) =>
+    `Online order ${orderLabel} picked up.`,
   online_order_pickup_exception: (orderLabel) =>
     `Pickup exception recorded for online order ${orderLabel}.`,
   online_order_ready_for_delivery: (orderLabel) =>
@@ -878,7 +885,9 @@ function TimelineMessage({
   const approvedProductLink = event.approvedProductLink;
   const approvedProductLabel = approvedProductLink?.label?.trim();
   const canRenderApprovedProductLink = Boolean(
-    approvedProductLink?.to && approvedProductLink.params && approvedProductLabel,
+    approvedProductLink?.to &&
+    approvedProductLink.params &&
+    approvedProductLabel,
   );
   const inlineLink =
     event.transactionLink ??
@@ -888,9 +897,13 @@ function TimelineMessage({
   const linkLabel = inlineLink?.label?.trim();
   const matchLabel = event.transactionLink
     ? undefined
-    : event.registerLink?.matchLabel ?? event.onlineOrderLink?.matchLabel;
+    : (event.registerLink?.matchLabel ?? event.onlineOrderLink?.matchLabel);
   const displayMessage = formatTimelineMessage(event.message);
-  const linkMatch = findTimelineLinkMatch(displayMessage, linkLabel, matchLabel);
+  const linkMatch = findTimelineLinkMatch(
+    displayMessage,
+    linkLabel,
+    matchLabel,
+  );
 
   const renderApprovedProductLink = () => {
     if (
@@ -1152,6 +1165,85 @@ function statusClassName(status: DailyOperationsLaneStatus) {
   }
 
   return "border-border bg-background text-muted-foreground";
+}
+
+function getPrimaryActionEmphasis(status: PrimaryActionEmphasisStatus) {
+  const sharedClassName =
+    "transition-[background-color,border-color,box-shadow,transform] duration-150 ease-out active:scale-[0.98]";
+
+  switch (status) {
+    case "not_opened":
+      return {
+        Icon: Clock3,
+        className: cn(
+          "border-border bg-background text-muted-foreground hover:bg-surface hover:text-foreground",
+          sharedClassName,
+        ),
+        iconClassName: "text-muted-foreground",
+      };
+    case "operating":
+      return {
+        Icon: null,
+        className: cn(
+          "border-action-workflow-border bg-action-workflow-soft text-action-workflow shadow-[0_1px_0_hsl(var(--action-workflow)/0.10)] hover:border-action-workflow/45 hover:bg-action-workflow-soft/75 hover:text-action-workflow",
+          sharedClassName,
+        ),
+        iconClassName: "text-action-workflow",
+      };
+    case "historical_operating":
+      return {
+        Icon: Clock3,
+        className: cn(
+          "border-warning/30 bg-warning/10 text-warning-foreground shadow-[0_1px_0_hsl(var(--warning)/0.10)] hover:border-warning/45 hover:bg-warning/15 hover:text-warning-foreground",
+          sharedClassName,
+        ),
+        iconClassName: "text-warning",
+      };
+    case "close_blocked":
+      return {
+        Icon: CircleAlert,
+        className: cn(
+          "border-danger/30 bg-danger/10 text-danger shadow-[0_1px_0_hsl(var(--danger)/0.10)] hover:border-danger/45 hover:bg-danger/15 hover:text-danger",
+          sharedClassName,
+        ),
+        iconClassName: "text-danger",
+      };
+    case "ready_to_close":
+      return {
+        Icon: Check,
+        className: cn(
+          "border-success/35 bg-success/10 text-success shadow-[0_1px_0_hsl(var(--success)/0.10)] hover:border-success/50 hover:bg-success/15 hover:text-success",
+          sharedClassName,
+        ),
+        iconClassName: "text-success",
+      };
+    case "closed":
+      return {
+        Icon: null,
+        className: cn(
+          "border-success/25 bg-success/10 text-success shadow-[0_1px_0_hsl(var(--success)/0.08)] hover:border-success/40 hover:bg-success/15 hover:text-success",
+          sharedClassName,
+        ),
+        iconClassName: "text-success",
+      };
+  }
+
+  const exhaustiveStatus: never = status;
+  return exhaustiveStatus;
+}
+
+function getPrimaryActionEmphasisStatus({
+  isHistoricalDate,
+  status,
+}: {
+  isHistoricalDate: boolean;
+  status: DailyOperationsLifecycleStatus;
+}): PrimaryActionEmphasisStatus {
+  if (isHistoricalDate && status === "operating") {
+    return "historical_operating";
+  }
+
+  return status;
 }
 
 function SuccessCheckIcon({
@@ -1785,15 +1877,25 @@ function HistoricalWorkflowPanel({
   storeUrlSlug: string;
 }) {
   const isClosed = snapshot.lifecycle.status === "closed";
+  const isHistoricalOperating = snapshot.lifecycle.status === "operating";
 
   return (
     <section className="space-y-layout-md">
       <h3 className="text-base font-medium text-foreground">
-        {isClosed ? "Closed store-day record" : "Historical store-day view"}
+        {isClosed
+          ? "Closed store-day record"
+          : isHistoricalOperating
+            ? "Incomplete store-day close"
+            : "Historical store-day view"}
       </h3>
       <div className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
         {isClosed ? (
-          <Button asChild size="sm" variant="outline">
+          <Button
+            asChild
+            className={getPrimaryActionEmphasis("closed").className}
+            size="sm"
+            variant="outline"
+          >
             <Link
               params={buildParams(orgUrlSlug, storeUrlSlug)}
               search={
@@ -1808,6 +1910,15 @@ function HistoricalWorkflowPanel({
               <ArrowUpRight aria-hidden="true" className="h-4 w-4" />
             </Link>
           </Button>
+        ) : isHistoricalOperating ? (
+          <>
+            <p className="text-sm leading-6 text-foreground">
+              This historical store day does not have a completed close.
+            </p>
+            <p className="mt-layout-xs text-sm leading-6 text-muted-foreground">
+              Review EOD before treating this date as a closed store-day record.
+            </p>
+          </>
         ) : (
           <>
             <p className="text-sm leading-6 text-foreground">
@@ -2655,6 +2766,7 @@ function OperatingDatePicker({
       </PopoverTrigger>
       <PopoverContent align="end" className="w-auto p-0">
         <Calendar
+          defaultMonth={selectedDate ?? latestSelectableDate}
           disabled={{ after: latestSelectableDate }}
           mode="single"
           onSelect={(date) => {
@@ -2747,10 +2859,7 @@ function WeekMetricsStrip({
               Seven days ending {formatOperatingDate(weekEndOperatingDate)}
             </span>
             {refreshedAt ? (
-              <span
-                aria-hidden="true"
-                className="hidden sm:inline"
-              >
+              <span aria-hidden="true" className="hidden sm:inline">
                 ·
               </span>
             ) : null}
@@ -3040,6 +3149,16 @@ export function DailyOperationsViewContent({
   const isHistoricalDate = snapshot
     ? isHistoricalOperatingDate(snapshot.operatingDate)
     : false;
+  const primaryActionEmphasisStatus = snapshot
+    ? getPrimaryActionEmphasisStatus({
+        isHistoricalDate,
+        status: snapshot.lifecycle.status,
+      })
+    : undefined;
+  const primaryActionEmphasis = primaryActionEmphasisStatus
+    ? getPrimaryActionEmphasis(primaryActionEmphasisStatus)
+    : null;
+  const PrimaryActionIcon = primaryActionEmphasis?.Icon;
   const storeRequestsApprovalsLane =
     snapshot && storeRequestsSnapshot?.operatingDate === snapshot.operatingDate
       ? storeRequestsSnapshot.approvalsLane
@@ -3047,8 +3166,7 @@ export function DailyOperationsViewContent({
   const operationLanes = snapshot
     ? replaceApprovalsLane(snapshot.lanes, storeRequestsApprovalsLane)
     : [];
-  const pendingApprovalsLane =
-    getPendingApprovalsLaneFromLanes(operationLanes);
+  const pendingApprovalsLane = getPendingApprovalsLaneFromLanes(operationLanes);
   const actionableLanes = operationLanes.filter(isActionableLane);
   const weekMetricsForDisplay =
     snapshot && (hasDetailSnapshot || !cachedWeekMetrics)
@@ -3139,7 +3257,10 @@ export function DailyOperationsViewContent({
                     {showHistoricalEodReviewAction ? (
                       <Button
                         asChild
-                        className="w-full sm:w-auto"
+                        className={cn(
+                          "w-full sm:w-auto",
+                          primaryActionEmphasis?.className,
+                        )}
                         variant="outline"
                       >
                         <Link
@@ -3155,6 +3276,15 @@ export function DailyOperationsViewContent({
                           }
                           to="/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close"
                         >
+                          {PrimaryActionIcon ? (
+                            <PrimaryActionIcon
+                              aria-hidden="true"
+                              className={cn(
+                                "h-3.5 w-3.5",
+                                primaryActionEmphasis.iconClassName,
+                              )}
+                            />
+                          ) : null}
                           Review EOD Review
                           <ArrowUpRight
                             aria-hidden="true"
@@ -3166,7 +3296,10 @@ export function DailyOperationsViewContent({
                     {showPrimaryAction ? (
                       <Button
                         asChild
-                        className="w-full sm:w-auto"
+                        className={cn(
+                          "w-full sm:w-auto",
+                          primaryActionEmphasis?.className,
+                        )}
                         variant="outline"
                       >
                         <Link
@@ -3179,6 +3312,15 @@ export function DailyOperationsViewContent({
                           }
                           to={snapshot.primaryAction.to}
                         >
+                          {PrimaryActionIcon ? (
+                            <PrimaryActionIcon
+                              aria-hidden="true"
+                              className={cn(
+                                "h-3.5 w-3.5",
+                                primaryActionEmphasis.iconClassName,
+                              )}
+                            />
+                          ) : null}
                           {snapshot.primaryAction.label}
                           <ArrowUpRight
                             aria-hidden="true"


### PR DESCRIPTION
## Summary

Daily operations now communicates EOD state more clearly across the app and manager email path. The operations dashboard applies tonal CTA states for blockers, clean close, historical in-progress days, and prepared manager review; the manager report email now uses the unbordered layout by default, includes prepared outcomes, handles open-register cash communication, and keeps follow-up copy written for a solo operator.

This also moves the login CTA onto the workflow action tone and adds the subtle dev indicator in the app chrome.

## Validation

- `bun run test -- convex/emails/DailyManagerReport.test.tsx convex/operations/dailyManagerReportEmail.test.ts convex/operations/dailyOperationsAutomation.test.ts src/components/operations/DailyOperationsView.test.tsx src/components/Navbar.test.tsx src/components/auth/Login/LoginForm.test.tsx src/components/auth/Login/InputOTP.test.tsx src/components/auth/Login/PosRecoveryCodeForm.test.tsx src/components/auth/Login/index.test.tsx`
- `bun run lint && bun run lint:frontend:changed`
- `bun run typecheck`
- `bunx prettier --check ...`
- `bun run build`
- `bun run graphify:rebuild`
- Pre-push validation passed: graphify check, compound check, architecture check, harness review, full Athena and storefront coverage suites, inferential review, daily operations regression suite, production build, and selected runtime behavior scenarios.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)