### PR TITLE
perf(convex): reduce hot-path read amplification

### DIFF
--- a/docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md
+++ b/docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md
@@ -1,6 +1,7 @@
 ---
 title: Athena Convex Posture Queries Stay Separate From Detail Reads
 date: 2026-06-29
+last_updated: 2026-07-06
 category: performance
 module: athena-webapp
 problem_type: convex_read_amplification
@@ -53,12 +54,47 @@ Split read contracts by intent:
   speed search and boot, but checkout/catalog commands must still validate
   current server truth.
 
+## July 2026 Follow-up: Push Selectivity Into Indexes
+
+When a production warning names a function close to Convex's per-execution read
+limit, do not stop at client caching. Inspect each server query in the route and
+move the selective predicates into index range expressions wherever the schema
+allows it.
+
+The daily operations read-reduction pass used this pattern:
+
+- `dailyClose` prior-close lookup now pushes `operatingDate < currentDate` into
+  `by_storeId_status_operatingDate` and walks the descending iterator only until
+  the existing lifecycle-compatible limit is reached.
+- terminal runtime status now uses `by_storeId_status_terminalId` for each
+  sale-usable status instead of scanning recent sessions by terminal alone. It
+  still takes a bounded window per status so a newer incompatible register
+  number does not hide an older compatible session.
+- context-event abuse quota checks now use
+  `by_storeId_surface_status_abusePartitionKey_receivedAt` instead of filtering
+  recorded events after a broader surface/status scan.
+- bag merge, saved-bag merge, POS recovery-code auth, and organization-member
+  authorization paths gained compound indexes matching the exact equality
+  predicates they use.
+
+The key review lesson was that an index optimization can accidentally narrow
+behavior. If the old path used `take(25).find(...)`, replacing it with `.first()`
+is only safe when the first row is guaranteed to be compatible. Add a regression
+test with a newer incompatible row and an older compatible row before accepting
+that kind of rewrite.
+
 ## Prevention
 
 - Do not add detail evidence, full history, or analytics payloads back to default
   route/register/roster subscriptions.
 - Add characterization tests that assert targeted paths do not call broad
   store-status indexes such as `by_store_status` when a target id is available.
+- For Convex performance fixes, prefer index names that spell out every indexed
+  field exactly. This keeps schema review aligned with Convex AI guidance and
+  makes source-level tests less ambiguous.
+- When replacing a broad scan with a selective index, preserve the old
+  compatibility predicates in tests, especially "skip incompatible newest row"
+  cases.
 - Add high-cardinality fixtures for roster, timeline, and catalog surfaces before
   changing read-model boundaries.
 - When adding a companion query, update the frontend so it is lazy or tied to an
@@ -77,6 +113,8 @@ Split read contracts by intent:
 - `bun run --filter '@athena/webapp' lint:convex:changed`
 - `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
 - `bun run --filter '@athena/webapp' build`
+- July 2026 follow-up:
+  `bun run test -- convex/operations/dailyClose.test.ts convex/operations/dailyOperations.test.ts convex/pos/application/terminals.test.ts convex/pos/infrastructure/repositories/terminalRepository.test.ts convex/inventory/sessionQueryIndexes.test.ts convex/storeFront/commerceQueryIndexes.test.ts convex/contextTracking/contextEvents.test.ts convex/pos/public/posRecoveryCodes.test.ts convex/remoteAssist/transportInternal.test.ts`
 
 ## Related Issues
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8680 nodes · 10572 edges · 2103 communities detected
+- 8684 nodes · 10577 edges · 2103 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2293,24 +2293,24 @@ Cohesion: 0.13
 Nodes (24): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClearedRegisterSessionCloseoutDatePatch(), buildClosedRegisterSessionPatch(), buildOperatingDateEvidence(), buildRegisterSession(), buildRegisterSessionCloseoutPatch() (+16 more)
 
 ### Community 38 - "Community 38"
+Cohesion: 0.17
+Nodes (25): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+17 more)
+
+### Community 39 - "Community 39"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.19
 Nodes (27): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+19 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.14
 Nodes (23): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+15 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.18
-Nodes (24): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+16 more)
 
 ### Community 43 - "Community 43"
 Cohesion: 0.16
@@ -2830,15 +2830,15 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 172 - "Community 172"
 Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 173 - "Community 173"
-Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 174 - "Community 174"
+### Community 173 - "Community 173"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
+
+### Community 174 - "Community 174"
+Cohesion: 0.33
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 175 - "Community 175"
 Cohesion: 0.29
@@ -2969,28 +2969,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 207 - "Community 207"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 208 - "Community 208"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 209 - "Community 209"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 210 - "Community 210"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 211 - "Community 211"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 212 - "Community 212"
+### Community 208 - "Community 208"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 209 - "Community 209"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 210 - "Community 210"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 211 - "Community 211"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 212 - "Community 212"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 213 - "Community 213"
 Cohesion: 0.22
@@ -3610,79 +3610,79 @@ Nodes (0):
 
 ### Community 367 - "Community 367"
 Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 368 - "Community 368"
-Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 369 - "Community 369"
+### Community 368 - "Community 368"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 370 - "Community 370"
+### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 371 - "Community 371"
+### Community 370 - "Community 370"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 372 - "Community 372"
+### Community 371 - "Community 371"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 373 - "Community 373"
+### Community 372 - "Community 372"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 374 - "Community 374"
+### Community 373 - "Community 373"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 375 - "Community 375"
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
+
+### Community 375 - "Community 375"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 376 - "Community 376"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 377 - "Community 377"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 378 - "Community 378"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 379 - "Community 379"
+### Community 378 - "Community 378"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 380 - "Community 380"
+### Community 379 - "Community 379"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 381 - "Community 381"
+### Community 380 - "Community 380"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 382 - "Community 382"
+### Community 381 - "Community 381"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 383 - "Community 383"
+### Community 382 - "Community 382"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 384 - "Community 384"
+### Community 383 - "Community 383"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 385 - "Community 385"
+### Community 384 - "Community 384"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 385 - "Community 385"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 386 - "Community 386"
 Cohesion: 0.4
@@ -3697,12 +3697,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 390 - "Community 390"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 390 - "Community 390"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 391 - "Community 391"
 Cohesion: 0.4
@@ -3713,20 +3713,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 393 - "Community 393"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 394 - "Community 394"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 395 - "Community 395"
+### Community 394 - "Community 394"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 396 - "Community 396"
+### Community 395 - "Community 395"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 396 - "Community 396"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 0.4
@@ -3749,80 +3749,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 402 - "Community 402"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 403 - "Community 403"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 404 - "Community 404"
+### Community 403 - "Community 403"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 405 - "Community 405"
+### Community 404 - "Community 404"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 406 - "Community 406"
+### Community 405 - "Community 405"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 407 - "Community 407"
+### Community 406 - "Community 406"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 408 - "Community 408"
+### Community 407 - "Community 407"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 409 - "Community 409"
+### Community 408 - "Community 408"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 410 - "Community 410"
+### Community 409 - "Community 409"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 411 - "Community 411"
+### Community 410 - "Community 410"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 412 - "Community 412"
+### Community 411 - "Community 411"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 413 - "Community 413"
+### Community 412 - "Community 412"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 414 - "Community 414"
+### Community 413 - "Community 413"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 415 - "Community 415"
+### Community 414 - "Community 414"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 416 - "Community 416"
+### Community 415 - "Community 415"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 417 - "Community 417"
+### Community 416 - "Community 416"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 418 - "Community 418"
+### Community 417 - "Community 417"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 419 - "Community 419"
+### Community 418 - "Community 418"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 420 - "Community 420"
+### Community 419 - "Community 419"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 420 - "Community 420"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 421 - "Community 421"
 Cohesion: 0.4
@@ -3833,40 +3833,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 423 - "Community 423"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 424 - "Community 424"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 425 - "Community 425"
+### Community 424 - "Community 424"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 426 - "Community 426"
+### Community 425 - "Community 425"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 427 - "Community 427"
+### Community 426 - "Community 426"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 428 - "Community 428"
+### Community 427 - "Community 427"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 429 - "Community 429"
+### Community 428 - "Community 428"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 430 - "Community 430"
+### Community 429 - "Community 429"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 431 - "Community 431"
+### Community 430 - "Community 430"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 431 - "Community 431"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.7
@@ -3897,60 +3897,60 @@ Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
 ### Community 439 - "Community 439"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 440 - "Community 440"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 440 - "Community 440"
+### Community 441 - "Community 441"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 441 - "Community 441"
+### Community 442 - "Community 442"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 442 - "Community 442"
+### Community 443 - "Community 443"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 443 - "Community 443"
+### Community 444 - "Community 444"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 444 - "Community 444"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 447 - "Community 447"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 449 - "Community 449"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 450 - "Community 450"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 451 - "Community 451"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 452 - "Community 452"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 453 - "Community 453"
 Cohesion: 0.5
@@ -3969,72 +3969,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 457 - "Community 457"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 458 - "Community 458"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 458 - "Community 458"
+### Community 459 - "Community 459"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 459 - "Community 459"
+### Community 460 - "Community 460"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 460 - "Community 460"
+### Community 461 - "Community 461"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 461 - "Community 461"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 462 - "Community 462"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 463 - "Community 463"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 464 - "Community 464"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 465 - "Community 465"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 465 - "Community 465"
+### Community 466 - "Community 466"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 466 - "Community 466"
+### Community 467 - "Community 467"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 468 - "Community 468"
+### Community 469 - "Community 469"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 469 - "Community 469"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 471 - "Community 471"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 472 - "Community 472"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 473 - "Community 473"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 473 - "Community 473"
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.5
@@ -4045,24 +4045,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 476 - "Community 476"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 477 - "Community 477"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 477 - "Community 477"
+### Community 478 - "Community 478"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 478 - "Community 478"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 480 - "Community 480"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.5
@@ -4081,68 +4081,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 485 - "Community 485"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 486 - "Community 486"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 487 - "Community 487"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 489 - "Community 489"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 490 - "Community 490"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 492 - "Community 492"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 494 - "Community 494"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 495 - "Community 495"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 495 - "Community 495"
+### Community 496 - "Community 496"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 496 - "Community 496"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 498 - "Community 498"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 499 - "Community 499"
-Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
-
-### Community 500 - "Community 500"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 500 - "Community 500"
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.5
@@ -4173,12 +4173,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 509 - "Community 509"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 509 - "Community 509"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.5
@@ -4189,12 +4189,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 512 - "Community 512"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 513 - "Community 513"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 513 - "Community 513"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 514 - "Community 514"
 Cohesion: 0.5
@@ -4205,120 +4205,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 516 - "Community 516"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 517 - "Community 517"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 517 - "Community 517"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 518 - "Community 518"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 519 - "Community 519"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 520 - "Community 520"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 521 - "Community 521"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 522 - "Community 522"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 523 - "Community 523"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 523 - "Community 523"
+### Community 524 - "Community 524"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 524 - "Community 524"
+### Community 525 - "Community 525"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 525 - "Community 525"
+### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 526 - "Community 526"
+### Community 527 - "Community 527"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 527 - "Community 527"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 529 - "Community 529"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 530 - "Community 530"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 531 - "Community 531"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 532 - "Community 532"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 532 - "Community 532"
+### Community 533 - "Community 533"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 533 - "Community 533"
+### Community 534 - "Community 534"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 534 - "Community 534"
+### Community 535 - "Community 535"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 535 - "Community 535"
+### Community 536 - "Community 536"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 536 - "Community 536"
+### Community 537 - "Community 537"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 537 - "Community 537"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 539 - "Community 539"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 540 - "Community 540"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 540 - "Community 540"
+### Community 541 - "Community 541"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 541 - "Community 541"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 542 - "Community 542"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 543 - "Community 543"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 544 - "Community 544"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 545 - "Community 545"
 Cohesion: 0.5
@@ -4349,63 +4349,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 552 - "Community 552"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 553 - "Community 553"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 554 - "Community 554"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 555 - "Community 555"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 555 - "Community 555"
+### Community 556 - "Community 556"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 556 - "Community 556"
+### Community 557 - "Community 557"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 557 - "Community 557"
+### Community 558 - "Community 558"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 558 - "Community 558"
+### Community 559 - "Community 559"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 559 - "Community 559"
+### Community 560 - "Community 560"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 560 - "Community 560"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 561 - "Community 561"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 562 - "Community 562"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 563 - "Community 563"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 563 - "Community 563"
+### Community 564 - "Community 564"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 564 - "Community 564"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 565 - "Community 565"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 567 - "Community 567"
@@ -4413,12 +4413,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 568 - "Community 568"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 569 - "Community 569"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 569 - "Community 569"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 570 - "Community 570"
 Cohesion: 0.67
@@ -4477,32 +4477,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 584 - "Community 584"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 585 - "Community 585"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 586 - "Community 586"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 587 - "Community 587"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 588 - "Community 588"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 589 - "Community 589"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 590 - "Community 590"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 591 - "Community 591"
 Cohesion: 0.67
@@ -4517,12 +4517,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 594 - "Community 594"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 595 - "Community 595"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 595 - "Community 595"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 596 - "Community 596"
 Cohesion: 0.67
@@ -4541,12 +4541,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 600 - "Community 600"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 601 - "Community 601"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 601 - "Community 601"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 602 - "Community 602"
 Cohesion: 0.67
@@ -4561,16 +4561,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 605 - "Community 605"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 606 - "Community 606"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 607 - "Community 607"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 608 - "Community 608"
 Cohesion: 0.67
@@ -4581,28 +4581,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 610 - "Community 610"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 611 - "Community 611"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 612 - "Community 612"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 613 - "Community 613"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 614 - "Community 614"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 615 - "Community 615"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 615 - "Community 615"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 616 - "Community 616"
 Cohesion: 0.67
@@ -4610,11 +4610,11 @@ Nodes (0):
 
 ### Community 617 - "Community 617"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 618 - "Community 618"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 619 - "Community 619"
 Cohesion: 0.67
@@ -4629,12 +4629,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 622 - "Community 622"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 623 - "Community 623"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 623 - "Community 623"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 624 - "Community 624"
 Cohesion: 0.67
@@ -4658,23 +4658,23 @@ Nodes (0):
 
 ### Community 629 - "Community 629"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 632 - "Community 632"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 633 - "Community 633"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 633 - "Community 633"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
@@ -4682,19 +4682,19 @@ Nodes (0):
 
 ### Community 635 - "Community 635"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 636 - "Community 636"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 637 - "Community 637"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 638 - "Community 638"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 638 - "Community 638"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
@@ -4705,16 +4705,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 641 - "Community 641"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 642 - "Community 642"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 643 - "Community 643"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
@@ -4749,12 +4749,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 652 - "Community 652"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 653 - "Community 653"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 653 - "Community 653"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 654 - "Community 654"
 Cohesion: 0.67
@@ -4774,79 +4774,79 @@ Nodes (0):
 
 ### Community 658 - "Community 658"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 660 - "Community 660"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 661 - "Community 661"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 662 - "Community 662"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 663 - "Community 663"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 664 - "Community 664"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 665 - "Community 665"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 666 - "Community 666"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 666 - "Community 666"
+### Community 667 - "Community 667"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 667 - "Community 667"
+### Community 668 - "Community 668"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 668 - "Community 668"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 669 - "Community 669"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 670 - "Community 670"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 672 - "Community 672"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 673 - "Community 673"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 674 - "Community 674"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 675 - "Community 675"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 676 - "Community 676"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 677 - "Community 677"
 Cohesion: 0.67
@@ -4878,11 +4878,11 @@ Nodes (0):
 
 ### Community 684 - "Community 684"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 685 - "Community 685"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 686 - "Community 686"
 Cohesion: 0.67
@@ -4913,52 +4913,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 693 - "Community 693"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 694 - "Community 694"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 694 - "Community 694"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 695 - "Community 695"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 696 - "Community 696"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 697 - "Community 697"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 698 - "Community 698"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 698 - "Community 698"
+### Community 699 - "Community 699"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 699 - "Community 699"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 700 - "Community 700"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 701 - "Community 701"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 702 - "Community 702"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 703 - "Community 703"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 704 - "Community 704"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 704 - "Community 704"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 705 - "Community 705"
 Cohesion: 0.67
@@ -4985,76 +4985,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 711 - "Community 711"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 712 - "Community 712"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 713 - "Community 713"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 714 - "Community 714"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 715 - "Community 715"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 716 - "Community 716"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 717 - "Community 717"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 718 - "Community 718"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 719 - "Community 719"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 720 - "Community 720"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 721 - "Community 721"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 722 - "Community 722"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 723 - "Community 723"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 724 - "Community 724"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 725 - "Community 725"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 726 - "Community 726"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 727 - "Community 727"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 728 - "Community 728"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 729 - "Community 729"
 Cohesion: 0.67
@@ -5069,12 +5069,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 732 - "Community 732"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 733 - "Community 733"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 733 - "Community 733"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 734 - "Community 734"
 Cohesion: 0.67
@@ -5085,12 +5085,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 736 - "Community 736"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 737 - "Community 737"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 737 - "Community 737"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 738 - "Community 738"
 Cohesion: 0.67
@@ -5157,16 +5157,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 754 - "Community 754"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 755 - "Community 755"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 756 - "Community 756"
+### Community 755 - "Community 755"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 756 - "Community 756"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 757 - "Community 757"
 Cohesion: 1.0
@@ -5181,24 +5181,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 760 - "Community 760"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 761 - "Community 761"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 761 - "Community 761"
+### Community 762 - "Community 762"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 762 - "Community 762"
+### Community 763 - "Community 763"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 763 - "Community 763"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 764 - "Community 764"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 765 - "Community 765"
 Cohesion: 1.0
@@ -6330,11 +6330,11 @@ Nodes (0):
 
 ### Community 1047 - "Community 1047"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1048 - "Community 1048"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1049 - "Community 1049"
 Cohesion: 1.0
@@ -10555,369 +10555,369 @@ Nodes (0):
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 764`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 765`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 766`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 767`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 768`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 769`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 770`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 771`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 772`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 773`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 774`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 775`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 776`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 777`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 778`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 779`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 780`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 781`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 782`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 783`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 784`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 785`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 786`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 787`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 788`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 789`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 790`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 791`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 792`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 793`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 794`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 795`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 796`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 797`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 798`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 799`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 800`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 801`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 802`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 803`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 804`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 805`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 806`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 807`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 808`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 809`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 810`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 811`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 812`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 813`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 814`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 815`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 816`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 817`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 818`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 819`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 820`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 821`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 822`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 823`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 824`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 825`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 826`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 827`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 828`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 829`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 830`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 831`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 832`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 833`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 834`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 835`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 836`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 837`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 838`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 839`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 840`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 841`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 842`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 843`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 844`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 845`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 846`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 847`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 848`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 849`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 850`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 851`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 852`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 853`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 854`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 855`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 856`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 857`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 858`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 859`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 860`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 861`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 862`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 863`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 864`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 865`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 866`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 867`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 868`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 869`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 870`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 871`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 872`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 873`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 874`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 875`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 876`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 877`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 878`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 879`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 880`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 881`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 882`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 883`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 884`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 885`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 886`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 887`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 888`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 889`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 890`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 891`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 892`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 893`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 894`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 895`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 896`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 897`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 898`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 899`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 900`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 901`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 902`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 903`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 904`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 905`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 906`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 907`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 908`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 909`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 910`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 911`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 912`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 913`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 914`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 915`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 916`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 917`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 918`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 919`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 920`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 921`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 922`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 923`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 924`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 925`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 926`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 927`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 928`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 929`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 930`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 931`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 932`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 933`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 934`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 935`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 936`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 937`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 938`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 939`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 940`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 941`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 942`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 943`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 944`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 945`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 946`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -10953,627 +10953,625 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 947`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 948`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 949`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 950`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 951`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 952`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 953`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 954`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 955`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 956`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 957`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 958`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 959`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 960`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
+- **Thin community `Community 961`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 962`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 963`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 964`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 965`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 966`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 967`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 968`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 969`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 970`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 971`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 972`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 973`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 974`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 975`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 976`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 977`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 978`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 979`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 980`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 981`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 982`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 983`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 984`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 985`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 986`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 987`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 988`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 989`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 990`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 991`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 992`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 993`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 994`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 995`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 996`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 997`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 998`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 999`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1000`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1001`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1002`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1003`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1004`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1005`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1006`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1007`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1008`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1009`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1010`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1011`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1012`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1013`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1014`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1015`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1016`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1017`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1018`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1019`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1020`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1021`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1022`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1023`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1024`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1025`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1026`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1027`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1028`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1029`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1030`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1031`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1032`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1033`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1034`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1035`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1036`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1037`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1038`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1039`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1040`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1041`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1042`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1043`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1044`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1045`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1046`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1047`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1048`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1049`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1050`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1051`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1052`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1053`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1054`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1055`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1056`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1057`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1058`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1059`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1060`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1061`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1062`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1063`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1064`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1065`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1066`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1067`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1068`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1069`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1070`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1071`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1072`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1073`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1074`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1075`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1076`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1077`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1078`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1079`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1080`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1081`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1082`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1083`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1084`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1085`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1086`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1087`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1088`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1089`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1090`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1091`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1092`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1093`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1094`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1095`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1096`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1097`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1098`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1099`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1100`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1101`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1102`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1103`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1104`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1105`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1106`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1107`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1108`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1109`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1110`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1111`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1112`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1113`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1114`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1115`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1116`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1117`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1118`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1119`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1120`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1121`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1122`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1123`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1124`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1125`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1126`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1127`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1128`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1129`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1130`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1131`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1132`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1133`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1134`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1135`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1136`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1137`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1138`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1139`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1140`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1141`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1142`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1143`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1144`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1145`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1146`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1147`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1148`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1149`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1150`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1151`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1152`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1153`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1154`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1155`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1156`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1157`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1158`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1159`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1160`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1161`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1162`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1163`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1164`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1165`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1166`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1167`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1168`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1169`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1170`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1171`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1172`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1173`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1174`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1175`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1176`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1177`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1178`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1179`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1180`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1181`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1182`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1183`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1184`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1185`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1186`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1187`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1188`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1189`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1190`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1191`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1192`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1193`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1194`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1195`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1196`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1197`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1198`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1199`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1200`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1201`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1202`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1203`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1204`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1205`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1206`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1207`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1208`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1209`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1210`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1211`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1212`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1213`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1214`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1215`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1216`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1217`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1218`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1219`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1220`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1221`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1222`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1223`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1224`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1225`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1226`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1227`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1228`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1229`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1230`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1231`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1232`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1233`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1234`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1235`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1236`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1237`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1238`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1239`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `api.js`
+- **Thin community `Community 1240`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1241`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1242`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `server.js`
+- **Thin community `Community 1243`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `app.ts`
+- **Thin community `Community 1244`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1245`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1246`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1247`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1248`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `auth.ts`
+- **Thin community `Community 1249`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1250`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1251`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1252`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `countries.ts`
+- **Thin community `Community 1253`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `email.ts`
+- **Thin community `Community 1254`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1255`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `payment.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `contextEvents.test.ts`
+- **Thin community `Community 1256`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1257`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2176
-- Graph nodes: 8680
-- Graph edges: 10572
+- Graph nodes: 8684
+- Graph edges: 10577
 - Communities: 2103
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/contextTracking/contextEvents.test.ts
+++ b/packages/athena-webapp/convex/contextTracking/contextEvents.test.ts
@@ -1,12 +1,134 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import {
+  appendContextEvent,
   buildContextEventSemanticEnvelopeHash,
   isContextEventWriteQuotaExceeded,
   selectContextEventAppendQuotaDecision,
 } from "./contextEvents";
 
+function getHandler(definition: unknown) {
+  return (definition as { _handler: Function })._handler;
+}
+
 describe("context event append safeguards", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("counts quota events by abuse partition and receivedAt window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const queryLog: Array<{
+      field: string;
+      operator: "eq" | "gte";
+      value: unknown;
+    }> = [];
+    const matchingRecentEvents = Array.from({ length: 119 }, (_, index) => ({
+      _id: `recent-${index}`,
+      abusePartitionKey: "store_1:anonymous",
+      idempotencyKey: `recent-${index}`,
+      receivedAt: 999_000 - index,
+      status: "recorded",
+      storeId: "store_1",
+      surface: "storefront",
+    }));
+    const contextEvent = [
+      ...matchingRecentEvents,
+      {
+        _id: "old-event",
+        abusePartitionKey: "store_1:anonymous",
+        idempotencyKey: "old-event",
+        receivedAt: 900_000,
+        status: "recorded",
+        storeId: "store_1",
+        surface: "storefront",
+      },
+      {
+        _id: "other-partition",
+        abusePartitionKey: "store_1:other",
+        idempotencyKey: "other-partition",
+        receivedAt: 999_000,
+        status: "recorded",
+        storeId: "store_1",
+        surface: "storefront",
+      },
+    ];
+    const ctx = buildContextEventCtx(contextEvent, queryLog);
+    const append = getHandler(appendContextEvent);
+    const args = {
+      abusePartitionKey: "store_1:anonymous",
+      eventId: "storefront.route_viewed",
+      idempotencyKey: "route:session:/shop",
+      occurredAt: 999_500,
+      payload: { route: "/shop" },
+      schemaVersion: 1,
+      storeId: "store_1",
+      surface: "storefront",
+      visibilityMode: "store_admin",
+      retentionClass: "standard",
+    };
+
+    await expect(append(ctx, args)).resolves.toMatchObject({
+      kind: "recorded",
+    });
+    expect(queryLog).toEqual(
+      expect.arrayContaining([
+        {
+          field: "abusePartitionKey",
+          operator: "eq",
+          value: "store_1:anonymous",
+        },
+        { field: "receivedAt", operator: "gte", value: 940_000 },
+      ]),
+    );
+
+    const quotaCtx = buildContextEventCtx(
+      [
+        ...matchingRecentEvents,
+        {
+          _id: "recent-limit",
+          abusePartitionKey: "store_1:anonymous",
+          idempotencyKey: "recent-limit",
+          receivedAt: 999_750,
+          status: "recorded",
+          storeId: "store_1",
+          surface: "storefront",
+        },
+      ],
+      [],
+    );
+
+    await expect(append(quotaCtx, args)).resolves.toMatchObject({
+      kind: "rejected",
+      message: "Context event write quota exceeded.",
+    });
+    expect(quotaCtx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("uses a targeted abuse-partition quota index instead of filtering recorded events", () => {
+    const root = process.cwd();
+    const schemaSource = readFileSync(
+      join(root, "convex", "schema.ts"),
+      "utf8",
+    );
+    const appendSource = readFileSync(
+      join(root, "convex", "contextTracking", "contextEvents.ts"),
+      "utf8",
+    );
+
+    expect(schemaSource).toContain(
+      '.index("by_storeId_surface_status_abusePartitionKey_receivedAt", [',
+    );
+    expect(appendSource).toContain("withIndex");
+    expect(appendSource).toContain(
+      '"by_storeId_surface_status_abusePartitionKey_receivedAt"',
+    );
+    expect(appendSource).not.toContain(".filter((q)");
+  });
+
   it("rejects writes once the abuse partition reaches the window quota", () => {
     expect(isContextEventWriteQuotaExceeded(119)).toBe(false);
     expect(isContextEventWriteQuotaExceeded(120)).toBe(true);
@@ -87,3 +209,70 @@ describe("context event append safeguards", () => {
     ).toBe(buildContextEventSemanticEnvelopeHash(base));
   });
 });
+
+function buildContextEventCtx(
+  contextEvent: Array<Record<string, unknown>>,
+  queryLog: Array<{
+    field: string;
+    operator: "eq" | "gte";
+    value: unknown;
+  }>,
+) {
+  return {
+    db: {
+      insert: vi.fn(async (table: string, value: Record<string, unknown>) => {
+        const id = `${table}-${contextEvent.length + 1}`;
+        contextEvent.push({ _id: id, ...value });
+        return id;
+      }),
+      query: vi.fn((table: string) =>
+        buildContextEventQuery(
+          table === "contextEvent" ? contextEvent : [],
+          queryLog,
+        ),
+      ),
+    },
+  };
+}
+
+function buildContextEventQuery(
+  rows: Array<Record<string, unknown>>,
+  queryLog: Array<{
+    field: string;
+    operator: "eq" | "gte";
+    value: unknown;
+  }>,
+) {
+  let currentRows = rows;
+  const chain = {
+    first: vi.fn(async () => currentRows[0] ?? null),
+    take: vi.fn(async (count: number) => currentRows.slice(0, count)),
+    withIndex: vi.fn(
+      (
+        _indexName: string,
+        build: (q: {
+          eq: (field: string, value: unknown) => unknown;
+          gte: (field: string, value: number) => unknown;
+        }) => unknown,
+      ) => {
+        const q = {
+          eq: (field: string, value: unknown) => {
+            queryLog.push({ field, operator: "eq", value });
+            currentRows = currentRows.filter((row) => row[field] === value);
+            return q;
+          },
+          gte: (field: string, value: number) => {
+            queryLog.push({ field, operator: "gte", value });
+            currentRows = currentRows.filter(
+              (row) => Number(row[field] ?? Number.NEGATIVE_INFINITY) >= value,
+            );
+            return q;
+          },
+        };
+        build(q);
+        return chain;
+      },
+    ),
+  };
+  return chain;
+}

--- a/packages/athena-webapp/convex/contextTracking/contextEvents.ts
+++ b/packages/athena-webapp/convex/contextTracking/contextEvents.ts
@@ -97,27 +97,26 @@ export const appendContextEvent = internalMutation({
       }
 
       return {
-          kind: "idempotency_conflict" as const,
+        kind: "idempotency_conflict" as const,
         contextEventId: existing._id,
         status: existing.status,
-        message: "Context event idempotency key already exists with different content.",
+        message:
+          "Context event idempotency key already exists with different content.",
       };
     }
 
     if (args.abusePartitionKey) {
       const recentEvents = await ctx.db
         .query("contextEvent")
-        .withIndex("by_storeId_surface_status_occurredAt", (q) =>
-          q
-            .eq("storeId", args.storeId)
-            .eq("surface", args.surface)
-            .eq("status", "recorded"),
-        )
-        .filter((q) =>
-          q.and(
-            q.eq(q.field("abusePartitionKey"), args.abusePartitionKey),
-            q.gte(q.field("receivedAt"), Date.now() - ABUSE_WINDOW_MS),
-          ),
+        .withIndex(
+          "by_storeId_surface_status_abusePartitionKey_receivedAt",
+          (q) =>
+            q
+              .eq("storeId", args.storeId)
+              .eq("surface", args.surface)
+              .eq("status", "recorded")
+              .eq("abusePartitionKey", args.abusePartitionKey)
+              .gte("receivedAt", Date.now() - ABUSE_WINDOW_MS),
         )
         .take(MAX_EVENTS_PER_ABUSE_WINDOW + 1);
 
@@ -180,6 +179,10 @@ export const appendContextEvent = internalMutation({
           : undefined,
     });
 
-    return { kind: "recorded" as const, contextEventId, status: "recorded" as const };
+    return {
+      kind: "recorded" as const,
+      contextEventId,
+      status: "recorded" as const,
+    };
   },
 });

--- a/packages/athena-webapp/convex/inventory/storeSchedule.test.ts
+++ b/packages/athena-webapp/convex/inventory/storeSchedule.test.ts
@@ -284,7 +284,9 @@ describe("store schedule validation", () => {
     expect(result.ok).toBe(false);
     expect(result.fields).toMatchObject({
       timezone: ["Choose a valid store timezone."],
-      weeklyWindows: ["These hours overlap. Adjust one time range before saving."],
+      weeklyWindows: [
+        "These hours overlap. Adjust one time range before saving.",
+      ],
     });
   });
 
@@ -348,9 +350,7 @@ describe("store schedule validation", () => {
     const ctx = {
       db: {
         get: vi.fn(async (table: string, id: string) =>
-          table === "store"
-            ? { _id: id, organizationId: "org-1" }
-            : null,
+          table === "store" ? { _id: id, organizationId: "org-1" } : null,
         ),
         query: vi.fn(() => ({
           withIndex: vi.fn(() => ({
@@ -372,7 +372,9 @@ describe("store schedule validation", () => {
       storeId: "store-1" as any,
       timezone: "America/New_York",
       weeklyClosedDays: [],
-      weeklyWindows: [{ dayOfWeek: 1, startMinute: 9 * 60, endMinute: 17 * 60 }],
+      weeklyWindows: [
+        { dayOfWeek: 1, startMinute: 9 * 60, endMinute: 17 * 60 },
+      ],
       dateExceptions: [],
       effectiveFrom: Date.parse("2026-06-01T00:00:00.000Z"),
       source: "admin",
@@ -383,7 +385,9 @@ describe("store schedule validation", () => {
       error: {
         code: "conflict",
         fields: {
-          effectiveFrom: ["Schedule effective dates overlap an active version."],
+          effectiveFrom: [
+            "Schedule effective dates overlap an active version.",
+          ],
         },
       },
     });
@@ -397,9 +401,8 @@ describe("store schedule schema indexes", () => {
     const schema = readProjectFile("convex", "schema.ts");
 
     expect(schema).toContain("storeSchedule: defineTable(storeScheduleSchema)");
-    expect(schema).toContain(
-      '.index("by_storeId_status_effectiveFrom", ["storeId", "status", "effectiveFrom"])',
-    );
+    expect(schema).toContain('.index("by_storeId_status_effectiveFrom", [');
+    expect(schema).toContain('"effectiveFrom",');
     expect(schema).toContain('.index("by_organizationId_storeId_status", [');
     expect(schema).toContain('"organizationId",');
     expect(schema).toContain('"storeId",');

--- a/packages/athena-webapp/convex/lib/athenaUserAuth.ts
+++ b/packages/athena-webapp/convex/lib/athenaUserAuth.ts
@@ -2,29 +2,28 @@ import { getAuthUserId } from "@convex-dev/auth/server";
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 
-type AthenaAuthCtx = Pick<QueryCtx, "auth" | "db"> | Pick<MutationCtx, "auth" | "db">;
+type AthenaAuthCtx =
+  | Pick<QueryCtx, "auth" | "db">
+  | Pick<MutationCtx, "auth" | "db">;
 type OrganizationMemberRole = "full_admin" | "pos_only";
 
 function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
 }
 
-async function findAthenaUserByEmailWithCtx(
-  ctx: AthenaAuthCtx,
-  email: string
-) {
+async function findAthenaUserByEmailWithCtx(ctx: AthenaAuthCtx, email: string) {
   const normalizedEmail = normalizeEmail(email);
   // Case-insensitive duplicate detection requires scanning until the schema gains
   // a normalized-email index for athenaUser records.
   // eslint-disable-next-line @convex-dev/no-collect-in-query
   const athenaUsers = await ctx.db.query("athenaUser").collect();
   const matchingUsers = athenaUsers.filter(
-    (athenaUser) => normalizeEmail(athenaUser.email) === normalizedEmail
+    (athenaUser) => normalizeEmail(athenaUser.email) === normalizedEmail,
   );
 
   if (matchingUsers.length > 1) {
     throw new Error(
-      "Multiple Athena users match this email. Resolve duplicate accounts before continuing."
+      "Multiple Athena users match this email. Resolve duplicate accounts before continuing.",
     );
   }
 
@@ -61,7 +60,9 @@ export async function getAuthenticatedAthenaUserWithCtx(ctx: AthenaAuthCtx) {
   return findAthenaUserByEmailWithCtx(ctx, authUserRecord.normalizedEmail);
 }
 
-export async function requireAuthenticatedAthenaUserWithCtx(ctx: AthenaAuthCtx) {
+export async function requireAuthenticatedAthenaUserWithCtx(
+  ctx: AthenaAuthCtx,
+) {
   const athenaUser = await getAuthenticatedAthenaUserWithCtx(ctx);
 
   if (!athenaUser) {
@@ -78,15 +79,12 @@ export async function requireOrganizationMemberRoleWithCtx(
     failureMessage: string;
     organizationId: Id<"organization">;
     userId: Id<"athenaUser">;
-  }
+  },
 ) {
   const membership = await ctx.db
     .query("organizationMember")
-    .filter((q) =>
-      q.and(
-        q.eq(q.field("organizationId"), args.organizationId),
-        q.eq(q.field("userId"), args.userId)
-      )
+    .withIndex("by_organizationId_userId", (q) =>
+      q.eq("organizationId", args.organizationId).eq("userId", args.userId),
     )
     .first();
 
@@ -106,7 +104,7 @@ export async function syncAuthenticatedAthenaUserWithCtx(ctx: MutationCtx) {
 
   const existingUser = await findAthenaUserByEmailWithCtx(
     ctx,
-    authUserRecord.normalizedEmail
+    authUserRecord.normalizedEmail,
   );
 
   if (existingUser) {

--- a/packages/athena-webapp/convex/mtn/foundation.test.ts
+++ b/packages/athena-webapp/convex/mtn/foundation.test.ts
@@ -14,10 +14,11 @@ describe("MTN collections foundation", () => {
     );
 
     expect(schemaSource).toContain(
-      'mtnCollectionsToken: defineTable(mtnCollectionsTokenSchema).index("by_storeId", ["storeId"])',
+      "mtnCollectionsToken: defineTable(mtnCollectionsTokenSchema)",
     );
+    expect(schemaSource).toContain('"by_storeId", ["storeId"]');
     expect(schemaSource).toContain(
-      'mtnCollectionTransaction: defineTable(mtnCollectionTransactionSchema)',
+      "mtnCollectionTransaction: defineTable(mtnCollectionTransactionSchema)",
     );
     expect(schemaSource).toContain(
       '.index("by_providerReference", ["providerReference"])',
@@ -30,6 +31,8 @@ describe("MTN collections foundation", () => {
   it("registers the MTN webhook route on the shared Hono router", () => {
     const httpRouter = readProjectFile("convex", "http.ts");
 
-    expect(httpRouter).toContain('app.route("/webhooks/mtn-momo", mtnMomoRoutes);');
+    expect(httpRouter).toContain(
+      'app.route("/webhooks/mtn-momo", mtnMomoRoutes);',
+    );
   });
 });

--- a/packages/athena-webapp/convex/operations/approvalRequests.test.ts
+++ b/packages/athena-webapp/convex/operations/approvalRequests.test.ts
@@ -179,7 +179,32 @@ function createApprovalRequestMutationCtx(args: {
     }
 
     if (table === "organizationMember") {
+      const findMember = (filters: Array<[string, unknown]>) =>
+        Array.from(tables.organizationMember.values()).find((record) =>
+          filters.every(([field, value]) => record[field] === value),
+        ) ?? null;
+
       return {
+        withIndex(
+          _index: string,
+          applyIndex: (queryBuilder: {
+            eq: (field: string, value: unknown) => unknown;
+          }) => unknown,
+        ) {
+          const filters: Array<[string, unknown]> = [];
+          const queryBuilder = {
+            eq(field: string, value: unknown) {
+              filters.push([field, value]);
+              return queryBuilder;
+            },
+          };
+
+          applyIndex(queryBuilder);
+
+          return {
+            first: async () => findMember(filters),
+          };
+        },
         filter(
           applyFilter: (queryBuilder: {
             and: (...conditions: unknown[]) => unknown;
@@ -202,10 +227,7 @@ function createApprovalRequestMutationCtx(args: {
           applyFilter(queryBuilder);
 
           return {
-            first: async () =>
-              Array.from(tables.organizationMember.values()).find((record) =>
-                filters.every(([field, value]) => record[field] === value),
-              ) ?? null,
+            first: async () => findMember(filters),
           };
         },
       };
@@ -600,16 +622,17 @@ describe("approval request helpers", () => {
     await expect(
       decideApprovalRequestAsAuthenticatedUserWithCtx(ctx, {
         approvalProofId: "proof-service-deposit" as Id<"approvalProof">,
-        approvalRequestId:
-          "approval-service-deposit" as Id<"approvalRequest">,
+        approvalRequestId: "approval-service-deposit" as Id<"approvalRequest">,
         decision: "approved",
       }),
     ).rejects.toThrow("Service deposit approval reviews can only be retired.");
 
-    expect(tables.approvalProof.get("proof-service-deposit")).not.toHaveProperty(
-      "consumedAt",
-    );
-    expect(tables.approvalRequest.get("approval-service-deposit")).toMatchObject({
+    expect(
+      tables.approvalProof.get("proof-service-deposit"),
+    ).not.toHaveProperty("consumedAt");
+    expect(
+      tables.approvalRequest.get("approval-service-deposit"),
+    ).toMatchObject({
       status: "pending",
     });
   });
@@ -684,10 +707,11 @@ describe("approval request helpers", () => {
       subjectId: "approval-item-1",
       subjectLabel: "pos_item_adjustment",
     });
-    vi.mocked(resolveTransactionItemAdjustmentApprovalDecisionWithCtx)
-      .mockRejectedValueOnce(
-        new Error("Register session expected cash cannot be negative."),
-      );
+    vi.mocked(
+      resolveTransactionItemAdjustmentApprovalDecisionWithCtx,
+    ).mockRejectedValueOnce(
+      new Error("Register session expected cash cannot be negative."),
+    );
 
     await expect(
       decideApprovalRequestAsCommandWithCtx(ctx, {
@@ -714,7 +738,9 @@ describe("approval request helpers", () => {
       reviewedByUserId: "manager-1",
       status: "cancelled",
     });
-    expect(tables.approvalRequest.get("approval-item-1")?.metadata).toMatchObject({
+    expect(
+      tables.approvalRequest.get("approval-item-1")?.metadata,
+    ).toMatchObject({
       applyFailureMessage: "Register session expected cash cannot be negative.",
     });
   });
@@ -738,12 +764,13 @@ describe("approval request helpers", () => {
       subjectId: "approval-item-1",
       subjectLabel: "pos_item_adjustment",
     });
-    vi.mocked(resolveTransactionItemAdjustmentApprovalDecisionWithCtx)
-      .mockRejectedValueOnce(
-        new Error(
-          "This transaction already has an item adjustment waiting for approval.",
-        ),
-      );
+    vi.mocked(
+      resolveTransactionItemAdjustmentApprovalDecisionWithCtx,
+    ).mockRejectedValueOnce(
+      new Error(
+        "This transaction already has an item adjustment waiting for approval.",
+      ),
+    );
 
     await expect(
       decideApprovalRequestAsCommandWithCtx(ctx, {
@@ -827,12 +854,12 @@ describe("approval request helpers", () => {
         status: "rejected",
       },
     });
-    expect(
-      tables.operationalWorkItem.get("work-item-service-1"),
-    ).toMatchObject({
-      approvalState: "rejected",
-      status: "cancelled",
-    });
+    expect(tables.operationalWorkItem.get("work-item-service-1")).toMatchObject(
+      {
+        approvalState: "rejected",
+        status: "cancelled",
+      },
+    );
   });
 
   it("does not retire unrelated work items from stale legacy approval links", async () => {
@@ -879,11 +906,13 @@ describe("approval request helpers", () => {
         status: "rejected",
       },
     });
-    expect(tables.operationalWorkItem.get("work-item-unrelated")).toMatchObject({
-      approvalRequestId: "approval-other",
-      approvalState: "pending",
-      status: "open",
-    });
+    expect(tables.operationalWorkItem.get("work-item-unrelated")).toMatchObject(
+      {
+        approvalRequestId: "approval-other",
+        approvalState: "pending",
+        status: "open",
+      },
+    );
   });
 
   it.each([
@@ -942,13 +971,13 @@ describe("approval request helpers", () => {
           status: "rejected",
         },
       });
-      expect(tables.operationalWorkItem.get("work-item-mismatch")).toMatchObject(
-        {
-          approvalState: "pending",
-          status: "open",
-          [field]: value,
-        },
-      );
+      expect(
+        tables.operationalWorkItem.get("work-item-mismatch"),
+      ).toMatchObject({
+        approvalState: "pending",
+        status: "open",
+        [field]: value,
+      });
     },
   );
 
@@ -1042,7 +1071,9 @@ describe("approval request helpers", () => {
       subjectId: "approval-void-1",
       subjectLabel: "pos_transaction_void",
     });
-    vi.mocked(resolveTransactionVoidApprovalDecisionWithCtx).mockRejectedValueOnce(
+    vi.mocked(
+      resolveTransactionVoidApprovalDecisionWithCtx,
+    ).mockRejectedValueOnce(
       new Error("Drawer closed. Open the drawer before voiding this sale."),
     );
 

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -68,6 +68,13 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
     table: TableName;
     value: Record<string, unknown>;
   }> = [];
+  const queryLog: Array<{
+    filters: Array<
+      [string, unknown | { gte?: unknown; lt?: unknown; lte?: unknown }]
+    >;
+    index: string;
+    table: TableName;
+  }> = [];
 
   const tableFor = (table: TableName) => {
     if (!tables.has(table)) {
@@ -143,8 +150,13 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
         return chain;
       },
       take: async (limit: number) => filteredRows().slice(0, limit),
+      async *[Symbol.asyncIterator]() {
+        for (const row of filteredRows()) {
+          yield row;
+        }
+      },
       withIndex(
-        _index: string,
+        index: string,
         applyIndex: (builder: {
           eq: (field: string, value: unknown) => typeof builder;
           gte: (field: string, value: unknown) => typeof builder;
@@ -152,26 +164,34 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
           lte: (field: string, value: unknown) => typeof builder;
         }) => unknown,
       ) {
+        const indexFilters: Array<
+          [string, unknown | { gte?: unknown; lt?: unknown; lte?: unknown }]
+        > = [];
         const builder = {
           eq(field: string, value: unknown) {
             filters.push([field, value]);
+            indexFilters.push([field, value]);
             return builder;
           },
           gte(field: string, value: unknown) {
             filters.push([field, { gte: value }]);
+            indexFilters.push([field, { gte: value }]);
             return builder;
           },
           lt(field: string, value: unknown) {
             filters.push([field, { lt: value }]);
+            indexFilters.push([field, { lt: value }]);
             return builder;
           },
           lte(field: string, value: unknown) {
             filters.push([field, { lte: value }]);
+            indexFilters.push([field, { lte: value }]);
             return builder;
           },
         };
 
         applyIndex(builder);
+        queryLog.push({ filters: indexFilters, index, table });
         return chain;
       },
     };
@@ -233,7 +253,7 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
     throw new Error(`Missing row ${id}`);
   }
 
-  return { db, inserts, patches, tables };
+  return { db, inserts, patches, queryLog, tables };
 }
 
 const store = {
@@ -5923,6 +5943,85 @@ describe("end-of-day review backend foundation", () => {
     ).not.toHaveProperty("totalPaid");
     expect(broadDetail?.reportSnapshot.sourceSubjects).toEqual([]);
     expect(patches).toEqual([]);
+  });
+
+  it("pushes the prior completed close date boundary into the daily close index", async () => {
+    const newerCompletedCloses = Array.from({ length: 250 }, (_, index) => {
+      const operatingDate = new Date(Date.UTC(2026, 6, 1 + index))
+        .toISOString()
+        .slice(0, 10);
+
+      return {
+        _id: `daily-close-newer-${index}`,
+        carryForwardWorkItemIds: [],
+        completedAt: Date.UTC(2026, 6, 1 + index, 22),
+        createdAt: Date.UTC(2026, 6, 1 + index, 22),
+        isCurrent: false,
+        lifecycleStatus: "active",
+        operatingDate,
+        organizationId: "org-1",
+        readiness: {
+          blockerCount: 0,
+          carryForwardCount: 0,
+          readyCount: 1,
+          reviewCount: 0,
+          status: "ready",
+        },
+        sourceSubjects: [],
+        status: "completed",
+        storeId: "store-1",
+        summary: dailyCloseSummary({ salesTotal: index + 1 }),
+        updatedAt: Date.UTC(2026, 6, 1 + index, 22),
+      };
+    });
+    const priorCompletedClose = {
+      _id: "daily-close-prior-indexed",
+      carryForwardWorkItemIds: [],
+      completedAt: Date.UTC(2026, 4, 7, 22),
+      createdAt: Date.UTC(2026, 4, 7, 22),
+      isCurrent: false,
+      lifecycleStatus: "active",
+      operatingDate: "2026-05-07",
+      organizationId: "org-1",
+      readiness: {
+        blockerCount: 0,
+        carryForwardCount: 0,
+        readyCount: 1,
+        reviewCount: 0,
+        status: "ready",
+      },
+      sourceSubjects: [],
+      status: "completed",
+      storeId: "store-1",
+      summary: dailyCloseSummary({ salesTotal: 45_000 }),
+      updatedAt: Date.UTC(2026, 4, 7, 22),
+    };
+    const { db, queryLog } = createDb({
+      dailyClose: [priorCompletedClose, ...newerCompletedCloses],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      {
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(snapshot.priorClose?._id).toBe("daily-close-prior-indexed");
+    expect(snapshot.priorDaySummary).toMatchObject({
+      salesTotal: 45_000,
+    });
+    const priorCloseQuery = queryLog.find(
+      (entry) =>
+        entry.table === "dailyClose" &&
+        entry.index === "by_storeId_status_operatingDate",
+    );
+    expect(priorCloseQuery?.filters).toContainEqual([
+      "operatingDate",
+      { lt: "2026-05-08" },
+    ]);
   });
 
   it("keeps human completion attribution when stale automation runs exist", async () => {

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -1095,22 +1095,30 @@ async function getPriorCompletedDailyClose(
     storeId: Id<"store">;
   },
 ) {
-  const completedCloses = await ctx.db
+  let scannedCloseCount = 0;
+  const completedCloses = ctx.db
     .query("dailyClose")
     .withIndex("by_storeId_status_operatingDate", (q) =>
-      q.eq("storeId", args.storeId).eq("status", "completed"),
+      q
+        .eq("storeId", args.storeId)
+        .eq("status", "completed")
+        .lt("operatingDate", args.operatingDate),
     )
-    .order("desc")
-    .take(DAILY_CLOSE_QUERY_LIMIT);
+    .order("desc");
 
-  return (
-    completedCloses.find(
-      (dailyClose) =>
-        dailyClose.operatingDate < args.operatingDate &&
-        (dailyClose.lifecycleStatus === undefined ||
-          dailyClose.lifecycleStatus === "active"),
-    ) ?? null
-  );
+  for await (const dailyClose of completedCloses) {
+    if (scannedCloseCount >= DAILY_CLOSE_QUERY_LIMIT) break;
+    scannedCloseCount += 1;
+
+    if (
+      dailyClose.lifecycleStatus === undefined ||
+      dailyClose.lifecycleStatus === "active"
+    ) {
+      return dailyClose;
+    }
+  }
+
+  return null;
 }
 
 async function listRegisterSessionsForDailyClose(

--- a/packages/athena-webapp/convex/operations/dailyOpening.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOpening.test.ts
@@ -45,11 +45,35 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
   });
 
   const query = (table: TableName) => {
-    const filters: Array<[string, unknown]> = [];
+    const filters: Array<
+      [string, unknown | { gte?: unknown; lt?: unknown; lte?: unknown }]
+    > = [];
     let sortDirection: "asc" | "desc" = "asc";
+    const compareValues = (left: unknown, right: unknown) =>
+      typeof left === "number" && typeof right === "number"
+        ? left - right
+        : String(left ?? "").localeCompare(String(right ?? ""));
     const filteredRows = () => {
       const rows = Array.from(tableFor(table).values()).filter((row) =>
-        filters.every(([field, value]) => row[field] === value),
+        filters.every(([field, value]) => {
+          if (value && typeof value === "object" && !Array.isArray(value)) {
+            if ("gte" in value && compareValues(row[field], value.gte) < 0) {
+              return false;
+            }
+
+            if ("lt" in value && compareValues(row[field], value.lt) >= 0) {
+              return false;
+            }
+
+            if ("lte" in value && compareValues(row[field], value.lte) > 0) {
+              return false;
+            }
+
+            return true;
+          }
+
+          return row[field] === value;
+        }),
       );
 
       return rows.sort((left, right) => {
@@ -65,6 +89,9 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
     const chain = {
       collect: async () => filteredRows(),
       first: async () => filteredRows()[0] ?? null,
+      async *[Symbol.asyncIterator]() {
+        yield* filteredRows();
+      },
       order(direction: "asc" | "desc") {
         sortDirection = direction;
         return chain;
@@ -74,11 +101,26 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
         _index: string,
         applyIndex: (builder: {
           eq: (field: string, value: unknown) => typeof builder;
+          gte: (field: string, value: unknown) => typeof builder;
+          lt: (field: string, value: unknown) => typeof builder;
+          lte: (field: string, value: unknown) => typeof builder;
         }) => unknown,
       ) {
         const builder = {
           eq(field: string, value: unknown) {
             filters.push([field, value]);
+            return builder;
+          },
+          gte(field: string, value: unknown) {
+            filters.push([field, { gte: value }]);
+            return builder;
+          },
+          lt(field: string, value: unknown) {
+            filters.push([field, { lt: value }]);
+            return builder;
+          },
+          lte(field: string, value: unknown) {
+            filters.push([field, { lte: value }]);
             return builder;
           },
         };
@@ -205,9 +247,7 @@ function completedDailyClose(overrides: Partial<Row> = {}): Row {
       reviewCount: 0,
       status: "ready",
     },
-    sourceSubjects: [
-      { type: "pos_transaction", id: "txn-1", label: "TXN-1" },
-    ],
+    sourceSubjects: [{ type: "pos_transaction", id: "txn-1", label: "TXN-1" }],
     status: "completed",
     storeId: "store-1",
     summary: { salesTotal: 12000 },

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -73,34 +73,26 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
 
   const query = (table: TableName) => {
     const filters: Array<
-      [string, unknown | { gte?: number; lt?: number; lte?: number }]
+      [string, unknown | { gte?: unknown; lt?: unknown; lte?: unknown }]
     > = [];
     let sortDirection: "asc" | "desc" = "asc";
+    const compareValues = (left: unknown, right: unknown) =>
+      typeof left === "number" && typeof right === "number"
+        ? left - right
+        : String(left ?? "").localeCompare(String(right ?? ""));
     const filteredRows = () => {
       const rows = Array.from(tableFor(table).values()).filter((row) =>
         filters.every(([field, value]) => {
           if (value && typeof value === "object" && !Array.isArray(value)) {
-            if (
-              "gte" in value &&
-              typeof value.gte === "number" &&
-              Number(row[field]) < value.gte
-            ) {
+            if ("gte" in value && compareValues(row[field], value.gte) < 0) {
               return false;
             }
 
-            if (
-              "lt" in value &&
-              typeof value.lt === "number" &&
-              Number(row[field]) >= value.lt
-            ) {
+            if ("lt" in value && compareValues(row[field], value.lt) >= 0) {
               return false;
             }
 
-            if (
-              "lte" in value &&
-              typeof value.lte === "number" &&
-              Number(row[field]) > value.lte
-            ) {
+            if ("lte" in value && compareValues(row[field], value.lte) > 0) {
               return false;
             }
 
@@ -127,6 +119,9 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
     const chain = {
       collect: async () => filteredRows(),
       first: async () => filteredRows()[0] ?? null,
+      async *[Symbol.asyncIterator]() {
+        yield* filteredRows();
+      },
       order(direction: "asc" | "desc") {
         sortDirection = direction;
         return chain;
@@ -136,9 +131,9 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
         _index: string,
         applyIndex: (builder: {
           eq: (field: string, value: unknown) => typeof builder;
-          gte: (field: string, value: number) => typeof builder;
-          lt: (field: string, value: number) => typeof builder;
-          lte: (field: string, value: number) => typeof builder;
+          gte: (field: string, value: unknown) => typeof builder;
+          lt: (field: string, value: unknown) => typeof builder;
+          lte: (field: string, value: unknown) => typeof builder;
         }) => unknown,
       ) {
         const builder = {
@@ -146,15 +141,15 @@ function createDb(seed: Partial<Record<TableName, Row[]>> = {}) {
             filters.push([field, value]);
             return builder;
           },
-          gte(field: string, value: number) {
+          gte(field: string, value: unknown) {
             filters.push([field, { gte: value }]);
             return builder;
           },
-          lt(field: string, value: number) {
+          lt(field: string, value: unknown) {
             filters.push([field, { lt: value }]);
             return builder;
           },
-          lte(field: string, value: number) {
+          lte(field: string, value: unknown) {
             filters.push([field, { lte: value }]);
             return builder;
           },

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -17,6 +17,7 @@ import {
   canInspectRuntimeCloudDrawerAuthority,
   isRegisterSessionSaleUsable,
 } from "../../../../shared/registerSessionLifecyclePolicy";
+import { POS_USABLE_REGISTER_SESSION_STATUSES } from "../../../../shared/registerSessionStatus";
 
 import {
   getTerminalByFingerprint,
@@ -35,6 +36,7 @@ const REGISTER_NUMBER_UNIQUE_MESSAGE =
   "A terminal with this register number already exists in this store.";
 const TERMINAL_REACTIVATION_REPROVISION_MESSAGE =
   "Re-provision this terminal before returning it to service.";
+const TERMINAL_REGISTER_SESSION_LOOKUP_LIMIT = 25;
 
 const REGISTER_TERMINAL_VALIDATION_MESSAGES = new Set([
   REGISTER_NUMBER_REQUIRED_MESSAGE,
@@ -118,9 +120,7 @@ export async function registerTerminal(
         ? normalizePosTerminalTransactionCapability(
             existing.transactionCapability,
           )
-        : normalizePosTerminalTransactionCapability(
-            args.transactionCapability,
-          );
+        : normalizePosTerminalTransactionCapability(args.transactionCapability);
     const loginMode =
       args.loginMode === undefined && existing
         ? normalizePosTerminalLoginMode(existing.loginMode)
@@ -308,7 +308,9 @@ export type TerminalRuntimeStatusInput = {
   };
   saleAuthority?: {
     observedAt: number;
-    status: NonNullable<Doc<"posTerminalRuntimeStatus">["saleAuthority"]>["status"];
+    status: NonNullable<
+      Doc<"posTerminalRuntimeStatus">["saleAuthority"]
+    >["status"];
     localPosSessionId?: string;
     localRegisterSessionId?: string;
     staffProfileId?: Id<"staffProfile">;
@@ -506,9 +508,7 @@ export async function submitTerminalRuntimeStatus(
     }),
     sync: omitUndefined({
       status: args.status.sync.status,
-      pendingEventCount: nonNegativeInteger(
-        args.status.sync.pendingEventCount,
-      ),
+      pendingEventCount: nonNegativeInteger(args.status.sync.pendingEventCount),
       uploadableEventCount: nonNegativeInteger(
         args.status.sync.uploadableEventCount,
       ),
@@ -555,13 +555,15 @@ export async function submitTerminalRuntimeStatus(
     drawerAuthority,
   });
 
-  const drawerAuthorityDirective =
-    await buildRuntimeDrawerAuthorityDirective(ctx, {
+  const drawerAuthorityDirective = await buildRuntimeDrawerAuthorityDirective(
+    ctx,
+    {
       activeRegisterSession,
       drawerAuthority,
       receivedAt,
       storeId: args.storeId,
-    });
+    },
+  );
   const activeRegisterSessionDirective =
     await buildRuntimeActiveRegisterSessionDirective(ctx, {
       activeRegisterSession,
@@ -605,11 +607,14 @@ async function buildRuntimeActiveRegisterSessionDirective(
     return undefined;
   }
 
-  const cloudRegisterSession = await getSaleUsableRegisterSessionForTerminal(ctx, {
-    registerNumber: args.terminal.registerNumber,
-    storeId: args.storeId,
-    terminalId: args.terminal._id,
-  });
+  const cloudRegisterSession = await getSaleUsableRegisterSessionForTerminal(
+    ctx,
+    {
+      registerNumber: args.terminal.registerNumber,
+      storeId: args.storeId,
+      terminalId: args.terminal._id,
+    },
+  );
   if (!cloudRegisterSession) {
     return undefined;
   }
@@ -661,7 +666,10 @@ async function getRuntimeActiveCloudRegisterSession(
     return null;
   }
 
-  const registerSession = await ctx.db.get("registerSession", registerSessionId);
+  const registerSession = await ctx.db.get(
+    "registerSession",
+    registerSessionId,
+  );
   if (!registerSession || registerSession.storeId !== args.storeId) {
     return null;
   }
@@ -677,52 +685,54 @@ async function getSaleUsableRegisterSessionForTerminal(
     terminalId: Id<"posTerminal">;
   },
 ): Promise<Doc<"registerSession"> | null> {
-  const recentByTerminal = await ctx.db
-    .query("registerSession")
-    .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
-    .order("desc")
-    .take(25);
-  const directMatch = recentByTerminal.find((session) =>
-    isSaleUsableRegisterSessionForRuntimeTerminal(session, args),
+  const registerNumber = args.registerNumber?.trim();
+  const recentSessionsByUsableStatus = await Promise.all(
+    POS_USABLE_REGISTER_SESSION_STATUSES.map((status) =>
+      ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_status_terminalId", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("status", status)
+            .eq("terminalId", args.terminalId),
+        )
+        .order("desc")
+        .take(TERMINAL_REGISTER_SESSION_LOOKUP_LIMIT),
+    ),
+  );
+  const directMatch = latestCompatibleRegisterSessionCandidate(
+    recentSessionsByUsableStatus.flat(),
+    { registerNumber },
   );
   if (directMatch) return directMatch;
 
-  const registerNumber = args.registerNumber?.trim();
-  if (!registerNumber) {
-    return null;
-  }
+  return null;
+}
 
-  const recentByRegisterNumber = await ctx.db
-    .query("registerSession")
-    .withIndex("by_storeId_registerNumber", (q) =>
-      q.eq("storeId", args.storeId).eq("registerNumber", registerNumber),
-    )
-    .order("desc")
-    .take(25);
-
+function latestCompatibleRegisterSessionCandidate(
+  sessions: Array<Doc<"registerSession">>,
+  args: {
+    registerNumber?: string;
+  },
+) {
   return (
-    recentByRegisterNumber.find((session) =>
-      isSaleUsableRegisterSessionForRuntimeTerminal(session, args),
-    ) ?? null
+    sessions
+      .filter((session) => isRegisterNumberCompatible(session, args))
+      .sort((left, right) => right._creationTime - left._creationTime)[0] ??
+    null
   );
 }
 
-function isSaleUsableRegisterSessionForRuntimeTerminal(
-  session: Doc<"registerSession">,
+function isRegisterNumberCompatible(
+  session: Pick<Doc<"registerSession">, "registerNumber">,
   args: {
-    registerNumber?: string | null;
-    storeId: Id<"store">;
-    terminalId: Id<"posTerminal">;
+    registerNumber?: string;
   },
 ) {
-  const registerNumber = args.registerNumber?.trim();
   return (
-    session.storeId === args.storeId &&
-    session.terminalId === args.terminalId &&
-    (!registerNumber ||
-      !session.registerNumber ||
-      session.registerNumber === registerNumber) &&
-    isRegisterSessionSaleUsable(session)
+    !args.registerNumber ||
+    !session.registerNumber ||
+    session.registerNumber === args.registerNumber
   );
 }
 
@@ -750,7 +760,8 @@ async function buildRuntimeDrawerAuthorityDirective(
     args.drawerAuthority.reason === "cloud_closed" &&
     args.drawerAuthority.localRegisterSessionId ===
       session.localRegisterSessionId &&
-    args.drawerAuthority.cloudRegisterSessionId === session.cloudRegisterSessionId
+    args.drawerAuthority.cloudRegisterSessionId ===
+      session.cloudRegisterSessionId
   ) {
     return undefined;
   }
@@ -797,7 +808,10 @@ function cleanSaleAuthority(
     status: saleAuthorityStatuses.has(saleAuthority.status)
       ? saleAuthority.status
       : "unknown",
-    localPosSessionId: cleanOptionalString(saleAuthority.localPosSessionId, 120),
+    localPosSessionId: cleanOptionalString(
+      saleAuthority.localPosSessionId,
+      120,
+    ),
     localRegisterSessionId: cleanOptionalString(
       saleAuthority.localRegisterSessionId,
       120,

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -381,7 +381,9 @@ describe("updateTerminal", () => {
         terminalId: "terminal-1" as Id<"posTerminal">,
         status: "active",
       }),
-    ).rejects.toThrow("Re-provision this terminal before returning it to service.");
+    ).rejects.toThrow(
+      "Re-provision this terminal before returning it to service.",
+    );
     expect(vi.mocked(patchTerminalRecord)).not.toHaveBeenCalled();
   });
 });
@@ -447,7 +449,9 @@ describe("submitTerminalRuntimeStatus", () => {
         acceptedForSideEffects: true,
       },
     });
-    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).toHaveBeenCalledWith(
       expect.anything(),
       expect.not.objectContaining({
         staffProofToken: expect.anything(),
@@ -457,7 +461,9 @@ describe("submitTerminalRuntimeStatus", () => {
         customerInfo: expect.anything(),
       }),
     );
-    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         storeId: "store-1",
@@ -495,24 +501,23 @@ describe("submitTerminalRuntimeStatus", () => {
       runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
     });
 
-    await submitTerminalRuntimeStatus(
-      { db: null as never } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: {
-          ...buildRuntimeStatus(),
-          activeRegisterSession: {
-            cloudRegisterSessionId: "cloud-register-1",
-            localRegisterSessionId: "local-register-1",
-            observedAt: 112,
-            status: "closeout_rejected",
-          },
-        } as never,
-      },
-    );
+    await submitTerminalRuntimeStatus({ db: null as never } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: {
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "local-register-1",
+          observedAt: 112,
+          status: "closeout_rejected",
+        },
+      } as never,
+    });
 
-    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         activeRegisterSession: expect.objectContaining({
@@ -530,21 +535,20 @@ describe("submitTerminalRuntimeStatus", () => {
       runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
     });
 
-    await submitTerminalRuntimeStatus(
-      { db: null as never } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: {
-          ...buildRuntimeStatus(),
-          appSessionRecovery: {
-            status: "retry_exhausted",
-          },
+    await submitTerminalRuntimeStatus({ db: null as never } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        appSessionRecovery: {
+          status: "retry_exhausted",
         },
       },
-    );
+    });
 
-    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         appSessionRecovery: {
@@ -570,29 +574,23 @@ describe("submitTerminalRuntimeStatus", () => {
       })),
     };
 
-    const result = await submitTerminalRuntimeStatus(
-      { db } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: {
-          ...buildRuntimeStatus(),
-          activeRegisterSession: {
-            cloudRegisterSessionId: "cloud-register-1",
-            localRegisterSessionId: "local-register-1",
-            observedAt: 120,
-            openedAt: 100,
-            registerNumber: "8",
-            status: "active",
-          },
+    const result = await submitTerminalRuntimeStatus({ db } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: {
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "local-register-1",
+          observedAt: 120,
+          openedAt: 100,
+          registerNumber: "8",
+          status: "active",
         },
       },
-    );
+    });
 
-    expect(db.get).toHaveBeenCalledWith(
-      "registerSession",
-      "cloud-register-1",
-    );
+    expect(db.get).toHaveBeenCalledWith("registerSession", "cloud-register-1");
     expect(result).toEqual({
       kind: "ok",
       data: expect.objectContaining({
@@ -641,28 +639,32 @@ describe("submitTerminalRuntimeStatus", () => {
         terminalId: "terminal-1",
       },
     ];
+    const indexNames: string[] = [];
     const db = {
-      query: vi.fn(() => buildTerminalHealthQuery(registerSessions)),
+      query: vi.fn(() =>
+        buildTerminalHealthQuery(registerSessions, indexNames),
+      ),
     };
 
-    const result = await submitTerminalRuntimeStatus(
-      { db } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: {
-          ...buildRuntimeStatus(),
-          activeRegisterSession: undefined,
-          localStore: {
-            available: true,
-            schemaVersion: 1,
-            terminalSeedReady: true,
-          },
+    const result = await submitTerminalRuntimeStatus({ db } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: undefined,
+        localStore: {
+          available: true,
+          schemaVersion: 1,
+          terminalSeedReady: true,
         },
       },
-    );
+    });
 
     expect(db.query).toHaveBeenCalledWith("registerSession");
+    expect(indexNames).toEqual([
+      "by_storeId_status_terminalId",
+      "by_storeId_status_terminalId",
+    ]);
     expect(result).toEqual({
       kind: "ok",
       data: expect.objectContaining({
@@ -679,6 +681,192 @@ describe("submitTerminalRuntimeStatus", () => {
         },
       }),
     });
+  });
+
+  it("does not direct a terminal to a usable drawer for another register number", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
+    const registerSessions = [
+      {
+        _creationTime: 300,
+        _id: "cloud-register-renumbered",
+        expectedCash: 10_000,
+        openedAt: 180,
+        openingFloat: 10_000,
+        openedByStaffProfileId: "staff-2",
+        registerNumber: "B2",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    ];
+    const indexNames: string[] = [];
+    const db = {
+      query: vi.fn(() =>
+        buildTerminalHealthQuery(registerSessions, indexNames),
+      ),
+    };
+
+    const result = await submitTerminalRuntimeStatus({ db } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: undefined,
+        localStore: {
+          available: true,
+          schemaVersion: 1,
+          terminalSeedReady: true,
+        },
+      },
+    });
+
+    expect(indexNames).toEqual([
+      "by_storeId_status_terminalId",
+      "by_storeId_status_terminalId",
+    ]);
+    expect(result).toEqual({
+      kind: "ok",
+      data: expect.not.objectContaining({
+        activeRegisterSessionDirective: expect.anything(),
+      }),
+    });
+  });
+
+  it("skips newer incompatible register sessions when an older compatible session exists", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
+    const registerSessions = [
+      {
+        _creationTime: 300,
+        _id: "cloud-register-renumbered",
+        expectedCash: 10_000,
+        openedAt: 180,
+        openingFloat: 10_000,
+        openedByStaffProfileId: "staff-2",
+        registerNumber: "B2",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+      {
+        _creationTime: 200,
+        _id: "cloud-register-compatible",
+        expectedCash: 13_000,
+        openedAt: 100,
+        openingFloat: 13_000,
+        openedByStaffProfileId: "staff-1",
+        registerNumber: "A1",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    ];
+    const db = {
+      query: vi.fn(() => buildTerminalHealthQuery(registerSessions)),
+    };
+
+    const result = await submitTerminalRuntimeStatus({ db } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: undefined,
+        localStore: {
+          available: true,
+          schemaVersion: 1,
+          terminalSeedReady: true,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: expect.objectContaining({
+        activeRegisterSessionDirective: expect.objectContaining({
+          cloudRegisterSessionId: "cloud-register-compatible",
+          expectedCash: 13_000,
+          registerNumber: "A1",
+          staffProfileId: "staff-1",
+        }),
+      }),
+    });
+  });
+
+  it("can direct a terminal to a compatible legacy drawer without a register number", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatusWithOutcome).mockResolvedValue({
+      didWrite: true,
+      runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    });
+    const registerSessions = [
+      {
+        _creationTime: 300,
+        _id: "cloud-register-legacy",
+        expectedCash: 11_000,
+        openedAt: 180,
+        openingFloat: 11_000,
+        openedByStaffProfileId: "staff-3",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+      {
+        _creationTime: 200,
+        _id: "cloud-register-other",
+        expectedCash: 10_000,
+        openedAt: 160,
+        openingFloat: 10_000,
+        openedByStaffProfileId: "staff-2",
+        registerNumber: "Z9",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    ];
+    const db = {
+      query: vi.fn(() => buildTerminalHealthQuery(registerSessions)),
+    };
+
+    const result = await submitTerminalRuntimeStatus({ db } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: undefined,
+        localStore: {
+          available: true,
+          schemaVersion: 1,
+          terminalSeedReady: true,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: expect.objectContaining({
+        activeRegisterSessionDirective: expect.objectContaining({
+          cloudRegisterSessionId: "cloud-register-legacy",
+          expectedCash: 11_000,
+          staffProfileId: "staff-3",
+        }),
+      }),
+    });
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        activeRegisterSessionDirective: expect.not.objectContaining({
+          registerNumber: "Z9",
+        }),
+      }),
+    );
   });
 
   it("returns an active register session directive when runtime is stuck on a closed cloud drawer", async () => {
@@ -712,6 +900,7 @@ describe("submitTerminalRuntimeStatus", () => {
         terminalId: "terminal-1",
       },
     ];
+    const indexNames: string[] = [];
     const db = {
       get: vi.fn(async (tableName: string, id: string) =>
         tableName === "registerSession"
@@ -724,36 +913,39 @@ describe("submitTerminalRuntimeStatus", () => {
           ? value
           : null,
       ),
-      query: vi.fn(() => buildTerminalHealthQuery(registerSessions)),
+      query: vi.fn(() =>
+        buildTerminalHealthQuery(registerSessions, indexNames),
+      ),
     };
 
-    const result = await submitTerminalRuntimeStatus(
-      { db } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: {
-          ...buildRuntimeStatus(),
-          activeRegisterSession: {
-            localRegisterSessionId: "cloud-register-closed",
-            observedAt: 190,
-            openedAt: 100,
-            registerNumber: "A1",
-            status: "active",
-          },
-          localStore: {
-            available: true,
-            schemaVersion: 1,
-            terminalSeedReady: true,
-          },
+    const result = await submitTerminalRuntimeStatus({ db } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: {
+          localRegisterSessionId: "cloud-register-closed",
+          observedAt: 190,
+          openedAt: 100,
+          registerNumber: "A1",
+          status: "active",
+        },
+        localStore: {
+          available: true,
+          schemaVersion: 1,
+          terminalSeedReady: true,
         },
       },
-    );
+    });
 
     expect(db.get).toHaveBeenCalledWith(
       "registerSession",
       "cloud-register-closed",
     );
+    expect(indexNames).toEqual([
+      "by_storeId_status_terminalId",
+      "by_storeId_status_terminalId",
+    ]);
     expect(result).toEqual({
       kind: "ok",
       data: expect.objectContaining({
@@ -788,29 +980,23 @@ describe("submitTerminalRuntimeStatus", () => {
       })),
     };
 
-    const result = await submitTerminalRuntimeStatus(
-      { db } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: {
-          ...buildRuntimeStatus(),
-          activeRegisterSession: {
-            cloudRegisterSessionId: "cloud-register-1",
-            localRegisterSessionId: "local-register-1",
-            observedAt: 120,
-            openedAt: 100,
-            registerNumber: "8",
-            status: "closing",
-          },
+    const result = await submitTerminalRuntimeStatus({ db } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: {
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "local-register-1",
+          observedAt: 120,
+          openedAt: 100,
+          registerNumber: "8",
+          status: "closing",
         },
       },
-    );
+    });
 
-    expect(db.get).toHaveBeenCalledWith(
-      "registerSession",
-      "cloud-register-1",
-    );
+    expect(db.get).toHaveBeenCalledWith("registerSession", "cloud-register-1");
     expect(result).toEqual({
       kind: "ok",
       data: expect.objectContaining({
@@ -835,24 +1021,21 @@ describe("submitTerminalRuntimeStatus", () => {
       get: vi.fn(),
     };
 
-    const result = await submitTerminalRuntimeStatus(
-      { db } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: {
-          ...buildRuntimeStatus(),
-          activeRegisterSession: {
-            cloudRegisterSessionId: "not-a-register-id",
-            localRegisterSessionId: "local-register-1",
-            observedAt: 120,
-            openedAt: 100,
-            registerNumber: "8",
-            status: "active",
-          },
+    const result = await submitTerminalRuntimeStatus({ db } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        activeRegisterSession: {
+          cloudRegisterSessionId: "not-a-register-id",
+          localRegisterSessionId: "local-register-1",
+          observedAt: 120,
+          openedAt: 100,
+          registerNumber: "8",
+          status: "active",
         },
       },
-    );
+    });
 
     expect(result).toEqual({
       kind: "ok",
@@ -874,36 +1057,35 @@ describe("submitTerminalRuntimeStatus", () => {
       runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
     });
 
-    await submitTerminalRuntimeStatus(
-      { db: null as never } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: {
-          ...buildRuntimeStatus(),
-          appUpdate: {
-            blockerSummary: "active_sale",
-            canApply: false,
-            commandExecutionId: "exec-123",
-            commandIssuedAt: 90,
-            commandNonce: "nonce-abc",
-            currentBuildId: " build-current ",
-            detectorStatus: "ok",
-            observedAt: 100,
-            pendingBuildId: "build-next",
-            selectedBlockerCode: "active_sale",
-            stagingAssetCount: 12.8,
-            stagingFailedAssetCount: -2,
-            stagingReason: "service-worker-error",
-            stagingRejectedAssetCount: 3.2,
-            stagingStatus: "staged",
-            status: "blocked",
-          },
+    await submitTerminalRuntimeStatus({ db: null as never } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: {
+        ...buildRuntimeStatus(),
+        appUpdate: {
+          blockerSummary: "active_sale",
+          canApply: false,
+          commandExecutionId: "exec-123",
+          commandIssuedAt: 90,
+          commandNonce: "nonce-abc",
+          currentBuildId: " build-current ",
+          detectorStatus: "ok",
+          observedAt: 100,
+          pendingBuildId: "build-next",
+          selectedBlockerCode: "active_sale",
+          stagingAssetCount: 12.8,
+          stagingFailedAssetCount: -2,
+          stagingReason: "service-worker-error",
+          stagingRejectedAssetCount: 3.2,
+          stagingStatus: "staged",
+          status: "blocked",
         },
       },
-    );
+    });
 
-    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         appUpdate: {
@@ -934,16 +1116,15 @@ describe("submitTerminalRuntimeStatus", () => {
       runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
     });
 
-    await submitTerminalRuntimeStatus(
-      { db: null as never } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: buildRuntimeStatus(),
-      },
-    );
+    await submitTerminalRuntimeStatus({ db: null as never } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: buildRuntimeStatus(),
+    });
 
-    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         appUpdate: undefined,
@@ -958,16 +1139,15 @@ describe("submitTerminalRuntimeStatus", () => {
       runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
     });
 
-    await submitTerminalRuntimeStatus(
-      { db: null as never } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: buildRuntimeStatus(),
-      },
-    );
+    await submitTerminalRuntimeStatus({ db: null as never } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: buildRuntimeStatus(),
+    });
 
-    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         appSessionRecovery: undefined,
@@ -982,16 +1162,15 @@ describe("submitTerminalRuntimeStatus", () => {
       runtimeStatusId: "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
     });
 
-    await submitTerminalRuntimeStatus(
-      { db: null as never } as never,
-      {
-        storeId: "store-1" as Id<"store">,
-        terminalId: "terminal-1" as Id<"posTerminal">,
-        status: buildRuntimeStatus(),
-      },
-    );
+    await submitTerminalRuntimeStatus({ db: null as never } as never, {
+      storeId: "store-1" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
+      status: buildRuntimeStatus(),
+    });
 
-    expect(vi.mocked(upsertLatestRuntimeStatusWithOutcome)).toHaveBeenCalledWith(
+    expect(
+      vi.mocked(upsertLatestRuntimeStatusWithOutcome),
+    ).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         drawerAuthority: undefined,
@@ -1030,7 +1209,9 @@ describe("submitTerminalRuntimeStatus", () => {
 describe("terminal health summaries", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(resolveTerminalRegisterSessionActionTarget).mockResolvedValue(null);
+    vi.mocked(resolveTerminalRegisterSessionActionTarget).mockResolvedValue(
+      null,
+    );
     vi.mocked(getActiveRegisterSessionForTerminal).mockResolvedValue(null);
     vi.mocked(getDrawerAuthorityRegisterSession).mockResolvedValue(null);
     vi.mocked(getLatestRegisterSessionForTerminal).mockResolvedValue(null);
@@ -1067,8 +1248,12 @@ describe("terminal health summaries", () => {
       patchCommand: vi.fn(),
       listCommandsForTerminal: vi.fn().mockResolvedValue([]),
     } satisfies TerminalRecoveryCommandRepository;
-    vi.mocked(createTerminalRecoveryCommandReadRepository).mockReturnValue(readRepository);
-    vi.mocked(createTerminalRecoveryCommandRepository).mockReturnValue(writeRepository);
+    vi.mocked(createTerminalRecoveryCommandReadRepository).mockReturnValue(
+      readRepository,
+    );
+    vi.mocked(createTerminalRecoveryCommandRepository).mockReturnValue(
+      writeRepository,
+    );
   });
 
   afterEach(() => {
@@ -1148,13 +1333,12 @@ describe("terminal health summaries", () => {
       }),
     ]);
     expect(vi.mocked(getTerminalSyncEvidence)).not.toHaveBeenCalled();
-    expect(vi.mocked(getTerminalSyncReviewSummaryEvidence)).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        storeId: "store-1",
-        terminalId: "terminal-1",
-      },
-    );
+    expect(
+      vi.mocked(getTerminalSyncReviewSummaryEvidence),
+    ).toHaveBeenCalledWith(expect.anything(), {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
   });
 
   it("carries support-safe app-session recovery status through terminal health", async () => {
@@ -1519,9 +1703,9 @@ describe("terminal health summaries", () => {
         type: "cloud_rejected",
       }),
     ]);
-    expect(
-      result?.attentionReasons.some((reason) => reason.actionTarget),
-    ).toBe(false);
+    expect(result?.attentionReasons.some((reason) => reason.actionTarget)).toBe(
+      false,
+    );
   });
 
   it("does not link manual-only cloud review counts to open work", async () => {
@@ -1645,7 +1829,8 @@ describe("terminal health summaries", () => {
           },
           {
             actionTarget: {
-              registerSessionId: "register-session-cash" as Id<"registerSession">,
+              registerSessionId:
+                "register-session-cash" as Id<"registerSession">,
               type: "register_session",
             },
             actionability: "cash_controls_review",
@@ -2629,11 +2814,16 @@ function buildTerminalHealthDb(
         ? value
         : null;
     }),
-    query: vi.fn((tableName: string) => buildTerminalHealthQuery(records[tableName] ?? [])),
+    query: vi.fn((tableName: string) =>
+      buildTerminalHealthQuery(records[tableName] ?? []),
+    ),
   };
 }
 
-function buildTerminalHealthQuery(records: Array<Record<string, unknown>>) {
+function buildTerminalHealthQuery(
+  records: Array<Record<string, unknown>>,
+  indexNames?: string[],
+) {
   let currentRecords = [...records];
   const chain = {
     first: vi.fn(async () => currentRecords[0] ?? null),
@@ -2641,23 +2831,33 @@ function buildTerminalHealthQuery(records: Array<Record<string, unknown>>) {
       currentRecords = [...currentRecords].sort((left, right) => {
         const leftTime = Number(left._creationTime ?? 0);
         const rightTime = Number(right._creationTime ?? 0);
-        return direction === "desc" ? rightTime - leftTime : leftTime - rightTime;
+        return direction === "desc"
+          ? rightTime - leftTime
+          : leftTime - rightTime;
       });
       return chain;
     }),
     take: vi.fn(async (count: number) => currentRecords.slice(0, count)),
-    withIndex: vi.fn((_indexName: string, build: (q: {
-      eq: (field: string, value: unknown) => unknown;
-    }) => unknown) => {
-      const q = {
-        eq: vi.fn((field: string, value: unknown) => {
-          currentRecords = currentRecords.filter((record) => record[field] === value);
-          return q;
-        }),
-      };
-      build(q);
-      return chain;
-    }),
+    withIndex: vi.fn(
+      (
+        indexName: string,
+        build: (q: {
+          eq: (field: string, value: unknown) => unknown;
+        }) => unknown,
+      ) => {
+        indexNames?.push(indexName);
+        const q = {
+          eq: vi.fn((field: string, value: unknown) => {
+            currentRecords = currentRecords.filter(
+              (record) => record[field] === value,
+            );
+            return q;
+          }),
+        };
+        build(q);
+        return chain;
+      },
+    ),
   };
   return chain;
 }

--- a/packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts
+++ b/packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import type { Id } from "../../_generated/dataModel";
 
@@ -61,6 +63,23 @@ describe("POS recovery codes", () => {
     });
   });
 
+  it("defines indexes for recovery store and membership lookups", () => {
+    const schemaSource = readFileSync(
+      join(process.cwd(), "convex", "schema.ts"),
+      "utf8",
+    );
+
+    expect(schemaSource).toContain(
+      'organization: defineTable(organizationSchema).index("by_slug", ["slug"])',
+    );
+    expect(schemaSource).toContain(
+      '.index("by_organizationId_slug", ["organizationId", "slug"])',
+    );
+    expect(schemaSource).toContain(
+      '.index("by_organizationId_userId", ["organizationId", "userId"])',
+    );
+  });
+
   it("creates a persisted credential and verifies the generated code", async () => {
     const ctx = buildCtx();
     const create = getHandler(createOrRotateRecoveryCodeForTest);
@@ -112,6 +131,13 @@ describe("POS recovery codes", () => {
         storeUrlSlug: "wigclub",
       }),
     ).resolves.toEqual({ authUserId: AUTH_USER_ID });
+    expect(ctx.queryLog).toEqual(
+      expect.arrayContaining([
+        "by_slug",
+        "by_organizationId_slug",
+        "by_organizationId_userId",
+      ]),
+    );
   });
 
   it("accepts recovery codes without exact casing or word separators", async () => {
@@ -210,7 +236,9 @@ describe("POS recovery codes", () => {
       }),
     );
     expect(ctx.tables.posRecoveryCredential[0]).not.toHaveProperty("lockedAt");
-    expect(ctx.tables.posRecoveryCredential[0]).not.toHaveProperty("lockedUntil");
+    expect(ctx.tables.posRecoveryCredential[0]).not.toHaveProperty(
+      "lockedUntil",
+    );
     const failedAttemptEvents = ctx.tables.operationalEvent.filter(
       (event) => event.eventType === "pos_recovery_code_login_failed",
     );
@@ -336,23 +364,26 @@ describe("POS recovery codes", () => {
       },
       reason: "POS recovery account auth user is not configured.",
     },
-  ])("does not generate recovery codes for $label", async ({ mutate, reason }) => {
-    const ctx = buildCtx();
-    const rotate = getHandler(rotateRecoveryCode);
-    mutate(ctx);
+  ])(
+    "does not generate recovery codes for $label",
+    async ({ mutate, reason }) => {
+      const ctx = buildCtx();
+      const rotate = getHandler(rotateRecoveryCode);
+      mutate(ctx);
 
-    authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
-    await expect(rotate(ctx, { storeId: STORE_ID })).rejects.toThrow(reason);
+      authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
+      await expect(rotate(ctx, { storeId: STORE_ID })).rejects.toThrow(reason);
 
-    expect(ctx.tables.posRecoveryCredential).toHaveLength(0);
-    expect(ctx.tables.operationalEvent).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          eventType: expect.stringMatching(/^pos_recovery_code_/),
-        }),
-      ]),
-    );
-  });
+      expect(ctx.tables.posRecoveryCredential).toHaveLength(0);
+      expect(ctx.tables.operationalEvent).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            eventType: expect.stringMatching(/^pos_recovery_code_/),
+          }),
+        ]),
+      );
+    },
+  );
 
   it.each([
     {
@@ -562,7 +593,9 @@ function buildCtx() {
     ],
   };
 
+  const queryLog: string[] = [];
   const ctx = {
+    queryLog,
     tables,
     db: {
       get: vi.fn(async (tableOrId: string, maybeId?: string) => {
@@ -580,25 +613,33 @@ function buildCtx() {
         tables[table].push({ _id: id, _creationTime: Date.now(), ...value });
         return id;
       }),
-      patch: vi.fn(async (...args: [string, string, Record<string, unknown>] | [string, Record<string, unknown>]) => {
-        const id = args.length === 3 ? args[1] : args[0];
-        const patch = args.length === 3 ? args[2] : args[1];
-        const row = Object.values(tables)
-          .flat()
-          .find((candidate) => candidate._id === id);
-        if (!row) {
-          throw new Error(`Missing row ${id}`);
-        }
-        Object.assign(row, patch);
-      }),
-      query: vi.fn((table: string) => createQuery(tables[table] ?? [])),
+      patch: vi.fn(
+        async (
+          ...args:
+            | [string, string, Record<string, unknown>]
+            | [string, Record<string, unknown>]
+        ) => {
+          const id = args.length === 3 ? args[1] : args[0];
+          const patch = args.length === 3 ? args[2] : args[1];
+          const row = Object.values(tables)
+            .flat()
+            .find((candidate) => candidate._id === id);
+          if (!row) {
+            throw new Error(`Missing row ${id}`);
+          }
+          Object.assign(row, patch);
+        },
+      ),
+      query: vi.fn((table: string) =>
+        createQuery(tables[table] ?? [], queryLog),
+      ),
     },
   };
 
   return ctx;
 }
 
-function createQuery(rows: any[]) {
+function createQuery(rows: any[], queryLog: string[]) {
   let currentRows = rows;
   const query = {
     collect: vi.fn(async () => currentRows),
@@ -608,7 +649,8 @@ function createQuery(rows: any[]) {
     }),
     first: vi.fn(async () => currentRows[0] ?? null),
     take: vi.fn(async (limit: number) => currentRows.slice(0, limit)),
-    withIndex: vi.fn((_name: string, predicate?: Function) => {
+    withIndex: vi.fn((name: string, predicate?: Function) => {
+      queryLog.push(name);
       if (predicate) {
         const indexBuilder = {
           eq: (field: string, value: unknown) => {

--- a/packages/athena-webapp/convex/pos/public/posRecoveryCodes.ts
+++ b/packages/athena-webapp/convex/pos/public/posRecoveryCodes.ts
@@ -157,8 +157,9 @@ function formatRecoveryCode(compactCode: string) {
 }
 
 function generateRecoveryCode() {
-  const words = Array.from({ length: 2 }, () =>
-    POS_RECOVERY_CODE_WORDS[randomIndex(POS_RECOVERY_CODE_WORDS.length)],
+  const words = Array.from(
+    { length: 2 },
+    () => POS_RECOVERY_CODE_WORDS[randomIndex(POS_RECOVERY_CODE_WORDS.length)],
   );
   const number = randomIndex(100).toString().padStart(2, "0");
 
@@ -166,7 +167,10 @@ function generateRecoveryCode() {
 }
 
 function normalizeRecoveryCode(code: string) {
-  const compactCode = code.trim().toUpperCase().replace(/[\s-]+/g, "");
+  const compactCode = code
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, "");
 
   if (
     compactCode.length === POS_RECOVERY_CODE_LENGTH &&
@@ -177,7 +181,10 @@ function normalizeRecoveryCode(code: string) {
     return formatRecoveryCode(compactCode);
   }
 
-  return code.trim().toLowerCase().replace(/[-\s]+/g, "");
+  return code
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, "");
 }
 
 function getFailureAuditBucket(now: number) {
@@ -190,16 +197,15 @@ export async function hashPosRecoveryCode(args: {
 }) {
   const digest = await crypto.subtle.digest(
     "SHA-256",
-    new TextEncoder().encode(`${args.salt}:${normalizeRecoveryCode(args.code)}`),
+    new TextEncoder().encode(
+      `${args.salt}:${normalizeRecoveryCode(args.code)}`,
+    ),
   );
 
   return bytesToHex(digest);
 }
 
-async function findAthenaUserByEmail(
-  ctx: PosRecoveryCtx,
-  email: string,
-) {
+async function findAthenaUserByEmail(ctx: PosRecoveryCtx, email: string) {
   const normalizedEmail = normalizeEmail(email);
   // Case-insensitive lookup mirrors the existing Athena auth-sync helper until
   // athenaUser gains a normalized-email index.
@@ -224,7 +230,10 @@ async function findAuthUserByEmail(ctx: PosRecoveryCtx, email: string) {
   const users = await ctx.db.query("users").collect();
   const matches = users.filter((user) => {
     const candidate = "email" in user ? user.email : undefined;
-    return typeof candidate === "string" && normalizeEmail(candidate) === normalizedEmail;
+    return (
+      typeof candidate === "string" &&
+      normalizeEmail(candidate) === normalizedEmail
+    );
   });
 
   if (matches.length > 1) {
@@ -269,7 +278,7 @@ async function resolveRecoveryStore(
 
   const organization = await ctx.db
     .query("organization")
-    .filter((q) => q.eq(q.field("slug"), orgSlug))
+    .withIndex("by_slug", (q) => q.eq("slug", orgSlug))
     .first();
   if (!organization) {
     return null;
@@ -277,11 +286,8 @@ async function resolveRecoveryStore(
 
   return ctx.db
     .query("store")
-    .filter((q) =>
-      q.and(
-        q.eq(q.field("organizationId"), organization._id),
-        q.eq(q.field("slug"), storeSlug),
-      ),
+    .withIndex("by_organizationId_slug", (q) =>
+      q.eq("organizationId", organization._id).eq("slug", storeSlug),
     )
     .first();
 }
@@ -358,11 +364,10 @@ async function requireUsablePosRecoveryAccount(
 ) {
   const membership = await ctx.db
     .query("organizationMember")
-    .filter((q) =>
-      q.and(
-        q.eq(q.field("organizationId"), args.organizationId),
-        q.eq(q.field("userId"), args.account._id),
-      ),
+    .withIndex("by_organizationId_userId", (q) =>
+      q
+        .eq("organizationId", args.organizationId)
+        .eq("userId", args.account._id),
     )
     .first();
 
@@ -444,7 +449,10 @@ async function rotateCredentialWithCtx(
       rotatedByUserId: args.actorUserId,
       status: "active",
     });
-    const credential = (await ctx.db.get("posRecoveryCredential", existing._id))!;
+    const credential = (await ctx.db.get(
+      "posRecoveryCredential",
+      existing._id,
+    ))!;
     await recordRecoveryCodeEvent(ctx, {
       actorUserId: args.actorUserId,
       credential,
@@ -500,11 +508,8 @@ async function verifyCredentialWithCtx(
 
   const membership = await ctx.db
     .query("organizationMember")
-    .filter((q) =>
-      q.and(
-        q.eq(q.field("organizationId"), store.organizationId),
-        q.eq(q.field("userId"), account._id),
-      ),
+    .withIndex("by_organizationId_userId", (q) =>
+      q.eq("organizationId", store.organizationId).eq("userId", account._id),
     )
     .first();
 
@@ -597,7 +602,10 @@ export const getRecoveryCodeStatus = query({
   },
   handler: async (ctx, args) => {
     await requireFullAdminRecoveryAccess(ctx, args.storeId);
-    const account = await findAthenaUserByEmail(ctx, POS_RECOVERY_ACCOUNT_EMAIL);
+    const account = await findAthenaUserByEmail(
+      ctx,
+      POS_RECOVERY_ACCOUNT_EMAIL,
+    );
     if (!account) {
       return null;
     }

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -299,6 +299,13 @@ const schema = defineSchema({
       "status",
       "occurredAt",
     ])
+    .index("by_storeId_surface_status_abusePartitionKey_receivedAt", [
+      "storeId",
+      "surface",
+      "status",
+      "abusePartitionKey",
+      "receivedAt",
+    ])
     .index("by_storeId_historicalImportRunId_status", [
       "storeId",
       "historicalImportRunId",
@@ -358,7 +365,9 @@ const schema = defineSchema({
       "status",
     ])
     .index("by_snapshotHash", ["snapshotHash"]),
-  intelligenceProviderInvocation: defineTable(intelligenceProviderInvocationSchema)
+  intelligenceProviderInvocation: defineTable(
+    intelligenceProviderInvocationSchema,
+  )
     .index("by_runId", ["runId"])
     .index("by_contextSnapshotId", ["contextSnapshotId"])
     .index("by_providerKey_status", ["providerKey", "status"])
@@ -372,6 +381,11 @@ const schema = defineSchema({
     .index("by_storeFrontUserId", ["storeFrontUserId"]),
   bagItem: defineTable(bagItemSchema)
     .index("by_bagId", ["bagId"])
+    .index("by_bagId_storeFrontUserId_productSkuId", [
+      "bagId",
+      "storeFrontUserId",
+      "productSkuId",
+    ])
     .index("by_productSkuId", ["productSkuId"]),
   bannerMessage: defineTable(bannerMessageSchema).index("by_storeId", [
     "storeId",
@@ -396,16 +410,12 @@ const schema = defineSchema({
       "hasCompletedCheckoutSession",
       "expiresAt",
     ]),
-  checkoutSessionItem: defineTable(checkoutSessionItemSchema).index(
-    "by_sessionId",
-    ["sesionId"]
-  ).index(
-    "by_productSkuId",
-    ["productSkuId"]
-  ),
+  checkoutSessionItem: defineTable(checkoutSessionItemSchema)
+    .index("by_sessionId", ["sesionId"])
+    .index("by_productSkuId", ["productSkuId"]),
   color: defineTable(colorSchema),
   complimentaryProductsCollection: defineTable(
-    complimentaryProductsCollectionSchema
+    complimentaryProductsCollectionSchema,
   ).index("by_storeId", ["storeId"]),
   complimentaryProduct: defineTable(complimentaryProductSchema)
     .index("by_storeId", ["storeId"])
@@ -451,11 +461,7 @@ const schema = defineSchema({
       "status",
       "expiresAt",
     ])
-    .index("by_storeId_status_expiresAt", [
-      "storeId",
-      "status",
-      "expiresAt",
-    ])
+    .index("by_storeId_status_expiresAt", ["storeId", "status", "expiresAt"])
     .index("by_sourceSessionId_status_productSkuId", [
       "sourceSessionId",
       "status",
@@ -464,7 +470,9 @@ const schema = defineSchema({
   inventoryImportReviewVersion: defineTable(inventoryImportReviewVersionSchema)
     .index("by_storeId_createdAt", ["storeId", "createdAt"])
     .index("by_storeId_importKey", ["storeId", "importKey"]),
-  inventoryImportProvisionalSku: defineTable(inventoryImportProvisionalSkuSchema)
+  inventoryImportProvisionalSku: defineTable(
+    inventoryImportProvisionalSkuSchema,
+  )
     .index("by_storeId_status", ["storeId", "status"])
     .index("by_storeId_status_saleEvidenceQuantity", [
       "storeId",
@@ -546,7 +554,10 @@ const schema = defineSchema({
   onlineOrderItem: defineTable(onlineOrderItemSchema).index("by_orderId", [
     "orderId",
   ]),
-  mtnCollectionsToken: defineTable(mtnCollectionsTokenSchema).index("by_storeId", ["storeId"]),
+  mtnCollectionsToken: defineTable(mtnCollectionsTokenSchema).index(
+    "by_storeId",
+    ["storeId"],
+  ),
   mtnCollectionTransaction: defineTable(mtnCollectionTransactionSchema)
     .index("by_providerReference", ["providerReference"])
     .index("by_storeId_requestedAt", ["storeId", "requestedAt"]),
@@ -558,8 +569,10 @@ const schema = defineSchema({
     .index("by_storeId_subject", ["storeId", "subjectType", "subjectId"])
     .index("by_providerMessageId", ["providerMessageId"])
     .index("by_storeId_intent_status", ["storeId", "intent", "status"]),
-  organization: defineTable(organizationSchema),
-  organizationMember: defineTable(organizationMemberSchema),
+  organization: defineTable(organizationSchema).index("by_slug", ["slug"]),
+  organizationMember: defineTable(organizationMemberSchema)
+    .index("by_organizationId_userId", ["organizationId", "userId"])
+    .index("by_userId", ["userId"]),
   posCustomer: defineTable(posCustomerSchema)
     .index("by_storeId", ["storeId"])
     .index("by_storeId_and_email", ["storeId", "email"])
@@ -606,12 +619,20 @@ const schema = defineSchema({
   remoteAssistSession: defineTable(remoteAssistSessionSchema)
     .index("by_client_status", ["clientId", "status"])
     .index("by_client_status_expiresAt", ["clientId", "status", "expiresAt"])
-    .index("by_organization_status", ["organizationId", "status", "requestedAt"])
+    .index("by_organization_status", [
+      "organizationId",
+      "status",
+      "requestedAt",
+    ])
     .index("by_expiresAt", ["expiresAt"]),
   remoteAssistSessionEvent: defineTable(remoteAssistSessionEventSchema)
     .index("by_session", ["sessionId", "occurredAt"])
     .index("by_client", ["clientId", "occurredAt"])
-    .index("by_organization_event", ["organizationId", "eventType", "occurredAt"]),
+    .index("by_organization_event", [
+      "organizationId",
+      "eventType",
+      "occurredAt",
+    ]),
   posTransaction: defineTable(posTransactionSchema)
     .index("by_storeId", ["storeId"])
     .index("by_staffProfileId", ["staffProfileId"])
@@ -652,9 +673,7 @@ const schema = defineSchema({
     .index("by_storeId_status_appliedAt", ["storeId", "status", "appliedAt"])
     .index("by_approvalRequestId", ["approvalRequestId"])
     .index("by_payloadFingerprint", ["payloadFingerprint"]),
-  posTransactionAdjustmentLine: defineTable(
-    posTransactionAdjustmentLineSchema,
-  )
+  posTransactionAdjustmentLine: defineTable(posTransactionAdjustmentLineSchema)
     .index("by_adjustmentId", ["adjustmentId"])
     .index("by_transactionId", ["transactionId"])
     .index("by_originalTransactionItemId", ["originalTransactionItemId"])
@@ -691,7 +710,9 @@ const schema = defineSchema({
       "provisionalProductId",
     ])
     .index("by_operationalWorkItemId", ["operationalWorkItemId"]),
-  posPendingCheckoutLookupAlias: defineTable(posPendingCheckoutLookupAliasSchema)
+  posPendingCheckoutLookupAlias: defineTable(
+    posPendingCheckoutLookupAliasSchema,
+  )
     .index("by_storeId_normalizedLookupCode_status", [
       "storeId",
       "normalizedLookupCode",
@@ -830,7 +851,7 @@ const schema = defineSchema({
     ]),
   expenseSessionItem: defineTable(expenseSessionItemSchema).index(
     "by_sessionId",
-    ["sessionId"]
+    ["sessionId"],
   ),
   expenseTransaction: defineTable(expenseTransactionSchema)
     .index("by_storeId", ["storeId"])
@@ -844,7 +865,7 @@ const schema = defineSchema({
     ]),
   expenseTransactionItem: defineTable(expenseTransactionItemSchema).index(
     "by_transactionId",
-    ["transactionId"]
+    ["transactionId"],
   ),
   product: defineTable(productSchema)
     .index("by_categoryId", ["categoryId"])
@@ -892,7 +913,11 @@ const schema = defineSchema({
     ])
     .index("by_primarySubject", ["primarySubjectType", "primarySubjectId"]),
   workflowTraceEvent: defineTable(workflowTraceEventSchema)
-    .index("by_storeId_traceId_occurredAt", ["storeId", "traceId", "occurredAt"])
+    .index("by_storeId_traceId_occurredAt", [
+      "storeId",
+      "traceId",
+      "occurredAt",
+    ])
     .index("by_storeId_traceId_sequence", ["storeId", "traceId", "sequence"])
     .index("by_storeId_traceId_eventKey", ["storeId", "traceId", "eventKey"])
     .index("by_traceId_sequence", ["traceId", "sequence"]),
@@ -966,11 +991,12 @@ const schema = defineSchema({
     .index("by_workItemId", ["workItemId"]),
   redeemedPromoCode: defineTable(redeemedPromoCodeSchema).index(
     "by_promoCodeId_storeFrontUserId",
-    ["promoCodeId", "storeFrontUserId"]
+    ["promoCodeId", "storeFrontUserId"],
   ),
   registerSession: defineTable(registerSessionSchema)
     .index("by_storeId", ["storeId"])
     .index("by_storeId_status", ["storeId", "status"])
+    .index("by_storeId_status_terminalId", ["storeId", "status", "terminalId"])
     .index("by_storeId_status_openedOperatingDate", [
       "storeId",
       "status",
@@ -991,9 +1017,13 @@ const schema = defineSchema({
   savedBag: defineTable(savedBagSchema).index("by_storeFrontUserId", [
     "storeFrontUserId",
   ]),
-  savedBagItem: defineTable(savedBagItemSchema).index("by_savedBagId", [
-    "savedBagId",
-  ]),
+  savedBagItem: defineTable(savedBagItemSchema)
+    .index("by_savedBagId", ["savedBagId"])
+    .index("by_savedBagId_storeFrontUserId_productSkuId", [
+      "savedBagId",
+      "storeFrontUserId",
+      "productSkuId",
+    ]),
   serviceAppointment: defineTable(serviceAppointmentSchema)
     .index("by_storeId_startAt", ["storeId", "startAt"])
     .index("by_staffProfileId_startAt", ["assignedStaffProfileId", "startAt"])
@@ -1011,15 +1041,21 @@ const schema = defineSchema({
     .index("by_appointmentId", ["appointmentId"]),
   serviceCaseLineItem: defineTable(serviceCaseLineItemSchema).index(
     "by_serviceCaseId",
-    ["serviceCaseId"]
+    ["serviceCaseId"],
   ),
   serviceInventoryUsage: defineTable(serviceInventoryUsageSchema)
     .index("by_serviceCaseId", ["serviceCaseId"])
     .index("by_productSkuId", ["productSkuId"]),
-  store: defineTable(storeSchema),
+  store: defineTable(storeSchema)
+    .index("by_slug", ["slug"])
+    .index("by_organizationId_slug", ["organizationId", "slug"]),
   storeAsset: defineTable(storeAssetSchema),
   storeSchedule: defineTable(storeScheduleSchema)
-    .index("by_storeId_status_effectiveFrom", ["storeId", "status", "effectiveFrom"])
+    .index("by_storeId_status_effectiveFrom", [
+      "storeId",
+      "status",
+      "effectiveFrom",
+    ])
     .index("by_organizationId_storeId_status", [
       "organizationId",
       "storeId",

--- a/packages/athena-webapp/convex/stockOps/adjustments.test.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.test.ts
@@ -44,7 +44,10 @@ function getHandler(definition: unknown) {
 function createInventorySnapshotQueryCtx() {
   const tables = {
     athenaUser: new Map<string, Record<string, unknown>>([
-      ["athena-user-1", { _id: "athena-user-1", email: "operator@example.com" }],
+      [
+        "athena-user-1",
+        { _id: "athena-user-1", email: "operator@example.com" },
+      ],
     ]),
     category: new Map<string, Record<string, unknown>>([
       ["category-1", { _id: "category-1", name: "Hair" }],
@@ -171,8 +174,13 @@ function createInventorySnapshotQueryCtx() {
       take: async (limit: number) => filteredRecords().slice(0, limit),
       filter(
         applyFilter?: (queryBuilder: {
-          and: (...predicates: Array<(row: Record<string, unknown>) => boolean>) => (row: Record<string, unknown>) => boolean;
-          eq: (field: string, value: unknown) => (row: Record<string, unknown>) => boolean;
+          and: (
+            ...predicates: Array<(row: Record<string, unknown>) => boolean>
+          ) => (row: Record<string, unknown>) => boolean;
+          eq: (
+            field: string,
+            value: unknown,
+          ) => (row: Record<string, unknown>) => boolean;
           field: (field: string) => string;
         }) => (row: Record<string, unknown>) => boolean,
       ) {
@@ -372,9 +380,7 @@ function createApprovalDecisionMutationCtx() {
     skuActivityEvent: 0,
   };
 
-  const queryTable = (
-    table: keyof typeof tables,
-  ) => ({
+  const queryTable = (table: keyof typeof tables) => ({
     withIndex(
       _index: string,
       applyIndex: (query: {
@@ -680,7 +686,32 @@ function createSubmissionMutationCtx(args: {
         }
 
         if (table === "organizationMember") {
+          const findMember = (filters: Array<[string, unknown]>) =>
+            Array.from(tables.organizationMember.values()).find((record) =>
+              filters.every(([field, value]) => record[field] === value),
+            ) ?? null;
+
           return {
+            withIndex(
+              _index: string,
+              applyIndex: (queryBuilder: {
+                eq: (field: string, value: unknown) => unknown;
+              }) => unknown,
+            ) {
+              const filters: Array<[string, unknown]> = [];
+              const queryBuilder = {
+                eq(field: string, value: unknown) {
+                  filters.push([field, value]);
+                  return queryBuilder;
+                },
+              };
+
+              applyIndex(queryBuilder);
+
+              return {
+                first: async () => findMember(filters),
+              };
+            },
             filter(
               applyFilter: (queryBuilder: {
                 and: (...conditions: unknown[]) => unknown;
@@ -703,13 +734,7 @@ function createSubmissionMutationCtx(args: {
               applyFilter(queryBuilder);
 
               return {
-                first: async () =>
-                  Array.from(tables.organizationMember.values()).find(
-                    (record) =>
-                      filters.every(
-                        ([field, value]) => record[field] === value,
-                      ),
-                  ) ?? null,
+                first: async () => findMember(filters),
               };
             },
           };
@@ -1874,45 +1899,48 @@ describe("stock ops adjustments", () => {
         });
       },
     ],
-  ])("blocks zero-sale provisional rows with %s", async (caseName, mutateTables) => {
-    const { ctx, tables } = createSubmissionMutationCtx({
-      authUserId: "auth-user-1",
-      membershipRole: "full_admin",
-    });
+  ])(
+    "blocks zero-sale provisional rows with %s",
+    async (caseName, mutateTables) => {
+      const { ctx, tables } = createSubmissionMutationCtx({
+        authUserId: "auth-user-1",
+        membershipRole: "full_admin",
+      });
 
-    mutateTables(tables);
-    tables.inventoryImportProvisionalSku.set("provisional-1", {
-      _id: "provisional-1",
-      productId: "product-1",
-      productSkuId: "sku-1",
-      saleEvidence: {
-        saleCount: 0,
-        totalQuantitySold: 0,
-      },
-      status: "active",
-      storeId: "store-1",
-    });
+      mutateTables(tables);
+      tables.inventoryImportProvisionalSku.set("provisional-1", {
+        _id: "provisional-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        saleEvidence: {
+          saleCount: 0,
+          totalQuantitySold: 0,
+        },
+        status: "active",
+        storeId: "store-1",
+      });
 
-    await expect(
-      submitStockAdjustmentBatchWithCtx(ctx, {
-        adjustmentType: "manual",
-        lineItems: [
-          {
-            productSkuId: "sku-1" as Id<"productSku">,
-            quantityDelta: 1,
-          },
-        ],
-        reasonCode: "correction",
-        storeId: "store-1" as Id<"store">,
-        submissionKey: `invalid-taxonomy-${caseName.replaceAll(" ", "-")}`,
-      }),
-    ).rejects.toThrow(
-      "Legacy import SKUs must be finalized before stock adjustments can update them.",
-    );
+      await expect(
+        submitStockAdjustmentBatchWithCtx(ctx, {
+          adjustmentType: "manual",
+          lineItems: [
+            {
+              productSkuId: "sku-1" as Id<"productSku">,
+              quantityDelta: 1,
+            },
+          ],
+          reasonCode: "correction",
+          storeId: "store-1" as Id<"store">,
+          submissionKey: `invalid-taxonomy-${caseName.replaceAll(" ", "-")}`,
+        }),
+      ).rejects.toThrow(
+        "Legacy import SKUs must be finalized before stock adjustments can update them.",
+      );
 
-    expect(tables.inventoryMovement.size).toBe(0);
-    expect(tables.stockAdjustmentBatch.size).toBe(0);
-  });
+      expect(tables.inventoryMovement.size).toBe(0);
+      expect(tables.stockAdjustmentBatch.size).toBe(0);
+    },
+  );
 
   it("rejects stock adjustments for unresolved POS pending checkout SKUs", async () => {
     const { ctx, tables } = createSubmissionMutationCtx({

--- a/packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts
+++ b/packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts
@@ -140,7 +140,32 @@ function createCycleCountDraftCtx() {
         }
 
         if (table === "organizationMember") {
+          const findMember = (filters: Array<[string, unknown]>) =>
+            Array.from(tables.organizationMember.values()).find((record) =>
+              filters.every(([field, value]) => record[field] === value),
+            ) ?? null;
+
           return {
+            withIndex(
+              _index: string,
+              applyIndex: (queryBuilder: {
+                eq: (field: string, value: unknown) => unknown;
+              }) => unknown,
+            ) {
+              const filters: Array<[string, unknown]> = [];
+              const queryBuilder = {
+                eq(field: string, value: unknown) {
+                  filters.push([field, value]);
+                  return queryBuilder;
+                },
+              };
+
+              applyIndex(queryBuilder);
+
+              return {
+                first: async () => findMember(filters),
+              };
+            },
             filter(
               applyFilter: (queryBuilder: {
                 and: (...conditions: unknown[]) => unknown;
@@ -163,13 +188,7 @@ function createCycleCountDraftCtx() {
               applyFilter(queryBuilder);
 
               return {
-                first: async () =>
-                  Array.from(tables.organizationMember.values()).find(
-                    (record) =>
-                      filters.every(
-                        ([field, value]) => record[field] === value,
-                      ),
-                  ) ?? null,
+                first: async () => findMember(filters),
               };
             },
           };

--- a/packages/athena-webapp/convex/storeFront/bagItem.ts
+++ b/packages/athena-webapp/convex/storeFront/bagItem.ts
@@ -19,12 +19,11 @@ export const addItemToBag = internalMutation({
 
     const existing = await ctx.db
       .query(entity)
-      .filter((q) =>
-        q.and(
-          q.eq(q.field("productSkuId"), args.productSkuId),
-          q.eq(q.field("bagId"), args.bagId),
-          q.eq(q.field("storeFrontUserId"), args.storeFrontUserId)
-        )
+      .withIndex("by_bagId_storeFrontUserId_productSkuId", (q) =>
+        q
+          .eq("bagId", args.bagId)
+          .eq("storeFrontUserId", args.storeFrontUserId)
+          .eq("productSkuId", args.productSkuId),
       )
       .first();
 
@@ -48,7 +47,9 @@ export const updateItemInBag = internalMutation({
     quantity: v.number(),
   },
   handler: async (ctx, args) => {
-    return await ctx.db.patch("bagItem", args.itemId, { quantity: args.quantity });
+    return await ctx.db.patch("bagItem", args.itemId, {
+      quantity: args.quantity,
+    });
   },
 });
 
@@ -77,7 +78,7 @@ export const getBagItemsForStore = query({
 
     // Get all the items for the bags
     const items: any[] = await Promise.all(
-      bags.map(async (bag) => await loadBagWithItems(ctx, bag))
+      bags.map(async (bag) => await loadBagWithItems(ctx, bag)),
     );
 
     return items.filter((item) => item.items.length > 0);

--- a/packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts
+++ b/packages/athena-webapp/convex/storeFront/commerceQueryIndexes.test.ts
@@ -46,6 +46,16 @@ describe("commerce query indexing", () => {
         fields: ["savedBagId"],
       },
       {
+        table: "bagItem",
+        descriptor: "by_bagId_storeFrontUserId_productSkuId",
+        fields: ["bagId", "storeFrontUserId", "productSkuId"],
+      },
+      {
+        table: "savedBagItem",
+        descriptor: "by_savedBagId_storeFrontUserId_productSkuId",
+        fields: ["savedBagId", "storeFrontUserId", "productSkuId"],
+      },
+      {
         table: "checkoutSession",
         descriptor: "by_storeFrontUserId",
         fields: ["storeFrontUserId"],
@@ -110,11 +120,21 @@ describe("commerce query indexing", () => {
 
   it("uses indexed lookups in the bag and saved-bag modules", () => {
     const bagSource = getSource("./bag.ts");
+    const bagItemSource = getSource("./bagItem.ts");
     const savedBagSource = getSource("./savedBag.ts");
+    const savedBagItemSource = getSource("./savedBagItem.ts");
 
     expect(bagSource).toContain('.withIndex("by_storeFrontUserId"');
+    expect(bagItemSource).toContain(
+      '.withIndex("by_bagId_storeFrontUserId_productSkuId"',
+    );
+    expect(bagItemSource).not.toContain(".filter((q)");
     expect(savedBagSource).toContain('.withIndex("by_storeFrontUserId"');
     expect(savedBagSource).toContain('.withIndex("by_savedBagId"');
+    expect(savedBagItemSource).toContain(
+      '.withIndex("by_savedBagId_storeFrontUserId_productSkuId"',
+    );
+    expect(savedBagItemSource).not.toContain(".filter((q)");
   });
 
   it("uses indexed lookups in the checkout-session and online-order modules", () => {

--- a/packages/athena-webapp/convex/storeFront/savedBagItem.ts
+++ b/packages/athena-webapp/convex/storeFront/savedBagItem.ts
@@ -17,12 +17,11 @@ export const addItemToBag = internalMutation({
 
     const existing = await ctx.db
       .query(entity)
-      .filter((q) =>
-        q.and(
-          q.eq(q.field("productSkuId"), args.productSkuId),
-          q.eq(q.field("savedBagId"), args.savedBagId),
-          q.eq(q.field("storeFrontUserId"), args.storeFrontUserId)
-        )
+      .withIndex("by_savedBagId_storeFrontUserId_productSkuId", (q) =>
+        q
+          .eq("savedBagId", args.savedBagId)
+          .eq("storeFrontUserId", args.storeFrontUserId)
+          .eq("productSkuId", args.productSkuId),
       )
       .first();
 
@@ -42,7 +41,9 @@ export const updateItemInBag = internalMutation({
     quantity: v.number(),
   },
   handler: async (ctx, args) => {
-    return await ctx.db.patch("savedBagItem", args.itemId, { quantity: args.quantity });
+    return await ctx.db.patch("savedBagItem", args.itemId, {
+      quantity: args.quantity,
+    });
   },
 });
 


### PR DESCRIPTION
## Summary

- reduce daily operations read amplification by pushing prior-close date selectivity into the `dailyClose` index range
- optimize terminal runtime-status drawer lookup with indexed usable-status scans while preserving register-number compatibility behavior
- add compound indexes for context-event quota checks, bag/saved-bag merge lookups, POS recovery-code auth, organization/store slug lookups, and organization-member auth
- refresh regression coverage and solution docs for Convex read-amplification fixes

## Production Read Baseline

- baseline warning path: `getDailyOperationsDetailSnapshot` was reading about 15.84 MB in one execution, near Convex's 16 MB warning threshold
- earlier deployed measurement after the daily-close slice was about 2.98 MB, roughly an 81% reduction for that hot path
- this branch keeps that reduction and addresses additional offending indexed-query opportunities found during review

## Validation

- reviewer loop: correctness, performance, testing, project standards, security, and data migrations all approved
- `bun run test -- convex/operations/dailyClose.test.ts convex/operations/dailyOperations.test.ts convex/operations/dailyOpening.test.ts convex/operations/dailyOperationsAutomation.test.ts convex/pos/application/terminals.test.ts convex/inventory/storeSchedule.test.ts convex/mtn/foundation.test.ts convex/operations/approvalRequests.test.ts convex/stockOps/adjustments.test.ts convex/stockOps/cycleCountDrafts.test.ts convex/contextTracking/contextEvents.test.ts convex/pos/public/posRecoveryCodes.test.ts convex/storeFront/commerceQueryIndexes.test.ts`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run graphify:rebuild`
- `git diff --check`
- pre-push gate passed, including full `@athena/webapp` test suite: 430 files, 4,778 tests
- pre-push build and harness behavior scenarios passed
