### PR TITLE
[V26-981]: Allow finalized-lineage repair on closed registers

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8807 nodes · 10729 edges · 2124 communities detected
+- 8810 nodes · 10735 edges · 2124 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2878,220 +2878,220 @@ Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
 ### Community 179 - "Community 179"
-Cohesion: 0.29
-Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
+Cohesion: 0.33
+Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.29
-Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
+Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
 ### Community 181 - "Community 181"
+Cohesion: 0.29
+Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
+
+### Community 182 - "Community 182"
 Cohesion: 0.27
 Nodes (5): getLocalOperatingDate(), getLocalOperatingDateRange(), getReadinessDiagnosticRows(), getReadinessLoadingBlockers(), POSReadinessLoadingState()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.24
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.31
 Nodes (7): architectureSolutionNote(), createFixtureRepo(), gitEnv(), nonFoundationalArchitectureSolutionNote(), runGit(), solutionNote(), write()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.38
 Nodes (9): assertFrontendDependencyParity(), checkFrontendDependencyParity(), collectDependencyDeclarations(), collectFrontendDependencyFailures(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall() (+1 more)
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.39
 Nodes (7): findActivePendingCheckoutLookupAliasByCode(), firstEvidenceTime(), normalizePendingCheckoutLookupCode(), resolvePendingCheckoutSku(), resolvePendingCheckoutSkuFromItem(), retirePendingCheckoutLookupAliasForItem(), upsertPendingCheckoutLookupAlias()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.47
 Nodes (8): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isPendingCheckoutLookupAliasVisible(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 214 - "Community 214"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 213 - "Community 213"
+### Community 215 - "Community 215"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 214 - "Community 214"
+### Community 216 - "Community 216"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 215 - "Community 215"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 216 - "Community 216"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 217 - "Community 217"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 218 - "Community 218"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 219 - "Community 219"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.32
 Nodes (4): createProductsQueryCtx(), createSkuMutationCtx(), pendingCheckoutEvidence(), pendingCheckoutItem()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 230 - "Community 230"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 231 - "Community 231"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 232 - "Community 232"
-Cohesion: 0.39
-Nodes (5): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), skipped()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 233 - "Community 233"
 Cohesion: 0.25
@@ -3510,8 +3510,8 @@ Cohesion: 0.4
 Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
 
 ### Community 337 - "Community 337"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 338 - "Community 338"
 Cohesion: 0.33
@@ -3526,80 +3526,80 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 341 - "Community 341"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 342 - "Community 342"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 343 - "Community 343"
+### Community 342 - "Community 342"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 343 - "Community 343"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 344 - "Community 344"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 345 - "Community 345"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 346 - "Community 346"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 347 - "Community 347"
+### Community 346 - "Community 346"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 348 - "Community 348"
+### Community 347 - "Community 347"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 349 - "Community 349"
+### Community 348 - "Community 348"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 350 - "Community 350"
+### Community 349 - "Community 349"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+
+### Community 350 - "Community 350"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 352 - "Community 352"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 353 - "Community 353"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 354 - "Community 354"
+### Community 353 - "Community 353"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 355 - "Community 355"
+### Community 354 - "Community 354"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 355 - "Community 355"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 356 - "Community 356"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 357 - "Community 357"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 358 - "Community 358"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 359 - "Community 359"
+### Community 358 - "Community 358"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 359 - "Community 359"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.53
@@ -4551,31 +4551,31 @@ Nodes (0):
 
 ### Community 597 - "Community 597"
 Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 598 - "Community 598"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 599 - "Community 599"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 600 - "Community 600"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 601 - "Community 601"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 602 - "Community 602"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 603 - "Community 603"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 604 - "Community 604"
 Cohesion: 0.67
@@ -4590,12 +4590,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 607 - "Community 607"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 608 - "Community 608"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 608 - "Community 608"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 609 - "Community 609"
 Cohesion: 0.67
@@ -4614,12 +4614,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 613 - "Community 613"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 614 - "Community 614"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 614 - "Community 614"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 615 - "Community 615"
 Cohesion: 0.67
@@ -4634,16 +4634,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 618 - "Community 618"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 619 - "Community 619"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 620 - "Community 620"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 621 - "Community 621"
 Cohesion: 0.67
@@ -4654,28 +4654,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 623 - "Community 623"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 624 - "Community 624"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 625 - "Community 625"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 626 - "Community 626"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 627 - "Community 627"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 628 - "Community 628"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 628 - "Community 628"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 629 - "Community 629"
 Cohesion: 0.67
@@ -4683,11 +4683,11 @@ Nodes (0):
 
 ### Community 630 - "Community 630"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 632 - "Community 632"
 Cohesion: 0.67
@@ -4702,12 +4702,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 635 - "Community 635"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 636 - "Community 636"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 636 - "Community 636"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 637 - "Community 637"
 Cohesion: 0.67
@@ -4731,23 +4731,23 @@ Nodes (0):
 
 ### Community 642 - "Community 642"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 643 - "Community 643"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 645 - "Community 645"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 646 - "Community 646"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 646 - "Community 646"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
@@ -4755,19 +4755,19 @@ Nodes (0):
 
 ### Community 648 - "Community 648"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 650 - "Community 650"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 651 - "Community 651"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 651 - "Community 651"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 652 - "Community 652"
 Cohesion: 0.67
@@ -4778,16 +4778,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 654 - "Community 654"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 655 - "Community 655"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 656 - "Community 656"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 657 - "Community 657"
 Cohesion: 0.67
@@ -4822,12 +4822,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 665 - "Community 665"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 666 - "Community 666"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 666 - "Community 666"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 667 - "Community 667"
 Cohesion: 0.67
@@ -4847,79 +4847,79 @@ Nodes (0):
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 672 - "Community 672"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 673 - "Community 673"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 674 - "Community 674"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 675 - "Community 675"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 676 - "Community 676"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 677 - "Community 677"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 678 - "Community 678"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 679 - "Community 679"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 679 - "Community 679"
+### Community 680 - "Community 680"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 680 - "Community 680"
+### Community 681 - "Community 681"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 681 - "Community 681"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 682 - "Community 682"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 683 - "Community 683"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 684 - "Community 684"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 685 - "Community 685"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 686 - "Community 686"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 687 - "Community 687"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 688 - "Community 688"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 689 - "Community 689"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 690 - "Community 690"
 Cohesion: 0.67
@@ -4951,11 +4951,11 @@ Nodes (0):
 
 ### Community 697 - "Community 697"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 698 - "Community 698"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 699 - "Community 699"
 Cohesion: 0.67
@@ -4986,52 +4986,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 706 - "Community 706"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 707 - "Community 707"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 707 - "Community 707"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 708 - "Community 708"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 709 - "Community 709"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 710 - "Community 710"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 711 - "Community 711"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 711 - "Community 711"
+### Community 712 - "Community 712"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 712 - "Community 712"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 713 - "Community 713"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 714 - "Community 714"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 715 - "Community 715"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 716 - "Community 716"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 717 - "Community 717"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 717 - "Community 717"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 718 - "Community 718"
 Cohesion: 0.67
@@ -5058,76 +5058,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 724 - "Community 724"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 725 - "Community 725"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 726 - "Community 726"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 727 - "Community 727"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 728 - "Community 728"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 729 - "Community 729"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 730 - "Community 730"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 731 - "Community 731"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 732 - "Community 732"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 733 - "Community 733"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 734 - "Community 734"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 735 - "Community 735"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 736 - "Community 736"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 737 - "Community 737"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 738 - "Community 738"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 739 - "Community 739"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 740 - "Community 740"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 741 - "Community 741"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 742 - "Community 742"
 Cohesion: 0.67
@@ -5142,12 +5142,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 745 - "Community 745"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 746 - "Community 746"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 746 - "Community 746"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 747 - "Community 747"
 Cohesion: 0.67
@@ -5158,12 +5158,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 749 - "Community 749"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 750 - "Community 750"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 750 - "Community 750"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 751 - "Community 751"
 Cohesion: 0.67
@@ -5230,16 +5230,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 767 - "Community 767"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 768 - "Community 768"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 769 - "Community 769"
+### Community 768 - "Community 768"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 769 - "Community 769"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 770 - "Community 770"
 Cohesion: 1.0
@@ -5254,24 +5254,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 773 - "Community 773"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 774 - "Community 774"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 774 - "Community 774"
+### Community 775 - "Community 775"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 775 - "Community 775"
+### Community 776 - "Community 776"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 776 - "Community 776"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 777 - "Community 777"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 778 - "Community 778"
 Cohesion: 1.0
@@ -10660,113 +10660,111 @@ Nodes (0):
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 777`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 778`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 779`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 780`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 781`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 782`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 783`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 784`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 785`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 786`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 787`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 788`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 789`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 790`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 791`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 792`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 793`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 794`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 795`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 796`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 797`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 798`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 799`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 800`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 801`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 802`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 803`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 804`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 805`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 806`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 807`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 808`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 809`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 810`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 811`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 812`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 813`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 814`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 815`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 816`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 817`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 818`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 819`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 820`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 821`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 822`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 823`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 824`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 825`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 826`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 827`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 828`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 829`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `repairConflict()`, `finalizedLineageRemediation.test.ts`
+- **Thin community `Community 830`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 831`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2197
-- Graph nodes: 8807
-- Graph edges: 10729
+- Graph nodes: 8810
+- Graph edges: 10735
 - Communities: 2124
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 218) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 219) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.test.ts
@@ -9,8 +9,9 @@ describe("finalized lineage remediation", () => {
       classifyFinalizedLineageRepairConflicts(
         [
           repairConflict("conflict-1"),
+          closedRegisterReplayConflict("conflict-2"),
           {
-            ...repairConflict("conflict-2"),
+            ...repairConflict("conflict-3"),
             status: "resolved",
           },
         ],
@@ -18,7 +19,7 @@ describe("finalized lineage remediation", () => {
       ),
     ).toEqual({
       kind: "repairable",
-      repairedConflictCount: 1,
+      repairedConflictCount: 2,
     });
   });
 
@@ -71,5 +72,16 @@ function repairConflict(id: string): LocalSyncConflictRecord {
     summary: "Provisional import row changed before this offline sale synced.",
     details: {},
     createdAt: 1_700_000_000_000,
+  };
+}
+
+function closedRegisterReplayConflict(id: string): LocalSyncConflictRecord {
+  return {
+    ...repairConflict(id),
+    conflictType: "permission",
+    summary: "Register was not open before this sale synced.",
+    details: {
+      status: "closed",
+    },
   };
 }

--- a/packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts
@@ -112,6 +112,7 @@ export const repairFinalizedLineageConflictedSales = internalMutation({
         syncEventId: event._id,
         now: event.acceptedAt ?? now,
         options: {
+          allowClosedRegisterSaleProjection: true,
           repairRunId: args.repairRunId,
           trustStoredStaffProof: true,
         },
@@ -256,9 +257,27 @@ export function classifyFinalizedLineageRepairConflicts(
 
 function isFinalizedLineageRepairConflict(conflict: LocalSyncConflictRecord) {
   return (
+    isProvisionalRowChangedConflict(conflict) ||
+    isClosedRegisterRepairReplayConflict(conflict)
+  );
+}
+
+function isProvisionalRowChangedConflict(conflict: LocalSyncConflictRecord) {
+  return (
     conflict.status === "needs_review" &&
     conflict.conflictType === "inventory" &&
     conflict.summary === PROVISIONAL_IMPORT_ROW_CHANGED_SUMMARY
+  );
+}
+
+function isClosedRegisterRepairReplayConflict(
+  conflict: LocalSyncConflictRecord,
+) {
+  return (
+    conflict.status === "needs_review" &&
+    conflict.conflictType === "permission" &&
+    conflict.summary === "Register was not open before this sale synced." &&
+    conflict.details.status === "closed"
   );
 }
 

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -6450,6 +6450,77 @@ describe("projectLocalSyncEvent", () => {
     },
   );
 
+  it("allows finalized-lineage repair replay against a closed register when the sale happened before closeout", async () => {
+    const repository = createProjectionRepository({
+      registerSession: {
+        _id: "register-session-1",
+        expectedCash: 100,
+        closeoutRecords: [],
+        closedAt: 200,
+        countedCash: 100,
+        registerNumber: "1",
+        status: "closed",
+        variance: 0,
+      },
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        productId: "product-1",
+        sku: "CAP-1",
+        price: 25,
+        quantityAvailable: 5,
+        inventoryCount: 5,
+        images: [],
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        ...buildSaleCompletedEvent({
+          occurredAt: 150,
+          payload: {
+            ...buildSaleCompletedEvent().payload,
+            payments: [
+              {
+                localPaymentId: "local-payment-1",
+                method: "mobile_money",
+                amount: 25,
+                timestamp: 151,
+              },
+            ],
+          },
+        }),
+        staffProofToken: undefined,
+      },
+      syncEventId: "sync-event-1",
+      now: 250,
+      options: {
+        allowClosedRegisterSaleProjection: true,
+        repairRunId: "repair-run-1",
+        trustStoredStaffProof: true,
+      },
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.createdTransactions).toEqual([
+      expect.objectContaining({
+        registerSessionId: "register-session-1",
+        transactionNumber: "LR-001",
+      }),
+    ]);
+    expect(repository.registerSessionPatches).toEqual([
+      {
+        registerSessionId: "register-session-1",
+        patch: {
+          workflowTraceId: "register-trace-1",
+        },
+      },
+    ]);
+  });
+
   it("projects a synced closeout as idempotent when the register was already closed with the same count", async () => {
     const repository = createProjectionRepository({
       registerSession: {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1617,6 +1617,12 @@ async function resolveSaleRegisterAndSession(
   const reviewedClosingRegisterSaleAllowed =
     args.options?.allowReviewedClosingRegisterSaleProjection === true &&
     registerSession.status === "closing";
+  const closedRegisterRepairReplayAllowed =
+    args.options?.allowClosedRegisterSaleProjection === true &&
+    Boolean(args.options.repairRunId) &&
+    registerSession.status === "closed" &&
+    typeof registerSession.closedAt === "number" &&
+    args.event.occurredAt <= registerSession.closedAt;
 
   if (
     registerSessionSaleUsable &&
@@ -1638,7 +1644,11 @@ async function resolveSaleRegisterAndSession(
     return conflictResult(conflict);
   }
 
-  if (!registerSessionSaleUsable && !reviewedClosingRegisterSaleAllowed) {
+  if (
+    !registerSessionSaleUsable &&
+    !reviewedClosingRegisterSaleAllowed &&
+    !closedRegisterRepairReplayAllowed
+  ) {
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
       summary: "Register was not open before this sale synced.",


### PR DESCRIPTION
## Summary
- Allow finalized-lineage remediation replay against a closed register only when the replay is repairRunId-scoped and the sale occurred before the register closed.
- Treat the specific closed-register replay conflict as repairable alongside the stale provisional-row conflict, with conflict resolution still gated on successful projection.
- Add focused projection and remediation conflict-classifier tests.

## Why
Production remediation for receipt 561137 exposed that historical repair replay can happen after the drawer is already closed. The replay should be allowed for the original sale when it occurred before closeout, while unrelated closed-register conflicts remain blocking.

## Validation
- bun run test -- convex/pos/application/sync/projectLocalEvents.test.ts convex/pos/application/sync/finalizedLineageRemediation.test.ts
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter '@athena/webapp' lint:convex:changed
- bun run --filter '@athena/webapp' audit:convex
- git diff --check

Note: local bun run pr:athena is blocked by Convex dev codegen hanging at 'Preparing Convex functions' after the production deploy; generated API is unchanged because this edits existing modules only. GitHub PR checks should provide the full merge gate.

Linear: V26-981