### PR TITLE
Finalize trusted legacy stock workflows

### DIFF
--- a/docs/solutions/performance-issues/athena-legacy-import-product-row-caps-2026-07-05.md
+++ b/docs/solutions/performance-issues/athena-legacy-import-product-row-caps-2026-07-05.md
@@ -1,0 +1,111 @@
+---
+title: Athena Legacy Import Cleanup Uses Product-Level Row Caps
+date: 2026-07-05
+category: performance-issues
+module: athena-webapp
+problem_type: performance_issue
+component: database
+symptoms:
+  - "Product taxonomy cleanup can accidentally probe every SKU and every active provisional row in one Convex mutation"
+  - "Ordinary product saves can inherit expensive legacy-import guard reads when trusted finalization state is checked SKU-by-SKU"
+root_cause: missing_index
+resolution_type: code_fix
+severity: high
+tags:
+  - convex
+  - inventory-import
+  - product-taxonomy
+  - stock-adjustments
+  - read-amplification
+---
+
+# Athena Legacy Import Cleanup Uses Product-Level Row Caps
+
+## Problem
+
+Legacy import finalization and taxonomy cleanup often start from a product page,
+but the active evidence rows live in `inventoryImportProvisionalSku`. A naive
+implementation walks every `productSku` for the product and then probes active
+provisional rows per SKU, which turns an ordinary product save or taxonomy save
+into a nested read-amplification path.
+
+## Symptoms
+
+- A product with many SKUs could make `products.update` perform thousands of
+  indexed SKU probes before deciding whether a legacy-import taxonomy save is
+  allowed.
+- `completeFinalizedLegacyImportRowsForProductTaxonomyWithCtx` could read a
+  large per-SKU row page for every SKU before completing catalog setup.
+- Reviewer checks correctly flagged that cap-plus-one reads were fail-closed but
+  still too large for a single Convex mutation.
+
+## What Didn't Work
+
+- Adding only a SKU-count overflow guard made correctness fail closed, but it
+  kept the nested SKU loop and left a large read surface in the mutation.
+- Keeping the provisional-row cap at the same 5000-row import finalization limit
+  was appropriate for batch import finalization, but too high for an ordinary
+  product taxonomy cleanup.
+
+## Solution
+
+Index active provisional import rows by store, product, and status:
+
+```ts
+inventoryImportProvisionalSku: defineTable(inventoryImportProvisionalSkuSchema)
+  .index("by_storeId_productId_status", ["storeId", "productId", "status"]);
+```
+
+Use that index for product-level guards and cleanup. Product update only needs
+to know whether active finalized legacy rows exist or whether the bounded row
+page overflowed:
+
+```ts
+const rows = await ctx.db
+  .query("inventoryImportProvisionalSku")
+  .withIndex("by_storeId_productId_status", (q) =>
+    q
+      .eq("storeId", storeId)
+      .eq("productId", productId)
+      .eq("status", "active"),
+  )
+  .take(PRODUCT_UPDATE_LEGACY_FINALIZED_ROW_SCAN_LIMIT + 1);
+```
+
+Catalog taxonomy cleanup uses the same product-level index with a small
+cleanup-specific cap. If the product still has too many active rows to finish in
+one mutation, throw a visible error instead of silently doing partial cleanup or
+reading a large nested set:
+
+```ts
+if (rows.length > CATALOG_TAXONOMY_FINALIZATION_ROW_LIMIT) {
+  throw new Error(
+    "Cannot complete catalog setup because this product has too many active legacy import rows to finalize safely.",
+  );
+}
+```
+
+## Why This Works
+
+The product page is the aggregate boundary for taxonomy setup. Querying active
+legacy rows by product directly matches that boundary and avoids converting a
+product-scoped operation into `productSku * provisionalRows` work. The small
+cap keeps ordinary saves and taxonomy completion within a predictable mutation
+budget while still failing closed when cleanup needs a batched workflow.
+
+## Prevention
+
+- When a Convex mutation is product-scoped, prefer a product-level index over
+  nested per-SKU probes.
+- Keep guard caps separate from batch import caps. Batch import finalization can
+  have a larger explicit import limit; product update and taxonomy cleanup need
+  small caps because they run on ordinary operator saves.
+- Add regression tests for both branches: active finalized row detection and
+  overflow fail-closed behavior.
+- Re-run `bunx convex codegen`, focused Vitest files, `bun run typecheck`, and
+  `bun run graphify:rebuild` after adding a Convex index.
+
+## Related Issues
+
+- `docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md`
+- `docs/solutions/architecture/athena-product-page-single-sku-provisional-trusted-finalization-2026-06-23.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8658 nodes · 10523 edges · 2103 communities detected
+- 8680 nodes · 10572 edges · 2103 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2173,12 +2173,12 @@ Cohesion: 0.09
 Nodes (47): buildLocalSyncEventRecordInput(), canonicalize(), canonicalJson(), createLocalSyncIngestionService(), getLocalSyncCursorIdentity(), getLocalSyncScope(), ingestLocalEventsWithCtx(), isNonEmptyString() (+39 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.05
-Nodes (24): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+16 more)
+Cohesion: 0.08
+Nodes (53): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+45 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.09
-Nodes (48): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+40 more)
+Cohesion: 0.05
+Nodes (24): assertPosLocalStoreOk(), buildRuntimeAppUpdateInput(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+16 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.08
@@ -2210,7 +2210,7 @@ Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecomm
 
 ### Community 17 - "Community 17"
 Cohesion: 0.07
-Nodes (19): Boolean(), buildMissingDraftResult(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemNumberDetail(), getQueueWorkItemStockAdjustmentSkuId(), getQueueWorkItemStringDetail() (+11 more)
+Nodes (20): Boolean(), buildMissingDraftResult(), formatCatalogSetupProductName(), formatQueueWorkItemValue(), formatWorkItemTitle(), getQueueWorkItemInventoryReviewLineCount(), getQueueWorkItemNumberDetail(), getQueueWorkItemStockAdjustmentSkuId() (+12 more)
 
 ### Community 18 - "Community 18"
 Cohesion: 0.09
@@ -2221,52 +2221,52 @@ Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
 ### Community 20 - "Community 20"
+Cohesion: 0.11
+Nodes (34): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), boundedNumber(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildInventoryImportEvidenceSource(), buildPendingCheckoutEvidenceSource() (+26 more)
+
+### Community 21 - "Community 21"
 Cohesion: 0.14
 Nodes (35): asRecord(), calculateLocalSaleExpectedCashDelta(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale() (+27 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.1
 Nodes (24): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildCatalogRepresentedPendingCheckoutProductSignatures(), buildLocalAvailabilityEventIndex(), buildLocalPendingCheckoutDefinitionEventIdsByItemId(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel() (+16 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.11
 Nodes (33): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+25 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.13
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
+Cohesion: 0.1
+Nodes (31): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+23 more)
+
+### Community 26 - "Community 26"
 Cohesion: 0.07
 Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
 
-### Community 25 - "Community 25"
-Cohesion: 0.11
-Nodes (32): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), boundedNumber(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildInventoryImportEvidenceSource(), buildPendingCheckoutEvidenceSource() (+24 more)
-
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.12
 Nodes (27): buildDiagnosticEvidence(), buildTerminalOperationalExplanation(), buildTerminalOperationalState(), buildTerminalRecoveryActions(), buildTerminalRecoveryManualReview(), buildTerminalSupportCleanupActions(), classifySalesReadiness(), classifySupportRecovery() (+19 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.07
 Nodes (11): formatCompactTextList(), formatPaymentMethods(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewTypeSummary(), formatTimestamp() (+3 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.15
 Nodes (27): addDays(), addField(), contextWindowsForDate(), dayOfWeek(), exceptionWindowsOverlap(), findNextWindow(), getFormatter(), getMissingStoreScheduleContext() (+19 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.12
-Nodes (26): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+18 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.16
@@ -2569,196 +2569,196 @@ Cohesion: 0.22
 Nodes (9): buildHistoricalContextEventAppendArgs(), buildHistoricalImportIdempotencyKey(), buildPrimarySubject(), buildStoppedReport(), countOmittedFields(), createEmptyReport(), increment(), planHistoricalStorefrontContextImport() (+1 more)
 
 ### Community 107 - "Community 107"
+Cohesion: 0.3
+Nodes (14): autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx(), conflictError(), findPostReviewStockUpdateWithCtx(), idMetadataValue(), inventoryReviewLocalId(), optionalMetadataMatches(), readLegacyOpenSyncedSaleInventoryReviewWorkItemsWithCtx(), readOpenSyncedSaleInventoryReviewWorkItemsWithCtx() (+6 more)
+
+### Community 108 - "Community 108"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.18
 Nodes (5): buildPendingCheckoutFinalizationPayloadHash(), buildPendingCheckoutSaleEvidenceFingerprint(), buildTrustedSkuFingerprint(), listPendingCheckoutProductPageBindingWithCtx(), stableStringify()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.2
 Nodes (9): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), drawerAuthorityMatchesActiveRegisterSession(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable() (+1 more)
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.3
 Nodes (13): assertApprovalDecisionCanApply(), buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError() (+5 more)
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.22
 Nodes (10): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), getRepairRegisterSessionCloseoutBoundaryAt(), isDuplicateRegisterOpenConflict() (+2 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getStatusesToOrdered() (+5 more)
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.2
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.14
 Nodes (0):
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.18
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 133 - "Community 133"
-Cohesion: 0.22
-Nodes (7): getConversionRequestId(), handleClick(), handleFinalize(), if(), normalizeCommandMessage(), restock(), updateProductVariants()
-
 ### Community 134 - "Community 134"
+Cohesion: 0.26
+Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
+
+### Community 135 - "Community 135"
 Cohesion: 0.18
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.17
 Nodes (2): getNextTransactionPageSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.17
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.18
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 147 - "Community 147"
-Cohesion: 0.29
-Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
-
 ### Community 148 - "Community 148"
+Cohesion: 0.24
+Nodes (7): getConversionRequestId(), handleClick(), handleFinalize(), if(), normalizeCommandMessage(), restock(), updateProductVariants()
+
+### Community 149 - "Community 149"
 Cohesion: 0.33
 Nodes (11): buildSkuActivityUntrustedSalesViewModel(), buildSourceRow(), buildTransactionRow(), capitalizeWords(), formatEvidenceLabel(), formatProductName(), getEmptyMessage(), getLookupLabel() (+3 more)
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.18
 Nodes (2): expenseItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 154 - "Community 154"
-Cohesion: 0.38
-Nodes (10): conflictError(), findPostReviewStockUpdateWithCtx(), idMetadataValue(), inventoryReviewLocalId(), optionalMetadataMatches(), readPositiveCurrentInventoryProofWithCtx(), resolveSyncedSaleInventoryReviewWithCtx(), stringMetadataValue() (+2 more)
 
 ### Community 155 - "Community 155"
 Cohesion: 0.36
@@ -2853,100 +2853,100 @@ Cohesion: 0.27
 Nodes (5): getLocalOperatingDate(), getLocalOperatingDateRange(), getReadinessDiagnosticRows(), getReadinessLoadingBlockers(), POSReadinessLoadingState()
 
 ### Community 178 - "Community 178"
+Cohesion: 0.24
+Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
+
+### Community 179 - "Community 179"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.31
 Nodes (7): architectureSolutionNote(), createFixtureRepo(), gitEnv(), nonFoundationalArchitectureSolutionNote(), runGit(), solutionNote(), write()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.39
 Nodes (7): findActivePendingCheckoutLookupAliasByCode(), firstEvidenceTime(), normalizePendingCheckoutLookupCode(), resolvePendingCheckoutSku(), resolvePendingCheckoutSkuFromItem(), retirePendingCheckoutLookupAliasForItem(), upsertPendingCheckoutLookupAlias()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.47
 Nodes (8): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isPendingCheckoutLookupAliasVisible(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
-
-### Community 201 - "Community 201"
-Cohesion: 0.28
-Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.25
@@ -3013,32 +3013,32 @@ Cohesion: 0.32
 Nodes (4): createProductsQueryCtx(), createSkuMutationCtx(), pendingCheckoutEvidence(), pendingCheckoutItem()
 
 ### Community 218 - "Community 218"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 219 - "Community 219"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 224 - "Community 224"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 225 - "Community 225"
 Cohesion: 0.25
@@ -3049,408 +3049,408 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 228 - "Community 228"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 229 - "Community 229"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 230 - "Community 230"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.43
 Nodes (7): clearAthenaAuthSyncHandoff(), failAthenaAuthSyncHandoff(), getAthenaAuthSyncHandoffStatus(), normalizeAuthSyncRedirect(), parseHandoff(), readRawHandoff(), startAthenaAuthSyncHandoff()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 238 - "Community 238"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.39
-Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 240 - "Community 240"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.39
+Nodes (4): createOptimisticExpenseItemId(), expenseCartItemSourceKey(), expenseLineMatchesProduct(), expenseLineSourceKey()
 
 ### Community 241 - "Community 241"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 242 - "Community 242"
-Cohesion: 0.29
-Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
-
-### Community 243 - "Community 243"
-Cohesion: 0.46
-Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
-
-### Community 244 - "Community 244"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 245 - "Community 245"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 246 - "Community 246"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 243 - "Community 243"
+Cohesion: 0.29
+Nodes (2): hasRegisterOperatorRole(), validateRestoredCashierPresence()
+
+### Community 244 - "Community 244"
+Cohesion: 0.46
+Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
+
+### Community 245 - "Community 245"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 246 - "Community 246"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 247 - "Community 247"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 248 - "Community 248"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.38
 Nodes (3): createAuthorizedRegisterDepositCtx(), createProjectedInventoryReviewQueryCtx(), createQueryCtx()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.48
 Nodes (5): containsSensitiveText(), invalidPayloadMessage(), isPublicContextValue(), validatePayloadValue(), validateRegisteredContextEventPayload()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.43
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.52
 Nodes (5): getBlockingRegisterSessionIdFromConflict(), isRegisterSessionConflict(), resolveScopedRegisterSession(), resolveTerminalRegisterConflict(), resolveTerminalRegisterSessionConflict()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.33
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.48
 Nodes (5): bestEffortRecordPurchaseOrderReceivingTraceWithCtx(), bestEffortRecordPurchaseOrderStatusTraceWithCtx(), compactDetails(), ensurePurchaseOrderTraceWithCtx(), getPurchaseOrderTraceStatusAt()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 270 - "Community 270"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 272 - "Community 272"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 273 - "Community 273"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
-
-### Community 274 - "Community 274"
-Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 275 - "Community 275"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 277 - "Community 277"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 278 - "Community 278"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 279 - "Community 279"
+### Community 280 - "Community 280"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 280 - "Community 280"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 282 - "Community 282"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 283 - "Community 283"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 284 - "Community 284"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 286 - "Community 286"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.52
-Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 288 - "Community 288"
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+
+### Community 289 - "Community 289"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 295 - "Community 295"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 296 - "Community 296"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.6
+Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 298 - "Community 298"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 299 - "Community 299"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.6
 Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 311 - "Community 311"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 313 - "Community 313"
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
+
+### Community 314 - "Community 314"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 315 - "Community 315"
+### Community 316 - "Community 316"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 317 - "Community 317"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.4
-Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 319 - "Community 319"
-Cohesion: 0.47
-Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
 ### Community 320 - "Community 320"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
 ### Community 321 - "Community 321"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 322 - "Community 322"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 323 - "Community 323"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 326 - "Community 326"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 327 - "Community 327"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 328 - "Community 328"
 Cohesion: 0.33
@@ -3461,228 +3461,228 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 330 - "Community 330"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 331 - "Community 331"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 332 - "Community 332"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 331 - "Community 331"
+### Community 333 - "Community 333"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 332 - "Community 332"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 333 - "Community 333"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 334 - "Community 334"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 335 - "Community 335"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 336 - "Community 336"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 335 - "Community 335"
+### Community 337 - "Community 337"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 336 - "Community 336"
+### Community 338 - "Community 338"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 337 - "Community 337"
+### Community 339 - "Community 339"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 338 - "Community 338"
+### Community 340 - "Community 340"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
-### Community 339 - "Community 339"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 340 - "Community 340"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
 ### Community 341 - "Community 341"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 342 - "Community 342"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 343 - "Community 343"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 342 - "Community 342"
+### Community 344 - "Community 344"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 343 - "Community 343"
+### Community 345 - "Community 345"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 344 - "Community 344"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 345 - "Community 345"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 346 - "Community 346"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 347 - "Community 347"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 349 - "Community 349"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 350 - "Community 350"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.53
 Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 360 - "Community 360"
+### Community 361 - "Community 361"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 362 - "Community 362"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 364 - "Community 364"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 365 - "Community 365"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 366 - "Community 366"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 367 - "Community 367"
 Cohesion: 0.6
-Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 368 - "Community 368"
+Cohesion: 0.6
+Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+
+### Community 369 - "Community 369"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
-
-### Community 375 - "Community 375"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 376 - "Community 376"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 377 - "Community 377"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 378 - "Community 378"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 385 - "Community 385"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 386 - "Community 386"
 Cohesion: 0.4
@@ -3697,12 +3697,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 390 - "Community 390"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.4
@@ -3713,20 +3713,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 393 - "Community 393"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 394 - "Community 394"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 395 - "Community 395"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 396 - "Community 396"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 397 - "Community 397"
 Cohesion: 0.4
@@ -3749,80 +3749,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 402 - "Community 402"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 403 - "Community 403"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 404 - "Community 404"
+### Community 405 - "Community 405"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 406 - "Community 406"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 409 - "Community 409"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 410 - "Community 410"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 412 - "Community 412"
+### Community 413 - "Community 413"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 413 - "Community 413"
+### Community 414 - "Community 414"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 414 - "Community 414"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 417 - "Community 417"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 418 - "Community 418"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 420 - "Community 420"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 421 - "Community 421"
 Cohesion: 0.4
@@ -3833,44 +3833,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 423 - "Community 423"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 424 - "Community 424"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 425 - "Community 425"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 426 - "Community 426"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 428 - "Community 428"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 429 - "Community 429"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 430 - "Community 430"
+### Community 431 - "Community 431"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 431 - "Community 431"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 432 - "Community 432"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.4
@@ -3881,72 +3881,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 435 - "Community 435"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 436 - "Community 436"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 438 - "Community 438"
+### Community 439 - "Community 439"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 439 - "Community 439"
+### Community 440 - "Community 440"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 440 - "Community 440"
+### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 441 - "Community 441"
+### Community 442 - "Community 442"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 443 - "Community 443"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 444 - "Community 444"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 445 - "Community 445"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 446 - "Community 446"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 446 - "Community 446"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 448 - "Community 448"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 449 - "Community 449"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 450 - "Community 450"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 451 - "Community 451"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 452 - "Community 452"
 Cohesion: 0.5
@@ -3965,24 +3965,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 456 - "Community 456"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
-
-### Community 457 - "Community 457"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
-
-### Community 458 - "Community 458"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
-
-### Community 459 - "Community 459"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 460 - "Community 460"
+### Community 457 - "Community 457"
 Cohesion: 0.83
-Nodes (3): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), formatOnlineOrderLabel()
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+
+### Community 458 - "Community 458"
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+
+### Community 459 - "Community 459"
+Cohesion: 0.67
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+
+### Community 460 - "Community 460"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2176
-- Graph nodes: 8658
-- Graph edges: 10523
+- Graph nodes: 8680
+- Graph edges: 10572
 - Communities: 2103
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/inventory/catalogImport.test.ts
+++ b/packages/athena-webapp/convex/inventory/catalogImport.test.ts
@@ -11,6 +11,7 @@ vi.mock("./skuSearch", () => ({
 }));
 
 import {
+  completeFinalizedLegacyImportRowsForProductTaxonomyWithCtx,
   finalizeTrustedInventoryFromProductPage,
   finalizeTrustedInventoryFromProductPageWithCtx,
   getLatestInventoryImportReviewVersion,
@@ -39,6 +40,7 @@ type TableName =
   | "inventoryImportProvisionalSku"
   | "inventoryImportReviewVersion"
   | "operationalEvent"
+  | "operationalWorkItem"
   | "product"
   | "productSku"
   | "skuActivityEvent"
@@ -63,6 +65,7 @@ function createMutationCtx(seed: Partial<Record<TableName, Row[]>> = {}) {
     inventoryImportProvisionalSku: new Map(),
     inventoryImportReviewVersion: new Map(),
     operationalEvent: new Map(),
+    operationalWorkItem: new Map(),
     product: new Map(),
     productSku: new Map(),
     skuActivityEvent: new Map(),
@@ -183,8 +186,8 @@ function seedTrustedConversionData(overrides: Partial<Record<TableName, Row[]>> 
     category: [
       {
         _id: "category-1",
-        name: "Hair",
-        slug: "hair",
+        name: "Legacy import",
+        slug: "legacy-import",
         storeId: "store-1",
       },
     ],
@@ -1025,7 +1028,7 @@ describe("catalog import", () => {
     expect(binding).toMatchObject({ activeRowCount: 2, state: "ambiguous" });
   });
 
-  it("finalizes one product-page provisional row with trusted SKU evidence and a real stock movement", async () => {
+  it("keeps one product-page provisional row active after trusted SKU evidence is finalized", async () => {
     const { ctx, tables } = seedTrustedConversionData();
     const binding = await readTrustedConversionBinding(ctx);
 
@@ -1055,6 +1058,9 @@ describe("catalog import", () => {
       inventoryMovementId: "inventoryMovement-1",
       productId: "product-1",
       productSkuId: "sku-1",
+      product: {
+        availability: "live",
+      },
       provisionalSoldQuantity: 2,
       provisionalSkuId: "provisional-1",
       quantityAvailable: 8,
@@ -1070,6 +1076,7 @@ describe("catalog import", () => {
       mockedSkuSearch.upsertProductSkuSearchProjection,
     ).toHaveBeenCalledWith(expect.anything(), "sku-1");
     expect(tables.product.get("product-1")).toMatchObject({
+      availability: "live",
       inventoryCount: 10,
       quantityAvailable: 8,
     });
@@ -1079,8 +1086,28 @@ describe("catalog import", () => {
       finalizationSourceSurface: "product_edit",
       posExposureStatus: "hidden",
       provisionalSoldQuantityAtFinalization: 2,
-      status: "finalized",
+      status: "active",
     });
+    expect(Array.from(tables.operationalWorkItem.values())).toEqual([
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          categorySlug: "legacy-import",
+          productId: "product-1",
+          productName: "Body Wave",
+          productSkuId: "sku-1",
+          provisionalSkuId: "provisional-1",
+          sku: "BW-18",
+          sourceId: "provisional-1",
+          sourceType: "inventoryImportProvisionalSku",
+        }),
+        notes:
+          "Assign an Athena category and subcategory before saving this product.",
+        priority: "medium",
+        status: "open",
+        title: "Assign catalog category: Body Wave",
+        type: "catalog_taxonomy_setup",
+      }),
+    ]);
     expect(Array.from(tables.inventoryMovement.values())).toHaveLength(1);
     expect(Array.from(tables.skuActivityEvent.values())).toEqual(
       expect.arrayContaining([
@@ -1145,6 +1172,7 @@ describe("catalog import", () => {
 
     expect(first).toEqual(second);
     expect(Array.from(tables.inventoryMovement.values())).toHaveLength(1);
+    expect(Array.from(tables.operationalWorkItem.values())).toHaveLength(1);
     expect(Array.from(tables.skuActivityEvent.values())).toHaveLength(2);
   });
 
@@ -1181,7 +1209,7 @@ describe("catalog import", () => {
     });
     expect(tables.inventoryImportProvisionalSku.get("provisional-1")).toMatchObject({
       finalTrustedQuantity: 10,
-      status: "finalized",
+      status: "active",
     });
     expect(Array.from(tables.inventoryMovement.values())).toHaveLength(1);
     expect(Array.from(tables.skuActivityEvent.values())).toHaveLength(2);
@@ -1403,7 +1431,7 @@ describe("catalog import", () => {
       quantityAvailable: 8,
     });
     expect(tables.inventoryImportProvisionalSku.get("provisional-1")).toMatchObject({
-      status: "finalized",
+      status: "active",
     });
   });
 
@@ -1632,6 +1660,77 @@ describe("catalog import", () => {
       quantityAvailable: 2,
     });
     expect(tables.operationalEvent.size).toBe(0);
+  });
+
+  it("rejects taxonomy cleanup when active product rows exceed the finalization cap", async () => {
+    const provisionalRows = Array.from({ length: 26 }, (_, index) => ({
+      _id: `provisional-${index}`,
+      finalTrustedQuantity: 2,
+      finalizedAt: 1_000 + index,
+      productId: "product-1",
+      productSkuId: "sku-1",
+      status: "active",
+      storeId: "store-1",
+    }));
+    const { ctx } = createMutationCtx({
+      category: [
+        {
+          _id: "category-1",
+          name: "Hair",
+          slug: "hair",
+          storeId: "store-1",
+        },
+      ],
+      product: [
+        {
+          _id: "product-1",
+          availability: "live",
+          categoryId: "category-1",
+          createdByUserId: "user-1",
+          currency: "GHS",
+          inventoryCount: 2,
+          name: "Body Wave",
+          organizationId: "org-1",
+          quantityAvailable: 2,
+          slug: "body-wave",
+          storeId: "store-1",
+          subcategoryId: "subcategory-1",
+        },
+      ],
+      inventoryImportProvisionalSku: provisionalRows,
+      productSku: [
+        {
+          _id: "sku-1",
+          barcode: "123456789012",
+          images: [],
+          inventoryCount: 2,
+          price: 30000,
+          productId: "product-1",
+          productName: "Body Wave",
+          quantityAvailable: 2,
+          sku: "BW-18",
+          storeId: "store-1",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-1",
+          categoryId: "category-1",
+          name: "Wigs",
+          slug: "wigs",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    await expect(
+      completeFinalizedLegacyImportRowsForProductTaxonomyWithCtx(ctx, {
+        productId: "product-1" as Id<"product">,
+        storeId: "store-1" as Id<"store">,
+      }),
+    ).rejects.toThrow(
+      "Cannot complete catalog setup because this product has too many active legacy import rows to finalize safely.",
+    );
   });
 
   it("creates hidden catalog identity for new staged rows while keeping imported counts provisional", async () => {

--- a/packages/athena-webapp/convex/inventory/catalogImport.ts
+++ b/packages/athena-webapp/convex/inventory/catalogImport.ts
@@ -18,6 +18,7 @@ import {
 } from "../operations/managerElevations";
 import { recordInventoryMovementWithCtx } from "../operations/inventoryMovements";
 import { recordOperationalEventWithCtx } from "../operations/operationalEvents";
+import { createOperationalWorkItemWithCtx } from "../operations/operationalWorkItems";
 import { recordSkuActivityEventWithCtx } from "../operations/skuActivity";
 import { toSlug } from "../utils";
 import { ok, userError, type CommandResult } from "../../shared/commandResult";
@@ -31,8 +32,15 @@ const REVIEW_VERSION_EVENT_TYPE = "inventory_import_review_version_saved";
 const PROVISIONAL_STAGE_EVENT_TYPE = "inventory_import_provisional_pos_staged";
 const PROVISIONAL_TRUST_FINALIZATION_EVENT_TYPE =
   "inventory_import_provisional_trusted_finalized";
+export const CATALOG_TAXONOMY_SETUP_WORK_ITEM_TYPE = "catalog_taxonomy_setup";
+const CATALOG_TAXONOMY_SETUP_WORK_ITEM_STATUSES = [
+  "open",
+  "in_progress",
+] as const;
 const PROVISIONAL_IMPORT_FINALIZATION_LIMIT = 5000;
+const CATALOG_TAXONOMY_FINALIZATION_ROW_LIMIT = 25;
 const TRUSTED_FINALIZATION_ACTIVE_CHECKOUT_SESSION_LIMIT = 200;
+const DEFAULT_CATEGORY_SLUG = toSlug(DEFAULT_CATEGORY_NAME);
 const TRUSTED_FINALIZATION_CHECKOUT_SESSION_ITEM_LIMIT = 200;
 
 type ProvisionalImportIdentity = {
@@ -184,6 +192,7 @@ export type ProductPageProvisionalSkuBinding =
       activeRowCount: 1;
       row: {
         _id: Id<"inventoryImportProvisionalSku">;
+        finalizedAt?: number;
         importKey: string;
         importedQuantity: number;
         lastPosTransactionId?: Id<"posTransaction">;
@@ -223,6 +232,9 @@ export type ProductPageTrustedInventoryFinalizationArgs = {
 export type ProductPageTrustedInventoryFinalizationResult = {
   finalTrustedQuantity: number;
   inventoryMovementId?: Id<"inventoryMovement">;
+  product?: {
+    availability?: Doc<"product">["availability"];
+  };
   productId: Id<"product">;
   productSkuId: Id<"productSku">;
   provisionalSkuId: Id<"inventoryImportProvisionalSku">;
@@ -1056,6 +1068,7 @@ export async function listProductPageProvisionalSkuBindingWithCtx(
       provisionalSoldQuantity: row.saleEvidence.totalQuantitySold,
       reviewVersionId: row.reviewVersionId,
       reviewVersionNumber: row.reviewVersionNumber,
+      finalizedAt: row.finalizedAt,
       rowKey: row.rowKey,
       rowNumber: row.rowNumber,
       saleCount: row.saleEvidence.saleCount,
@@ -1126,6 +1139,16 @@ export async function finalizeTrustedInventoryFromProductPageWithCtx(
   } = validation.data;
 
   await ctx.db.patch("productSku", normalizedArgs.productSkuId, productSkuPatch);
+  await ctx.db.patch("product", normalizedArgs.productId, {
+    availability: "live",
+  });
+  await ensureCatalogTaxonomySetupWorkForProductWithCtx(ctx, {
+    actorUserId: access.athenaUser._id,
+    productId: normalizedArgs.productId,
+    productSkuId: normalizedArgs.productSkuId,
+    provisionalSkuId: activeRow._id,
+    storeId: normalizedArgs.storeId,
+  });
   await upsertProductSkuSearchProjection(ctx, normalizedArgs.productSkuId);
 
   let inventoryMovementId: Id<"inventoryMovement"> | undefined;
@@ -1166,7 +1189,6 @@ export async function finalizeTrustedInventoryFromProductPageWithCtx(
     hiddenAt: now,
     posExposureStatus: "hidden",
     provisionalSoldQuantityAtFinalization: activeRow.saleEvidence.totalQuantitySold,
-    status: "finalized",
     updatedAt: now,
   });
   await refreshCatalogSummaryWithCtx(ctx, normalizedArgs.storeId);
@@ -1203,6 +1225,235 @@ export async function finalizeTrustedInventoryFromProductPageWithCtx(
   });
 
   return ok(finalizationResult);
+}
+
+async function readProductTaxonomyStateWithCtx(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    productId: Id<"product">;
+    storeId: Id<"store">;
+  },
+) {
+  const product = await ctx.db.get("product", args.productId);
+  if (!product || product.storeId !== args.storeId) return null;
+
+  const [category, subcategory] = await Promise.all([
+    ctx.db.get("category", product.categoryId),
+    ctx.db.get("subcategory", product.subcategoryId),
+  ]);
+
+  const hasAthenaTaxonomy = Boolean(
+    category &&
+      subcategory &&
+      category.storeId === args.storeId &&
+      subcategory.storeId === args.storeId &&
+      subcategory.categoryId === category._id &&
+      category.slug !== DEFAULT_CATEGORY_SLUG,
+  );
+
+  return {
+    category,
+    hasAthenaTaxonomy,
+    product,
+    subcategory,
+  };
+}
+
+async function findCurrentCatalogTaxonomySetupWorkItemsWithCtx(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    productId: Id<"product">;
+    storeId: Id<"store">;
+  },
+) {
+  const lanes = await Promise.all(
+    CATALOG_TAXONOMY_SETUP_WORK_ITEM_STATUSES.map((status) =>
+      ctx.db
+        .query("operationalWorkItem")
+        .withIndex("by_storeId_type_status_productId", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("type", CATALOG_TAXONOMY_SETUP_WORK_ITEM_TYPE)
+            .eq("status", status)
+            .eq("productId", args.productId),
+        )
+        .take(CATALOG_TAXONOMY_SETUP_WORK_ITEM_STATUSES.length + 1),
+    ),
+  );
+
+  return lanes.flat();
+}
+
+export async function ensureCatalogTaxonomySetupWorkForProductWithCtx(
+  ctx: MutationCtx,
+  args: {
+    actorUserId?: Id<"athenaUser">;
+    productId: Id<"product">;
+    productSkuId?: Id<"productSku">;
+    provisionalSkuId?: Id<"inventoryImportProvisionalSku">;
+    storeId: Id<"store">;
+  },
+) {
+  const taxonomyState = await readProductTaxonomyStateWithCtx(ctx, args);
+  if (!taxonomyState || taxonomyState.hasAthenaTaxonomy) return null;
+
+  const { category, product, subcategory } = taxonomyState;
+  const productSku = args.productSkuId
+    ? await ctx.db.get("productSku", args.productSkuId)
+    : null;
+  const now = Date.now();
+  const title = `Assign catalog category: ${product.name}`;
+  const metadata = {
+    categorySlug: category?.slug,
+    productId: product._id,
+    productName: product.name,
+    productSkuId: args.productSkuId,
+    provisionalSkuId: args.provisionalSkuId,
+    sku: productSku?.sku,
+    sourceId: args.provisionalSkuId,
+    sourceType: "inventoryImportProvisionalSku",
+    subcategorySlug: subcategory?.slug,
+  };
+
+  const existingWorkItems =
+    await findCurrentCatalogTaxonomySetupWorkItemsWithCtx(ctx, args);
+  const existingWorkItem = existingWorkItems[0];
+  if (existingWorkItem) {
+    await ctx.db.patch("operationalWorkItem", existingWorkItem._id, {
+      metadata: {
+        ...(existingWorkItem.metadata ?? {}),
+        ...metadata,
+        refreshedAt: now,
+      },
+      priority: "medium",
+      title,
+    });
+
+    return ctx.db.get("operationalWorkItem", existingWorkItem._id);
+  }
+
+  const workItem = await createOperationalWorkItemWithCtx(ctx, {
+    createdByUserId: args.actorUserId,
+    metadata,
+    notes: "Assign an Athena category and subcategory before saving this product.",
+    organizationId: product.organizationId,
+    priority: "medium",
+    productId: product._id,
+    productSkuId: args.productSkuId,
+    status: "open",
+    storeId: args.storeId,
+    title,
+    type: CATALOG_TAXONOMY_SETUP_WORK_ITEM_TYPE,
+  });
+
+  if (workItem) {
+    await recordOperationalEventWithCtx(ctx, {
+      actorUserId: args.actorUserId,
+      eventType: "catalog_taxonomy_setup_work_created",
+      message: "Catalog setup work opened.",
+      metadata: {
+        productId: product._id,
+        productSkuId: args.productSkuId,
+        provisionalSkuId: args.provisionalSkuId,
+      },
+      organizationId: product.organizationId,
+      storeId: args.storeId,
+      subjectId: product._id,
+      subjectLabel: product.name,
+      subjectType: "product",
+      workItemId: workItem._id,
+    });
+  }
+
+  return workItem;
+}
+
+export async function completeCatalogTaxonomySetupWorkForProductWithCtx(
+  ctx: MutationCtx,
+  args: {
+    productId: Id<"product">;
+    storeId: Id<"store">;
+  },
+) {
+  const taxonomyState = await readProductTaxonomyStateWithCtx(ctx, args);
+  if (!taxonomyState || !taxonomyState.hasAthenaTaxonomy) return 0;
+
+  const workItems = await findCurrentCatalogTaxonomySetupWorkItemsWithCtx(
+    ctx,
+    args,
+  );
+  const now = Date.now();
+
+  for (const workItem of workItems) {
+    await ctx.db.patch("operationalWorkItem", workItem._id, {
+      completedAt: now,
+      metadata: {
+        ...(workItem.metadata ?? {}),
+        completedReason: "athena_taxonomy_applied",
+      },
+      status: "completed",
+    });
+
+    await recordOperationalEventWithCtx(ctx, {
+      actorType: "automation",
+      eventType: "catalog_taxonomy_setup_work_completed",
+      message: "Catalog setup work completed.",
+      metadata: {
+        productId: taxonomyState.product._id,
+        workItemId: workItem._id,
+      },
+      organizationId: taxonomyState.product.organizationId,
+      storeId: args.storeId,
+      subjectId: taxonomyState.product._id,
+      subjectLabel: taxonomyState.product.name,
+      subjectType: "product",
+      workItemId: workItem._id,
+    });
+  }
+
+  return workItems.length;
+}
+
+export async function completeFinalizedLegacyImportRowsForProductTaxonomyWithCtx(
+  ctx: MutationCtx,
+  args: {
+    productId: Id<"product">;
+    storeId: Id<"store">;
+  },
+) {
+  const taxonomyState = await readProductTaxonomyStateWithCtx(ctx, args);
+  if (!taxonomyState || !taxonomyState.hasAthenaTaxonomy) return 0;
+
+  const rows = await ctx.db
+    .query("inventoryImportProvisionalSku")
+    .withIndex("by_storeId_productId_status", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("productId", args.productId)
+        .eq("status", "active"),
+    )
+    .take(CATALOG_TAXONOMY_FINALIZATION_ROW_LIMIT + 1);
+
+  if (rows.length > CATALOG_TAXONOMY_FINALIZATION_ROW_LIMIT) {
+    throw new Error(
+      "Cannot complete catalog setup because this product has too many active legacy import rows to finalize safely.",
+    );
+  }
+
+  const now = Date.now();
+  let completedCount = 0;
+
+  for (const row of rows) {
+    if (row.finalizedAt === undefined) continue;
+
+    await ctx.db.patch("inventoryImportProvisionalSku", row._id, {
+      status: "finalized",
+      updatedAt: now,
+    });
+    completedCount += 1;
+  }
+
+  return completedCount;
 }
 
 async function validateProductPageTrustedInventoryFinalization(
@@ -1338,6 +1589,9 @@ async function validateProductPageTrustedInventoryFinalization(
   });
   const finalizationResultBase = {
     finalTrustedQuantity: args.reviewedInventoryCount,
+    product: {
+      availability: "live" as const,
+    },
     productId: args.productId,
     productSkuId: args.productSkuId,
     provisionalSkuId: args.provisionalSkuId,

--- a/packages/athena-webapp/convex/inventory/products.sku.test.ts
+++ b/packages/athena-webapp/convex/inventory/products.sku.test.ts
@@ -45,6 +45,7 @@ type TableName =
   | "catalogSummary"
   | "category"
   | "inventoryHold"
+  | "inventoryImportProvisionalSku"
   | "operationalEvent"
   | "operationalWorkItem"
   | "posPendingCheckoutItem"
@@ -136,6 +137,9 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
     inventoryHold: new Map(
       (seed.inventoryHold ?? []).map((row) => [row._id, row]),
     ),
+    inventoryImportProvisionalSku: new Map(
+      (seed.inventoryImportProvisionalSku ?? []).map((row) => [row._id, row]),
+    ),
     operationalEvent: new Map(
       (seed.operationalEvent ?? []).map((row) => [row._id, row]),
     ),
@@ -153,6 +157,7 @@ function createSkuMutationCtx(seed: Partial<Record<TableName, Row[]>>) {
     catalogSummary: seed.catalogSummary?.length ?? 0,
     category: 0,
     inventoryHold: seed.inventoryHold?.length ?? 0,
+    inventoryImportProvisionalSku: seed.inventoryImportProvisionalSku?.length ?? 0,
     operationalEvent: seed.operationalEvent?.length ?? 0,
     operationalWorkItem: seed.operationalWorkItem?.length ?? 0,
     posPendingCheckoutItem: seed.posPendingCheckoutItem?.length ?? 0,
@@ -1217,6 +1222,469 @@ describe("product archiving", () => {
       needsRefresh: false,
       productCount: 1,
       storeId: "storezzzz",
+    });
+  });
+
+  it("completes finalized legacy import review rows when product taxonomy leaves legacy import", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "storezzzz",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional001",
+          finalTrustedQuantity: 5,
+          finalizedAt: 1_000,
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "active",
+          storeId: "storezzzz",
+        },
+      ],
+      operationalWorkItem: [
+        {
+          _id: "taxonomy-work-001",
+          approvalState: "not_required",
+          createdAt: 1_000,
+          metadata: {
+            categorySlug: "legacy-import",
+            productId: "product001",
+            productSkuId: "sku001",
+            provisionalSkuId: "provisional001",
+          },
+          organizationId: "org0001",
+          priority: "medium",
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "open",
+          storeId: "storezzzz",
+          title: "Assign catalog category: Quick And Go Bonding Glue",
+          type: "catalog_taxonomy_setup",
+        },
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "draft",
+          categoryId: "category-legacy",
+          name: "Quick And Go Bonding Glue",
+          organizationId: "org0001",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-protectant",
+          categoryId: "category-hair",
+          name: "Heat Protectant",
+          slug: "heat-protectant",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(update)(ctx, {
+      categoryId: "category-hair" as Id<"category">,
+      id: "product001" as Id<"product">,
+      subcategoryId: "subcategory-protectant" as Id<"subcategory">,
+    });
+
+    expect(tables.inventoryImportProvisionalSku.get("provisional001")).toMatchObject({
+      status: "finalized",
+      updatedAt: expect.any(Number),
+    });
+    expect(tables.operationalWorkItem.get("taxonomy-work-001")).toMatchObject({
+      completedAt: expect.any(Number),
+      metadata: expect.objectContaining({
+        completedReason: "athena_taxonomy_applied",
+        productId: "product001",
+      }),
+      status: "completed",
+    });
+  });
+
+  it("rejects finalized legacy import review row saves when taxonomy remains legacy import", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      category: [
+        {
+          _id: "category-legacy",
+          name: "Legacy import",
+          slug: "legacy-import",
+          storeId: "storezzzz",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional001",
+          finalTrustedQuantity: 5,
+          finalizedAt: 1_000,
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "active",
+          storeId: "storezzzz",
+        },
+      ],
+      operationalWorkItem: [
+        {
+          _id: "taxonomy-work-001",
+          approvalState: "not_required",
+          createdAt: 1_000,
+          metadata: {
+            categorySlug: "legacy-import",
+            productId: "product001",
+            productSkuId: "sku001",
+            provisionalSkuId: "provisional001",
+          },
+          organizationId: "org0001",
+          priority: "medium",
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "open",
+          storeId: "storezzzz",
+          title: "Assign catalog category: Quick And Go Bonding Glue",
+          type: "catalog_taxonomy_setup",
+        },
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "draft",
+          categoryId: "category-legacy",
+          name: "Quick And Go Bonding Glue",
+          organizationId: "org0001",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-legacy",
+          categoryId: "category-legacy",
+          name: "872",
+          slug: "872",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(update)(ctx, {
+        categoryId: "category-legacy" as Id<"category">,
+        id: "product001" as Id<"product">,
+        subcategoryId: "subcategory-legacy" as Id<"subcategory">,
+      }),
+    ).rejects.toThrow(
+      "Catalog setup required. Assign an Athena category and subcategory before saving.",
+    );
+
+    expect(tables.inventoryImportProvisionalSku.get("provisional001")).toMatchObject({
+      status: "active",
+    });
+    expect(tables.operationalWorkItem.get("taxonomy-work-001")).toMatchObject({
+      status: "open",
+    });
+  });
+
+  it("skips legacy import taxonomy cleanup when non-taxonomy product fields change", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "storezzzz",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional001",
+          finalTrustedQuantity: 5,
+          finalizedAt: 1_000,
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "active",
+          storeId: "storezzzz",
+        },
+      ],
+      operationalWorkItem: [
+        {
+          _id: "taxonomy-work-001",
+          approvalState: "not_required",
+          createdAt: 1_000,
+          metadata: {
+            productId: "product001",
+            productSkuId: "sku001",
+          },
+          organizationId: "org0001",
+          priority: "medium",
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "open",
+          storeId: "storezzzz",
+          title: "Assign catalog category: Quick And Go Bonding Glue",
+          type: "catalog_taxonomy_setup",
+        },
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          categoryId: "category-hair",
+          name: "Quick And Go Bonding Glue",
+          organizationId: "org0001",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-protectant",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          productName: "Quick And Go Bonding Glue",
+          storeId: "storezzzz",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-protectant",
+          categoryId: "category-hair",
+          name: "Heat Protectant",
+          slug: "heat-protectant",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(update)(ctx, {
+      id: "product001" as Id<"product">,
+      name: "Quick & Go Bonding Glue",
+    });
+
+    expect(tables.inventoryImportProvisionalSku.get("provisional001")).toMatchObject({
+      status: "active",
+    });
+    expect(tables.operationalWorkItem.get("taxonomy-work-001")).toMatchObject({
+      status: "open",
+    });
+  });
+
+  it("blocks non-taxonomy saves after trusted inventory is finalized for legacy import rows", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      category: [
+        {
+          _id: "category-legacy",
+          name: "Legacy import",
+          slug: "legacy-import",
+          storeId: "storezzzz",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional001",
+          finalTrustedQuantity: 5,
+          finalizedAt: 1_000,
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "active",
+          storeId: "storezzzz",
+        },
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          categoryId: "category-legacy",
+          name: "Quick And Go Bonding Glue",
+          organizationId: "org0001",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          productName: "Quick And Go Bonding Glue",
+          storeId: "storezzzz",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-legacy",
+          categoryId: "category-legacy",
+          name: "872",
+          slug: "872",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(update)(ctx, {
+        id: "product001" as Id<"product">,
+        name: "Quick & Go Bonding Glue",
+      }),
+    ).rejects.toThrow(
+      "Catalog setup required. Assign an Athena category and subcategory before saving.",
+    );
+
+    expect(tables.product.get("product001")).toMatchObject({
+      name: "Quick And Go Bonding Glue",
+    });
+    expect(tables.productSku.get("sku001")).toMatchObject({
+      productName: "Quick And Go Bonding Glue",
+    });
+  });
+
+  it("fails closed when finalized legacy import row checks exceed the product SKU cap", async () => {
+    const productSkus = Array.from({ length: 5_001 }, (_, index) => ({
+      _id: `sku-${index}`,
+      productId: "product001",
+      productName: "Quick And Go Bonding Glue",
+      storeId: "storezzzz",
+    }));
+    const { ctx, tables } = createSkuMutationCtx({
+      category: [
+        {
+          _id: "category-legacy",
+          name: "Legacy import",
+          slug: "legacy-import",
+          storeId: "storezzzz",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-overflow",
+          finalTrustedQuantity: 5,
+          finalizedAt: 1_000,
+          productId: "product001",
+          productSkuId: "sku-5000",
+          status: "active",
+          storeId: "storezzzz",
+        },
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          categoryId: "category-legacy",
+          name: "Quick And Go Bonding Glue",
+          organizationId: "org0001",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: productSkus,
+      subcategory: [
+        {
+          _id: "subcategory-legacy",
+          categoryId: "category-legacy",
+          name: "872",
+          slug: "872",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(update)(ctx, {
+        id: "product001" as Id<"product">,
+        name: "Quick & Go Bonding Glue",
+      }),
+    ).rejects.toThrow(
+      "Catalog setup required. Assign an Athena category and subcategory before saving.",
+    );
+
+    expect(tables.product.get("product001")).toMatchObject({
+      name: "Quick And Go Bonding Glue",
+    });
+    expect(tables.productSku.get("sku-5000")).toMatchObject({
+      productName: "Quick And Go Bonding Glue",
+    });
+  });
+
+  it("fails closed when active legacy import rows exceed the per-SKU product update cap", async () => {
+    const provisionalRows = Array.from({ length: 26 }, (_, index) => ({
+      _id: `provisional-${index}`,
+      productId: "product001",
+      productSkuId: "sku001",
+      status: "active",
+      storeId: "storezzzz",
+    }));
+    const { ctx, tables } = createSkuMutationCtx({
+      category: [
+        {
+          _id: "category-legacy",
+          name: "Legacy import",
+          slug: "legacy-import",
+          storeId: "storezzzz",
+        },
+      ],
+      inventoryImportProvisionalSku: provisionalRows,
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          categoryId: "category-legacy",
+          name: "Quick And Go Bonding Glue",
+          organizationId: "org0001",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          productName: "Quick And Go Bonding Glue",
+          storeId: "storezzzz",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-legacy",
+          categoryId: "category-legacy",
+          name: "872",
+          slug: "872",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(update)(ctx, {
+        id: "product001" as Id<"product">,
+        name: "Quick & Go Bonding Glue",
+      }),
+    ).rejects.toThrow(
+      "Catalog setup required. Assign an Athena category and subcategory before saving.",
+    );
+
+    expect(tables.product.get("product001")).toMatchObject({
+      name: "Quick And Go Bonding Glue",
+    });
+    expect(tables.productSku.get("sku001")).toMatchObject({
+      productName: "Quick And Go Bonding Glue",
     });
   });
 

--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -29,8 +29,66 @@ import {
   ensurePendingCheckoutReviewWorkForUnarchivedProduct,
   retirePendingCheckoutReviewWorkForArchivedProduct,
 } from "../pos/application/commands/pendingCheckoutReviewWorkLifecycle";
+import {
+  completeCatalogTaxonomySetupWorkForProductWithCtx,
+  completeFinalizedLegacyImportRowsForProductTaxonomyWithCtx,
+} from "./catalogImport";
 
 const entity = "product";
+const LEGACY_IMPORT_CATEGORY_SLUG = "legacy-import";
+const PRODUCT_UPDATE_LEGACY_FINALIZED_ROW_SCAN_LIMIT = 25;
+
+async function hasAthenaTaxonomyWithCtx(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    categoryId?: Id<"category">;
+    storeId: Id<"store">;
+    subcategoryId?: Id<"subcategory">;
+  },
+) {
+  if (!args.categoryId || !args.subcategoryId) return false;
+
+  const [category, subcategory] = await Promise.all([
+    ctx.db.get("category", args.categoryId),
+    ctx.db.get("subcategory", args.subcategoryId),
+  ]);
+
+  return Boolean(
+    category &&
+      subcategory &&
+      category.storeId === args.storeId &&
+      subcategory.storeId === args.storeId &&
+      subcategory.categoryId === category._id &&
+      category.slug !== LEGACY_IMPORT_CATEGORY_SLUG,
+  );
+}
+
+async function hasActiveFinalizedLegacyImportRowsForProductWithCtx(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  args: {
+    productId: Id<"product">;
+    storeId: Id<"store">;
+  },
+) {
+  const rows = await ctx.db
+    .query("inventoryImportProvisionalSku")
+    .withIndex("by_storeId_productId_status", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("productId", args.productId)
+        .eq("status", "active"),
+    )
+    .take(PRODUCT_UPDATE_LEGACY_FINALIZED_ROW_SCAN_LIMIT + 1);
+
+  if (
+    rows.some((row) => row.finalizedAt !== undefined) ||
+    rows.length > PRODUCT_UPDATE_LEGACY_FINALIZED_ROW_SCAN_LIMIT
+  ) {
+    return true;
+  }
+
+  return false;
+}
 
 function generateSKU({
   storeId,
@@ -993,6 +1051,33 @@ export const update = mutation({
   handler: async (ctx, args) => {
     const { id, ...rest } = args;
     const productBefore = await ctx.db.get("product", args.id);
+    const taxonomyChanged =
+      productBefore &&
+      ((args.categoryId !== undefined &&
+        args.categoryId !== productBefore.categoryId) ||
+        (args.subcategoryId !== undefined &&
+          args.subcategoryId !== productBefore.subcategoryId));
+    if (productBefore) {
+      const nextCategoryId = args.categoryId ?? productBefore.categoryId;
+      const nextSubcategoryId =
+        args.subcategoryId ?? productBefore.subcategoryId;
+      const hasAthenaTaxonomy = await hasAthenaTaxonomyWithCtx(ctx, {
+        categoryId: nextCategoryId,
+        storeId: productBefore.storeId,
+        subcategoryId: nextSubcategoryId,
+      });
+      if (
+        !hasAthenaTaxonomy &&
+        (await hasActiveFinalizedLegacyImportRowsForProductWithCtx(ctx, {
+          productId: productBefore._id,
+          storeId: productBefore.storeId,
+        }))
+      ) {
+        throw new Error(
+          "Catalog setup required. Assign an Athena category and subcategory before saving.",
+        );
+      }
+    }
 
     if (args.name) {
       const allSkus = await ctx.db
@@ -1008,6 +1093,19 @@ export const update = mutation({
     }
 
     await ctx.db.patch("product", args.id, { ...rest });
+    if (taxonomyChanged) {
+      const productAfterPatch = await ctx.db.get("product", args.id);
+      if (productAfterPatch) {
+        await completeFinalizedLegacyImportRowsForProductTaxonomyWithCtx(ctx, {
+          productId: productAfterPatch._id,
+          storeId: productAfterPatch.storeId,
+        });
+        await completeCatalogTaxonomySetupWorkForProductWithCtx(ctx, {
+          productId: productAfterPatch._id,
+          storeId: productAfterPatch.storeId,
+        });
+      }
+    }
     await refreshProductSkuSearchForProduct(ctx, args.id);
 
     const product = await ctx.db.get("product", args.id);

--- a/packages/athena-webapp/convex/operations/approvalRequests.test.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.test.ts
@@ -214,6 +214,7 @@ function createApprovalRequestMutationCtx(args: {
     if (
       table === "inventoryMovement" ||
       table === "operationalEvent" ||
+      table === "operationalWorkItem" ||
       table === "skuActivityEvent"
     ) {
       return {
@@ -242,6 +243,12 @@ function createApprovalRequestMutationCtx(args: {
               Array.from(tables[table].values()).find((record) =>
                 filters.every(([field, value]) => record[field] === value),
               ) ?? null,
+            take: async (limit: number) =>
+              Array.from(tables[table].values())
+                .filter((record) =>
+                  filters.every(([field, value]) => record[field] === value),
+                )
+                .slice(0, limit),
           };
         },
       };

--- a/packages/athena-webapp/convex/operations/helpers/eventBuilders.test.ts
+++ b/packages/athena-webapp/convex/operations/helpers/eventBuilders.test.ts
@@ -49,4 +49,24 @@ describe("buildOperationalEventMessage", () => {
       ).toBe(expectedMessage);
     }
   });
+
+  it("uses operator-friendly copy for stock adjustment decision events", () => {
+    const expectedMessages: Record<string, string> = {
+      stock_adjustment_approved: "Stock adjustment approved for 1 SKU.",
+      stock_adjustment_cancelled: "Stock adjustment cancelled for 1 SKU.",
+      stock_adjustment_rejected: "Stock adjustment rejected for 1 SKU.",
+    };
+
+    for (const [eventType, expectedMessage] of Object.entries(
+      expectedMessages,
+    )) {
+      expect(
+        buildOperationalEventMessage({
+          eventType,
+          subjectLabel: "Stock adjustment review · 1 SKU",
+          subjectType: "stock_adjustment_batch",
+        }),
+      ).toBe(expectedMessage);
+    }
+  });
 });

--- a/packages/athena-webapp/convex/operations/helpers/eventBuilders.ts
+++ b/packages/athena-webapp/convex/operations/helpers/eventBuilders.ts
@@ -13,6 +13,15 @@ export function buildOperationalEventMessage(args: {
     return onlineOrderMessage;
   }
 
+  const stockAdjustmentMessage = buildStockAdjustmentOperationalEventMessage({
+    eventType: args.eventType,
+    subject,
+  });
+
+  if (stockAdjustmentMessage) {
+    return stockAdjustmentMessage;
+  }
+
   return `${args.eventType} on ${subject}`;
 }
 
@@ -67,6 +76,37 @@ export function buildOnlineOrderOperationalEventMessage(args: {
   }
 
   return template(formatOnlineOrderLabel(args.subject));
+}
+
+const STOCK_ADJUSTMENT_EVENT_MESSAGE_TEMPLATES: Record<
+  string,
+  (subjectDetail: string) => string
+> = {
+  stock_adjustment_approved: (subjectDetail) =>
+    `Stock adjustment approved${subjectDetail}.`,
+  stock_adjustment_cancelled: (subjectDetail) =>
+    `Stock adjustment cancelled${subjectDetail}.`,
+  stock_adjustment_rejected: (subjectDetail) =>
+    `Stock adjustment rejected${subjectDetail}.`,
+};
+
+export function buildStockAdjustmentOperationalEventMessage(args: {
+  eventType: string;
+  subject: string;
+}) {
+  const template = STOCK_ADJUSTMENT_EVENT_MESSAGE_TEMPLATES[args.eventType];
+
+  if (!template) {
+    return null;
+  }
+
+  return template(formatStockAdjustmentSubjectDetail(args.subject));
+}
+
+function formatStockAdjustmentSubjectDetail(subject: string) {
+  const [, detail] = subject.split("·").map((part) => part.trim());
+
+  return detail ? ` for ${detail}` : "";
 }
 
 function formatOnlineOrderLabel(subject: string) {

--- a/packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts
+++ b/packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts
@@ -4,6 +4,7 @@ import type { Doc, Id } from "../_generated/dataModel";
 import * as athenaUserAuth from "../lib/athenaUserAuth";
 import { assertConformsToExportedReturns } from "../lib/returnValidatorContract";
 import {
+  autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx,
   resolveSyncedSaleInventoryReview,
   resolveSyncedSaleInventoryReviewWithCtx,
 } from "./openWorkInventoryReviews";
@@ -33,6 +34,171 @@ beforeEach(() => {
 });
 
 describe("resolveSyncedSaleInventoryReviewWithCtx", () => {
+  it("auto-resolves matching synced sale inventory review work from applied stock movements", async () => {
+    const ctx = buildCtx();
+
+    const result =
+      await autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx(
+        ctx as never,
+        {
+          actorUserId: "user-1" as Id<"athenaUser">,
+          inventoryMovements: [buildInventoryMovement()],
+          organizationId: "org-1" as Id<"organization">,
+          stockAdjustmentBatchId: "batch-1" as Id<"stockAdjustmentBatch">,
+          storeId: "store-1" as Id<"store">,
+        },
+      );
+
+    expect(result).toEqual({ resolvedCount: 1 });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-item-1",
+      expect.objectContaining({
+        completedAt: 1_772_550_000_000,
+        metadata: expect.objectContaining({
+          resolution: expect.objectContaining({
+            actorUserId: "user-1",
+            authority: {
+              kind: "system",
+              reason: "stock_adjustment_applied",
+            },
+            domainTrace: {
+              boundary:
+                "operations.openWorkInventoryReviews.autoResolveSyncedSaleInventoryReviewsForStockAdjustment",
+              inventoryMovementId: "movement-1",
+              proofKind: "stock_update_movement",
+              stockAdjustmentBatchId: "batch-1",
+            },
+            outcome: "completed",
+            reason: "Resolved by applied stock adjustment.",
+            stockUpdate: expect.objectContaining({
+              inventoryMovementId: "movement-1",
+              productSkuId: "sku-1",
+            }),
+          }),
+        }),
+        status: "completed",
+      }),
+    );
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "operationalEvent",
+      expect.objectContaining({
+        eventType: "synced_sale_inventory_review_completed",
+        message: "Synced sale inventory review completed by stock adjustment.",
+        subjectId: "work-item-1",
+      }),
+    );
+  });
+
+  it("auto-resolves in-progress synced sale inventory review work", async () => {
+    const ctx = buildCtx({
+      operationalWorkItem: buildWorkItem({ status: "in_progress" }),
+    });
+
+    const result =
+      await autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx(
+        ctx as never,
+        {
+          inventoryMovements: [buildInventoryMovement()],
+          stockAdjustmentBatchId: "batch-1" as Id<"stockAdjustmentBatch">,
+          storeId: "store-1" as Id<"store">,
+        },
+      );
+
+    expect(result).toEqual({ resolvedCount: 1 });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-item-1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          resolution: expect.objectContaining({
+            priorState: { status: "in_progress" },
+          }),
+        }),
+        status: "completed",
+      }),
+    );
+  });
+
+  it("auto-resolves legacy synced sale inventory review work keyed only by metadata", async () => {
+    const ctx = buildCtx({
+      operationalWorkItem: buildWorkItem({ productSkuId: undefined }),
+    });
+
+    const result =
+      await autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx(
+        ctx as never,
+        {
+          inventoryMovements: [buildInventoryMovement()],
+          stockAdjustmentBatchId: "batch-1" as Id<"stockAdjustmentBatch">,
+          storeId: "store-1" as Id<"store">,
+        },
+      );
+
+    expect(result).toEqual({ resolvedCount: 1 });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "operationalWorkItem",
+      "work-item-1",
+      expect.objectContaining({
+        status: "completed",
+      }),
+    );
+  });
+
+  it.each([
+    ["older than the work item", buildInventoryMovement({ createdAt: 0 })],
+    [
+      "not from a stock adjustment batch",
+      buildInventoryMovement({ sourceType: "manual_review" }),
+    ],
+    ["not an adjustment movement", buildInventoryMovement({ movementType: "sale" })],
+    ["missing a product SKU", buildInventoryMovement({ productSkuId: undefined })],
+  ] as Array<[string, Doc<"inventoryMovement">]>)(
+    "does not auto-resolve when the stock movement is %s",
+    async (_caseName, movement) => {
+      const ctx = buildCtx();
+
+      const result =
+        await autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx(
+          ctx as never,
+          {
+            inventoryMovements: [movement],
+            stockAdjustmentBatchId: "batch-1" as Id<"stockAdjustmentBatch">,
+            storeId: "store-1" as Id<"store">,
+          },
+        );
+
+      expect(result).toEqual({ resolvedCount: 0 });
+      expect(ctx.db.patch).not.toHaveBeenCalled();
+      expect(ctx.db.insert).not.toHaveBeenCalled();
+    },
+  );
+
+  it("skips auto-resolution probing when too many SKUs are adjusted at once", async () => {
+    const ctx = buildCtx();
+    const inventoryMovements = Array.from({ length: 101 }, (_, index) =>
+      buildInventoryMovement({
+        _id: `movement-${index}` as Id<"inventoryMovement">,
+        productSkuId: `sku-${index}` as Id<"productSku">,
+      }),
+    );
+
+    const result =
+      await autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx(
+        ctx as never,
+        {
+          inventoryMovements,
+          stockAdjustmentBatchId: "batch-1" as Id<"stockAdjustmentBatch">,
+          storeId: "store-1" as Id<"store">,
+        },
+      );
+
+    expect(result).toEqual({ resolvedCount: 0 });
+    expect(ctx.db.query).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
   it("resolves current synced sale inventory review work after the affected SKU has a stock update", async () => {
     const ctx = buildCtx();
 
@@ -522,6 +688,15 @@ function buildCtx(seed: BuildCtxSeed = {}) {
             ? row
             : null;
         }),
+        take: vi.fn(async () => {
+          const row = rows[tableName as keyof typeof rows];
+          if (!row) return [];
+          return Object.entries(constraints).every(
+            ([field, value]) => row[field as keyof typeof row] === value,
+          )
+            ? [row]
+            : [];
+        }),
         unique: vi.fn(async () => {
           const row = rows[tableName as keyof typeof rows];
           if (!row) return null;
@@ -597,6 +772,7 @@ function buildWorkItem(
     },
     organizationId: "org-1" as Id<"organization">,
     priority: "high",
+    productSkuId: "sku-1" as Id<"productSku">,
     status: "open",
     storeId: "store-1" as Id<"store">,
     title: "Review inventory for Wig Cap",

--- a/packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts
+++ b/packages/athena-webapp/convex/operations/openWorkInventoryReviews.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 
-import type { Id, TableNames } from "../_generated/dataModel";
+import type { Doc, Id, TableNames } from "../_generated/dataModel";
 import { mutation, type MutationCtx } from "../_generated/server";
 import { commandResultValidator } from "../lib/commandResultValidators";
 import {
@@ -15,6 +15,10 @@ const INVENTORY_REVIEW_LOCAL_ID_KIND = "inventoryReviewWorkItem";
 const TERMINAL_STATUSES = new Set(["completed", "cancelled"]);
 const STOCK_UPDATE_SOURCE_TYPE = "stock_adjustment_batch";
 const STOCK_UPDATE_MOVEMENT_TYPES = new Set(["adjustment", "cycle_count"]);
+const AUTO_RESOLVE_STOCK_REVIEW_SCAN_LIMIT = 500;
+const AUTO_RESOLVE_STOCK_REVIEW_SKU_PROBE_LIMIT = 100;
+const AUTO_RESOLVE_STOCK_REVIEW_REASON =
+  "Resolved by applied stock adjustment.";
 
 const syncedSaleInventoryReviewOutcomeValidator = v.union(
   v.literal("completed"),
@@ -48,6 +52,14 @@ type ResolveSyncedSaleInventoryReviewData = {
   outcome: SyncedSaleInventoryReviewOutcome;
   status: "completed" | "cancelled";
   workItemId: Id<"operationalWorkItem">;
+};
+
+type AutoResolveSyncedSaleInventoryReviewsArgs = {
+  actorUserId?: Id<"athenaUser">;
+  inventoryMovements: Doc<"inventoryMovement">[];
+  organizationId?: Id<"organization">;
+  stockAdjustmentBatchId: Id<"stockAdjustmentBatch">;
+  storeId: Id<"store">;
 };
 
 function inventoryReviewLocalId(localTransactionId: string) {
@@ -149,6 +161,235 @@ function terminalStatusForOutcome(
   outcome: SyncedSaleInventoryReviewOutcome,
 ): "completed" | "cancelled" {
   return outcome === "completed" ? "completed" : "cancelled";
+}
+
+function sourceMetadataFromWorkItem(metadata: Record<string, unknown>) {
+  const localTransactionId = stringMetadataValue(metadata, "localTransactionId");
+
+  return {
+    localId: localTransactionId
+      ? inventoryReviewLocalId(localTransactionId)
+      : null,
+    localIdKind: INVENTORY_REVIEW_LOCAL_ID_KIND,
+    localRegisterSessionId: stringMetadataValue(
+      metadata,
+      "localRegisterSessionId",
+    ),
+    localTransactionId,
+    receiptNumber: stringMetadataValue(metadata, "receiptNumber"),
+    registerSessionId: idMetadataValue<"registerSession">(
+      metadata,
+      "registerSessionId",
+    ),
+    sourceId: idMetadataValue<"posTransaction">(metadata, "sourceId"),
+    terminalId: idMetadataValue<"posTerminal">(metadata, "terminalId"),
+  };
+}
+
+async function readOpenSyncedSaleInventoryReviewWorkItemsWithCtx(
+  ctx: MutationCtx,
+  args: {
+    productSkuId: Id<"productSku">;
+    status: "open" | "in_progress";
+    storeId: Id<"store">;
+  },
+) {
+  return ctx.db
+    .query("operationalWorkItem")
+    .withIndex("by_storeId_type_status_productSkuId", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("type", SYNCED_SALE_INVENTORY_REVIEW_TYPE)
+        .eq("status", args.status)
+        .eq("productSkuId", args.productSkuId),
+    )
+    .take(AUTO_RESOLVE_STOCK_REVIEW_SCAN_LIMIT);
+}
+
+async function readLegacyOpenSyncedSaleInventoryReviewWorkItemsWithCtx(
+  ctx: MutationCtx,
+  args: {
+    productSkuIds: Set<Id<"productSku">>;
+    status: "open" | "in_progress";
+    storeId: Id<"store">;
+  },
+) {
+  const rows = await ctx.db
+    .query("operationalWorkItem")
+    .withIndex("by_storeId_type_status", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("type", SYNCED_SALE_INVENTORY_REVIEW_TYPE)
+        .eq("status", args.status),
+    )
+    .take(AUTO_RESOLVE_STOCK_REVIEW_SCAN_LIMIT + 1);
+
+  if (rows.length > AUTO_RESOLVE_STOCK_REVIEW_SCAN_LIMIT) {
+    throw new Error(
+      "Too many synced sale inventory review work items to scan for legacy auto-resolution. Resolve older inventory review work and retry.",
+    );
+  }
+
+  return rows.filter((workItem) => {
+    if (workItem.productSkuId) return false;
+    const primaryProductSkuId = idMetadataValue<"productSku">(
+      workItem.metadata ?? {},
+      "primaryProductSkuId",
+    );
+    return Boolean(
+      primaryProductSkuId && args.productSkuIds.has(primaryProductSkuId),
+    );
+  });
+}
+
+export async function autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx(
+  ctx: MutationCtx,
+  args: AutoResolveSyncedSaleInventoryReviewsArgs,
+) {
+  const movementsBySkuId = new Map<
+    Id<"productSku">,
+    Doc<"inventoryMovement">
+  >();
+
+  for (const movement of args.inventoryMovements) {
+    if (
+      movement.storeId !== args.storeId ||
+      movement.sourceType !== STOCK_UPDATE_SOURCE_TYPE ||
+      !STOCK_UPDATE_MOVEMENT_TYPES.has(movement.movementType) ||
+      !movement.productSkuId
+    ) {
+      continue;
+    }
+
+    const existingMovement = movementsBySkuId.get(movement.productSkuId);
+    if (!existingMovement || movement.createdAt > existingMovement.createdAt) {
+      movementsBySkuId.set(movement.productSkuId, movement);
+    }
+  }
+
+  if (movementsBySkuId.size === 0) {
+    return { resolvedCount: 0 };
+  }
+  if (movementsBySkuId.size > AUTO_RESOLVE_STOCK_REVIEW_SKU_PROBE_LIMIT) {
+    return { resolvedCount: 0 };
+  }
+
+  const workItemGroups = [];
+  const productSkuIds = Array.from(movementsBySkuId.keys());
+  for (const status of ["open", "in_progress"] as const) {
+    for (const productSkuId of productSkuIds) {
+      workItemGroups.push(
+        await readOpenSyncedSaleInventoryReviewWorkItemsWithCtx(ctx, {
+          productSkuId,
+          status,
+          storeId: args.storeId,
+        }),
+      );
+    }
+    workItemGroups.push(
+      await readLegacyOpenSyncedSaleInventoryReviewWorkItemsWithCtx(ctx, {
+        productSkuIds: new Set(productSkuIds),
+        status,
+        storeId: args.storeId,
+      }),
+    );
+  }
+  const resolvedAt = Date.now();
+  let resolvedCount = 0;
+
+  for (const workItem of workItemGroups.flat()) {
+    const metadata = workItem.metadata ?? {};
+    const primaryProductSkuId = idMetadataValue<"productSku">(
+      metadata,
+      "primaryProductSkuId",
+    );
+    const stockUpdate = primaryProductSkuId
+      ? movementsBySkuId.get(primaryProductSkuId)
+      : null;
+
+    if (!primaryProductSkuId || !stockUpdate) {
+      continue;
+    }
+    if (stockUpdate.createdAt < workItem.createdAt) {
+      continue;
+    }
+
+    const domainTrace = {
+      boundary:
+        "operations.openWorkInventoryReviews.autoResolveSyncedSaleInventoryReviewsForStockAdjustment",
+      inventoryMovementId: stockUpdate._id,
+      proofKind: "stock_update_movement",
+      stockAdjustmentBatchId: args.stockAdjustmentBatchId,
+    };
+    const resolution = {
+      ...(args.actorUserId ? { actorUserId: args.actorUserId } : {}),
+      authority: {
+        kind: "system",
+        reason: "stock_adjustment_applied",
+      },
+      domainTrace,
+      outcome: "completed" as const,
+      priorState: {
+        status: workItem.status,
+      },
+      reason: AUTO_RESOLVE_STOCK_REVIEW_REASON,
+      resolvedAt,
+      source: sourceMetadataFromWorkItem(metadata),
+      stockState: null,
+      stockUpdate: {
+        createdAt: stockUpdate.createdAt,
+        inventoryMovementId: stockUpdate._id,
+        movementType: stockUpdate.movementType,
+        productSkuId: primaryProductSkuId,
+        quantityDelta: stockUpdate.quantityDelta,
+        reasonCode: stockUpdate.reasonCode ?? null,
+        sourceId: stockUpdate.sourceId,
+        sourceType: stockUpdate.sourceType,
+      },
+      nextState: {
+        status: "completed" as const,
+      },
+    };
+
+    await ctx.db.patch("operationalWorkItem", workItem._id, {
+      completedAt: resolvedAt,
+      metadata: {
+        ...metadata,
+        resolution,
+      },
+      status: "completed",
+    });
+
+    await recordOperationalEventWithCtx(ctx, {
+      actorUserId: args.actorUserId,
+      eventType: "synced_sale_inventory_review_completed",
+      message: "Synced sale inventory review completed by stock adjustment.",
+      organizationId: workItem.organizationId ?? args.organizationId,
+      reason: AUTO_RESOLVE_STOCK_REVIEW_REASON,
+      storeId: args.storeId,
+      subjectId: workItem._id,
+      subjectLabel: workItem.title,
+      subjectType: SYNCED_SALE_INVENTORY_REVIEW_TYPE,
+      workItemId: workItem._id,
+      metadata: {
+        authority: resolution.authority,
+        domainTrace,
+        inventoryMovementId: stockUpdate._id,
+        nextState: resolution.nextState,
+        outcome: resolution.outcome,
+        priorState: resolution.priorState,
+        reason: resolution.reason,
+        source: resolution.source,
+        stockState: null,
+        stockUpdate: resolution.stockUpdate,
+        terminalAudit: null,
+      },
+    });
+
+    resolvedCount += 1;
+  }
+
+  return { resolvedCount };
 }
 
 export async function resolveSyncedSaleInventoryReviewWithCtx(

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
@@ -479,6 +479,20 @@ describe("getQueueSnapshot", () => {
     const ctx = createQueueContext({
       workItems: [
         workItem({
+          _id: "work-catalog-taxonomy" as Id<"operationalWorkItem">,
+          createdAt: 40,
+          metadata: {
+            categorySlug: "legacy-import",
+            productId: "product-1",
+            productName: "Packaging Rubber",
+            productSkuId: "sku-1",
+            sku: "6N2Y-PKG-RBR",
+            subcategorySlug: "472",
+          },
+          status: "open",
+          type: "catalog_taxonomy_setup",
+        }),
+        workItem({
           _id: "work-purchase-z" as Id<"operationalWorkItem">,
           createdAt: 5,
           metadata: { purchaseOrderId: "po-z" },
@@ -532,12 +546,25 @@ describe("getQueueSnapshot", () => {
     });
 
     expect(result.workItems.map((item: QueueTestRow) => item._id)).toEqual([
+      "work-catalog-taxonomy",
       "work-adjustment-approval",
       "work-synced-in-progress",
       "work-synced-open",
       "work-purchase-a",
       "work-purchase-z",
     ]);
+    expect(result.workItems[0]).toMatchObject({
+      details: {
+        categorySlug: "legacy-import",
+        productId: "product-1",
+        productName: "Packaging Rubber",
+        productSkuId: "sku-1",
+        sku: "6N2Y-PKG-RBR",
+        subcategorySlug: "472",
+      },
+      sourceIdentity: "catalog_taxonomy_setup:product-1",
+    });
+    expect(JSON.stringify(result.workItems[0])).not.toContain("metadata");
   });
 
   it("returns explicit overflow metadata when open, in-progress, or approval lanes exceed the queue cap", async () => {

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.ts
@@ -31,6 +31,7 @@ const QUEUE_APPROVAL_REQUEST_TYPES = [
   "variance_review",
 ] as const;
 const QUEUE_WORK_ITEM_TYPES = [
+  "catalog_taxonomy_setup",
   "daily_close_carry_forward",
   "pos_pending_checkout_item_review",
   "purchase_order",
@@ -70,6 +71,13 @@ function stableOperationalWorkItemSourceIdentity(
   const metadata = item.metadata;
 
   switch (item.type) {
+    case "catalog_taxonomy_setup": {
+      const productId = metadataString(metadata, "productId");
+      if (productId) {
+        return joinSourceIdentity([item.type, productId]);
+      }
+      break;
+    }
     case "daily_close_carry_forward": {
       const businessDate = metadataString(metadata, "businessDate");
       const sourceId =
@@ -183,6 +191,7 @@ function stableOperationalWorkItemSourceIdentity(
 
 function workItemPriorityBucket(item: Doc<"operationalWorkItem">) {
   if (
+    item.type === "catalog_taxonomy_setup" ||
     item.approvalRequestId ||
     item.approvalState === "pending" ||
     APPROVAL_BLOCKED_WORK_ITEM_TYPES.has(item.type)
@@ -325,6 +334,15 @@ function sanitizeOperationalWorkItemDetails(item: Doc<"operationalWorkItem">) {
   const metadata = item.metadata;
 
   switch (item.type) {
+    case "catalog_taxonomy_setup":
+      return {
+        categorySlug: metadataString(metadata, "categorySlug"),
+        productId: metadataString(metadata, "productId"),
+        productName: metadataString(metadata, "productName"),
+        productSkuId: metadataString(metadata, "productSkuId"),
+        sku: metadataString(metadata, "sku"),
+        subcategorySlug: metadataString(metadata, "subcategorySlug"),
+      };
     case "daily_close_carry_forward":
       return {
         businessDate: metadataString(metadata, "businessDate"),
@@ -520,6 +538,8 @@ export function buildOperationalWorkItem(args: {
   createdByStaffProfileId?: Id<"staffProfile">;
   assignedToStaffProfileId?: Id<"staffProfile">;
   customerProfileId?: Id<"customerProfile">;
+  productId?: Id<"product">;
+  productSkuId?: Id<"productSku">;
   approvalRequestId?: Id<"approvalRequest">;
   appointmentId?: Id<"serviceAppointment">;
 }) {
@@ -557,6 +577,8 @@ export const createOperationalWorkItem = internalMutation({
     createdByStaffProfileId: v.optional(v.id("staffProfile")),
     assignedToStaffProfileId: v.optional(v.id("staffProfile")),
     customerProfileId: v.optional(v.id("customerProfile")),
+    productId: v.optional(v.id("product")),
+    productSkuId: v.optional(v.id("productSku")),
     approvalRequestId: v.optional(v.id("approvalRequest")),
     appointmentId: v.optional(v.id("serviceAppointment")),
   },

--- a/packages/athena-webapp/convex/operations/skuActivity.test.ts
+++ b/packages/athena-webapp/convex/operations/skuActivity.test.ts
@@ -13,6 +13,7 @@ type TableName =
   | "checkoutSessionItem"
   | "inventoryHold"
   | "inventoryImportProvisionalSku"
+  | "product"
   | "productSku"
   | "posPendingCheckoutItem"
   | "posTransaction"
@@ -29,6 +30,7 @@ function createIndexedDb(seed: Partial<Tables>) {
     checkoutSessionItem: new Map(),
     inventoryHold: new Map(),
     inventoryImportProvisionalSku: new Map(),
+    product: new Map(),
     productSku: new Map(),
     posPendingCheckoutItem: new Map(),
     posTransaction: new Map(),
@@ -828,6 +830,203 @@ describe("untrusted SKU sale evidence read model", () => {
           }),
         },
       ],
+    });
+  });
+
+  it("filters linked archived legacy import products out of untrusted sale evidence", async () => {
+    const { ctx } = createIndexedDb({
+      inventoryImportProvisionalSku: new Map([
+        [
+          "provisional-archived",
+          {
+            _id: "provisional-archived",
+            importKey: "legacy-import-1",
+            importedPrice: 120,
+            importedProductName: "Archived zirconia earring",
+            importedQuantity: 5,
+            normalizedImportedProductName: "archived zirconia earring",
+            organizationId: "org-1",
+            posExposureStatus: "hidden",
+            productId: "product-archived",
+            productSkuId: "sku-archived",
+            reviewVersionId: "review-version-1",
+            reviewVersionNumber: 1,
+            rowKey: "row-archived",
+            rowNumber: 12,
+            saleEvidence: {
+              lastSoldAt: 3_000,
+              saleCount: 1,
+              totalQuantitySold: 4,
+            },
+            sourceFormat: "csv",
+            status: "active",
+            storeId: "store-1",
+            updatedAt: 3_100,
+          },
+        ],
+        [
+          "provisional-live",
+          {
+            _id: "provisional-live",
+            importKey: "legacy-import-1",
+            importedPrice: 90,
+            importedProductName: "Live wig bag",
+            importedQuantity: 3,
+            normalizedImportedProductName: "live wig bag",
+            organizationId: "org-1",
+            posExposureStatus: "available",
+            productId: "product-live",
+            productSkuId: "sku-live",
+            reviewVersionId: "review-version-1",
+            reviewVersionNumber: 1,
+            rowKey: "row-live",
+            rowNumber: 13,
+            saleEvidence: {
+              lastSoldAt: 2_000,
+              saleCount: 1,
+              totalQuantitySold: 1,
+            },
+            sourceFormat: "csv",
+            status: "active",
+            storeId: "store-1",
+            updatedAt: 2_100,
+          },
+        ],
+        [
+          "provisional-unlinked",
+          {
+            _id: "provisional-unlinked",
+            importKey: "legacy-import-1",
+            importedPrice: 75,
+            importedProductName: "Unlinked import row",
+            importedQuantity: 2,
+            normalizedImportedProductName: "unlinked import row",
+            organizationId: "org-1",
+            posExposureStatus: "available",
+            reviewVersionId: "review-version-1",
+            reviewVersionNumber: 1,
+            rowKey: "row-unlinked",
+            rowNumber: 14,
+            saleEvidence: {
+              lastSoldAt: 1_000,
+              saleCount: 1,
+              totalQuantitySold: 1,
+            },
+            sourceFormat: "csv",
+            status: "active",
+            storeId: "store-1",
+            updatedAt: 1_100,
+          },
+        ],
+      ]),
+      product: new Map([
+        [
+          "product-archived",
+          {
+            _id: "product-archived",
+            availability: "archived",
+            storeId: "store-1",
+          },
+        ],
+        [
+          "product-live",
+          {
+            _id: "product-live",
+            availability: "live",
+            storeId: "store-1",
+          },
+        ],
+      ]),
+    });
+
+    const result = await getUntrustedSkuSaleEvidenceWithCtx(ctx, {
+      selectedSource: {
+        sourceId: "provisional-archived",
+        sourceType: "inventoryImportProvisionalSku",
+      },
+      sourceFilter: "legacy_import",
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(result.sources.map((source) => source.id)).toEqual([
+      "provisional-live",
+      "provisional-unlinked",
+    ]);
+    expect(result.selected).toBeNull();
+  });
+
+  it("treats active finalized legacy import rows as reviewed sale evidence", async () => {
+    const { ctx } = createIndexedDb({
+      inventoryImportProvisionalSku: new Map([
+        [
+          "provisional-finalized",
+          {
+            _id: "provisional-finalized",
+            finalizedAt: 3_000,
+            importKey: "legacy-import-1",
+            importedPrice: 120,
+            importedProductName: "Finalized legacy wig",
+            importedQuantity: 5,
+            normalizedImportedProductName: "finalized legacy wig",
+            organizationId: "org-1",
+            posExposureStatus: "hidden",
+            productId: "product-live",
+            productSkuId: "sku-live",
+            reviewVersionId: "review-version-1",
+            reviewVersionNumber: 1,
+            rowKey: "row-finalized",
+            rowNumber: 12,
+            saleEvidence: {
+              lastSoldAt: 2_000,
+              saleCount: 1,
+              totalQuantitySold: 4,
+            },
+            sourceFormat: "csv",
+            status: "active",
+            storeId: "store-1",
+            updatedAt: 3_100,
+          },
+        ],
+      ]),
+      product: new Map([
+        [
+          "product-live",
+          {
+            _id: "product-live",
+            availability: "live",
+            storeId: "store-1",
+          },
+        ],
+      ]),
+    });
+
+    const openResult = await getUntrustedSkuSaleEvidenceWithCtx(ctx, {
+      reviewStatus: "open",
+      sourceFilter: "legacy_import",
+      storeId: "store-1" as Id<"store">,
+    });
+    expect(openResult.sources).toEqual([]);
+
+    const reviewedResult = await getUntrustedSkuSaleEvidenceWithCtx(ctx, {
+      reviewStatus: "reviewed",
+      selectedSource: {
+        sourceId: "provisional-finalized",
+        sourceType: "inventoryImportProvisionalSku",
+      },
+      sourceFilter: "legacy_import",
+      storeId: "store-1" as Id<"store">,
+    });
+    expect(reviewedResult.sources).toEqual([
+      expect.objectContaining({
+        id: "provisional-finalized",
+        reviewState: "reviewed",
+      }),
+    ]);
+    expect(reviewedResult.selected).toMatchObject({
+      source: {
+        id: "provisional-finalized",
+        reviewState: "reviewed",
+      },
     });
   });
 

--- a/packages/athena-webapp/convex/operations/skuActivity.ts
+++ b/packages/athena-webapp/convex/operations/skuActivity.ts
@@ -572,7 +572,10 @@ function getImportStatusesForReviewStatus(
   }
 
   if (reviewStatus === "reviewed") {
-    return REVIEWED_IMPORT_PROVISIONAL_STATUSES;
+    return [
+      ...OPEN_IMPORT_PROVISIONAL_STATUSES,
+      ...REVIEWED_IMPORT_PROVISIONAL_STATUSES,
+    ];
   }
 
   return [
@@ -605,16 +608,23 @@ function getSourceReviewState(
   return openStatuses.includes(status) ? "open" : "reviewed";
 }
 
+function getInventoryImportEvidenceReviewState(
+  row: Doc<"inventoryImportProvisionalSku">
+) {
+  if (row.finalizedAt !== undefined) {
+    return "reviewed" as const;
+  }
+
+  return getSourceReviewState(row.status, OPEN_IMPORT_PROVISIONAL_STATUSES);
+}
+
 function buildInventoryImportEvidenceSource(
   row: Doc<"inventoryImportProvisionalSku">
 ) {
   return {
     id: row._id,
     sourceType: "inventoryImportProvisionalSku" as const,
-    reviewState: getSourceReviewState(
-      row.status,
-      OPEN_IMPORT_PROVISIONAL_STATUSES
-    ),
+    reviewState: getInventoryImportEvidenceReviewState(row),
     status: row.status,
     title: row.importedProductName,
     sku: row.importedSku ?? null,
@@ -634,6 +644,27 @@ function buildInventoryImportEvidenceSource(
     lastActivityAt: row.saleEvidence.lastSoldAt ?? row.updatedAt,
     updatedAt: row.updatedAt,
   };
+}
+
+async function hasArchivedLinkedProduct(
+  ctx: QueryCtx,
+  productCache: Map<Id<"product">, Doc<"product"> | null>,
+  row: Doc<"inventoryImportProvisionalSku">
+) {
+  if (!row.productId) {
+    return false;
+  }
+
+  if (!productCache.has(row.productId)) {
+    productCache.set(row.productId, await ctx.db.get("product", row.productId));
+  }
+
+  const product = productCache.get(row.productId);
+  return Boolean(
+    product &&
+      product.storeId === row.storeId &&
+      product.availability === "archived"
+  );
 }
 
 function buildPendingCheckoutEvidenceSource(
@@ -678,6 +709,7 @@ async function listInventoryImportEvidenceSources(
   }
 ) {
   const rows: Doc<"inventoryImportProvisionalSku">[] = [];
+  const productCache = new Map<Id<"product">, Doc<"product"> | null>();
   for (const status of getImportStatusesForReviewStatus(args.reviewStatus)) {
     const matches = await ctx.db
       .query("inventoryImportProvisionalSku")
@@ -693,7 +725,20 @@ async function listInventoryImportEvidenceSources(
     rows.push(...matches);
   }
 
-  return rows.map(buildInventoryImportEvidenceSource);
+  const sources = [];
+  for (const row of rows) {
+    const reviewState = getInventoryImportEvidenceReviewState(row);
+    if (args.reviewStatus !== "all" && reviewState !== args.reviewStatus) {
+      continue;
+    }
+
+    if (await hasArchivedLinkedProduct(ctx, productCache, row)) {
+      continue;
+    }
+    sources.push(buildInventoryImportEvidenceSource(row));
+  }
+
+  return sources;
 }
 
 async function listPendingCheckoutEvidenceSources(
@@ -917,7 +962,8 @@ async function loadSelectedUntrustedEvidenceSource(
     if (
       !row ||
       row.storeId !== args.storeId ||
-      row.saleEvidence.totalQuantitySold <= 0
+      row.saleEvidence.totalQuantitySold <= 0 ||
+      (await hasArchivedLinkedProduct(ctx, new Map(), row))
     ) {
       return null;
     }

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -2857,6 +2857,7 @@ describe("projectLocalSyncEvent", () => {
           ],
         }),
         priority: "high",
+        productSkuId: "sku-1",
         status: "open",
         title: "Review inventory for Wig Cap",
         type: "synced_sale_inventory_review",

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -2394,6 +2394,8 @@ async function createSkippedInventoryReviewWorkItem(
   }
 
   const primarySkippedItem = input.inventoryValidation.skippedMutationItems[0];
+  const primaryProductSkuId =
+    primarySkippedItem?.productSkuId ?? trustedLines[0]?.productSkuId;
   const primaryProductName =
     primarySkippedItem?.productName ?? trustedLines[0]?.productName;
   const title = primaryProductName
@@ -2424,8 +2426,7 @@ async function createSkippedInventoryReviewWorkItem(
       localEventId: args.event.localEventId,
       localRegisterSessionId: args.event.localRegisterSessionId,
       localTransactionId: input.payload.localTransactionId,
-      primaryProductSkuId:
-        primarySkippedItem?.productSkuId ?? trustedLines[0]?.productSkuId,
+      primaryProductSkuId,
       receiptNumber: input.payload.receiptNumber,
       registerSessionId: input.session.registerSession._id,
       skippedMutationItems: input.inventoryValidation.skippedMutationItems,
@@ -2438,6 +2439,7 @@ async function createSkippedInventoryReviewWorkItem(
       "Synced sale activity was retained from cash controls. Inventory was not decremented because stock availability still needs correction.",
     organizationId: input.store.organizationId,
     priority: "high",
+    productSkuId: primaryProductSkuId,
     status: "open",
     storeId: args.storeId,
     title,

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -516,6 +516,8 @@ export type SyncProjectionRepository = {
     createdByUserId?: Id<"athenaUser">;
     createdByStaffProfileId?: Id<"staffProfile">;
     customerProfileId?: Id<"customerProfile">;
+    productId?: Id<"product">;
+    productSkuId?: Id<"productSku">;
   }): Promise<Id<"operationalWorkItem">>;
   createServiceCase(input: {
     customerProfileId: Id<"customerProfile">;

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -478,6 +478,7 @@ const schema = defineSchema({
       "productSkuId",
       "status",
     ])
+    .index("by_storeId_productId_status", ["storeId", "productId", "status"])
     .index("by_storeId_importKey_rowKey", ["storeId", "importKey", "rowKey"])
     .index("by_storeId_reviewVersionId", ["storeId", "reviewVersionId"])
     .index("by_storeId_finalizationConversionRequestId", [
@@ -934,6 +935,18 @@ const schema = defineSchema({
     .index("by_storeId_status", ["storeId", "status"])
     .index("by_storeId_type", ["storeId", "type"])
     .index("by_storeId_type_status", ["storeId", "type", "status"])
+    .index("by_storeId_type_status_productId", [
+      "storeId",
+      "type",
+      "status",
+      "productId",
+    ])
+    .index("by_storeId_type_status_productSkuId", [
+      "storeId",
+      "type",
+      "status",
+      "productSkuId",
+    ])
     .index("by_storeId_type_status_appointmentId", [
       "storeId",
       "type",

--- a/packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts
+++ b/packages/athena-webapp/convex/schemas/operations/operationalWorkItem.ts
@@ -18,6 +18,8 @@ export const operationalWorkItemSchema = v.object({
   createdByStaffProfileId: v.optional(v.id("staffProfile")),
   assignedToStaffProfileId: v.optional(v.id("staffProfile")),
   customerProfileId: v.optional(v.id("customerProfile")),
+  productId: v.optional(v.id("product")),
+  productSkuId: v.optional(v.id("productSku")),
   approvalRequestId: v.optional(v.id("approvalRequest")),
   appointmentId: v.optional(v.id("serviceAppointment")),
 });

--- a/packages/athena-webapp/convex/stockOps/adjustments.test.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.test.ts
@@ -137,6 +137,18 @@ function createInventorySnapshotQueryCtx() {
       ["store-1", { _id: "store-1", organizationId: "org-1" }],
       ["store-2", { _id: "store-2", organizationId: "org-2" }],
     ]),
+    subcategory: new Map<string, Record<string, unknown>>([
+      [
+        "subcategory-1",
+        {
+          _id: "subcategory-1",
+          categoryId: "category-1",
+          name: "Hair Pins",
+          slug: "hair-pins",
+          storeId: "store-1",
+        },
+      ],
+    ]),
     users: new Map<string, Record<string, unknown>>([
       ["auth-user-1", { _id: "auth-user-1", email: "operator@example.com" }],
     ]),
@@ -528,6 +540,18 @@ function createSubmissionMutationCtx(args: {
         },
       ],
     ]),
+    subcategory: new Map<string, Record<string, unknown>>([
+      [
+        "subcategory-1",
+        {
+          _id: "subcategory-1",
+          categoryId: "category-1",
+          name: "Closures",
+          slug: "closures",
+          storeId: "store-1",
+        },
+      ],
+    ]),
     users: new Map<string, Record<string, unknown>>([
       [
         "auth-user-1",
@@ -566,11 +590,13 @@ function createSubmissionMutationCtx(args: {
       | "inventoryMovement"
       | "inventoryImportProvisionalSku"
       | "operationalEvent"
+      | "operationalWorkItem"
       | "posPendingCheckoutItem"
       | "product"
       | "productSku"
       | "skuActivityEvent"
-      | "stockAdjustmentBatch",
+      | "stockAdjustmentBatch"
+      | "subcategory",
   ) => ({
     withIndex(
       _index: string,
@@ -693,13 +719,15 @@ function createSubmissionMutationCtx(args: {
           table === "inventoryMovement" ||
           table === "inventoryImportProvisionalSku" ||
           table === "operationalEvent" ||
+          table === "operationalWorkItem" ||
           table === "posPendingCheckoutItem" ||
           table === "catalogSummary" ||
           table === "category" ||
           table === "product" ||
           table === "productSku" ||
           table === "skuActivityEvent" ||
-          table === "stockAdjustmentBatch"
+          table === "stockAdjustmentBatch" ||
+          table === "subcategory"
         ) {
           return indexedQuery(table);
         }
@@ -973,6 +1001,45 @@ describe("stock ops adjustments", () => {
     ]);
   });
 
+  it("does not block zero-sale provisional rows linked to onboarded trusted SKUs", async () => {
+    const { ctx, tables } = createInventorySnapshotQueryCtx();
+
+    tables.category.set("category-1", {
+      _id: "category-1",
+      name: "Hair Accessories",
+      slug: "hair-accessories",
+      storeId: "store-1",
+    });
+    tables.product.set("product-1", {
+      _id: "product-1",
+      availability: "live",
+      categoryId: "category-1",
+      name: "Tweezers",
+      storeId: "store-1",
+      subcategoryId: "subcategory-1",
+    });
+    tables.inventoryImportProvisionalSku.set("provisional-1", {
+      _id: "provisional-1",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      saleEvidence: {
+        saleCount: 0,
+        totalQuantitySold: 0,
+      },
+      status: "active",
+      storeId: "store-1",
+    });
+
+    const rows = await listInventorySnapshotWithCtx(ctx, {
+      now: 1_000,
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).not.toHaveProperty("stockAdjustmentBlockedMessage");
+    expect(rows[0]).not.toHaveProperty("stockAdjustmentBlockedReason");
+  });
+
   it("does not block stock adjustments after a legacy import SKU is finalized", async () => {
     const { ctx, tables } = createInventorySnapshotQueryCtx();
 
@@ -984,6 +1051,30 @@ describe("stock ops adjustments", () => {
       productSkuId: "sku-1",
       provisionalSoldQuantityAtFinalization: 2,
       status: "finalized",
+      storeId: "store-1",
+    });
+
+    const rows = await listInventorySnapshotWithCtx(ctx, {
+      now: 1_000,
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).not.toHaveProperty("stockAdjustmentBlockedMessage");
+    expect(rows[0]).not.toHaveProperty("stockAdjustmentBlockedReason");
+  });
+
+  it("does not block trusted legacy import SKUs that remain active for catalog setup", async () => {
+    const { ctx, tables } = createInventorySnapshotQueryCtx();
+
+    tables.inventoryImportProvisionalSku.set("provisional-1", {
+      _id: "provisional-1",
+      finalTrustedQuantity: 10,
+      finalizedAt: 1_000,
+      posExposureStatus: "hidden",
+      productSkuId: "sku-1",
+      provisionalSoldQuantityAtFinalization: 2,
+      status: "active",
       storeId: "store-1",
     });
 
@@ -1460,6 +1551,369 @@ describe("stock ops adjustments", () => {
     );
   });
 
+  it("completes synced sale inventory review work when the affected SKU is adjusted", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "pos_only",
+    });
+
+    tables.operationalWorkItem.set("inventory-review-1", {
+      _id: "inventory-review-1",
+      createdAt: 1,
+      metadata: {
+        localTransactionId: "local-sale-1",
+        primaryProductSkuId: "sku-1",
+        receiptNumber: "#001",
+      },
+      organizationId: "org-1",
+      productSkuId: "sku-1",
+      status: "open",
+      storeId: "store-1",
+      title: "Review inventory for Closure wig",
+      type: "synced_sale_inventory_review",
+    });
+
+    await submitStockAdjustmentBatchWithCtx(ctx, {
+      adjustmentType: "manual",
+      lineItems: [
+        {
+          productSkuId: "sku-1" as Id<"productSku">,
+          quantityDelta: 1,
+        },
+      ],
+      reasonCode: "correction",
+      storeId: "store-1" as Id<"store">,
+      submissionKey: "auto-resolve-inventory-review",
+    });
+
+    const stockMovement = Array.from(tables.inventoryMovement.values())[0];
+
+    expect(tables.operationalWorkItem.get("inventory-review-1")).toMatchObject({
+      completedAt: expect.any(Number),
+      metadata: {
+        resolution: {
+          actorUserId: "operator-1",
+          authority: {
+            kind: "system",
+            reason: "stock_adjustment_applied",
+          },
+          domainTrace: {
+            inventoryMovementId: stockMovement._id,
+            proofKind: "stock_update_movement",
+            stockAdjustmentBatchId: "stockAdjustmentBatch-1",
+          },
+          outcome: "completed",
+          reason: "Resolved by applied stock adjustment.",
+          stockUpdate: {
+            inventoryMovementId: stockMovement._id,
+            productSkuId: "sku-1",
+            quantityDelta: 1,
+          },
+        },
+      },
+      status: "completed",
+    });
+    expect(Array.from(tables.operationalEvent.values())).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "synced_sale_inventory_review_completed",
+          message:
+            "Synced sale inventory review completed by stock adjustment.",
+          subjectId: "inventory-review-1",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps unrelated synced sale inventory review work open", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "pos_only",
+    });
+
+    tables.operationalWorkItem.set("inventory-review-1", {
+      _id: "inventory-review-1",
+      createdAt: 1,
+      metadata: {
+        primaryProductSkuId: "other-sku",
+      },
+      organizationId: "org-1",
+      productSkuId: "other-sku",
+      status: "open",
+      storeId: "store-1",
+      title: "Review inventory for another SKU",
+      type: "synced_sale_inventory_review",
+    });
+
+    await submitStockAdjustmentBatchWithCtx(ctx, {
+      adjustmentType: "manual",
+      lineItems: [
+        {
+          productSkuId: "sku-1" as Id<"productSku">,
+          quantityDelta: 1,
+        },
+      ],
+      reasonCode: "correction",
+      storeId: "store-1" as Id<"store">,
+      submissionKey: "unrelated-inventory-review",
+    });
+
+    expect(tables.operationalWorkItem.get("inventory-review-1")).toMatchObject({
+      status: "open",
+    });
+    expect(
+      tables.operationalWorkItem.get("inventory-review-1"),
+    ).not.toHaveProperty("completedAt");
+  });
+
+  it("allows stock adjustments for trusted legacy import SKUs that still need catalog setup", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "full_admin",
+    });
+
+    tables.inventoryImportProvisionalSku.set("provisional-1", {
+      _id: "provisional-1",
+      finalTrustedQuantity: 8,
+      finalizedAt: 1_000,
+      posExposureStatus: "hidden",
+      productSkuId: "sku-1",
+      provisionalSoldQuantityAtFinalization: 2,
+      status: "active",
+      storeId: "store-1",
+    });
+
+    await submitStockAdjustmentBatchWithCtx(ctx, {
+      adjustmentType: "manual",
+      lineItems: [
+        {
+          productSkuId: "sku-1" as Id<"productSku">,
+          quantityDelta: 1,
+        },
+      ],
+      reasonCode: "correction",
+      storeId: "store-1" as Id<"store">,
+      submissionKey: "trusted-legacy-import-catalog-setup-adjustment",
+    });
+
+    expect(tables.productSku.get("sku-1")).toMatchObject({
+      inventoryCount: 9,
+      quantityAvailable: 7,
+    });
+    expect(Array.from(tables.stockAdjustmentBatch.values())).toEqual([
+      expect.objectContaining({
+        status: "applied",
+        submissionKey: "trusted-legacy-import-catalog-setup-adjustment",
+      }),
+    ]);
+  });
+
+  it("blocks stock adjustments when any active provisional row for the SKU still needs review", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "full_admin",
+    });
+
+    tables.inventoryImportProvisionalSku.set("provisional-trusted", {
+      _id: "provisional-trusted",
+      finalTrustedQuantity: 8,
+      finalizedAt: 1_000,
+      posExposureStatus: "hidden",
+      productSkuId: "sku-1",
+      provisionalSoldQuantityAtFinalization: 2,
+      status: "active",
+      storeId: "store-1",
+    });
+    tables.inventoryImportProvisionalSku.set("provisional-unresolved", {
+      _id: "provisional-unresolved",
+      productSkuId: "sku-1",
+      saleEvidence: {
+        totalQuantitySold: 1,
+      },
+      status: "active",
+      storeId: "store-1",
+    });
+
+    await expect(
+      submitStockAdjustmentBatchWithCtx(ctx, {
+        adjustmentType: "manual",
+        lineItems: [
+          {
+            productSkuId: "sku-1" as Id<"productSku">,
+            quantityDelta: 1,
+          },
+        ],
+        reasonCode: "correction",
+        storeId: "store-1" as Id<"store">,
+        submissionKey: "mixed-provisional-rows-block",
+      }),
+    ).rejects.toThrow(
+      "Legacy import SKUs must be finalized before stock adjustments can update them.",
+    );
+
+    expect(tables.inventoryMovement.size).toBe(0);
+    expect(tables.stockAdjustmentBatch.size).toBe(0);
+  });
+
+  it("fails closed when active provisional rows exceed the per-SKU blocker cap", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "full_admin",
+    });
+
+    for (let index = 0; index < 26; index += 1) {
+      tables.inventoryImportProvisionalSku.set(`provisional-${index}`, {
+        _id: `provisional-${index}`,
+        finalTrustedQuantity: 8,
+        finalizedAt: 1_000 + index,
+        posExposureStatus: "hidden",
+        productSkuId: "sku-1",
+        provisionalSoldQuantityAtFinalization: 0,
+        status: "active",
+        storeId: "store-1",
+      });
+    }
+
+    await expect(
+      submitStockAdjustmentBatchWithCtx(ctx, {
+        adjustmentType: "manual",
+        lineItems: [
+          {
+            productSkuId: "sku-1" as Id<"productSku">,
+            quantityDelta: 1,
+          },
+        ],
+        reasonCode: "correction",
+        storeId: "store-1" as Id<"store">,
+        submissionKey: "provisional-row-cap-block",
+      }),
+    ).rejects.toThrow(
+      "Legacy import SKUs must be finalized before stock adjustments can update them.",
+    );
+
+    expect(tables.inventoryMovement.size).toBe(0);
+    expect(tables.stockAdjustmentBatch.size).toBe(0);
+  });
+
+  it("allows stock adjustments for zero-sale provisional rows linked to onboarded trusted SKUs", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "full_admin",
+    });
+
+    tables.inventoryImportProvisionalSku.set("provisional-1", {
+      _id: "provisional-1",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      saleEvidence: {
+        saleCount: 0,
+        totalQuantitySold: 0,
+      },
+      status: "active",
+      storeId: "store-1",
+    });
+
+    await submitStockAdjustmentBatchWithCtx(ctx, {
+      adjustmentType: "manual",
+      lineItems: [
+        {
+          productSkuId: "sku-1" as Id<"productSku">,
+          quantityDelta: 1,
+        },
+      ],
+      reasonCode: "correction",
+      storeId: "store-1" as Id<"store">,
+      submissionKey: "trusted-zero-sale-provisional-adjustment",
+    });
+
+    expect(tables.productSku.get("sku-1")).toMatchObject({
+      inventoryCount: 9,
+      quantityAvailable: 7,
+    });
+    expect(Array.from(tables.stockAdjustmentBatch.values())).toEqual([
+      expect.objectContaining({
+        status: "applied",
+        submissionKey: "trusted-zero-sale-provisional-adjustment",
+      }),
+    ]);
+  });
+
+  it.each([
+    [
+      "missing category",
+      (tables: ReturnType<typeof createSubmissionMutationCtx>["tables"]) => {
+        tables.category.delete("category-1");
+      },
+    ],
+    [
+      "cross-store category",
+      (tables: ReturnType<typeof createSubmissionMutationCtx>["tables"]) => {
+        tables.category.set("category-1", {
+          _id: "category-1",
+          name: "Hair",
+          slug: "hair",
+          storeId: "store-2",
+        });
+      },
+    ],
+    [
+      "missing subcategory",
+      (tables: ReturnType<typeof createSubmissionMutationCtx>["tables"]) => {
+        tables.subcategory.delete("subcategory-1");
+      },
+    ],
+    [
+      "mismatched subcategory",
+      (tables: ReturnType<typeof createSubmissionMutationCtx>["tables"]) => {
+        tables.subcategory.set("subcategory-1", {
+          _id: "subcategory-1",
+          categoryId: "category-other",
+          name: "Closures",
+          slug: "closures",
+          storeId: "store-1",
+        });
+      },
+    ],
+  ])("blocks zero-sale provisional rows with %s", async (caseName, mutateTables) => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "full_admin",
+    });
+
+    mutateTables(tables);
+    tables.inventoryImportProvisionalSku.set("provisional-1", {
+      _id: "provisional-1",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      saleEvidence: {
+        saleCount: 0,
+        totalQuantitySold: 0,
+      },
+      status: "active",
+      storeId: "store-1",
+    });
+
+    await expect(
+      submitStockAdjustmentBatchWithCtx(ctx, {
+        adjustmentType: "manual",
+        lineItems: [
+          {
+            productSkuId: "sku-1" as Id<"productSku">,
+            quantityDelta: 1,
+          },
+        ],
+        reasonCode: "correction",
+        storeId: "store-1" as Id<"store">,
+        submissionKey: `invalid-taxonomy-${caseName.replaceAll(" ", "-")}`,
+      }),
+    ).rejects.toThrow(
+      "Legacy import SKUs must be finalized before stock adjustments can update them.",
+    );
+
+    expect(tables.inventoryMovement.size).toBe(0);
+    expect(tables.stockAdjustmentBatch.size).toBe(0);
+  });
+
   it("rejects stock adjustments for unresolved POS pending checkout SKUs", async () => {
     const { ctx, tables } = createSubmissionMutationCtx({
       authUserId: "auth-user-1",
@@ -1652,6 +2106,49 @@ describe("stock ops adjustments", () => {
       internal.inventory.catalogSummary.markCatalogSummaryNeedsRefreshInternal,
       { storeId: "store-1" },
     );
+  });
+
+  it("completes synced sale inventory review work only after approval-gated stock adjustments are applied", async () => {
+    const { ctx, tables } = createApprovalDecisionMutationCtx();
+
+    tables.operationalWorkItem.set("inventory-review-1", {
+      _id: "inventory-review-1",
+      createdAt: 1,
+      metadata: {
+        primaryProductSkuId: "sku-1",
+      },
+      organizationId: "org-1",
+      productSkuId: "sku-1",
+      status: "open",
+      storeId: "store-1",
+      title: "Review inventory for Closure wig",
+      type: "synced_sale_inventory_review",
+    });
+
+    await resolveStockAdjustmentApprovalDecisionWithCtx(ctx, {
+      approvalRequestId: "approval-1" as Id<"approvalRequest">,
+      decision: "approved",
+      reviewedByUserId: "manager-1" as Id<"athenaUser">,
+    });
+
+    const stockMovement = Array.from(tables.inventoryMovement.values())[0];
+
+    expect(tables.operationalWorkItem.get("inventory-review-1")).toMatchObject({
+      completedAt: expect.any(Number),
+      metadata: {
+        resolution: {
+          actorUserId: "manager-1",
+          domainTrace: {
+            inventoryMovementId: stockMovement._id,
+            proofKind: "stock_update_movement",
+            stockAdjustmentBatchId: "batch-1",
+          },
+          outcome: "completed",
+          reason: "Resolved by applied stock adjustment.",
+        },
+      },
+      status: "completed",
+    });
   });
 
   it("rejects approval-gated stock adjustments without mutating inventory", async () => {

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -5,7 +5,7 @@ import {
   type QueryCtx,
 } from "../_generated/server";
 import { internal } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import {
@@ -19,6 +19,7 @@ import {
   createOperationalWorkItemWithCtx,
   updateOperationalWorkItemStatusWithCtx,
 } from "../operations/operationalWorkItems";
+import { autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx } from "../operations/openWorkInventoryReviews";
 import {
   CYCLE_COUNT_REASON_CODE,
   MANUAL_STOCK_ADJUSTMENT_REASON_CODES,
@@ -74,6 +75,7 @@ const ACTIVE_CHECKOUT_SESSION_SUM_LIMIT = 1000;
 const ACTIVE_CHECKOUT_ITEM_SUM_LIMIT = 5000;
 const STOCK_ADJUSTMENT_BLOCKER_POINT_LOOKUP_LIMIT = 50;
 const ACTIVE_PROVISIONAL_IMPORT_BLOCKER_SCAN_LIMIT = 1500;
+const ACTIVE_PROVISIONAL_IMPORT_BLOCKER_ROWS_PER_SKU_LIMIT = 25;
 const ACTIVE_PENDING_CHECKOUT_BLOCKER_SCAN_LIMIT = 2000;
 const INVENTORY_SNAPSHOT_DEFAULT_LIMIT = 500;
 const INVENTORY_SNAPSHOT_MAX_LIMIT = 750;
@@ -109,6 +111,10 @@ type StockAdjustmentBlockedSkuStatus = {
   reason: StockAdjustmentBlockedSkuReason;
 };
 
+type ProductReadCache = Map<Id<"product">, Doc<"product"> | null>;
+type CategoryReadCache = Map<Id<"category">, Doc<"category"> | null>;
+type SubcategoryReadCache = Map<Id<"subcategory">, Doc<"subcategory"> | null>;
+
 function trimOptional(value?: string | null) {
   const nextValue = value?.trim();
   return nextValue ? nextValue : undefined;
@@ -116,6 +122,104 @@ function trimOptional(value?: string | null) {
 
 function getStockAdjustmentScopeKey(categoryName?: string | null) {
   return categoryName?.trim() || UNCATEGORIZED_SCOPE_KEY;
+}
+
+async function readProductWithCache(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  cache: ProductReadCache,
+  productId: Id<"product">,
+) {
+  if (!cache.has(productId)) {
+    cache.set(productId, await ctx.db.get("product", productId));
+  }
+
+  return cache.get(productId) ?? null;
+}
+
+async function readCategoryWithCache(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  cache: CategoryReadCache,
+  categoryId: Id<"category">,
+) {
+  if (!cache.has(categoryId)) {
+    cache.set(categoryId, await ctx.db.get("category", categoryId));
+  }
+
+  return cache.get(categoryId) ?? null;
+}
+
+async function readSubcategoryWithCache(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  cache: SubcategoryReadCache,
+  subcategoryId: Id<"subcategory">,
+) {
+  if (!cache.has(subcategoryId)) {
+    cache.set(subcategoryId, await ctx.db.get("subcategory", subcategoryId));
+  }
+
+  return cache.get(subcategoryId) ?? null;
+}
+
+async function isOnboardedTrustedProductForStockAdjustment(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  caches: {
+    categories: CategoryReadCache;
+    products: ProductReadCache;
+    subcategories: SubcategoryReadCache;
+  },
+  args: {
+    productId?: Id<"product">;
+    storeId: Id<"store">;
+  },
+) {
+  if (!args.productId) return false;
+
+  const product = await readProductWithCache(ctx, caches.products, args.productId);
+  if (!product || product.storeId !== args.storeId) return false;
+  if (product.availability === "draft" || product.availability === "archived") {
+    return false;
+  }
+  if (!product.categoryId || !product.subcategoryId) return false;
+
+  const [category, subcategory] = await Promise.all([
+    readCategoryWithCache(ctx, caches.categories, product.categoryId),
+    readSubcategoryWithCache(ctx, caches.subcategories, product.subcategoryId),
+  ]);
+
+  return Boolean(
+    category &&
+      subcategory &&
+      category.storeId === args.storeId &&
+      subcategory.storeId === args.storeId &&
+      subcategory.categoryId === category._id &&
+      category.slug !== "legacy-import",
+  );
+}
+
+async function shouldBlockStockAdjustmentForProvisionalImportRow(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  caches: {
+    categories: CategoryReadCache;
+    products: ProductReadCache;
+    subcategories: SubcategoryReadCache;
+  },
+  args: {
+    row: Doc<"inventoryImportProvisionalSku">;
+    storeId: Id<"store">;
+  },
+) {
+  if (args.row.finalizedAt !== undefined) return false;
+  if ((args.row.saleEvidence?.totalQuantitySold ?? 0) > 0) return true;
+
+  const isTrustedProduct = await isOnboardedTrustedProductForStockAdjustment(
+    ctx,
+    caches,
+    {
+      productId: args.row.productId,
+      storeId: args.storeId,
+    },
+  );
+  return !isTrustedProduct;
 }
 
 async function listProductSkusForStockAdjustmentScopeWithCtx(
@@ -311,6 +415,7 @@ async function applyStockAdjustmentBatchWithCtx(
   },
 ) {
   const sourceId = buildStockAdjustmentSourceId(String(args.batchId));
+  const inventoryMovements: Doc<"inventoryMovement">[] = [];
 
   for (const lineItem of args.lineItems) {
     const productSku = await ctx.db.get("productSku", lineItem.productSkuId);
@@ -327,7 +432,7 @@ async function applyStockAdjustmentBatchWithCtx(
       ),
     });
 
-    await recordInventoryMovementWithCtx(ctx, {
+    const inventoryMovement = await recordInventoryMovementWithCtx(ctx, {
       actorUserId: args.actorUserId,
       movementType:
         lineItem.countedQuantity === undefined ? "adjustment" : "cycle_count",
@@ -342,7 +447,19 @@ async function applyStockAdjustmentBatchWithCtx(
       storeId: args.storeId,
       workItemId: args.workItemId,
     });
+
+    if (inventoryMovement) {
+      inventoryMovements.push(inventoryMovement);
+    }
   }
+
+  await autoResolveSyncedSaleInventoryReviewsForStockAdjustmentWithCtx(ctx, {
+    actorUserId: args.actorUserId,
+    inventoryMovements,
+    organizationId: args.organizationId,
+    stockAdjustmentBatchId: args.batchId,
+    storeId: args.storeId,
+  });
 
   await scheduleCatalogSummaryDirtyMarker(ctx, args.storeId);
 }
@@ -361,6 +478,11 @@ async function readActiveProvisionalImportSkuIdsWithCtx(
   }
 
   const productSkuIdSet = new Set(productSkuIds);
+  const caches = {
+    categories: new Map<Id<"category">, Doc<"category"> | null>(),
+    products: new Map<Id<"product">, Doc<"product"> | null>(),
+    subcategories: new Map<Id<"subcategory">, Doc<"subcategory"> | null>(),
+  };
 
   if (productSkuIds.length > STOCK_ADJUSTMENT_BLOCKER_POINT_LOOKUP_LIMIT) {
     const rows = await ctx.db
@@ -376,18 +498,29 @@ async function readActiveProvisionalImportSkuIdsWithCtx(
       );
     }
 
-    return new Set(
-      rows.flatMap((row) =>
-        row.productSkuId && productSkuIdSet.has(row.productSkuId)
-          ? [row.productSkuId as Id<"productSku">]
-          : [],
-      ),
-    );
+    const blockedSkuIds = new Set<Id<"productSku">>();
+    for (const row of rows) {
+      if (!row.productSkuId || !productSkuIdSet.has(row.productSkuId)) {
+        continue;
+      }
+
+      if (
+        await shouldBlockStockAdjustmentForProvisionalImportRow(ctx, caches, {
+          row,
+          storeId: args.storeId,
+        })
+      ) {
+        blockedSkuIds.add(row.productSkuId as Id<"productSku">);
+      }
+    }
+
+    return blockedSkuIds;
   }
 
-  const rows = await Promise.all(
-    productSkuIds.map((productSkuId) =>
-      ctx.db
+  const rowGroups = await Promise.all(
+    productSkuIds.map(async (productSkuId) => ({
+      productSkuId,
+      rows: await ctx.db
         .query("inventoryImportProvisionalSku")
         .withIndex("by_storeId_productSkuId_status", (q) =>
           q
@@ -395,15 +528,33 @@ async function readActiveProvisionalImportSkuIdsWithCtx(
             .eq("productSkuId", productSkuId)
             .eq("status", "active"),
         )
-        .first(),
-    ),
+        .take(ACTIVE_PROVISIONAL_IMPORT_BLOCKER_ROWS_PER_SKU_LIMIT + 1),
+    })),
   );
 
-  return new Set(
-    rows.flatMap((row) =>
-      row?.productSkuId ? [row.productSkuId as Id<"productSku">] : [],
-    ),
-  );
+  const blockedSkuIds = new Set<Id<"productSku">>();
+  for (const { productSkuId, rows } of rowGroups) {
+    if (rows.length > ACTIVE_PROVISIONAL_IMPORT_BLOCKER_ROWS_PER_SKU_LIMIT) {
+      blockedSkuIds.add(productSkuId);
+      continue;
+    }
+
+    for (const row of rows) {
+      if (!row.productSkuId) continue;
+
+      if (
+        await shouldBlockStockAdjustmentForProvisionalImportRow(ctx, caches, {
+          row,
+          storeId: args.storeId,
+        })
+      ) {
+        blockedSkuIds.add(row.productSkuId as Id<"productSku">);
+        break;
+      }
+    }
+  }
+
+  return blockedSkuIds;
 }
 
 async function readActivePendingCheckoutSkuIdsWithCtx(

--- a/packages/athena-webapp/src/components/add-product/ProductCategorization.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductCategorization.tsx
@@ -36,7 +36,13 @@ function ProductCategorization({
 }: {
   setInitialSelectedOption: (option: CategoryManageOption) => void;
 }) {
-  const { showLoaderForProduct, productData, updateProductData } = useProduct();
+  const {
+    activeProduct,
+    showLoaderForProduct,
+    productData,
+    trustedInventoryFinalizedSkuIds,
+    updateProductData,
+  } = useProduct();
 
   const { activeStore } = useGetActiveStore();
 
@@ -59,15 +65,17 @@ function ProductCategorization({
       updateProductData({
         categoryId: categoryInSearch._id,
         categoryName: categoryInSearch.name,
+        categorySlug: categoryInSearch.slug,
       });
     }
-  }, [categoryInSearch]);
+  }, [categoryInSearch, updateProductData]);
 
   const categories =
     categoriesData
       ?.map((category) => ({
         name: category.name,
         id: category._id,
+        slug: category.slug,
       }))
       .sort((a, b) => a.name.localeCompare(b.name)) || [];
 
@@ -76,12 +84,20 @@ function ProductCategorization({
       ?.map((subcategory) => ({
         name: subcategory.name,
         id: subcategory._id,
+        slug: subcategory.slug,
         categoryId: subcategory.categoryId,
       }))
       .filter(
         (subcategory) => subcategory.categoryId === productData.categoryId,
       )
       .sort((a, b) => a.name.localeCompare(b.name)) || [];
+
+  const shouldShowCatalogSetupRequirement =
+    trustedInventoryFinalizedSkuIds.size > 0 &&
+    activeProduct?.categorySlug === "legacy-import" &&
+    (productData.categorySlug === "legacy-import" ||
+      !productData.categorySlug ||
+      !productData.subcategorySlug);
 
   return (
     <>
@@ -103,11 +119,16 @@ function ProductCategorization({
           {showLoaderForProduct ? null : (
             <Select
               onValueChange={(value: string) => {
+                const selectedCategory = categories.find(
+                  (category) => category.id === value,
+                );
                 updateProductData({
                   categoryId: value as Id<"category">,
-                  categoryName: categories.find(
-                    (category) => category.id === value,
-                  )?.name,
+                  categoryName: selectedCategory?.name,
+                  categorySlug: selectedCategory?.slug,
+                  subcategoryId: undefined,
+                  subcategoryName: undefined,
+                  subcategorySlug: undefined,
                 });
               }}
               value={productData.categoryId?.toString()}
@@ -152,8 +173,13 @@ function ProductCategorization({
           {showLoaderForProduct ? null : (
             <Select
               onValueChange={(value: string) => {
+                const selectedSubcategory = subcategories.find(
+                  (subcategory) => subcategory.id === value,
+                );
                 updateProductData({
                   subcategoryId: value as Id<"subcategory">,
+                  subcategoryName: selectedSubcategory?.name,
+                  subcategorySlug: selectedSubcategory?.slug,
                 });
               }}
               value={productData.subcategoryId?.toString()}
@@ -183,6 +209,12 @@ function ProductCategorization({
           )} */}
         </div>
       </div>
+      {shouldShowCatalogSetupRequirement ? (
+        <p className="px-4 pb-4 text-xs leading-5 text-amber-500">
+          Catalog setup required. Assign an Athena category and subcategory
+          before saving.
+        </p>
+      ) : null}
     </>
   );
 }

--- a/packages/athena-webapp/src/components/add-product/ProductStock.test.ts
+++ b/packages/athena-webapp/src/components/add-product/ProductStock.test.ts
@@ -17,6 +17,7 @@ import type { ProductVariant } from "./ProductStock";
 import {
   mergeProductDataWithActiveProductRefresh,
   mergeProductVariantsWithActiveProductRefresh,
+  mergeTrustedInventoryFinalizationIntoProduct,
   mergeTrustedInventoryFinalizationIntoVariants,
 } from "@/contexts/ProductContext";
 
@@ -533,6 +534,33 @@ describe("ProductStock money inputs", () => {
       images: [{ preview: "dirty-image.webp" }],
     });
     expect(merged[1]).toBe(variants[1]);
+  });
+
+  it("applies trusted inventory product status updates to the active product snapshot", () => {
+    const product = {
+      _id: "product-1",
+      availability: "draft",
+      inventoryCount: 0,
+      isVisible: false,
+      name: "Apron Stylist",
+      quantityAvailable: 0,
+      skus: [],
+    } as unknown as Product;
+
+    const merged = mergeTrustedInventoryFinalizationIntoProduct(product, {
+      availability: "live",
+      inventoryCount: 1,
+      quantityAvailable: 1,
+    });
+
+    expect(merged).toMatchObject({
+      _id: "product-1",
+      availability: "live",
+      inventoryCount: 1,
+      isVisible: false,
+      name: "Apron Stylist",
+      quantityAvailable: 1,
+    });
   });
 
   it("preserves dirty product and SKU edits across a post-finalization product refresh", () => {

--- a/packages/athena-webapp/src/components/add-product/ProductStock.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductStock.tsx
@@ -11,7 +11,6 @@ import {
 import { Label } from "../ui/label";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
-import { Badge } from "../ui/badge";
 import {
   DotsHorizontalIcon,
   PlusCircledIcon,
@@ -38,7 +37,6 @@ import {
   X,
   ScanBarcode,
 } from "lucide-react";
-import useGetActiveProduct from "@/hooks/useGetActiveProduct";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { BarcodeQRViewer } from "./BarcodeQRViewer";
 import { useMutation, useQuery } from "convex/react";
@@ -317,11 +315,8 @@ export function ProductStockView() {
   );
 }
 
-function isLegacyImportDraftProduct(activeProduct?: Product | null) {
-  return (
-    activeProduct?.availability === "draft" &&
-    activeProduct?.categorySlug === "legacy-import"
-  );
+function isLegacyImportProduct(activeProduct?: Product | null) {
+  return activeProduct?.categorySlug === "legacy-import";
 }
 
 function isPendingCheckoutDraftProduct(activeProduct?: Product | null) {
@@ -392,6 +387,7 @@ function LegacyImportTrustPreview({
   const [commandMessage, setCommandMessage] = useState<string | null>(null);
   const [requiresReviewRefresh, setRequiresReviewRefresh] = useState(false);
   const [bindingRefreshNonce, setBindingRefreshNonce] = useState(0);
+  const { markTrustedInventoryFinalized } = useProduct();
 
   const binding = useQuery(
     listProvisionalSkuBindingQuery,
@@ -407,10 +403,13 @@ function LegacyImportTrustPreview({
   const finalizeTrustedInventory = useMutation(
     finalizeTrustedInventoryMutation,
   );
+  const isServerFinalized =
+    binding?.state === "unique" && binding.row.finalizedAt !== undefined;
+  const isTrustedInventoryFinalized = Boolean(finalized || isServerFinalized);
 
   const reviewState = resolveTrustedInventoryReviewState({
     binding,
-    finalized,
+    finalized: isTrustedInventoryFinalized,
     isFinalizing,
     isRefreshing: isContextRefreshing,
     reservationType,
@@ -437,6 +436,12 @@ function LegacyImportTrustPreview({
     bindingState,
     bindingTrustedSkuFingerprint,
   ]);
+
+  useEffect(() => {
+    if (isServerFinalized) {
+      markTrustedInventoryFinalized(variant.id);
+    }
+  }, [isServerFinalized, markTrustedInventoryFinalized, variant.id]);
 
   const getConversionRequestId = () => {
     const existing = conversionRequestIds[variant.id];
@@ -499,9 +504,7 @@ function LegacyImportTrustPreview({
           isVisible: variant.isVisible,
         },
       });
-      setCommandMessage(
-        "Inventory finalized. Save remaining product changes separately.",
-      );
+      setCommandMessage(null);
     } catch (error) {
       console.error(error);
       setCommandMessage("Trusted inventory was not finalized. Try again.");
@@ -548,6 +551,12 @@ function LegacyImportTrustPreview({
   const isCtaDisabled = requiresReviewRefresh ? false : reviewState.disabled;
   const isFinalized = reviewState.status === "success";
   const isLinkedToCatalogState = isLinkedToCatalog || Boolean(linkedTarget);
+  const reviewTitle = isFinalized
+    ? linkedTarget
+      ? "SKU linked to catalog"
+      : "Trusted inventory finalized"
+    : "Trusted inventory review";
+  const shouldShowStatusMessage = !isFinalized || Boolean(commandMessage);
   const canOpenLinkDialog = Boolean(
     canLinkPendingCheckoutItem &&
     activeProduct &&
@@ -556,6 +565,16 @@ function LegacyImportTrustPreview({
     !isFinalized &&
     !isLinkedToCatalogState,
   );
+  const shouldRenderTrustPreview =
+    (binding !== undefined && binding.state !== "none") ||
+    finalized ||
+    isFinalizing ||
+    requiresReviewRefresh ||
+    Boolean(commandMessage);
+
+  if (!shouldRenderTrustPreview) {
+    return null;
+  }
 
   if (hideWhenLinkedToCatalog && isLinkedToCatalogState) {
     return null;
@@ -569,66 +588,75 @@ function LegacyImportTrustPreview({
     >
       <TableCell colSpan={8} className="px-4 py-3">
         <div
-          className={`flex flex-col gap-3 rounded-md border bg-background px-3 py-3 transition-[border-color,box-shadow] duration-150 ease-out sm:flex-row sm:items-center sm:justify-between ${
+          className={`flex flex-col gap-3 rounded-md border bg-muted/15 px-3 py-3 transition-[border-color,box-shadow] duration-150 ease-out sm:flex-row sm:items-center sm:justify-between ${
             isFinalized
               ? "border-action-workflow-border shadow-sm"
               : "border-border"
           }`}
         >
-          <div className="min-w-0 space-y-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <Badge variant="outline" className="gap-1.5 text-foreground">
-                <ShieldCheck className="h-3.5 w-3.5" />
-                Trusted inventory review
-              </Badge>
-              <Badge
-                variant="outline"
-                className="border-border bg-muted/40 text-muted-foreground"
-              >
-                Pending item
-              </Badge>
-              {isFinalized ? (
-                <Badge
-                  variant="outline"
-                  className="gap-1.5 border-action-workflow-border bg-background text-action-workflow"
-                >
-                  <Check className="h-3.5 w-3.5" />
-                  {linkedTarget ? "Linked SKU" : "Finalized"}
-                </Badge>
-              ) : null}
+          <div className="flex min-w-0 gap-3">
+            <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground">
+              <ShieldCheck className="h-3.5 w-3.5" />
             </div>
-            <p
-              className="max-w-3xl text-pretty text-xs leading-5 text-muted-foreground"
-              role="status"
-              aria-live="polite"
-            >
-              {statusMessage}
-            </p>
-            {linkedTarget ? (
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] leading-4 text-muted-foreground">
-                <span className="font-medium text-foreground">
-                  Linked to {capitalizeWords(linkedTarget.productName)}
-                </span>
-                <span>{linkedTarget.sku || "No SKU"}</span>
-                {typeof linkedTarget.price === "number" ? (
-                  <span>
-                    {formatStoredAmount(linkedSkuFormatter, linkedTarget.price)}
+            <div className="min-w-0 space-y-1.5">
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <p className="text-xs font-medium leading-5 text-foreground">
+                  {reviewTitle}
+                </p>
+                {!isFinalized ? (
+                  <span className="text-[11px] leading-4 text-muted-foreground">
+                    Pending item
                   </span>
                 ) : null}
-                {typeof linkedTarget.quantityAvailable === "number" ? (
-                  <span>{linkedTarget.quantityAvailable} available</span>
+                {isFinalized && linkedTarget ? (
+                  <span className="inline-flex items-center gap-1 text-[11px] font-medium leading-4 text-action-workflow">
+                    <Check className="h-3.5 w-3.5" />
+                    Linked SKU
+                  </span>
                 ) : null}
               </div>
-            ) : binding?.state === "unique" ? (
-              <p className="text-[11px] leading-4 text-muted-foreground">
-                {sourceLabel === "Linked import row"
-                  ? `${sourceLabel} ${binding.row.rowNumber}`
-                  : sourceLabel}
-                {binding.row.provisionalSoldQuantity !== undefined
-                  ? ` · provisional sales ${binding.row.provisionalSoldQuantity}`
-                  : ""}
-              </p>
-            ) : null}
+              {shouldShowStatusMessage ? (
+                <p
+                  className="max-w-3xl text-pretty text-xs leading-5 text-muted-foreground"
+                  role="status"
+                  aria-live="polite"
+                >
+                  {statusMessage}
+                </p>
+              ) : null}
+              {linkedTarget ? (
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] leading-4 text-muted-foreground">
+                  <span className="font-medium text-foreground">
+                    Linked to {capitalizeWords(linkedTarget.productName)}
+                  </span>
+                  <span>{linkedTarget.sku || "No SKU"}</span>
+                  {typeof linkedTarget.price === "number" ? (
+                    <span>
+                      {formatStoredAmount(
+                        linkedSkuFormatter,
+                        linkedTarget.price,
+                      )}
+                    </span>
+                  ) : null}
+                  {typeof linkedTarget.quantityAvailable === "number" ? (
+                    <span>{linkedTarget.quantityAvailable} available</span>
+                  ) : null}
+                </div>
+              ) : binding?.state === "unique" ? (
+                <p className="text-[11px] leading-4 text-muted-foreground">
+                  <span>
+                    {sourceLabel === "Linked import row"
+                      ? `${sourceLabel} ${binding.row.rowNumber}`
+                      : sourceLabel}
+                  </span>
+                  {binding.row.provisionalSoldQuantity !== undefined ? (
+                    <span className="ml-2">
+                      Provisional sales {binding.row.provisionalSoldQuantity}
+                    </span>
+                  ) : null}
+                </p>
+              ) : null}
+            </div>
           </div>
 
           <div className="flex flex-wrap items-center gap-2 sm:justify-end">
@@ -654,12 +682,12 @@ function LegacyImportTrustPreview({
               </div>
             ) : isFinalized ? (
               <div
-                className="inline-flex min-h-10 items-center gap-2 rounded-md px-3 text-xs font-medium text-muted-foreground"
+                aria-label="Trusted inventory finalized"
+                className="inline-flex min-h-10 items-center rounded-md px-3 text-action-workflow"
                 role="status"
                 aria-live="polite"
               >
-                <Check className="h-3.5 w-3.5 text-action-workflow" />
-                Trusted SKU ready
+                <Check className="h-3.5 w-3.5" />
               </div>
             ) : (
               <Button
@@ -1092,10 +1120,9 @@ function Stock({
     updateProductVariants,
     activeProductVariant,
     setActiveProductVariant,
+    activeProduct,
     showLoaderForProduct,
   } = useProduct();
-
-  const { activeProduct } = useGetActiveProduct();
 
   const { activeStore } = useGetActiveStore();
 
@@ -1378,7 +1405,7 @@ function Stock({
   const isPendingCheckoutDraft = isPendingCheckoutDraftProduct(activeProduct);
   const isPendingCheckoutSku = isPendingCheckoutProduct(activeProduct);
   const shouldShowTrustPreview =
-    isLegacyImportDraftProduct(activeProduct) || isPendingCheckoutDraft;
+    isLegacyImportProduct(activeProduct) || isPendingCheckoutDraft;
   const trustedInventoryApi = isPendingCheckoutDraft
     ? {
         finalizeTrustedInventoryMutation:

--- a/packages/athena-webapp/src/components/add-product/ProductStockInput.ts
+++ b/packages/athena-webapp/src/components/add-product/ProductStockInput.ts
@@ -219,6 +219,7 @@ export type ProductPageProvisionalSkuBinding =
       row: {
         _id: Id<"inventoryImportProvisionalSku"> | Id<"posPendingCheckoutItem">;
         importKey: string;
+        finalizedAt?: number;
         importedQuantity: number;
         lastSoldAt?: number;
         linkedTarget?: {
@@ -233,7 +234,14 @@ export type ProductPageProvisionalSkuBinding =
         provisionalSoldQuantity: number;
         rowNumber: number;
         saleCount: number;
-        status?: "pending_review" | "flagged" | "linked_to_catalog";
+        status?:
+          | "active"
+          | "finalized"
+          | "rejected"
+          | "closed"
+          | "pending_review"
+          | "flagged"
+          | "linked_to_catalog";
       };
       saleEvidenceFingerprint: string;
       trustedSkuFingerprint: string;
@@ -340,8 +348,7 @@ export function resolveTrustedInventoryReviewState({
       action: "none",
       ctaLabel: "Trusted inventory finalized",
       disabled: true,
-      message:
-        "Inventory finalized. Save remaining product changes separately.",
+      message: "Trusted inventory finalized.",
       status: "success",
     };
   }

--- a/packages/athena-webapp/src/components/add-product/ProductView.test.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductView.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildVariantSkuMoneyPayload,
+  resolveLegacyTaxonomySaveGate,
   getArchivedProductRedirect,
 } from "./ProductView";
 
@@ -76,5 +77,59 @@ describe("ProductView archived product redirects", () => {
       categorySlug: "makeup",
       kind: "category",
     });
+  });
+});
+
+describe("ProductView legacy taxonomy save gate", () => {
+  it("blocks save after trusted inventory finalization while legacy taxonomy remains selected", () => {
+    expect(
+      resolveLegacyTaxonomySaveGate({
+        activeProduct: {
+          categorySlug: "legacy-import",
+          subcategorySlug: "872",
+        },
+        hasTrustedInventoryFinalized: true,
+        productData: {
+          categorySlug: "legacy-import",
+          subcategorySlug: "872",
+        },
+      }),
+    ).toEqual({
+      blocked: true,
+      message:
+        "Catalog setup required. Assign an Athena category and subcategory before saving.",
+    });
+  });
+
+  it("allows save after trusted inventory finalization once Athena taxonomy is selected", () => {
+    expect(
+      resolveLegacyTaxonomySaveGate({
+        activeProduct: {
+          categorySlug: "legacy-import",
+          subcategorySlug: "872",
+        },
+        hasTrustedInventoryFinalized: true,
+        productData: {
+          categorySlug: "hair-care",
+          subcategorySlug: "heat-protectant",
+        },
+      }),
+    ).toEqual({ blocked: false });
+  });
+
+  it("does not block non-finalized legacy products", () => {
+    expect(
+      resolveLegacyTaxonomySaveGate({
+        activeProduct: {
+          categorySlug: "legacy-import",
+          subcategorySlug: "872",
+        },
+        hasTrustedInventoryFinalized: false,
+        productData: {
+          categorySlug: "legacy-import",
+          subcategorySlug: "872",
+        },
+      }),
+    ).toEqual({ blocked: false });
   });
 });

--- a/packages/athena-webapp/src/components/add-product/ProductView.tsx
+++ b/packages/athena-webapp/src/components/add-product/ProductView.tsx
@@ -11,7 +11,6 @@ import { AlertModal } from "../ui/modals/alert-modal";
 import ProductPage from "./ProductPage";
 import { ProductProvider, useProduct } from "@/contexts/ProductContext";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
-import useGetActiveProduct from "@/hooks/useGetActiveProduct";
 import { useAction, useMutation } from "convex/react";
 import { api } from "~/convex/_generated/api";
 import { capitalizeWords, toSlug } from "../../lib/utils";
@@ -30,6 +29,40 @@ type VariantMoneyInput = {
   cost?: number;
   netPrice?: number;
 };
+
+const LEGACY_IMPORT_CATEGORY_SLUG = "legacy-import";
+
+type ProductTaxonomyLike = {
+  categorySlug?: string | null;
+  subcategorySlug?: string | null;
+};
+
+export function resolveLegacyTaxonomySaveGate(args: {
+  activeProduct?: ProductTaxonomyLike | null;
+  hasTrustedInventoryFinalized: boolean;
+  productData: ProductTaxonomyLike;
+}): { blocked: false } | { blocked: true; message: string } {
+  if (
+    !args.hasTrustedInventoryFinalized ||
+    args.activeProduct?.categorySlug !== LEGACY_IMPORT_CATEGORY_SLUG
+  ) {
+    return { blocked: false };
+  }
+
+  if (
+    args.productData.categorySlug === LEGACY_IMPORT_CATEGORY_SLUG ||
+    !args.productData.categorySlug ||
+    !args.productData.subcategorySlug
+  ) {
+    return {
+      blocked: true,
+      message:
+        "Catalog setup required. Assign an Athena category and subcategory before saving.",
+    };
+  }
+
+  return { blocked: false };
+}
 
 export function buildVariantSkuMoneyPayload(
   variant: VariantMoneyInput,
@@ -93,8 +126,14 @@ function archivedProductNestedOrigin(args: {
 }
 
 function ProductViewContent() {
-  const { productData, revertChanges, productVariants, updateProductVariants } =
-    useProduct();
+  const {
+    productData,
+    activeProduct,
+    revertChanges,
+    productVariants,
+    trustedInventoryFinalizedSkuIds,
+    updateProductVariants,
+  } = useProduct();
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [productId, setProductid] = useState<Id<"product"> | null>(null);
@@ -106,7 +145,6 @@ function ProductViewContent() {
   const navigate = useNavigate();
 
   const { activeStore } = useGetActiveStore();
-  const { activeProduct } = useGetActiveProduct();
   const { user } = useAuth();
 
   const createProduct = useMutation(api.inventory.products.create);
@@ -127,6 +165,11 @@ function ProductViewContent() {
   const updateProductSku = useMutation(api.inventory.productSku.update);
 
   const { o } = useSearch({ strict: false });
+  const legacyTaxonomySaveGate = resolveLegacyTaxonomySaveGate({
+    activeProduct,
+    hasTrustedInventoryFinalized: trustedInventoryFinalizedSkuIds.size > 0,
+    productData,
+  });
 
   const deleteActiveProduct = async () => {
     if (!activeProduct?._id || !activeStore)
@@ -417,6 +460,11 @@ function ProductViewContent() {
   };
 
   const onSubmit = async () => {
+    if (legacyTaxonomySaveGate.blocked) {
+      toast.error(legacyTaxonomySaveGate.message);
+      return;
+    }
+
     if (activeProduct?._id || productId) await modifyProduct();
     else await saveProduct();
   };
@@ -464,8 +512,6 @@ function ProductViewContent() {
   const Navigation = () => {
     const { productSlug } = useParams({ strict: false });
 
-    const { activeProduct } = useGetActiveProduct();
-
     const isValid = productSlug ? !!activeProduct : true;
 
     const header = productSlug
@@ -480,6 +526,7 @@ function ProductViewContent() {
 
     const isUpdatingProduct =
       isCreateMutationPending || isUpdateMutationPending;
+    const isSaveDisabled = !isValid;
 
     return (
       <ComposedPageHeader
@@ -555,7 +602,7 @@ function ProductViewContent() {
               </>
             )}
             <LoadingButton
-              disabled={!isValid}
+              disabled={isSaveDisabled}
               isLoading={isUpdatingProduct}
               onClick={onSubmit}
               variant={"outline"}

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -1174,7 +1174,7 @@ function getPrimaryActionEmphasis(status: PrimaryActionEmphasisStatus) {
   switch (status) {
     case "not_opened":
       return {
-        Icon: Clock3,
+        Icon: null,
         className: cn(
           "border-border bg-background text-muted-foreground hover:bg-surface hover:text-foreground",
           sharedClassName,

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -987,6 +987,56 @@ describe("OperationsQueueViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("routes catalog taxonomy setup work to the product edit page", () => {
+    render(
+      <OperationsQueueViewContent
+        {...baseProps}
+        activeWorkflow="queue"
+        orgUrlSlug="wigclub"
+        storeUrlSlug="wigclub"
+        workItems={[
+          {
+            _id: "work-catalog-taxonomy" as Id<"operationalWorkItem">,
+            approvalState: "not_required",
+            createdAt: Date.UTC(2026, 6, 1, 10, 0, 0),
+            details: {
+              productId: "product-1",
+              productName: "BLACK HAIR BAND SMALL",
+              productSkuId: "sku-1",
+              sku: "6N2Y-PKG-RBR",
+            },
+            priority: "medium",
+            status: "open",
+            title: "Assign catalog category: Packaging Rubber",
+            type: "catalog_taxonomy_setup",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("Catalog setup").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Black Hair Band Small").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.queryByText("BLACK HAIR BAND SMALL")).not.toBeInTheDocument();
+    expect(screen.getByText("6N2Y-PKG-RBR")).toBeInTheDocument();
+    expect(
+      screen.getByText("Assign category and subcategory"),
+    ).toBeInTheDocument();
+
+    const catalogSetupHref = new URL(
+      screen
+        .getByRole("link", { name: "Assign category" })
+        .getAttribute("href") ?? "",
+      "http://localhost",
+    );
+    expect(catalogSetupHref.pathname).toBe(
+      "/wigclub/store/wigclub/products/product-1/edit",
+    );
+    expect(catalogSetupHref.searchParams.get("o")).toBe("%2F");
+    expect(catalogSetupHref.searchParams.get("variant")).toBe("sku-1");
+  });
+
   it("does not render service deposit review as a supported open work row", () => {
     render(
       <OperationsQueueViewContent

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -15,6 +15,7 @@ import {
   Lock,
   LockOpen,
   PackageCheck,
+  PackageSearch,
   ReceiptText,
   Scissors,
   ShoppingCart,
@@ -111,6 +112,9 @@ type QueueWorkItem = {
     lookupCode?: string | null;
     price?: number | null;
     primaryProductSkuId?: string | null;
+    productId?: string | null;
+    productName?: string | null;
+    productSkuId?: string | null;
     provisionalProductId?: string | null;
     provisionalProductSkuId?: string | null;
     purchaseOrderNumber?: string | null;
@@ -118,6 +122,7 @@ type QueueWorkItem = {
     reasonLabel?: string | null;
     receiptNumber?: string | null;
     registerSessionId?: string | null;
+    sku?: string | null;
     sourceId?: string | null;
     terminalId?: string | null;
     totalQuantitySold?: number | null;
@@ -275,9 +280,22 @@ function getWorkItemTitleSubject(title: string, prefix: string) {
   return subject ? preserveOperationalAcronyms(capitalizeWords(subject)) : null;
 }
 
+function formatCatalogSetupProductName(item: QueueWorkItem) {
+  const productName = getQueueWorkItemStringDetail(item, "productName");
+  if (productName) {
+    return preserveOperationalAcronyms(capitalizeWords(productName));
+  }
+
+  return getQueueWorkItemStringDetail(item, "productId") ?? "Product not recorded";
+}
+
 function getQueueWorkItemTypeLabel(type: string) {
   if (type === "pos_pending_checkout_item_review") {
     return "POS pending checkout";
+  }
+
+  if (type === "catalog_taxonomy_setup") {
+    return "Catalog setup";
   }
 
   if (type === "synced_sale_inventory_review") {
@@ -381,6 +399,16 @@ function getQueueWorkItemContextPresentation(type: string) {
     return {
       cardClassName: "bg-surface-raised hover:border-border",
       Icon: ShoppingCart,
+      iconClassName:
+        "border-action-workflow-border bg-action-workflow-soft text-action-workflow",
+      contextLabelClassName: "text-action-workflow",
+    };
+  }
+
+  if (type === "catalog_taxonomy_setup") {
+    return {
+      cardClassName: "bg-surface-raised hover:border-border",
+      Icon: PackageSearch,
       iconClassName:
         "border-action-workflow-border bg-action-workflow-soft text-action-workflow",
       contextLabelClassName: "text-action-workflow",
@@ -659,6 +687,33 @@ function QueueWorkItemActionSlot({
         <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
       </Link>
     );
+  }
+
+  if (item.type === "catalog_taxonomy_setup") {
+    const productId = getQueueWorkItemStringDetail(item, "productId");
+    const productSkuId = getQueueWorkItemStringDetail(item, "productSkuId");
+
+    if (productId) {
+      return (
+        <Link
+          className={openWorkActionLinkClassName}
+          from="/$orgUrlSlug/store/$storeUrlSlug/operations/open-work"
+          params={{
+            orgUrlSlug,
+            productSlug: productId,
+            storeUrlSlug,
+          }}
+          search={{
+            o: getOrigin(),
+            ...(productSkuId ? { variant: productSkuId } : {}),
+          }}
+          to="/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit"
+        >
+          Assign category
+          <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+        </Link>
+      );
+    }
   }
 
   if (item.type === "synced_sale_inventory_review") {
@@ -959,6 +1014,25 @@ function QueueWorkItemCard({
       value: getRelativeTime(item.createdAt),
     },
   ];
+  const catalogTaxonomyCollapsedMetadataEntries: OperationReviewMetadataEntry[] =
+    [
+      {
+        label: "Product",
+        value: formatCatalogSetupProductName(item),
+      },
+      {
+        label: "SKU",
+        value: getQueueWorkItemStringDetail(item, "sku") ?? "Not recorded",
+      },
+      {
+        label: "Next action",
+        value: "Assign category and subcategory",
+      },
+      {
+        label: "Created",
+        value: getRelativeTime(item.createdAt),
+      },
+    ];
   const pendingCheckoutCollapsedMetadataEntries: OperationReviewMetadataEntry[] =
     [
       {
@@ -1007,17 +1081,19 @@ function QueueWorkItemCard({
   const collapsedMetadataEntries =
     item.type === "pos_pending_checkout_item_review"
       ? pendingCheckoutCollapsedMetadataEntries
-      : item.type === "synced_sale_inventory_review"
-        ? syncedSaleCollapsedMetadataEntries
-        : item.type === "purchase_order"
-          ? purchaseOrderCollapsedMetadataEntries
-          : item.type === "stock_adjustment_review"
-            ? stockAdjustmentReviewCollapsedMetadataEntries
-            : item.type === "daily_close_carry_forward"
-              ? dailyCloseCollapsedMetadataEntries
-              : item.type === "service_deposit_review"
-                ? unsupportedCollapsedMetadataEntries
-                : serviceCollapsedMetadataEntries;
+      : item.type === "catalog_taxonomy_setup"
+        ? catalogTaxonomyCollapsedMetadataEntries
+        : item.type === "synced_sale_inventory_review"
+          ? syncedSaleCollapsedMetadataEntries
+          : item.type === "purchase_order"
+            ? purchaseOrderCollapsedMetadataEntries
+            : item.type === "stock_adjustment_review"
+              ? stockAdjustmentReviewCollapsedMetadataEntries
+              : item.type === "daily_close_carry_forward"
+                ? dailyCloseCollapsedMetadataEntries
+                : item.type === "service_deposit_review"
+                  ? unsupportedCollapsedMetadataEntries
+                  : serviceCollapsedMetadataEntries;
   const expandedOnlyMetadataEntries: OperationReviewMetadataEntry[] =
     item.type === "synced_sale_inventory_review"
       ? [

--- a/packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx
+++ b/packages/athena-webapp/src/components/operations/SkuActivityUntrustedSales.tsx
@@ -369,9 +369,9 @@ function SourceList({
           <button
             aria-pressed={source.isSelected}
             className={cn(
-              "group w-full bg-background px-layout-md py-layout-lg text-left transition-[background-color,box-shadow,transform] duration-150 ease-out active:scale-[0.998] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              "group w-full bg-background px-layout-md py-layout-lg text-left transition-[background-color,transform] duration-150 ease-out active:scale-[0.998] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
               source.isSelected
-                ? "bg-action-workflow-soft/55 shadow-[inset_3px_0_0_hsl(var(--action-workflow))] hover:bg-action-workflow-soft/70"
+                ? "bg-action-workflow-soft/55 hover:bg-action-workflow-soft/70"
                 : "hover:bg-muted/40",
             )}
             onClick={() =>
@@ -509,9 +509,6 @@ function SelectedSourceDetail({
         <div className="space-y-layout-md border-b border-border bg-muted/20 px-layout-md py-layout-md">
           <div className="flex flex-col gap-layout-md sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0 space-y-layout-xs">
-              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                Selected source
-              </p>
               <h2 className="line-clamp-2 text-base font-medium text-foreground">
                 {loadingSource.title}
               </h2>
@@ -621,9 +618,6 @@ function SelectedSourceDetail({
       <div className="space-y-layout-md border-b border-border bg-muted/20 px-layout-md py-layout-md">
         <div className="flex flex-col gap-layout-md sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0 space-y-layout-xs">
-            <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-              Selected source
-            </p>
             <h2 className="line-clamp-2 text-base font-medium text-foreground">
               {selected.source.title}
             </h2>

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -2673,7 +2673,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
       }),
     ).not.toBeInTheDocument();
 
-    const bodyWaveRow = screen.getByText("Body Wave Bundle").closest("tr");
+    const bodyWaveRow = within(screen.getByRole("table"))
+      .getByText("Body Wave Bundle")
+      .closest("tr");
     expect(bodyWaveRow).not.toBeNull();
 
     await user.click(bodyWaveRow!);
@@ -2691,6 +2693,66 @@ describe("StockAdjustmentWorkspaceContent", () => {
       "/wigclub/store/wigclub/products/product-2?o=%2Fwigclub%2Fstore%2Fwigclub%2Foperations%2Fstock-adjustments",
     );
     expect(bodyWaveRow).toHaveClass("bg-muted/60");
+  });
+
+  it("keeps an already selected stock row selected when the row is clicked", async () => {
+    const user = userEvent.setup();
+    const onSearchStateChange = vi.fn();
+
+    renderStockAdjustmentWorkspace({
+      onSearchStateChange,
+      searchState: {
+        mode: "manual",
+        selectedSku: "sku-2",
+      },
+    });
+
+    const bodyWaveRow = within(screen.getByRole("table"))
+      .getByText("Body Wave Bundle")
+      .closest("tr");
+    expect(bodyWaveRow).not.toBeNull();
+    expect(bodyWaveRow).toHaveClass("bg-muted/60");
+
+    await user.click(bodyWaveRow!);
+
+    expect(bodyWaveRow).toHaveClass("bg-muted/60");
+    expect(onSearchStateChange).not.toHaveBeenCalledWith({
+      selectedSku: undefined,
+      sku: undefined,
+    });
+  });
+
+  it("keeps route-selected stock rows selected when their inputs are focused", async () => {
+    const user = userEvent.setup();
+    const onSearchStateChange = vi.fn();
+
+    renderStockAdjustmentWorkspace({
+      onSearchStateChange,
+      searchState: {
+        mode: "manual",
+        sku: "sku-2",
+      },
+    });
+
+    const bodyWaveRow = within(screen.getByRole("table"))
+      .getByText("Body Wave Bundle")
+      .closest("tr");
+    expect(bodyWaveRow).not.toBeNull();
+    expect(bodyWaveRow).toHaveClass("bg-muted/60");
+
+    await user.click(
+      screen.getByLabelText(/adjustment delta for body wave bundle/i),
+    );
+
+    expect(bodyWaveRow).toHaveClass("bg-muted/60");
+    expect(onSearchStateChange).not.toHaveBeenCalledWith({
+      selectedSku: "sku-2",
+      sku: undefined,
+    });
+    expect(onSearchStateChange).not.toHaveBeenCalledWith({
+      selectedSku: undefined,
+      sku: undefined,
+    });
   });
 
   it("presents safe command errors without raising a success toast", async () => {

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -2028,6 +2028,8 @@ export function StockAdjustmentWorkspaceContent({
     routeFilteredInventoryItemId ??
     routeSelectedInventoryItemId ??
     activeInventoryItemId;
+  const selectedInventoryItemIdRef = useRef(selectedInventoryItemId);
+  selectedInventoryItemIdRef.current = selectedInventoryItemId;
   const routeSkuFilterQuery =
     !filters.query.trim() && routeFilteredInventoryItemId
       ? routeFilteredInventoryItemId
@@ -2608,7 +2610,11 @@ export function StockAdjustmentWorkspaceContent({
                 disabled={isBlocked}
                 inputMode="numeric"
                 min={adjustmentType === "manual" ? undefined : 0}
-                onFocus={() => handleSelectInventoryItem(item._id)}
+                onFocus={() => {
+                  if (item._id === selectedInventoryItemIdRef.current) return;
+
+                  handleSelectInventoryItem(item._id);
+                }}
                 onBlur={(event) =>
                   saveCycleCountDraftValue(item._id, event.currentTarget.value)
                 }
@@ -3311,9 +3317,12 @@ export function StockAdjustmentWorkspaceContent({
                       : undefined
                   }
                   onPageIndexChange={handleStockTablePageIndexChange}
-                  onRowClick={(row) =>
-                    handleSelectInventoryItem(row.original.inventoryItem._id)
-                  }
+                  onRowClick={(row) => {
+                    const rowInventoryItemId = row.original.inventoryItem._id;
+                    if (rowInventoryItemId === selectedInventoryItemId) return;
+
+                    handleSelectInventoryItem(rowInventoryItemId);
+                  }}
                   isLoadingMore={isLoadingMoreInventoryItems}
                   onLoadMore={
                     canLoadMoreInventoryItems

--- a/packages/athena-webapp/src/contexts/ProductContext.tsx
+++ b/packages/athena-webapp/src/contexts/ProductContext.tsx
@@ -5,6 +5,7 @@ import React, {
   ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
 } from "react";
 import { ProductVariant } from "@/components/add-product/ProductStock";
@@ -40,6 +41,8 @@ interface ProductContextType {
   mergeTrustedInventoryFinalization: (
     result: TrustedInventoryFinalizationMerge,
   ) => void;
+  markTrustedInventoryFinalized: (skuId: string) => void;
+  trustedInventoryFinalizedSkuIds: Set<string>;
   isLoading: boolean;
   updateVariantImages: (variantId: string, newImages: ImageFile[]) => void;
   updateAppState: (newState: Partial<AppState>) => void;
@@ -56,6 +59,7 @@ export type TrustedInventoryFinalizationMerge = {
     availability?: Product["availability"];
     isVisible?: boolean;
   };
+  productId?: string;
   sku: {
     id: string;
     stock: number;
@@ -206,6 +210,17 @@ export function mergeTrustedInventoryFinalizationIntoVariants(
   );
 }
 
+export function mergeTrustedInventoryFinalizationIntoProduct(
+  product: Product | null | undefined,
+  productPatch: TrustedInventoryFinalizationMerge["product"],
+): Product | null | undefined {
+  if (!product || !productPatch) return product;
+  return {
+    ...product,
+    ...productPatch,
+  };
+}
+
 interface AppState {
   isInitialLoad: boolean;
   didRevertChanges: boolean;
@@ -246,6 +261,15 @@ export function ProductProvider({
 
   const [activeProductVariant, setActiveProductVariant] =
     useState<ProductVariant>(productVariants[0]);
+  const [
+    trustedInventoryFinalizedSkuIds,
+    setTrustedInventoryFinalizedSkuIds,
+  ] = useState<Set<string>>(() => new Set());
+  const [trustedInventoryProductPatch, setTrustedInventoryProductPatch] =
+    useState<{
+      productId?: string;
+      product?: TrustedInventoryFinalizationMerge["product"];
+    }>();
 
   const [images, updateImages] = useState<ImageFile[]>([]);
   const [error, setError] = useState<ZodError | null>(null);
@@ -254,6 +278,24 @@ export function ProductProvider({
   const { productSlug } = useParams({ strict: false });
 
   const { activeProduct } = useGetActiveProduct({ includeArchived });
+  const trustedInventoryPatchForActiveProduct = useMemo(() => {
+    if (!trustedInventoryProductPatch) return undefined;
+    if (
+      trustedInventoryProductPatch.productId !== undefined &&
+      trustedInventoryProductPatch.productId !== activeProduct?._id
+    ) {
+      return undefined;
+    }
+    return trustedInventoryProductPatch.product;
+  }, [activeProduct?._id, trustedInventoryProductPatch]);
+  const effectiveActiveProduct = useMemo(
+    () =>
+      mergeTrustedInventoryFinalizationIntoProduct(
+        activeProduct,
+        trustedInventoryPatchForActiveProduct,
+      ),
+    [activeProduct, trustedInventoryPatchForActiveProduct],
+  );
   const previousActiveProductRef = useRef<Product | null>(null);
 
   const updateAppState = (newState: Partial<AppState>) => {
@@ -332,9 +374,28 @@ export function ProductProvider({
     );
   };
 
+  const markTrustedInventoryFinalized = useCallback((skuId: string) => {
+    setTrustedInventoryFinalizedSkuIds((prev) => {
+      if (prev.has(skuId)) return prev;
+      const next = new Set(prev);
+      next.add(skuId);
+      return next;
+    });
+  }, []);
+
   const mergeTrustedInventoryFinalization = (
     result: TrustedInventoryFinalizationMerge,
   ) => {
+    markTrustedInventoryFinalized(result.sku.id);
+    if (result.product) {
+      setTrustedInventoryProductPatch((prevPatch) => ({
+        productId: result.productId ?? activeProduct?._id,
+        product: {
+          ...prevPatch?.product,
+          ...result.product,
+        },
+      }));
+    }
     setProductData((prevData) => ({
       ...prevData,
       ...(result.product?.inventoryCount !== undefined
@@ -368,9 +429,9 @@ export function ProductProvider({
     }
   };
 
-  const updateProductData = (newData: Partial<Product>) => {
+  const updateProductData = useCallback((newData: Partial<Product>) => {
     setProductData((prevData) => ({ ...prevData, ...newData }));
-  };
+  }, []);
 
   const revertChanges = () => {
     if (!activeProduct) return;
@@ -418,6 +479,13 @@ export function ProductProvider({
         return variants;
       });
 
+      if (
+        !previousActiveProduct ||
+        previousActiveProduct._id !== activeProduct._id
+      ) {
+        setTrustedInventoryFinalizedSkuIds(new Set());
+        setTrustedInventoryProductPatch(undefined);
+      }
       previousActiveProductRef.current = activeProduct;
 
       setIsLoading(false);
@@ -443,7 +511,7 @@ export function ProductProvider({
 
   const value = {
     appState,
-    activeProduct,
+    activeProduct: effectiveActiveProduct,
     productData,
     updateProductData,
     activeProductVariant,
@@ -460,6 +528,8 @@ export function ProductProvider({
     updateVariantImages,
     updateProductVariant,
     mergeTrustedInventoryFinalization,
+    markTrustedInventoryFinalized,
+    trustedInventoryFinalizedSkuIds,
     updateAppState,
     isLoading,
     showLoaderForProduct: Boolean(productSlug && activeProduct === undefined),


### PR DESCRIPTION
## Summary
- finalize trusted legacy-import inventory from the product page while keeping catalog taxonomy setup work open until an Athena taxonomy is assigned
- surface catalog taxonomy setup in operations, link it back to product edit, and complete it from backend product taxonomy saves
- unblock stock adjustments only for trusted legacy rows with valid taxonomy, auto-resolve matching synced-sale inventory review work after bounded stock updates, and preserve safe fail-closed behavior for large legacy-import cleanup sets
- add indexed product/SKU work item fields and product-level provisional-row caps to keep Convex reads bounded
- document the reusable product-level row-cap pattern in `docs/solutions/performance-issues/`

## Review
- Unanimous reviewer approval after repair loops: correctness, testing, performance, TypeScript, project standards, scoped agent-native.

## Validation
- `bunx convex codegen`
- `bun run test -- convex/inventory/catalogImport.test.ts convex/inventory/products.sku.test.ts convex/operations/helpers/eventBuilders.test.ts convex/operations/openWorkInventoryReviews.test.ts convex/operations/operationalWorkItems.test.ts convex/operations/skuActivity.test.ts convex/stockOps/adjustments.test.ts convex/pos/application/sync/projectLocalEvents.test.ts src/components/add-product/ProductStock.test.ts src/components/add-product/ProductView.test.tsx src/components/operations/OperationsQueueView.test.tsx src/components/operations/StockAdjustmentWorkspace.test.tsx`
- `bun run lint:convex:changed && bun run lint:frontend:changed && bun run typecheck`
- `bun run audit:convex`
- `bun run build`
- `python3 .agents/skills/ce-compound/scripts/validate-frontmatter.py docs/solutions/performance-issues/athena-legacy-import-product-row-caps-2026-07-05.md`
- `bun run compound:check -- --base origin/main`
- `bun run graphify:rebuild`
- pre-push validation: full `@athena/webapp` test suite, build, scenario harnesses, inferential review
