### PR TITLE
feat(pos): gate operational surfaces by manager access

### DIFF
--- a/docs/solutions/architecture-patterns/athena-manager-gated-operational-surfaces-2026-07-07.md
+++ b/docs/solutions/architecture-patterns/athena-manager-gated-operational-surfaces-2026-07-07.md
@@ -1,0 +1,81 @@
+---
+title: Manager-gated operational surfaces and closeout policy controls
+date: 2026-07-07
+category: docs/solutions/architecture-patterns
+module: Athena POS and operations access
+problem_type: architecture_pattern
+component: authentication
+resolution_type: code_fix
+severity: medium
+applies_when:
+  - "A POS-facing route exposes cash, product, operations, or trace evidence that cashiers should not see by default"
+  - "Manager elevation should unlock the same page-level operational affordances as manager access"
+  - "A store policy control affects backend register closeout approval behavior"
+tags: [athena, pos, access-control, manager-elevation, closeout]
+---
+
+# Manager-gated operational surfaces and closeout policy controls
+
+## Problem
+POS operators need a fast sales surface, but related operational areas expose sensitive cash, trace, product, and store-day evidence. The same project also stores register closeout approval policy in store config, so the UI control for that policy must write the exact backend field the closeout gate already reads.
+
+## Solution
+Treat manager-visible POS-adjacent surfaces as one access posture instead of scattering one-off checks. Route and navigation guards should use the shared manager/full-admin capability, while backend policy writes that change store configuration should still require full-admin access.
+
+For register closeout approvals, the backend gate reads:
+
+```ts
+operations.cashControls.varianceApprovalThreshold
+```
+
+Expose the POS settings control through a narrow full-admin query/mutation that:
+
+- Reads the active store's cash-controls config with the same helper used by closeout review.
+- Accepts display currency from the UI, converts it to minor units client-side, and stores the minor-unit threshold.
+- Preserves existing `operations.cashControls` flags such as signoff for shortages or overages.
+- Rejects invalid negative or non-finite thresholds at the API boundary.
+
+Keep the threshold copy precise: variances greater than the threshold require manager approval. The comparison is strict, so a threshold of `5000` minor units means a GHS 50 variance is still allowed unless another signoff flag requires review.
+
+## Why This Matters
+Operational access bugs usually appear as small UI leaks: a metric card, trace button, cash position value, or sidebar route remains visible to a cashier after the main route was gated. Centralizing the capability makes the page, nav, and component decisions agree.
+
+Policy controls need a stricter boundary than read-only manager elevation. A manager-elevated cashier can view and act on operational work, but changing store-level policy should stay full-admin-only and should be covered by backend authorization, not only hidden UI.
+
+## Prevention
+- Gate cash controls, operations, products, and POS diagnostics with a shared manager/full-admin capability instead of local route-specific booleans.
+- Keep sensitive component-level readouts behind the same capability even when the parent page remains usable for cashier workflows.
+- Put store-policy writes behind full-admin Convex mutations, even when the setting appears on a manager-facing page.
+- Preserve backend policy units in tests: UI fields may show major currency units, but Convex policy fields should store minor units.
+- Cover both route protection and hidden-card behavior with focused frontend tests.
+
+## Examples
+Use shared access for route-level protection:
+
+```tsx
+<ProtectedRoute requires="manager">
+  <CashControlsDashboard />
+</ProtectedRoute>
+```
+
+Use a narrow policy mutation for closeout approval configuration:
+
+```ts
+await ctx.db.patch("store", storeId, {
+  config: {
+    ...currentConfig,
+    operations: {
+      ...operations,
+      cashControls: {
+        ...cashControls,
+        varianceApprovalThreshold,
+      },
+    },
+  },
+});
+```
+
+## Related
+- [Register closeout shared gate](../logic-errors/athena-register-closeout-shared-gate-2026-07-01.md)
+- [Manager approval authority standard](../architecture/athena-manager-approval-authority-standard-2026-07-01.md)
+- [POS operations metric redaction and cash allocation](../logic-errors/athena-pos-operations-metric-redaction-and-cash-allocation-2026-06-21.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2198 files · ~0 words
+- 2199 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8822 nodes · 10760 edges · 2125 communities detected
+- 8844 nodes · 10788 edges · 2126 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2135,6 +2135,7 @@
 - [[_COMMUNITY_Community 2122|Community 2122]]
 - [[_COMMUNITY_Community 2123|Community 2123]]
 - [[_COMMUNITY_Community 2124|Community 2124]]
+- [[_COMMUNITY_Community 2125|Community 2125]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2203,8 +2204,8 @@ Cohesion: 0.08
 Nodes (53): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+45 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.08
-Nodes (42): addDaysToOperatingDate(), automationErrorMessage(), automationIdempotencyKey(), configuredEodAutoCompleteStoreDayContext(), configuredOpeningOperatingDate(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming() (+34 more)
+Cohesion: 0.07
+Nodes (44): addDaysToOperatingDate(), automationErrorMessage(), automationIdempotencyKey(), configuredEodAutoCompleteStoreDayContext(), configuredOpeningOperatingDate(), eodAutoCompleteDecision(), eodAutoCompletePolicyCronWindow(), eodAutoCompleteTiming() (+36 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.07
@@ -2335,152 +2336,152 @@ Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
 ### Community 43 - "Community 43"
+Cohesion: 0.07
+Nodes (0):
+
+### Community 44 - "Community 44"
 Cohesion: 0.16
 Nodes (25): acknowledgeTerminalRecoveryCommand(), arraysEqualAsSets(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), hasRuntimeLocalReviewDetails(), isActiveCommand() (+17 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.17
 Nodes (19): buildBlockers(), buildCarryForwardItems(), buildDailyManagerReportPayload(), buildPaymentTotals(), buildPreparedBlockers(), buildPreparedCarryForwardItems(), buildPreparedDailyManagerReportPayload(), buildPreparedReviewItems() (+11 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.15
 Nodes (20): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), linkedPendingCheckoutItemMatchesTrustedLine(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity() (+12 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.17
 Nodes (25): getRegisterCatalogPrice(), getRegisterCatalogProjectionPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isLinkedPendingCheckoutAliasVisible(), isLinkedPendingCheckoutApprovedSkuVisible(), isPendingCheckoutItemVisible(), isTrustedRegisterCatalogProjection() (+17 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.12
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 49 - "Community 49"
+### Community 50 - "Community 50"
 Cohesion: 0.09
 Nodes (5): buildPersistedRuntimeStatus(), buildQueryCtx(), buildRegisterSession(), buildRuntimeStatus(), buildTrackedQueryCtx()
 
-### Community 50 - "Community 50"
+### Community 51 - "Community 51"
 Cohesion: 0.09
 Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.16
 Nodes (20): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getRuntimeReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady() (+12 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.2
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.14
 Nodes (18): findCurrentStoreDayOpening(), findLatestStoreDayOpening(), getTodaySummary(), getTransactionById(), isActivePosSummaryOpeningAt(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames() (+10 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.12
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.19
 Nodes (22): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem(), findOrCreatePendingCheckoutCategory() (+14 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.17
 Nodes (21): buildHomepageSnapshotV1(), hydrateCategory(), hydrateFeaturedItem(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts(), isCustomerVisibleProduct(), isCustomerVisibleSku() (+13 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.17
 Nodes (19): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+11 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.16
 Nodes (16): actionableWorkItemTimestamp(), buildOperationalWorkItem(), compareOperationalWorkItems(), compareStrings(), createOperationalWorkItemWithCtx(), filterArchivedPendingCheckoutWorkItems(), joinSourceIdentity(), metadataArrayCount() (+8 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.1
 Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.13
 Nodes (11): dateInputToCalendarDate(), formatDateLabel(), formatNextCloseSummaryLabel(), formatNextOpenSummaryLabel(), formatScheduleSummaryLabel(), formatTimeLabel(), getCurrentOpenWindow(), getDayLabel() (+3 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.19
 Nodes (17): applyLinkedPendingAliasDisplay(), compactSearchText(), dedupeRegisterCatalogRows(), extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier() (+9 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.13
 Nodes (9): asCloudOperableSession(), countPendingSyncableLocalEventsForStaff(), hasSyncedSaleLocalEventsForStaff(), hasUploadedLocalEventsForStaff(), isCloudOperableSession(), isEmptyLocalSaleShell(), selectPassiveCloseoutBlockedRegisterSession(), trimOptional() (+1 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.17
 Nodes (15): createConvexRegisterSessionActivityRepository(), createRegisterSessionActivityIngestionService(), findMappedCloudId(), groupMappingsByLocalEvent(), hasDisallowedMetadataKey(), hasUnsafeMetadataString(), ingestRegisterSessionActivityWithCtx(), isRegisterNumberBound() (+7 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.11
 Nodes (3): formatMinuteOfDayLabel(), formatStoreHoursTimeLabel(), parseStoreHoursTimeLabel()
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.27
 Nodes (18): assertConformsToExportedReturns(), collectReturnValidatorIssues(), decodeSerializedFloat64(), decodeSerializedInt64(), decodeSerializedLiteralValue(), describeValue(), formatReturnValidatorIssues(), isConvexValue() (+10 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.22
 Nodes (15): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+7 more)
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
-
-### Community 79 - "Community 79"
-Cohesion: 0.11
-Nodes (0):
 
 ### Community 80 - "Community 80"
 Cohesion: 0.22
@@ -2939,144 +2940,144 @@ Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
 ### Community 194 - "Community 194"
-Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Cohesion: 0.22
+Nodes (0):
 
 ### Community 195 - "Community 195"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 196 - "Community 196"
 Cohesion: 0.39
-Nodes (7): findActivePendingCheckoutLookupAliasByCode(), firstEvidenceTime(), normalizePendingCheckoutLookupCode(), resolvePendingCheckoutSku(), resolvePendingCheckoutSkuFromItem(), retirePendingCheckoutLookupAliasForItem(), upsertPendingCheckoutLookupAlias()
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
 ### Community 197 - "Community 197"
+Cohesion: 0.39
+Nodes (7): findActivePendingCheckoutLookupAliasByCode(), firstEvidenceTime(), normalizePendingCheckoutLookupCode(), resolvePendingCheckoutSku(), resolvePendingCheckoutSkuFromItem(), retirePendingCheckoutLookupAliasForItem(), upsertPendingCheckoutLookupAlias()
+
+### Community 198 - "Community 198"
 Cohesion: 0.47
 Nodes (8): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isPendingCheckoutLookupAliasVisible(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 217 - "Community 217"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 219 - "Community 219"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 220 - "Community 220"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.32
 Nodes (4): createProductsQueryCtx(), createSkuMutationCtx(), pendingCheckoutEvidence(), pendingCheckoutItem()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
-
-### Community 228 - "Community 228"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.36
@@ -3267,152 +3268,152 @@ Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
 ### Community 276 - "Community 276"
+Cohesion: 0.57
+Nodes (6): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx(), requireAdminWorkflowTraceAccess(), requireFullAdminOrManagerElevationTraceAccess()
+
+### Community 277 - "Community 277"
 Cohesion: 0.52
 Nodes (6): buildContextEventEnvelope(), buildContextEventIdempotencyKey(), compactContextPayload(), compactContextValue(), hashStableValue(), stableContextStringify()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 278 - "Community 278"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 280 - "Community 280"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 281 - "Community 281"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
-
-### Community 282 - "Community 282"
-Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 283 - "Community 283"
-Cohesion: 0.29
-Nodes (1): ResizeObserverStub
+Cohesion: 0.33
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
 ### Community 285 - "Community 285"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 286 - "Community 286"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 288 - "Community 288"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 290 - "Community 290"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 291 - "Community 291"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 292 - "Community 292"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 294 - "Community 294"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 295 - "Community 295"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.43
 Nodes (4): createPackage(), installFixturePackages(), writeFixtureManifests(), writeJson()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 297 - "Community 297"
+### Community 298 - "Community 298"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 298 - "Community 298"
+### Community 299 - "Community 299"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 301 - "Community 301"
+### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.6
 Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
-
-### Community 306 - "Community 306"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 308 - "Community 308"
-Cohesion: 0.73
-Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
-
-### Community 309 - "Community 309"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 309 - "Community 309"
+Cohesion: 0.73
+Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
+
 ### Community 310 - "Community 310"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 311 - "Community 311"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
-
-### Community 312 - "Community 312"
-Cohesion: 0.6
-Nodes (4): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.6
@@ -3483,36 +3484,36 @@ Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
 ### Community 330 - "Community 330"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
 
 ### Community 331 - "Community 331"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 332 - "Community 332"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 333 - "Community 333"
 Cohesion: 0.47
 Nodes (3): buildReceivedQuantitiesAfterSubmission(), buildSubmissionKey(), handleSubmit()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 335 - "Community 335"
+### Community 336 - "Community 336"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 336 - "Community 336"
+### Community 337 - "Community 337"
 Cohesion: 0.4
 Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
-
-### Community 337 - "Community 337"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 338 - "Community 338"
 Cohesion: 0.33
@@ -3523,124 +3524,124 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 340 - "Community 340"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 341 - "Community 341"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 343 - "Community 343"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 342 - "Community 342"
+### Community 344 - "Community 344"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 343 - "Community 343"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 344 - "Community 344"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 345 - "Community 345"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 346 - "Community 346"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 347 - "Community 347"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 346 - "Community 346"
+### Community 348 - "Community 348"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 347 - "Community 347"
+### Community 349 - "Community 349"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 348 - "Community 348"
+### Community 350 - "Community 350"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 349 - "Community 349"
+### Community 351 - "Community 351"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
-### Community 350 - "Community 350"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 351 - "Community 351"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
 ### Community 352 - "Community 352"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 353 - "Community 353"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 354 - "Community 354"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 353 - "Community 353"
+### Community 355 - "Community 355"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 354 - "Community 354"
+### Community 356 - "Community 356"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 355 - "Community 355"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 356 - "Community 356"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 357 - "Community 357"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 358 - "Community 358"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 360 - "Community 360"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 361 - "Community 361"
 Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 363 - "Community 363"
-Cohesion: 0.67
-Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
 ### Community 364 - "Community 364"
 Cohesion: 0.53
-Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
 ### Community 365 - "Community 365"
+Cohesion: 0.67
+Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
+
+### Community 366 - "Community 366"
+Cohesion: 0.53
+Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
+
+### Community 367 - "Community 367"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 366 - "Community 366"
+### Community 368 - "Community 368"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 367 - "Community 367"
+### Community 369 - "Community 369"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
-
-### Community 368 - "Community 368"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 369 - "Community 369"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.4
@@ -3648,107 +3649,107 @@ Nodes (0):
 
 ### Community 371 - "Community 371"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 372 - "Community 372"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 373 - "Community 373"
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+
+### Community 374 - "Community 374"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 375 - "Community 375"
 Cohesion: 0.5
 Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
-### Community 374 - "Community 374"
+### Community 376 - "Community 376"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 375 - "Community 375"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 376 - "Community 376"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 377 - "Community 377"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 378 - "Community 378"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 379 - "Community 379"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 385 - "Community 385"
+### Community 386 - "Community 386"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
-
-### Community 386 - "Community 386"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 387 - "Community 387"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 388 - "Community 388"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 389 - "Community 389"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 392 - "Community 392"
+### Community 393 - "Community 393"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 395 - "Community 395"
+### Community 396 - "Community 396"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 396 - "Community 396"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 0.4
@@ -3763,12 +3764,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 400 - "Community 400"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 401 - "Community 401"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 401 - "Community 401"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 402 - "Community 402"
 Cohesion: 0.4
@@ -3779,20 +3780,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 404 - "Community 404"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 405 - "Community 405"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 406 - "Community 406"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 407 - "Community 407"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.4
@@ -3815,16 +3816,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
-
-### Community 414 - "Community 414"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 414 - "Community 414"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
 ### Community 415 - "Community 415"
-Cohesion: 0.8
-Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 0.4
@@ -3931,12 +3932,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 442 - "Community 442"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 443 - "Community 443"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.4
@@ -3947,80 +3948,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 446 - "Community 446"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 447 - "Community 447"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
-
-### Community 449 - "Community 449"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 450 - "Community 450"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 451 - "Community 451"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 452 - "Community 452"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 455 - "Community 455"
+### Community 456 - "Community 456"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 456 - "Community 456"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 458 - "Community 458"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
-
-### Community 459 - "Community 459"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 459 - "Community 459"
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 460 - "Community 460"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 461 - "Community 461"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 462 - "Community 462"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 462 - "Community 462"
+### Community 463 - "Community 463"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 463 - "Community 463"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 464 - "Community 464"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.5
@@ -4039,80 +4040,80 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 469 - "Community 469"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 470 - "Community 470"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
-
-### Community 472 - "Community 472"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 474 - "Community 474"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 475 - "Community 475"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 475 - "Community 475"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 477 - "Community 477"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 478 - "Community 478"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 478 - "Community 478"
+### Community 479 - "Community 479"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 479 - "Community 479"
+### Community 480 - "Community 480"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 480 - "Community 480"
+### Community 481 - "Community 481"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 481 - "Community 481"
+### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 482 - "Community 482"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 484 - "Community 484"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 485 - "Community 485"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 487 - "Community 487"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.5
@@ -4123,24 +4124,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 490 - "Community 490"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 491 - "Community 491"
 Cohesion: 0.67
 Nodes (2): buildCtx(), buildQueryCtx()
 
-### Community 491 - "Community 491"
+### Community 492 - "Community 492"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 492 - "Community 492"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 494 - "Community 494"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.5
@@ -4159,68 +4160,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 499 - "Community 499"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 500 - "Community 500"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 500 - "Community 500"
+### Community 501 - "Community 501"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 501 - "Community 501"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 502 - "Community 502"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 503 - "Community 503"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 504 - "Community 504"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 505 - "Community 505"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 506 - "Community 506"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 507 - "Community 507"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 508 - "Community 508"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 509 - "Community 509"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 509 - "Community 509"
+### Community 510 - "Community 510"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 510 - "Community 510"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 511 - "Community 511"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 512 - "Community 512"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 513 - "Community 513"
-Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
-
-### Community 514 - "Community 514"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 514 - "Community 514"
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.5
@@ -4251,12 +4252,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 522 - "Community 522"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 523 - "Community 523"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 523 - "Community 523"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.5
@@ -4267,12 +4268,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 526 - "Community 526"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 527 - "Community 527"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 527 - "Community 527"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.5
@@ -4283,120 +4284,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 530 - "Community 530"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 531 - "Community 531"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 531 - "Community 531"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 532 - "Community 532"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 533 - "Community 533"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 534 - "Community 534"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 536 - "Community 536"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 537 - "Community 537"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 537 - "Community 537"
+### Community 538 - "Community 538"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 538 - "Community 538"
+### Community 539 - "Community 539"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 539 - "Community 539"
+### Community 540 - "Community 540"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 540 - "Community 540"
+### Community 541 - "Community 541"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 541 - "Community 541"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 542 - "Community 542"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 543 - "Community 543"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 544 - "Community 544"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 545 - "Community 545"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 546 - "Community 546"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 546 - "Community 546"
+### Community 547 - "Community 547"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 547 - "Community 547"
+### Community 548 - "Community 548"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 548 - "Community 548"
+### Community 549 - "Community 549"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 549 - "Community 549"
+### Community 550 - "Community 550"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 550 - "Community 550"
+### Community 551 - "Community 551"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 551 - "Community 551"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 552 - "Community 552"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 553 - "Community 553"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 554 - "Community 554"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 554 - "Community 554"
+### Community 555 - "Community 555"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 555 - "Community 555"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 556 - "Community 556"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 557 - "Community 557"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 558 - "Community 558"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 559 - "Community 559"
 Cohesion: 0.5
@@ -4427,63 +4428,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 567 - "Community 567"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 568 - "Community 568"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 569 - "Community 569"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 569 - "Community 569"
+### Community 570 - "Community 570"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 570 - "Community 570"
+### Community 571 - "Community 571"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 571 - "Community 571"
+### Community 572 - "Community 572"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 572 - "Community 572"
+### Community 573 - "Community 573"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 573 - "Community 573"
+### Community 574 - "Community 574"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 574 - "Community 574"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 575 - "Community 575"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 576 - "Community 576"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 577 - "Community 577"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 577 - "Community 577"
+### Community 578 - "Community 578"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 578 - "Community 578"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 579 - "Community 579"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 580 - "Community 580"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 581 - "Community 581"
@@ -4491,12 +4492,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 582 - "Community 582"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 583 - "Community 583"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 583 - "Community 583"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 584 - "Community 584"
 Cohesion: 0.67
@@ -4555,36 +4556,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 598 - "Community 598"
-Cohesion: 1.0
-Nodes (2): closedRegisterReplayConflict(), repairConflict()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 599 - "Community 599"
 Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 600 - "Community 600"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 601 - "Community 601"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 602 - "Community 602"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 603 - "Community 603"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 604 - "Community 604"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 605 - "Community 605"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 606 - "Community 606"
 Cohesion: 0.67
@@ -4599,12 +4600,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 609 - "Community 609"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 610 - "Community 610"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 610 - "Community 610"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 611 - "Community 611"
 Cohesion: 0.67
@@ -4623,12 +4624,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 615 - "Community 615"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 616 - "Community 616"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 616 - "Community 616"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 617 - "Community 617"
 Cohesion: 0.67
@@ -4643,16 +4644,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 620 - "Community 620"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 621 - "Community 621"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 622 - "Community 622"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 623 - "Community 623"
 Cohesion: 0.67
@@ -4663,28 +4664,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 625 - "Community 625"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 626 - "Community 626"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 627 - "Community 627"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 628 - "Community 628"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 629 - "Community 629"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 630 - "Community 630"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 630 - "Community 630"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 631 - "Community 631"
 Cohesion: 0.67
@@ -4692,11 +4693,11 @@ Nodes (0):
 
 ### Community 632 - "Community 632"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 633 - "Community 633"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.67
@@ -4711,12 +4712,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 637 - "Community 637"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 638 - "Community 638"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 638 - "Community 638"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
@@ -4740,23 +4741,23 @@ Nodes (0):
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 647 - "Community 647"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 648 - "Community 648"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 648 - "Community 648"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
@@ -4764,19 +4765,19 @@ Nodes (0):
 
 ### Community 650 - "Community 650"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 651 - "Community 651"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 652 - "Community 652"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 653 - "Community 653"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 653 - "Community 653"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 654 - "Community 654"
 Cohesion: 0.67
@@ -4787,16 +4788,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 656 - "Community 656"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 657 - "Community 657"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 658 - "Community 658"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 659 - "Community 659"
 Cohesion: 0.67
@@ -4831,12 +4832,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 667 - "Community 667"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
-
-### Community 668 - "Community 668"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 668 - "Community 668"
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 669 - "Community 669"
 Cohesion: 0.67
@@ -4856,79 +4857,79 @@ Nodes (0):
 
 ### Community 673 - "Community 673"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 674 - "Community 674"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 675 - "Community 675"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 676 - "Community 676"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 677 - "Community 677"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 678 - "Community 678"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 679 - "Community 679"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 680 - "Community 680"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 681 - "Community 681"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 681 - "Community 681"
+### Community 682 - "Community 682"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 682 - "Community 682"
+### Community 683 - "Community 683"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 683 - "Community 683"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 684 - "Community 684"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 685 - "Community 685"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 686 - "Community 686"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 687 - "Community 687"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 688 - "Community 688"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 689 - "Community 689"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 690 - "Community 690"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 691 - "Community 691"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 692 - "Community 692"
 Cohesion: 0.67
@@ -4960,11 +4961,11 @@ Nodes (0):
 
 ### Community 699 - "Community 699"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 700 - "Community 700"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 701 - "Community 701"
 Cohesion: 0.67
@@ -4995,52 +4996,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 708 - "Community 708"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 709 - "Community 709"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 709 - "Community 709"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 710 - "Community 710"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 711 - "Community 711"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 712 - "Community 712"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 713 - "Community 713"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 713 - "Community 713"
+### Community 714 - "Community 714"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 714 - "Community 714"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 715 - "Community 715"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 716 - "Community 716"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 717 - "Community 717"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 718 - "Community 718"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 719 - "Community 719"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 719 - "Community 719"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 720 - "Community 720"
 Cohesion: 0.67
@@ -5067,76 +5068,76 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 726 - "Community 726"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 727 - "Community 727"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 728 - "Community 728"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 729 - "Community 729"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 730 - "Community 730"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 731 - "Community 731"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 732 - "Community 732"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 733 - "Community 733"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 734 - "Community 734"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 735 - "Community 735"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 736 - "Community 736"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 737 - "Community 737"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 738 - "Community 738"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 739 - "Community 739"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 740 - "Community 740"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 741 - "Community 741"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 742 - "Community 742"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 743 - "Community 743"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 744 - "Community 744"
 Cohesion: 0.67
@@ -5151,12 +5152,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 747 - "Community 747"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 748 - "Community 748"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 748 - "Community 748"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 749 - "Community 749"
 Cohesion: 0.67
@@ -5167,12 +5168,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 751 - "Community 751"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 752 - "Community 752"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 752 - "Community 752"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 753 - "Community 753"
 Cohesion: 0.67
@@ -5239,16 +5240,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 769 - "Community 769"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 770 - "Community 770"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 771 - "Community 771"
+### Community 770 - "Community 770"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 771 - "Community 771"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 772 - "Community 772"
 Cohesion: 1.0
@@ -5263,24 +5264,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 775 - "Community 775"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 776 - "Community 776"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 776 - "Community 776"
+### Community 777 - "Community 777"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 777 - "Community 777"
+### Community 778 - "Community 778"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 778 - "Community 778"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 779 - "Community 779"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 780 - "Community 780"
 Cohesion: 1.0
@@ -10662,344 +10663,346 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2125 - "Community 2125"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 779`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 780`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 781`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 782`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 783`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 784`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 785`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 786`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 787`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 788`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 789`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 790`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 791`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 792`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 793`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 794`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 795`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 796`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 797`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 798`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 799`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 800`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 801`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 802`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 803`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 804`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 805`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 806`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 807`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 808`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 809`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 810`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 811`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 812`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 813`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 814`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 815`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 816`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 817`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 818`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 819`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 820`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 821`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 822`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 823`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 824`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 825`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 826`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 827`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 828`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 829`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 830`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 831`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 832`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
+- **Thin community `Community 833`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 834`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 835`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 836`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 837`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 838`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 839`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 840`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 841`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 842`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 843`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 844`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 845`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 846`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 847`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 848`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 849`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 850`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 851`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 852`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 853`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 854`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 855`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 856`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 857`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 858`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 859`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 860`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 861`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 862`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 863`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 864`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 865`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 866`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 867`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 868`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 869`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 870`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 871`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 872`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 873`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 874`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 875`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 876`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 877`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 878`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 879`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 880`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 881`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 882`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 883`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 884`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 885`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 886`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 887`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 888`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 889`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 890`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 891`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 892`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 893`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 894`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 895`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 896`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 897`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 898`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 899`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 900`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 901`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 902`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 903`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 904`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 905`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 906`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 907`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 908`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 909`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 910`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 911`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 912`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 913`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 914`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 915`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 916`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 917`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 918`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 919`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 920`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 921`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 922`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 923`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 924`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 925`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 926`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 927`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 928`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 929`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 930`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 931`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 932`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 933`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 934`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 935`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 936`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 937`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 938`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 939`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 940`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 941`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 942`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 943`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 944`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 945`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `PinInput.tsx`, `PinInput()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `PointOfSaleView.tsx`, `PointOfSaleView()`
+- **Thin community `Community 946`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 947`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -11365,937 +11368,937 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1111`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1112`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1113`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1114`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1115`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1116`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1117`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1118`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1119`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1120`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1121`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1122`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1123`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1124`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1125`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1126`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1127`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1128`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1129`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1130`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1131`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1132`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1133`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1134`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1135`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1136`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1137`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1138`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1139`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1140`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1141`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1142`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1143`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1144`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1145`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1146`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1147`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1148`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1149`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1150`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1151`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1152`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1153`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1154`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1155`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1156`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1157`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1158`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1159`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1160`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1161`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1162`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1163`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1164`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1165`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1166`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1167`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1168`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1169`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1170`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1171`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1172`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1173`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1174`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1175`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1176`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1177`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1178`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1179`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1180`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1181`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1182`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1183`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1184`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1185`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1186`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1187`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1188`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1189`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1190`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1191`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1192`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1193`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1194`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1195`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1196`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1197`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1198`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1199`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1200`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1201`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1202`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1203`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1204`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1205`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1206`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1207`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1208`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1209`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1210`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1211`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1212`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1213`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1214`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1215`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1216`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1217`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1218`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1219`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1220`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1221`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1222`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1223`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1224`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1225`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1226`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1227`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1228`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1229`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1230`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1231`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1232`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1233`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1234`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1235`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1236`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1237`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1238`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1239`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1240`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1241`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1242`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1243`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1244`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1245`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1246`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1247`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1248`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1249`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1250`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1251`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1252`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1253`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1254`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1255`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `api.js`
+- **Thin community `Community 1256`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1257`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1258`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `server.js`
+- **Thin community `Community 1259`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `app.ts`
+- **Thin community `Community 1260`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1262`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1263`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1264`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `auth.ts`
+- **Thin community `Community 1265`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1266`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1267`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1268`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `countries.ts`
+- **Thin community `Community 1269`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `email.ts`
+- **Thin community `Community 1270`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1271`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `payment.ts`
+- **Thin community `Community 1272`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1273`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `types.ts`
+- **Thin community `Community 1274`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1275`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `crons.ts`
+- **Thin community `Community 1276`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1277`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `internal.ts`
+- **Thin community `Community 1278`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1279`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1283`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `DailyManagerReport.tsx`
+- **Thin community `Community 1285`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1286`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1287`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1288`** (1 nodes): `DailyManagerReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1289`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1291`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `env.ts`
+- **Thin community `Community 1292`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1293`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `auth.ts`
+- **Thin community `Community 1294`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `colors.ts`
+- **Thin community `Community 1296`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `index.ts`
+- **Thin community `Community 1297`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1298`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `products.ts`
+- **Thin community `Community 1299`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `stores.ts`
+- **Thin community `Community 1301`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1302`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `bag.ts`
+- **Thin community `Community 1303`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `guest.ts`
+- **Thin community `Community 1304`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `index.ts`
+- **Thin community `Community 1306`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `me.ts`
+- **Thin community `Community 1307`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `offers.ts`
+- **Thin community `Community 1308`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1309`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1310`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1311`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1312`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1313`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1314`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1315`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1316`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1317`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `user.ts`
+- **Thin community `Community 1318`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1319`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `index.ts`
+- **Thin community `Community 1320`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1321`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `http.ts`
+- **Thin community `Community 1322`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `access.ts`
+- **Thin community `Community 1323`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1324`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1325`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `index.ts`
+- **Thin community `Community 1327`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `types.ts`
+- **Thin community `Community 1329`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1330`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `categories.ts`
+- **Thin community `Community 1331`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `colors.ts`
+- **Thin community `Community 1332`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1333`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1334`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1335`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1336`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `pos.ts`
+- **Thin community `Community 1337`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1338`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1339`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1340`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1341`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1343`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1344`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1345`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1346`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1347`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1349`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1350`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1351`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1352`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1353`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1354`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `types.ts`
+- **Thin community `Community 1355`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1357`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1358`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1359`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1360`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1361`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1363`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1364`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1365`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1366`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `dto.ts`
+- **Thin community `Community 1367`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1368`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1369`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1370`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1371`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `types.ts`
+- **Thin community `Community 1372`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `facts.ts`
+- **Thin community `Community 1373`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `types.ts`
+- **Thin community `Community 1374`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1375`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1376`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1377`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1378`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `customers.ts`
+- **Thin community `Community 1379`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1380`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `register.ts`
+- **Thin community `Community 1381`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `sync.ts`
+- **Thin community `Community 1382`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1383`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1384`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1385`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `schema.ts`
+- **Thin community `Community 1386`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `automation.ts`
+- **Thin community `Community 1387`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1388`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1389`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `index.ts`
+- **Thin community `Community 1390`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1391`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1392`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1393`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1394`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1395`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1396`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1397`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `category.ts`
+- **Thin community `Community 1398`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `color.ts`
+- **Thin community `Community 1399`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1400`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1401`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `index.ts`
+- **Thin community `Community 1402`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1403`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1404`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1405`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1406`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `organization.ts`
+- **Thin community `Community 1407`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1408`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `product.ts`
+- **Thin community `Community 1409`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1410`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1411`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1412`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `store.ts`
+- **Thin community `Community 1413`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1414`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1415`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `index.ts`
+- **Thin community `Community 1416`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1417`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1418`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1419`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1420`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1421`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1422`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1423`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `index.ts`
+- **Thin community `Community 1424`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1425`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1426`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1427`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1428`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1429`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1430`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1431`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1432`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1433`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1434`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1435`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `customer.ts`
+- **Thin community `Community 1436`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1437`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1438`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1439`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1440`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `index.ts`
+- **Thin community `Community 1441`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1442`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1443`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1444`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1445`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1446`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1447`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1448`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1449`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 1450`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 1451`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1452`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1453`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1455`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1456`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1457`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1458`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1459`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1460`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1461`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1462`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1463`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `index.ts`
+- **Thin community `Community 1464`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1465`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1466`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1467`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1468`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1469`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1470`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1471`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1472`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1473`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `index.ts`
+- **Thin community `Community 1474`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1475`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1476`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1477`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1478`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1479`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1480`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `bag.ts`
+- **Thin community `Community 1481`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1482`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1483`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1484`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `guest.ts`
+- **Thin community `Community 1485`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `index.ts`
+- **Thin community `Community 1486`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `offer.ts`
+- **Thin community `Community 1487`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1488`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1489`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `review.ts`
+- **Thin community `Community 1490`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1491`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1492`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1493`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1494`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1495`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1496`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1497`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1498`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `bag.ts`
+- **Thin community `Community 1499`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1500`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `customer.ts`
+- **Thin community `Community 1501`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `guest.ts`
+- **Thin community `Community 1502`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1503`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1504`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1506`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1507`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1508`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1509`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `users.ts`
+- **Thin community `Community 1510`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `payment.ts`
+- **Thin community `Community 1511`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1513`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1514`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1515`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1516`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1517`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1518`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `index.ts`
+- **Thin community `Community 1519`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1520`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1521`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1522`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1523`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `auth.ts`
+- **Thin community `Community 1524`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1526`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1527`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1528`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1529`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1530`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1531`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `index.ts`
+- **Thin community `Community 1532`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1533`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1534`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 1535`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1536`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1537`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1538`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1539`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1540`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1541`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1542`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1543`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 1544`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1545`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1546`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1547`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1548`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1549`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1550`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1551`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1552`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1553`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1554`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1555`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1556`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `constants.ts`
+- **Thin community `Community 1557`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1558`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1559`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1560`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `types.ts`
+- **Thin community `Community 1561`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1562`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1563`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1564`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1565`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1566`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1567`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1568`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1569`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1570`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1571`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1572`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1573`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1574`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1575`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1576`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1578`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -12303,1093 +12306,1095 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1580`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1581`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `constants.ts`
+- **Thin community `Community 1582`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1583`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1584`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1585`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `data.ts`
+- **Thin community `Community 1586`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1587`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1588`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1589`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1590`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1591`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1592`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1593`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1594`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1597`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `constants.ts`
+- **Thin community `Community 1598`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1599`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1600`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1601`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `data.ts`
+- **Thin community `Community 1602`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1603`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1604`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1605`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1606`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1607`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1608`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1609`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1610`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1611`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1612`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1613`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `constants.ts`
+- **Thin community `Community 1614`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1615`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1616`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1617`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1618`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1619`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1620`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1622`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1623`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1625`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1627`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1628`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1629`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1630`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1631`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1632`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1633`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1634`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1635`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1637`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1638`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1639`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1640`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1641`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1643`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1644`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 1645`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1646`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1647`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1648`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1649`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1650`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1651`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `constants.ts`
+- **Thin community `Community 1652`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1653`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1654`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1655`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `data.ts`
+- **Thin community `Community 1656`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1657`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1658`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `constants.ts`
+- **Thin community `Community 1659`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1660`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1661`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1662`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1663`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `data.ts`
+- **Thin community `Community 1664`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1665`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `constants.ts`
+- **Thin community `Community 1666`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1667`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1668`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1669`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1670`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `data.ts`
+- **Thin community `Community 1671`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1672`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1673`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1674`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1675`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1676`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1677`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1678`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1679`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1680`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1681`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1682`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1683`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1684`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1685`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1686`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1687`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1688`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1689`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1690`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1691`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1692`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1693`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1694`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1695`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1696`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1697`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1698`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1699`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `types.ts`
+- **Thin community `Community 1700`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1701`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1702`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1703`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1704`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 1705`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1706`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 1707`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1708`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1709`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1710`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1711`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1712`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1713`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1714`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1715`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1716`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1717`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1718`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `data.ts`
+- **Thin community `Community 1719`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1720`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1721`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1722`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1723`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1724`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1725`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1726`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1727`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1728`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1729`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1730`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1731`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `constants.ts`
+- **Thin community `Community 1732`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1733`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1734`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1735`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `data.ts`
+- **Thin community `Community 1736`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `types.ts`
+- **Thin community `Community 1737`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1738`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1739`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1740`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1741`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1742`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `index.ts`
+- **Thin community `Community 1743`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1744`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1745`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1746`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1747`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `index.tsx`
+- **Thin community `Community 1748`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1749`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1750`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1751`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1753`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1754`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1755`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1756`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1757`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1758`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `index.tsx`
+- **Thin community `Community 1759`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1760`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1761`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1762`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `button.tsx`
+- **Thin community `Community 1763`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1764`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `card.tsx`
+- **Thin community `Community 1765`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1766`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1767`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `command.tsx`
+- **Thin community `Community 1768`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1769`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1770`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1771`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `form.tsx`
+- **Thin community `Community 1772`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1773`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1774`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `input.tsx`
+- **Thin community `Community 1775`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1776`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1777`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1778`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1779`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1780`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1781`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `select.tsx`
+- **Thin community `Community 1782`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1783`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1784`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1785`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1786`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `table.tsx`
+- **Thin community `Community 1787`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1788`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1789`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1790`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1791`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1792`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1793`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1794`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1795`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `constants.ts`
+- **Thin community `Community 1796`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1797`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1798`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1799`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `data.ts`
+- **Thin community `Community 1800`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1801`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1802`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1803`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1804`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1805`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1806`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1807`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1808`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1809`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1810`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `index.ts`
+- **Thin community `Community 1811`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1812`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1813`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1816`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1817`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1821`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 1822`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1823`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 1825`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 1826`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `index.ts`
+- **Thin community `Community 1827`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 1828`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `index.ts`
+- **Thin community `Community 1829`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 1830`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `aws.ts`
+- **Thin community `Community 1832`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `constants.ts`
+- **Thin community `Community 1833`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `countries.ts`
+- **Thin community `Community 1834`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1835`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1836`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1837`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1838`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1839`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1840`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1841`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 1842`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `dto.ts`
+- **Thin community `Community 1843`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `ports.ts`
+- **Thin community `Community 1844`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `constants.ts`
+- **Thin community `Community 1845`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1846`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1847`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `index.ts`
+- **Thin community `Community 1848`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1849`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `types.ts`
+- **Thin community `Community 1850`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1851`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1852`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1853`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1854`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1855`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1857`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1858`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1859`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 1860`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 1861`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 1862`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 1863`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 1864`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1865`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1866`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1867`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1868`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `index.ts`
+- **Thin community `Community 1869`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1870`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `category.ts`
+- **Thin community `Community 1871`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `product.ts`
+- **Thin community `Community 1872`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `store.ts`
+- **Thin community `Community 1873`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1874`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `user.ts`
+- **Thin community `Community 1875`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1876`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1877`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1878`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1879`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1880`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `main.tsx`
+- **Thin community `Community 1881`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1882`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1883`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1884`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1885`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1886`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1887`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `index.tsx`
+- **Thin community `Community 1888`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `index.tsx`
+- **Thin community `Community 1889`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `index.tsx`
+- **Thin community `Community 1890`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1891`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1892`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 1893`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1894`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1895`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1896`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `index.tsx`
+- **Thin community `Community 1897`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1898`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1899`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1900`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `home.tsx`
+- **Thin community `Community 1901`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1902`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1903`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1904`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `index.tsx`
+- **Thin community `Community 1905`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `review.tsx`
+- **Thin community `Community 1906`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1907`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1908`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1909`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1910`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1911`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1912`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1913`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1914`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1915`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1916`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1917`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1918`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1919`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 1920`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `index.tsx`
+- **Thin community `Community 1921`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1922`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1923`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1924`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1925`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1926`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1927`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1928`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1929`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1930`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `index.tsx`
+- **Thin community `Community 1931`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1932`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `index.tsx`
+- **Thin community `Community 1933`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `new.tsx`
+- **Thin community `Community 1934`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `index.tsx`
+- **Thin community `Community 1935`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1936`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1937`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1938`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `index.tsx`
+- **Thin community `Community 1939`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `new.tsx`
+- **Thin community `Community 1940`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `index.tsx`
+- **Thin community `Community 1941`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1942`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1943`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1944`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1945`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `index.tsx`
+- **Thin community `Community 1946`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1947`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1948`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1949`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `index.tsx`
+- **Thin community `Community 1950`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1951`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 1952`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1953`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `index.tsx`
+- **Thin community `Community 1954`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1955`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1956`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1957`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 1958`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 1959`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1960`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 1961`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1962`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1963`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1964`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1965`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1966`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1967`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1968`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1969`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1970`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1971`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1972`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1973`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1974`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1975`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1976`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1977`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `setup.ts`
+- **Thin community `Community 1978`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1979`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `types.ts`
+- **Thin community `Community 1980`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1981`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1982`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1983`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1984`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1985`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1986`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1987`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `types.ts`
+- **Thin community `Community 1988`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1989`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1990`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1991`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1992`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1993`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1994`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1995`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1996`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `schema.ts`
+- **Thin community `Community 1997`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1998`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1999`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2000`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2001`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2002`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2003`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2004`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2005`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2006`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `types.ts`
+- **Thin community `Community 2007`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2008`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2009`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2010`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2011`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2012`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2013`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2014`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `constants.ts`
+- **Thin community `Community 2015`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2016`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `About.tsx`
+- **Thin community `Community 2017`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2018`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2019`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2020`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2021`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2022`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2023`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2024`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2025`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2026`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2027`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `types.ts`
+- **Thin community `Community 2028`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2029`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2030`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2031`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2032`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2033`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2034`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2035`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2036`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2037`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2038`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2039`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `button.tsx`
+- **Thin community `Community 2040`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `card.tsx`
+- **Thin community `Community 2041`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2042`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `command.tsx`
+- **Thin community `Community 2043`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2044`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2045`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2046`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `form.tsx`
+- **Thin community `Community 2047`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2048`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2049`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2050`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2051`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `input.tsx`
+- **Thin community `Community 2052`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `label.tsx`
+- **Thin community `Community 2053`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2054`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2055`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2056`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `index.ts`
+- **Thin community `Community 2057`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `types.ts`
+- **Thin community `Community 2058`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2059`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2060`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2061`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2062`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `select.tsx`
+- **Thin community `Community 2063`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2064`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2065`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `table.tsx`
+- **Thin community `Community 2066`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2067`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2068`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2069`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2070`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2071`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `config.ts`
+- **Thin community `Community 2072`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2073`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2074`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2075`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2076`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2077`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `constants.ts`
+- **Thin community `Community 2078`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `countries.ts`
+- **Thin community `Community 2079`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2080`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2081`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2082`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2083`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `index.ts`
+- **Thin community `Community 2084`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2085`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `store.ts`
+- **Thin community `Community 2086`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `bag.ts`
+- **Thin community `Community 2087`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2088`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `category.ts`
+- **Thin community `Community 2089`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `organization.ts`
+- **Thin community `Community 2090`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `product.ts`
+- **Thin community `Community 2091`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `store.ts`
+- **Thin community `Community 2092`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2093`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `user.ts`
+- **Thin community `Community 2094`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `states.ts`
+- **Thin community `Community 2095`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2096`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2097`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2098`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2099`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2100`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2101`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2102`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2103`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `index.tsx`
+- **Thin community `Community 2104`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2105`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `index.tsx`
+- **Thin community `Community 2106`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2107`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2108`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2108`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2109`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2110`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2111`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `index.tsx`
+- **Thin community `Community 2112`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2113`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2114`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2115`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2116`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2117`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `index.js`
+- **Thin community `Community 2118`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2119`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2120`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2121`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2122`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2123`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2124`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2125`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2198
-- Graph nodes: 8822
-- Graph edges: 10760
-- Communities: 2125
+- Code files discovered: 2199
+- Graph nodes: 8844
+- Graph edges: 10788
+- Communities: 2126
 
 ## Graph Hotspots
 - `dailyClose.ts` (86 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 14) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 14) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 68) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 69) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 88) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 105) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 219) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 220) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pr:athena:delivery-run": "bun scripts/pr-athena-delivery-run.ts",
     "pr:athena:prepare": "bun run dependency:check && bun run pre-commit:generated-artifacts && bun scripts/pre-push-validation-proof.ts prepare-pr-athena",
     "pr:athena:validate": "bun run pr:athena:validate-provider && bun scripts/pr-athena-delivery-run.ts write-provider-evidence && bun run pr:athena:validate-review",
-    "pr:athena:validate-provider": "bun run compound:check && bun run workflow:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' lint:frontend:changed && bun run architecture:check && bun run test:coverage",
+    "pr:athena:validate-provider": "bun run compound:check && bun run workflow:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' lint:frontend:changed && bun run architecture:check && bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json && bun run test:coverage",
     "pr:athena:validate-review": "bun run harness:review --base origin/main --repo-validation-provided-by pr:athena --provider-evidence artifacts/harness-delivery-runs/provider-evidence.json && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",
     "pr:athena:record-proof": "bun scripts/pre-push-validation-proof.ts record-pr-athena",
     "pr:athena:scorecard": "bun run harness:scorecard",

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -5867,6 +5867,7 @@ describe("end-of-day review backend foundation", () => {
     expect(broadSnapshot.completedClose).toMatchObject({
       actorType: "automation",
       automationRunId: "automation-run-1",
+      dailyCloseId: "daily-close-automation",
       restrictedDetailsRedacted: true,
     });
     expect(broadSnapshot.completedClose).not.toHaveProperty(

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -201,6 +201,7 @@ type DailyCloseSnapshot = {
   endAt: number;
   existingClose: Doc<"dailyClose"> | null;
   completedClose: {
+    dailyCloseId: Id<"dailyClose">;
     actorType?: "human" | "automation";
     automationDecisionReason?: string;
     automationPolicyVersion?: string;
@@ -308,6 +309,7 @@ function normalizeCompletedDailyCloseSnapshot(args: {
     endAt: reportSnapshot.closeMetadata.endAt,
     existingClose: args.dailyClose,
     completedClose: {
+      dailyCloseId: args.dailyClose._id,
       ...(attribution.actorType ? { actorType: attribution.actorType } : {}),
       ...(attribution.automationDecisionReason
         ? { automationDecisionReason: attribution.automationDecisionReason }
@@ -2962,6 +2964,7 @@ export async function buildDailyCloseSnapshotWithCtx(
           );
 
           return {
+            dailyCloseId: existingClose._id,
             ...(attribution.actorType ? { actorType: attribution.actorType } : {}),
             ...(attribution.automationDecisionReason
               ? {

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   getEodAutoCompletePolicy,
   getOpeningAutoStartPolicy,
+  getRegisterCloseoutApprovalPolicy,
   prepareDailyCloseAutomationWithCtx,
   runHistoricEodAutoCloseBatchWithCtx,
   runDailyCloseAutoCompleteEligibilityWithCtx,
@@ -17,6 +18,7 @@ import {
   sendDailyManagerReportsForAppliedEodAutomationWithCtx,
   updateEodAutoCompletePolicy,
   updateOpeningAutoStartPolicy,
+  updateRegisterCloseoutApprovalPolicy,
 } from "./dailyOperationsAutomation";
 
 const accessMocks = vi.hoisted(() => ({
@@ -331,6 +333,14 @@ function completedDailyClose(overrides: Partial<Row> = {}): Row {
   };
 }
 
+function restoreStageEnv(originalStage: string | undefined) {
+  if (originalStage === undefined) {
+    delete process.env.STAGE;
+  } else {
+    process.env.STAGE = originalStage;
+  }
+}
+
 describe("daily operations automation adapter", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -406,6 +416,98 @@ describe("daily operations automation adapter", () => {
     ).rejects.toThrow("Only full admins can access stock operations.");
     expect(inserts).toEqual([]);
     expect(patches).toEqual([]);
+  });
+
+  it("requires full-admin access for register closeout approval policy reads", async () => {
+    const { db } = createDb({ store: [store] });
+    accessMocks.requireStoreFullAdminAccess.mockRejectedValue(
+      new Error("Only full admins can access stock operations."),
+    );
+
+    await expect(
+      getHandler(getRegisterCloseoutApprovalPolicy)(
+        { db } as unknown as MutationCtx,
+        {
+          storeId: "store-1" as Id<"store">,
+        },
+      ),
+    ).rejects.toThrow("Only full admins can access stock operations.");
+  });
+
+  it("updates the register closeout approval threshold in store config", async () => {
+    const configuredStore = {
+      ...store,
+      config: {
+        operations: {
+          cashControls: {
+            requireManagerSignoffForShorts: true,
+            varianceApprovalThreshold: 5000,
+          },
+        },
+      },
+    };
+    const { db, patches } = createDb({ store: [configuredStore] });
+    accessMocks.requireStoreFullAdminAccess.mockResolvedValue({
+      athenaUser: { _id: "user-1" },
+      store: configuredStore,
+    });
+
+    const readResult = await getHandler(getRegisterCloseoutApprovalPolicy)(
+      { db } as unknown as MutationCtx,
+      {
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(readResult).toMatchObject({
+      requireManagerSignoffForShorts: true,
+      varianceApprovalThreshold: 5000,
+    });
+
+    const updateResult = await getHandler(updateRegisterCloseoutApprovalPolicy)(
+      { db } as unknown as MutationCtx,
+      {
+        storeId: "store-1" as Id<"store">,
+        varianceApprovalThreshold: 7500,
+      },
+    );
+
+    expect(updateResult).toMatchObject({
+      requireManagerSignoffForShorts: true,
+      varianceApprovalThreshold: 7500,
+    });
+    expect(patches).toContainEqual({
+      id: "store-1",
+      table: "store",
+      value: {
+        config: {
+          operations: {
+            cashControls: {
+              requireManagerSignoffForShorts: true,
+              varianceApprovalThreshold: 7500,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects invalid register closeout approval thresholds", async () => {
+    const { db } = createDb({ store: [store] });
+    accessMocks.requireStoreFullAdminAccess.mockResolvedValue({
+      athenaUser: { _id: "user-1" },
+      store,
+    });
+
+    await expect(
+      getHandler(updateRegisterCloseoutApprovalPolicy)(
+        { db } as unknown as MutationCtx,
+        {
+          storeId: "store-1" as Id<"store">,
+          varianceApprovalThreshold: -1,
+        },
+      ),
+    ).rejects.toThrow("Variance approval threshold must be non-negative.");
   });
 
   it("maps Opening auto-start policy API values at the public handler boundary", async () => {
@@ -935,6 +1037,8 @@ describe("daily operations automation adapter", () => {
   });
 
   it("sends manager reports for freshly applied or prepared EOD automation outcomes", async () => {
+    const originalStage = process.env.STAGE;
+    process.env.STAGE = "prod";
     const runAction = vi.fn(async (_functionRef: unknown, args: unknown) => {
       const operatingDate = (args as { operatingDate: string }).operatingDate;
 
@@ -951,90 +1055,133 @@ describe("daily operations automation adapter", () => {
       ];
     });
 
-    const result = await sendDailyManagerReportsForAppliedEodAutomationWithCtx(
-      { runAction } as never,
-      {
-        results: [
-          {
-            action: "applied",
-            run: {
-              _id: "automation-run-applied",
-              operatingDate: "2026-06-08",
-              outcome: "applied",
-              storeId: "store-1",
+    try {
+      const result = await sendDailyManagerReportsForAppliedEodAutomationWithCtx(
+        { runAction } as never,
+        {
+          results: [
+            {
+              action: "applied",
+              run: {
+                _id: "automation-run-applied",
+                operatingDate: "2026-06-08",
+                outcome: "applied",
+                storeId: "store-1",
+              },
             },
-          },
-          {
-            action: "already_recorded",
-            run: {
-              _id: "automation-run-existing",
-              operatingDate: "2026-06-07",
-              outcome: "applied",
-              storeId: "store-1",
+            {
+              action: "already_recorded",
+              run: {
+                _id: "automation-run-existing",
+                operatingDate: "2026-06-07",
+                outcome: "applied",
+                storeId: "store-1",
+              },
             },
-          },
-          {
-            action: "recorded",
-            run: {
-              _id: "automation-run-skipped",
-              operatingDate: "2026-06-06",
-              outcome: "skipped",
-              storeId: "store-1",
+            {
+              action: "recorded",
+              run: {
+                _id: "automation-run-skipped",
+                operatingDate: "2026-06-06",
+                outcome: "skipped",
+                storeId: "store-1",
+              },
             },
-          },
-          {
-            action: "recorded",
-            run: {
-              _id: "automation-run-prepared",
-              operatingDate: "2026-06-05",
-              outcome: "prepared",
-              storeId: "store-1",
+            {
+              action: "recorded",
+              run: {
+                _id: "automation-run-prepared",
+                operatingDate: "2026-06-05",
+                outcome: "prepared",
+                storeId: "store-1",
+              },
             },
-          },
-        ] as never,
-      },
-    );
+          ] as never,
+        },
+      );
 
-    expect(runAction).toHaveBeenCalledTimes(2);
-    expect(runAction.mock.calls[0]?.[1]).toEqual({
-      operatingDate: "2026-06-08",
-      status: "applied",
-      storeId: "store-1",
-    });
-    expect(runAction.mock.calls[1]?.[1]).toEqual({
-      operatingDate: "2026-06-05",
-      status: "prepared",
-      storeId: "store-1",
-    });
-    expect(result).toEqual([
-      {
+      expect(runAction).toHaveBeenCalledTimes(2);
+      expect(runAction.mock.calls[0]?.[1]).toEqual({
         operatingDate: "2026-06-08",
-        reports: [
-          {
-            dailyCloseId: "daily-close-1",
-            operatingDate: "2026-06-08",
-            recipientEmail: "manager@example.com",
-            status: 202,
-            storeName: "Accra",
-          },
-        ],
-        runId: "automation-run-applied",
+        status: "applied",
         storeId: "store-1",
-      },
-      {
+      });
+      expect(runAction.mock.calls[1]?.[1]).toEqual({
         operatingDate: "2026-06-05",
-        reports: [
-          {
-            operatingDate: "2026-06-05",
-            recipientEmail: "manager@example.com",
-            status: 202,
-            storeName: "Accra",
-          },
-        ],
-        runId: "automation-run-prepared",
+        status: "prepared",
         storeId: "store-1",
-      },
-    ]);
+      });
+      expect(result).toEqual([
+        {
+          operatingDate: "2026-06-08",
+          reports: [
+            {
+              dailyCloseId: "daily-close-1",
+              operatingDate: "2026-06-08",
+              recipientEmail: "manager@example.com",
+              status: 202,
+              storeName: "Accra",
+            },
+          ],
+          runId: "automation-run-applied",
+          storeId: "store-1",
+        },
+        {
+          operatingDate: "2026-06-05",
+          reports: [
+            {
+              operatingDate: "2026-06-05",
+              recipientEmail: "manager@example.com",
+              status: 202,
+              storeName: "Accra",
+            },
+          ],
+          runId: "automation-run-prepared",
+          storeId: "store-1",
+        },
+      ]);
+    } finally {
+      restoreStageEnv(originalStage);
+    }
+  });
+
+  it("skips scheduled manager report sends outside production", async () => {
+    const originalStage = process.env.STAGE;
+    process.env.STAGE = "";
+    const runAction = vi.fn();
+
+    try {
+      const result = await sendDailyManagerReportsForAppliedEodAutomationWithCtx(
+        { runAction } as never,
+        {
+          results: [
+            {
+              action: "applied",
+              run: {
+                _id: "automation-run-applied",
+                operatingDate: "2026-06-08",
+                outcome: "applied",
+                storeId: "store-1",
+              },
+            },
+            {
+              action: "recorded",
+              run: {
+                _id: "automation-run-prepared",
+                operatingDate: "2026-06-05",
+                outcome: "prepared",
+                storeId: "store-1",
+              },
+            },
+          ] as never,
+        },
+      );
+
+      expect(runAction).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    } finally {
+      restoreStageEnv(originalStage);
+    }
   });
 
   it("persists canonical store schedule context in EOD auto-complete evidence", async () => {

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -37,6 +37,7 @@ import {
   completeDailyCloseForAutomationWithCtx,
 } from "./dailyClose";
 import { requireStoreFullAdminAccess } from "../stockOps/access";
+import { getCashControlsConfig } from "./registerSessionCloseoutGate";
 import {
   getStoreScheduleContextForStoreAtWithCtx,
   resolveStoreOperatingRangeForDateWithCtx,
@@ -2093,12 +2094,20 @@ function isReportableEodAutoCompleteResult(
   );
 }
 
+function shouldSendScheduledDailyManagerReports() {
+  return process.env.STAGE === "prod";
+}
+
 export async function sendDailyManagerReportsForAppliedEodAutomationWithCtx(
   ctx: Pick<ActionCtx, "runAction">,
   args: {
     results: DailyOperationsAutomationResult["eodAutoCompleteResults"];
   },
 ): Promise<DailyManagerReportAutomationSendResult[]> {
+  if (!shouldSendScheduledDailyManagerReports()) {
+    return [];
+  }
+
   const reportableResults = args.results.filter(
     isReportableEodAutoCompleteResult,
   );
@@ -2358,6 +2367,84 @@ export const updateEodAutoCompletePolicy = mutation({
         policy.operatingTimezoneOffsetMinutes ?? null,
       paused: Boolean(policy.paused),
       policyVersion: policy.policyVersion,
+    };
+  },
+});
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as Record<string, unknown>;
+}
+
+export const getRegisterCloseoutApprovalPolicy = query({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    const { store } = await requireStoreFullAdminAccess(ctx, args.storeId);
+    const config = getCashControlsConfig(store);
+
+    return {
+      requireManagerSignoffForAnyVariance:
+        config.requireManagerSignoffForAnyVariance,
+      requireManagerSignoffForOvers: config.requireManagerSignoffForOvers,
+      requireManagerSignoffForShorts: config.requireManagerSignoffForShorts,
+      varianceApprovalThreshold: config.varianceApprovalThreshold,
+    };
+  },
+});
+
+export const updateRegisterCloseoutApprovalPolicy = mutation({
+  args: {
+    storeId: v.id("store"),
+    varianceApprovalThreshold: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const { store } = await requireStoreFullAdminAccess(ctx, args.storeId);
+    if (
+      !Number.isFinite(args.varianceApprovalThreshold) ||
+      args.varianceApprovalThreshold < 0
+    ) {
+      throw new Error("Variance approval threshold must be non-negative.");
+    }
+
+    const threshold = Math.max(
+      0,
+      Math.round(args.varianceApprovalThreshold),
+    );
+    const currentConfig = asRecord(store.config);
+    const operations = asRecord(currentConfig.operations);
+    const cashControls = asRecord(operations.cashControls);
+    const nextConfig = {
+      ...currentConfig,
+      operations: {
+        ...operations,
+        cashControls: {
+          ...cashControls,
+          varianceApprovalThreshold: threshold,
+        },
+      },
+    };
+
+    await ctx.db.patch("store", args.storeId, { config: nextConfig });
+
+    return {
+      requireManagerSignoffForAnyVariance:
+        typeof cashControls.requireManagerSignoffForAnyVariance === "boolean"
+          ? cashControls.requireManagerSignoffForAnyVariance
+          : false,
+      requireManagerSignoffForOvers:
+        typeof cashControls.requireManagerSignoffForOvers === "boolean"
+          ? cashControls.requireManagerSignoffForOvers
+          : false,
+      requireManagerSignoffForShorts:
+        typeof cashControls.requireManagerSignoffForShorts === "boolean"
+          ? cashControls.requireManagerSignoffForShorts
+          : false,
+      varianceApprovalThreshold: threshold,
     };
   },
 });

--- a/packages/athena-webapp/convex/workflowTraces/public.ts
+++ b/packages/athena-webapp/convex/workflowTraces/public.ts
@@ -5,6 +5,8 @@ import type { QueryCtx } from "../_generated/server";
 import { query } from "../_generated/server";
 import { normalizeWorkflowTraceLookupValue } from "../../shared/workflowTrace";
 import { requireStoreFullAdminAccess } from "../stockOps/access";
+import { getAuthenticatedAthenaUserWithCtx } from "../lib/athenaUserAuth";
+import { getActiveManagerElevationWithCtx } from "../operations/managerElevations";
 import { listWorkflowTraceEventsWithCtx } from "./core";
 import { buildWorkflowTraceViewModel } from "./presentation";
 
@@ -12,6 +14,7 @@ export type WorkflowTraceAccessAuthorizer = (
   ctx: QueryCtx,
   args: {
     storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
     trace: {
       traceId: string;
       workflowType: string;
@@ -30,14 +33,47 @@ const requireAdminWorkflowTraceAccess: WorkflowTraceAccessAuthorizer = async (
   ctx,
   args,
 ) => {
-  await requireStoreFullAdminAccess(ctx, args.storeId);
+  await requireFullAdminOrManagerElevationTraceAccess(ctx, args);
   return true;
 };
+
+async function requireFullAdminOrManagerElevationTraceAccess(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
+  },
+) {
+  try {
+    await requireStoreFullAdminAccess(ctx, args.storeId);
+    return;
+  } catch (error) {
+    if (!args.terminalId) {
+      throw error;
+    }
+
+    const account = await getAuthenticatedAthenaUserWithCtx(ctx);
+    if (!account) {
+      throw error;
+    }
+
+    const elevation = await getActiveManagerElevationWithCtx(ctx, {
+      accountId: account._id,
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    });
+
+    if (!elevation) {
+      throw error;
+    }
+  }
+}
 
 async function assertWorkflowTraceAccess(
   ctx: QueryCtx,
   args: {
     storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
     trace: {
       traceId: string;
       workflowType: string;
@@ -52,6 +88,7 @@ async function assertWorkflowTraceAccess(
     requireAdminWorkflowTraceAccess;
   const isAuthorized = await authorizer(ctx, {
     storeId: args.storeId,
+    terminalId: args.terminalId,
     trace: args.trace,
   });
 
@@ -65,19 +102,21 @@ async function assertDefaultWorkflowTraceAccess(
   args: {
     accessAuthorizers?: WorkflowTraceAccessAuthorizers;
     storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
   },
 ) {
   if (args.accessAuthorizers) {
     return;
   }
 
-  await requireStoreFullAdminAccess(ctx, args.storeId);
+  await requireFullAdminOrManagerElevationTraceAccess(ctx, args);
 }
 
 export async function getWorkflowTraceViewByIdWithCtx(
   ctx: QueryCtx,
   args: {
     storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
     traceId: string;
     accessAuthorizers?: WorkflowTraceAccessAuthorizers;
   },
@@ -97,6 +136,7 @@ export async function getWorkflowTraceViewByIdWithCtx(
 
   await assertWorkflowTraceAccess(ctx, {
     storeId: args.storeId,
+    terminalId: args.terminalId,
     trace,
     accessAuthorizers: args.accessAuthorizers,
   });
@@ -112,6 +152,7 @@ export async function getWorkflowTraceViewByIdWithCtx(
 export const getWorkflowTraceViewById = query({
   args: {
     storeId: v.id("store"),
+    terminalId: v.optional(v.id("posTerminal")),
     traceId: v.string(),
   },
   handler: (ctx, args) => getWorkflowTraceViewByIdWithCtx(ctx, args),
@@ -121,6 +162,7 @@ export async function getWorkflowTraceViewByLookupWithCtx(
   ctx: QueryCtx,
   args: {
     storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
     workflowType: string;
     lookupType: string;
     lookupValue: string;
@@ -146,6 +188,7 @@ export async function getWorkflowTraceViewByLookupWithCtx(
 
   return getWorkflowTraceViewByIdWithCtx(ctx as never, {
     storeId: args.storeId,
+    terminalId: args.terminalId,
     traceId: lookup.traceId,
     accessAuthorizers: args.accessAuthorizers,
   });
@@ -154,6 +197,7 @@ export async function getWorkflowTraceViewByLookupWithCtx(
 export const getWorkflowTraceByLookup = query({
   args: {
     storeId: v.id("store"),
+    terminalId: v.optional(v.id("posTerminal")),
     workflowType: v.string(),
     lookupType: v.string(),
     lookupValue: v.string(),

--- a/packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts
+++ b/packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts
@@ -1,11 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const authMock = vi.hoisted(() => ({
   getAuthUserId: vi.fn(),
 }));
+const managerElevationMock = vi.hoisted(() => ({
+  getActiveManagerElevationWithCtx: vi.fn(),
+}));
 
 vi.mock("@convex-dev/auth/server", () => ({
   getAuthUserId: authMock.getAuthUserId,
+}));
+
+vi.mock("../operations/managerElevations", () => ({
+  getActiveManagerElevationWithCtx:
+    managerElevationMock.getActiveManagerElevationWithCtx,
 }));
 
 import type { Id } from "../_generated/dataModel";
@@ -221,6 +229,12 @@ function createAdminTraceReadCtx(
     query(tableName: string) {
       if (tableName === "athenaUser") {
         return {
+          collect: async () => [
+            {
+              _id: "athena-user-1",
+              email: "manager@example.com",
+            },
+          ],
           filter: () => ({
             first: async () => ({
               _id: "athena-user-1",
@@ -251,6 +265,10 @@ function createAdminTraceReadCtx(
 }
 
 describe("workflow trace core and public helpers", () => {
+  beforeEach(() => {
+    managerElevationMock.getActiveManagerElevationWithCtx.mockReset();
+  });
+
   it("updates existing traces instead of duplicating the same store-scoped trace id", async () => {
     const storeId = "store-a" as Id<"store">;
     const ctx = createTestCtx();
@@ -664,6 +682,55 @@ describe("workflow trace core and public helpers", () => {
         lookupValue: "JOB-42",
       }),
     ).rejects.toThrow("Only full admins can access stock operations.");
+  });
+
+  it("allows default trace reads with active terminal manager elevation", async () => {
+    authMock.getAuthUserId.mockResolvedValue("auth-user-1");
+    managerElevationMock.getActiveManagerElevationWithCtx.mockResolvedValue({
+      accountId: "athena-user-1",
+      elevationId: "manager-elevation-1",
+      expiresAt: Date.now() + 60_000,
+      managerDisplayName: "Ato Kofi",
+      managerStaffProfileId: "staff-manager-1",
+      organizationId: "org-1",
+      startedAt: Date.now(),
+      storeId: "store-a",
+      terminalId: "terminal-1",
+    });
+    const storeId = "store-a" as Id<"store">;
+    const terminalId = "terminal-1" as Id<"posTerminal">;
+    const ctx = createAdminTraceReadCtx(undefined, "pos_only");
+
+    await createWorkflowTraceWithCtx(ctx as never, {
+      storeId,
+      traceId: "register_session:8a1zs5",
+      workflowType: "register_session",
+      title: "Register session 8A1ZS5",
+      status: "started",
+      health: "healthy",
+      startedAt: 100,
+      primaryLookupType: "register_session_id",
+      primaryLookupValue: "8A1ZS5",
+    });
+
+    await expect(
+      getWorkflowTraceViewByIdWithCtx(ctx as never, {
+        storeId,
+        terminalId,
+        traceId: "register_session:8a1zs5",
+      }),
+    ).resolves.toMatchObject({
+      header: {
+        traceId: "register_session:8a1zs5",
+      },
+    });
+    expect(
+      managerElevationMock.getActiveManagerElevationWithCtx,
+    ).toHaveBeenCalledWith(expect.anything(), {
+      accountId: "athena-user-1",
+      storeId,
+      terminalId,
+    });
   });
 
   it("routes lookup reads through the same workflow authorizer as direct trace reads", async () => {

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 95 file(s); key children: -authed-layout.tsx, -index-route-view.tsx, __root.tsx, _authed, _authed.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 648 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 649 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 33 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -234,6 +234,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/auth/convexAuthUrl.test.ts`](../../src/auth/convexAuthUrl.test.ts)
 - [`src/components/Navbar.test.tsx`](../../src/components/Navbar.test.tsx)
 - [`src/components/OrganizationView.test.tsx`](../../src/components/OrganizationView.test.tsx)
+- [`src/components/ProtectedRoute.test.tsx`](../../src/components/ProtectedRoute.test.tsx)
 - [`src/components/StoreView.test.tsx`](../../src/components/StoreView.test.tsx)
 - [`src/components/View.test.tsx`](../../src/components/View.test.tsx)
 - [`src/components/add-product/AttributesTable.test.ts`](../../src/components/add-product/AttributesTable.test.ts)

--- a/packages/athena-webapp/src/components/ProtectedRoute.test.tsx
+++ b/packages/athena-webapp/src/components/ProtectedRoute.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProtectedRoute } from "./ProtectedRoute";
+
+const mocks = vi.hoisted(() => ({
+  usePermissions: vi.fn(),
+}));
+
+vi.mock("../hooks/usePermissions", () => ({
+  usePermissions: mocks.usePermissions,
+}));
+
+describe("ProtectedRoute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.scrollTo = vi.fn();
+  });
+
+  it("allows manager-protected routes for full admins and active manager elevation", () => {
+    mocks.usePermissions.mockReturnValue({
+      hasFinancialDetailsAccess: true,
+      isLoading: false,
+      role: "pos_only",
+    });
+
+    const { rerender } = render(
+      <ProtectedRoute requires="manager">
+        <div>Manager content</div>
+      </ProtectedRoute>,
+    );
+
+    expect(screen.getByText("Manager content")).toBeInTheDocument();
+
+    mocks.usePermissions.mockReturnValue({
+      hasFinancialDetailsAccess: true,
+      isLoading: false,
+      role: "full_admin",
+    });
+
+    rerender(
+      <ProtectedRoute requires="manager">
+        <div>Manager content</div>
+      </ProtectedRoute>,
+    );
+
+    expect(screen.getByText("Manager content")).toBeInTheDocument();
+  });
+
+  it("blocks manager-protected routes for POS-only sessions without elevation", () => {
+    mocks.usePermissions.mockReturnValue({
+      hasFinancialDetailsAccess: false,
+      isLoading: false,
+      role: "pos_only",
+    });
+
+    render(
+      <ProtectedRoute requires="manager">
+        <div>Manager content</div>
+      </ProtectedRoute>,
+    );
+
+    expect(screen.queryByText("Manager content")).not.toBeInTheDocument();
+    expect(screen.getByText("Access Denied")).toBeInTheDocument();
+  });
+});

--- a/packages/athena-webapp/src/components/ProtectedRoute.tsx
+++ b/packages/athena-webapp/src/components/ProtectedRoute.tsx
@@ -5,11 +5,11 @@ import { NoPermissionView } from "./states/no-permission/NoPermissionView";
 
 interface ProtectedRouteProps {
   children: ReactNode;
-  requires: Role;
+  requires: Role | "manager";
 }
 
 export function ProtectedRoute({ children, requires }: ProtectedRouteProps) {
-  const { role, isLoading } = usePermissions();
+  const { hasFinancialDetailsAccess, role, isLoading } = usePermissions();
 
   if (isLoading) {
     return null;
@@ -24,6 +24,10 @@ export function ProtectedRoute({ children, requires }: ProtectedRouteProps) {
     requires === "pos_only" &&
     (role === "pos_only" || role === "full_admin")
   ) {
+    return <>{children}</>;
+  }
+
+  if (requires === "manager" && hasFinancialDetailsAccess) {
     return <>{children}</>;
   }
 

--- a/packages/athena-webapp/src/components/app-sidebar.test.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.test.tsx
@@ -170,15 +170,16 @@ describe("AppSidebar capability gates", () => {
     });
   });
 
-  it("lets POS-only accounts open store-day surfaces without admin surfaces", () => {
+  it("keeps manager surfaces disabled for POS-only accounts", () => {
     mocks.usePermissions.mockReturnValue({
       canAccessAdmin: () => false,
       canAccessFullAdminSurfaces: () => false,
       canAccessPOS: () => true,
       canAccessOperations: () => true,
-      canAccessStoreDaySurfaces: () => true,
+      canAccessStoreDaySurfaces: () => false,
       hasFullAdminAccess: false,
-      hasStoreDaySurfaceAccess: true,
+      hasFinancialDetailsAccess: false,
+      hasStoreDaySurfaceAccess: false,
       isLoading: false,
       role: "pos_only",
     });
@@ -187,26 +188,30 @@ describe("AppSidebar capability gates", () => {
 
     expect(screen.getByRole("link", { name: /cash controls/i })).toHaveAttribute(
       "aria-disabled",
-      "false",
+      "true",
     );
     expect(screen.getByRole("button", { name: /operations/i })).toHaveAttribute(
       "aria-disabled",
-      "false",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /products/i })).toHaveAttribute(
+      "aria-disabled",
+      "true",
     );
     expect(screen.getByRole("link", { name: /open work/i })).toHaveAttribute(
       "aria-disabled",
-      "false",
+      "true",
     );
     expect(screen.getByRole("link", { name: /approvals/i })).toHaveAttribute(
       "aria-disabled",
-      "false",
+      "true",
     );
     expect(
       screen.getByRole("link", { name: /stock adjustments/i }),
-    ).toHaveAttribute("aria-disabled", "false");
+    ).toHaveAttribute("aria-disabled", "true");
     expect(screen.getByRole("link", { name: /sku activity/i })).toHaveAttribute(
       "aria-disabled",
-      "false",
+      "true",
     );
 
     expect(screen.getByRole("link", { name: /procurement/i })).toHaveAttribute(
@@ -233,6 +238,36 @@ describe("AppSidebar capability gates", () => {
     expect(screen.queryByRole("heading", { name: /organization/i })).toBeNull();
   });
 
+  it("lets manager-elevated sessions open Cash Controls, Operations, and Products", () => {
+    mocks.usePermissions.mockReturnValue({
+      canAccessAdmin: () => false,
+      canAccessFullAdminSurfaces: () => false,
+      canAccessPOS: () => true,
+      canAccessOperations: () => true,
+      canAccessStoreDaySurfaces: () => true,
+      hasFullAdminAccess: false,
+      hasFinancialDetailsAccess: true,
+      hasStoreDaySurfaceAccess: true,
+      isLoading: false,
+      role: "pos_only",
+    });
+
+    render(<AppSidebar />);
+
+    expect(screen.getByRole("link", { name: /cash controls/i })).toHaveAttribute(
+      "aria-disabled",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: /operations/i })).toHaveAttribute(
+      "aria-disabled",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: /products/i })).toHaveAttribute(
+      "aria-disabled",
+      "false",
+    );
+  });
+
   it("renders the contained shell variant full-height on mobile and fit-height on desktop", () => {
     mocks.usePermissions.mockReturnValue({
       canAccessAdmin: () => true,
@@ -241,6 +276,7 @@ describe("AppSidebar capability gates", () => {
       canAccessOperations: () => true,
       canAccessStoreDaySurfaces: () => true,
       hasFullAdminAccess: true,
+      hasFinancialDetailsAccess: true,
       hasStoreDaySurfaceAccess: true,
       isLoading: false,
       role: "full_admin",
@@ -279,6 +315,7 @@ describe("AppSidebar capability gates", () => {
       canAccessOperations: () => true,
       canAccessStoreDaySurfaces: () => true,
       hasFullAdminAccess: true,
+      hasFinancialDetailsAccess: true,
       hasStoreDaySurfaceAccess: true,
       isLoading: false,
       role: "full_admin",
@@ -300,6 +337,7 @@ describe("AppSidebar capability gates", () => {
       canAccessOperations: () => true,
       canAccessStoreDaySurfaces: () => true,
       hasFullAdminAccess: true,
+      hasFinancialDetailsAccess: true,
       hasStoreDaySurfaceAccess: true,
       isLoading: false,
       role: "full_admin",

--- a/packages/athena-webapp/src/components/app-sidebar.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.tsx
@@ -172,7 +172,10 @@ export function AppSidebar({
     activeStore?._id ? { storeId: activeStore._id } : "skip",
   );
 
-  const { canAccessStoreDaySurfaces, hasFullAdminAccess } = usePermissions();
+  const {
+    hasFinancialDetailsAccess,
+    hasFullAdminAccess,
+  } = usePermissions();
   const isOperationsRoute = location.pathname.includes("/operations");
   const isOrdersRoute = location.pathname.includes("/orders");
   const isProductsRoute = location.pathname.includes("/products");
@@ -223,7 +226,7 @@ export function AppSidebar({
 
               <SidebarMenuItem>
                 <SidebarMenuButton
-                  disabled={!canAccessStoreDaySurfaces()}
+                  disabled={!hasFinancialDetailsAccess}
                   asChild
                 >
                   <Link
@@ -243,7 +246,7 @@ export function AppSidebar({
 
               <SidebarMenuCollapsible
                 defaultOpen={isOperationsRoute}
-                disabled={!canAccessStoreDaySurfaces()}
+                disabled={!hasFinancialDetailsAccess}
                 icon={Workflow}
                 label="Operations"
                 onClick={() => {
@@ -259,7 +262,7 @@ export function AppSidebar({
                 <SidebarMenuSub>
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
+                      disabled={!hasFinancialDetailsAccess}
                       asChild
                     >
                       <Link
@@ -278,7 +281,7 @@ export function AppSidebar({
 
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
+                      disabled={!hasFinancialDetailsAccess}
                       asChild
                     >
                       <Link
@@ -297,7 +300,7 @@ export function AppSidebar({
 
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
+                      disabled={!hasFinancialDetailsAccess}
                       asChild
                     >
                       <Link
@@ -316,7 +319,7 @@ export function AppSidebar({
 
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
+                      disabled={!hasFinancialDetailsAccess}
                       asChild
                     >
                       <Link
@@ -335,7 +338,7 @@ export function AppSidebar({
 
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
+                      disabled={!hasFinancialDetailsAccess}
                       asChild
                     >
                       <Link
@@ -354,7 +357,7 @@ export function AppSidebar({
 
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
+                      disabled={!hasFinancialDetailsAccess}
                       asChild
                     >
                       <Link
@@ -373,7 +376,7 @@ export function AppSidebar({
 
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
+                      disabled={!hasFinancialDetailsAccess}
                       asChild
                     >
                       <Link
@@ -392,7 +395,7 @@ export function AppSidebar({
 
                   <SidebarMenuSubItem>
                     <SidebarMenuButton
-                      disabled={!canAccessStoreDaySurfaces()}
+                      disabled={!hasFinancialDetailsAccess}
                       asChild
                     >
                       <Link
@@ -640,6 +643,7 @@ export function AppSidebar({
               {/* Products section */}
               <SidebarMenuCollapsible
                 defaultOpen={isProductsRoute}
+                disabled={!hasFinancialDetailsAccess}
                 icon={Tag}
                 label="Products"
                 onClick={() => {
@@ -655,7 +659,10 @@ export function AppSidebar({
                 {categories?.map((category) => (
                   <SidebarMenuSub key={category._id}>
                     <SidebarMenuSubItem>
-                      <SidebarMenuButton asChild>
+                      <SidebarMenuButton
+                        disabled={!hasFinancialDetailsAccess}
+                        asChild
+                      >
                         <Link
                           to="/$orgUrlSlug/store/$storeUrlSlug/products"
                           params={(p) => ({
@@ -678,7 +685,10 @@ export function AppSidebar({
                 {productsWithNoImages && productsWithNoImages.length > 0 && (
                   <SidebarMenuSub>
                     <SidebarMenuSubItem>
-                      <SidebarMenuButton asChild>
+                      <SidebarMenuButton
+                        disabled={!hasFinancialDetailsAccess}
+                        asChild
+                      >
                         <Link
                           to="/$orgUrlSlug/store/$storeUrlSlug/products/unresolved"
                           params={(p) => ({

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.auth.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.auth.test.tsx
@@ -62,7 +62,9 @@ vi.mock("../common/PageHeader", () => ({
 
 const readyProtectedState = {
   activeStore: { _id: "store-1" as Id<"store">, currency: "USD" },
+  canAccessProtectedSurface: true,
   canQueryProtectedData: true,
+  hasFinancialDetailsAccess: true,
   hasFullAdminAccess: true,
   isAuthenticated: true,
   isLoadingAccess: false,
@@ -119,6 +121,9 @@ describe("CashControlsDashboard auth readiness", () => {
   it("subscribes to cash-controls data once the shared admin gate is ready", () => {
     render(<CashControlsDashboard />);
 
+    expect(mockedHooks.useProtectedAdminPageState).toHaveBeenCalledWith({
+      surface: "cash_controls",
+    });
     expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
       { storeId: "store-1" },
     ]);

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -1452,7 +1452,7 @@ export function CashControlsDashboard() {
     hasFullAdminAccess,
     isAuthenticated,
     isLoadingAccess,
-  } = useProtectedAdminPageState({ surface: "store_day" });
+  } = useProtectedAdminPageState({ surface: "cash_controls" });
   const canAccessSurface = canAccessProtectedSurface ?? hasFullAdminAccess;
   const params = useParams({ strict: false }) as
     | {

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.auth.test.tsx
@@ -65,7 +65,9 @@ vi.mock("../common/PageHeader", () => ({
 
 const readyProtectedState = {
   activeStore: { _id: "store-1" as Id<"store">, currency: "USD" },
+  canAccessProtectedSurface: true,
   canQueryProtectedData: true,
+  hasFinancialDetailsAccess: true,
   hasFullAdminAccess: true,
   isAuthenticated: true,
   isLoadingAccess: false,
@@ -127,6 +129,9 @@ describe("RegisterSessionView auth readiness", () => {
 
     render(<RegisterSessionView />);
 
+    expect(mockedHooks.useProtectedAdminPageState).toHaveBeenCalledWith({
+      surface: "cash_controls",
+    });
     expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
       {
         registerSessionId: "session-1",

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -1,11 +1,7 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  GENERIC_UNEXPECTED_ERROR_MESSAGE,
-  ok,
-  userError,
-} from "~/shared/commandResult";
+import { ok, userError } from "~/shared/commandResult";
 
 import {
   RegisterSessionActivityViewContent,
@@ -404,9 +400,9 @@ describe("RegisterSessionViewContent", () => {
     expect(screen.getByRole("button", { name: "Submit closeout" })).toHaveClass(
       "bg-action-workflow",
     );
-    expect(screen.getByText("Deposit history")).toBeInTheDocument();
-    expect(screen.getByText("Record cash deposit")).toBeInTheDocument();
-    expect(screen.getAllByText("BANK-339").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Deposit history")).not.toBeInTheDocument();
+    expect(screen.queryByText("Record cash deposit")).not.toBeInTheDocument();
+    expect(screen.queryByText("BANK-339")).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "View trace" }),
     ).toBeInTheDocument();
@@ -424,6 +420,63 @@ describe("RegisterSessionViewContent", () => {
     expect(screen.getByRole("link", { name: "View trace" })).not.toHaveClass(
       "w-full",
     );
+  });
+
+  it("hides register cash details while keeping closeout input available to non-manager staff", () => {
+    render(
+      <RegisterSessionViewContent
+        actorStaffProfileId="staff-1"
+        actorUserId="user-1"
+        canViewFinancialDetails={false}
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        orgUrlSlug="wigclub"
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            countedCash: undefined,
+            expectedCash: 148500,
+            netExpectedCash: 148500,
+            openingFloat: 15000,
+            totalDeposited: 0,
+            variance: 0,
+            workflowTraceId: "register_session:reg-3",
+          },
+        }}
+        storeId="store-1"
+        storeUrlSlug="wigclub"
+      />,
+    );
+
+    expect(screen.getByText("Cash position")).toBeInTheDocument();
+    expect(screen.getAllByText("Manager only").length).toBeGreaterThan(0);
+    expect(screen.queryByText("GH₵1,485")).not.toBeInTheDocument();
+    expect(screen.getByText("GH₵150")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Correct opening float" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Closeout workflow")).toBeInTheDocument();
+    expect(screen.getByText("Count and close drawer")).toBeInTheDocument();
+    expect(screen.getByLabelText("Closeout counted cash")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Draft variance"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Submit closeout" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "POS activity" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "View trace" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Deposit history")).not.toBeInTheDocument();
+    expect(screen.queryByText("Record cash deposit")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Deposit amount")).not.toBeInTheDocument();
   });
 
   it("links to POS activity without rendering the activity log inline", () => {
@@ -2550,6 +2603,54 @@ describe("RegisterSessionViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides closed closeout metrics from non-manager staff", () => {
+    render(
+      <RegisterSessionViewContent
+        actorUserId="user-1"
+        canViewFinancialDetails={false}
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            closedAt: new Date("2026-07-06T01:54:00.000Z").getTime(),
+            closedByStaffName: "Kwamina Mensah",
+            countedCash: 100000,
+            expectedCash: 94200,
+            netExpectedCash: 94200,
+            status: "closed",
+            variance: 5800,
+          },
+        }}
+        storeId="store-1"
+      />,
+    );
+
+    const closedCloseoutPanel = screen
+      .getByText("Closeout complete")
+      .closest("div");
+
+    expect(closedCloseoutPanel).toBeInTheDocument();
+    expect(
+      within(closedCloseoutPanel as HTMLElement).queryByText("GH₵942"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(closedCloseoutPanel as HTMLElement).queryByText("GH₵1,000"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(closedCloseoutPanel as HTMLElement).queryByText("GH₵58"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(closedCloseoutPanel as HTMLElement).queryByText("Variance"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Reopen closeout/i }),
+    ).toBeInTheDocument();
+  });
+
   it("reopens a closed closeout after manager approval", async () => {
     const user = userEvent.setup();
     const onAuthenticateStaff = vi.fn().mockResolvedValue(
@@ -2983,10 +3084,12 @@ describe("RegisterSessionViewContent", () => {
     expect(
       screen.queryByRole("button", { name: "Finalize closeout" }),
     ).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Deposit amount")).toBeDisabled();
-    expect(screen.getByLabelText("Deposit reference")).toBeDisabled();
-    expect(screen.getByLabelText("Deposit notes")).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Record deposit" })).toBeDisabled();
+    expect(screen.queryByLabelText("Deposit amount")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Deposit reference")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Deposit notes")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Record deposit" }),
+    ).not.toBeInTheDocument();
   });
 
   it("holds cash item-adjustment closeouts without finalize or deposit actions", () => {
@@ -3031,8 +3134,10 @@ describe("RegisterSessionViewContent", () => {
     expect(
       screen.queryByRole("button", { name: "Finalize closeout" }),
     ).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Deposit amount")).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Record deposit" })).toBeDisabled();
+    expect(screen.queryByLabelText("Deposit amount")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Record deposit" }),
+    ).not.toBeInTheDocument();
   });
 
   it("wraps submitted closeout metrics when after-adjustment context is shown", () => {
@@ -4103,60 +4208,7 @@ describe("RegisterSessionViewContent", () => {
     );
   });
 
-  it("submits a deposit with store, session, and actor context", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1000);
-
-    const user = userEvent.setup();
-    const onRecordDeposit = vi.fn().mockResolvedValue(
-      ok({
-        action: "recorded",
-      }),
-    );
-
-    render(
-      <RegisterSessionViewContent
-        actorStaffProfileId="staff-1"
-        actorUserId="user-1"
-        currency="USD"
-        isLoading={false}
-        onRecordDeposit={onRecordDeposit}
-        {...closeoutHandlers}
-        registerSessionSnapshot={activeSnapshot}
-        storeId="store-1"
-      />,
-    );
-
-    await user.type(screen.getByLabelText("Deposit amount"), "2500");
-    await user.type(screen.getByLabelText("Deposit reference"), "BANK-440");
-    await user.type(
-      screen.getByLabelText("Deposit notes"),
-      "Safe drop before final closeout.",
-    );
-    await user.click(screen.getByRole("button", { name: "Record deposit" }));
-
-    await waitFor(() =>
-      expect(onRecordDeposit).toHaveBeenCalledWith({
-        actorStaffProfileId: "staff-1",
-        actorUserId: "user-1",
-        amount: 2500,
-        notes: "Safe drop before final closeout.",
-        reference: "BANK-440",
-        registerSessionId: "session-1",
-        storeId: "store-1",
-        submissionKey: "register-session-deposit-session-1-rs",
-      }),
-    );
-  });
-
-  it("supplies the linked active staff profile from the production container when recording deposits", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1000);
-
-    const user = userEvent.setup();
-    const recordDepositMutation = vi.fn().mockResolvedValue(
-      ok({
-        action: "recorded",
-      }),
-    );
+  it("uses manager elevation financial access for register detail visibility", () => {
     protectedPageMocks.useProtectedAdminPageState.mockReturnValue({
       activeStore: {
         _id: "store-1",
@@ -4164,6 +4216,7 @@ describe("RegisterSessionViewContent", () => {
       },
       canAccessProtectedSurface: true,
       canQueryProtectedData: true,
+      hasFinancialDetailsAccess: true,
       hasFullAdminAccess: false,
       isAuthenticated: true,
       isLoadingAccess: false,
@@ -4171,7 +4224,7 @@ describe("RegisterSessionViewContent", () => {
     authMocks.useAuth.mockReturnValue({
       user: { _id: "user-1" },
     });
-    convexMocks.useMutation.mockReturnValue(recordDepositMutation);
+    convexMocks.useMutation.mockReturnValue(vi.fn());
     convexMocks.useQuery.mockImplementation((_query, args) => {
       if (args === "skip") {
         return undefined;
@@ -4185,6 +4238,7 @@ describe("RegisterSessionViewContent", () => {
         {
           _id: "staff-1",
           linkedUserId: "user-1",
+          roles: ["cashier"],
           status: "active",
           storeId: "store-1",
         },
@@ -4193,76 +4247,8 @@ describe("RegisterSessionViewContent", () => {
 
     render(<RegisterSessionView />);
 
-    await user.type(screen.getByLabelText("Deposit amount"), "2500");
-    await user.click(screen.getByRole("button", { name: "Record deposit" }));
-
-    await waitFor(() =>
-      expect(recordDepositMutation).toHaveBeenCalledWith(
-        expect.objectContaining({
-          actorStaffProfileId: "staff-1",
-          actorUserId: "user-1",
-        }),
-      ),
-    );
+    expect(screen.getAllByText("$176").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Manager only")).not.toBeInTheDocument();
   });
 
-  it("shows safe inline errors for deposit user_error results", async () => {
-    const user = userEvent.setup();
-    const onRecordDeposit = vi.fn().mockResolvedValue(
-      userError({
-        code: "precondition_failed",
-        message: "Register session is not accepting new deposits.",
-      }),
-    );
-
-    render(
-      <RegisterSessionViewContent
-        actorUserId="user-1"
-        currency="USD"
-        isLoading={false}
-        onRecordDeposit={onRecordDeposit}
-        {...closeoutHandlers}
-        registerSessionSnapshot={activeSnapshot}
-        storeId="store-1"
-      />,
-    );
-
-    await user.type(screen.getByLabelText("Deposit amount"), "2500");
-    await user.click(screen.getByRole("button", { name: "Record deposit" }));
-
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Register session is not accepting new deposits.",
-    );
-    expect(screen.getByLabelText("Deposit amount")).toHaveValue(2500);
-  });
-
-  it("shows generic inline errors for unexpected deposit failures", async () => {
-    const user = userEvent.setup();
-    const onRecordDeposit = vi.fn().mockResolvedValue({
-      kind: "unexpected_error",
-      error: {
-        title: "Something went wrong",
-        message: GENERIC_UNEXPECTED_ERROR_MESSAGE,
-      },
-    });
-
-    render(
-      <RegisterSessionViewContent
-        actorUserId="user-1"
-        currency="USD"
-        isLoading={false}
-        onRecordDeposit={onRecordDeposit}
-        {...closeoutHandlers}
-        registerSessionSnapshot={activeSnapshot}
-        storeId="store-1"
-      />,
-    );
-
-    await user.type(screen.getByLabelText("Deposit amount"), "2500");
-    await user.click(screen.getByRole("button", { name: "Record deposit" }));
-
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      GENERIC_UNEXPECTED_ERROR_MESSAGE,
-    );
-  });
 });

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -64,6 +64,7 @@ import { currencyDisplaySymbol } from "~/shared/currencyFormatter";
 import { formatStaffDisplayName } from "~/shared/staffDisplayName";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
+import { FinancialValue } from "../common/FinancialValue";
 import { ListPagination } from "../common/ListPagination";
 import { ComposedPageHeader } from "../common/PageHeader";
 import { EmptyState } from "../states/empty/empty-state";
@@ -439,6 +440,7 @@ type StaffAuthenticationRole = "cashier" | "manager";
 type RegisterSessionViewContentProps = {
   actorStaffProfileId?: string;
   actorUserId?: string;
+  canViewFinancialDetails?: boolean;
   currency: string;
   isLoading: boolean;
   onRecordDeposit: (
@@ -545,10 +547,6 @@ function isManagerStaff(staff: StaffAuthenticationResult) {
   return staff.activeRoles?.includes("manager") ?? false;
 }
 
-function buildDepositSubmissionKey(registerSessionId: string) {
-  return `register-session-deposit-${registerSessionId}-${Date.now().toString(36)}`;
-}
-
 const REGISTER_SESSION_SYNC_REVIEW_APPROVAL_ACTION_KEY =
   "cash_controls.register_session.resolve_sync_review";
 
@@ -560,6 +558,24 @@ function formatCurrency(currency: string, amount?: number | null) {
   return formatStoredCurrencyAmount(currency, amount, {
     revealMinorUnits: true,
   });
+}
+
+function CashControlsFinancialValue({
+  amount,
+  canView,
+  currency,
+  label,
+}: {
+  amount?: number | null;
+  canView: boolean;
+  currency: string;
+  label: string;
+}) {
+  return (
+    <FinancialValue canView={canView} label={label}>
+      {formatCurrency(currency, amount)}
+    </FinancialValue>
+  );
 }
 
 function formatStoredAmountForInput(amount: number) {
@@ -1103,7 +1119,7 @@ function getVarianceTone(variance?: number) {
     return "text-foreground";
   }
 
-  return variance > 0 ? "text-emerald-700" : "text-destructive";
+  return variance > 0 ? "text-success" : "text-destructive";
 }
 
 function getPaymentMethodIcon({
@@ -3009,59 +3025,9 @@ function RegisterSessionTransactionCard({
   );
 }
 
-function RegisterSessionDepositCard({
-  currency,
-  deposit,
-}: {
-  currency: string;
-  deposit: RegisterSessionDeposit;
-}) {
-  return (
-    <article className="rounded-lg border border-border/70 bg-background p-layout-md">
-      <div className="flex items-start justify-between gap-layout-md">
-        <div className="min-w-0 space-y-1">
-          <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-            Recorded
-          </p>
-          <p className="text-sm leading-5 text-foreground">
-            {formatTimestamp(deposit.recordedAt)}
-          </p>
-        </div>
-        <p className="shrink-0 font-numeric text-sm tabular-nums text-foreground">
-          {formatCurrency(currency, deposit.amount)}
-        </p>
-      </div>
-      <dl className="mt-layout-md grid gap-layout-sm border-t border-border/70 pt-layout-sm text-xs text-muted-foreground">
-        <div className="flex items-center justify-between gap-layout-sm">
-          <dt className="font-medium uppercase tracking-[0.14em]">Reference</dt>
-          <dd className="min-w-0 truncate text-right text-foreground">
-            {deposit.reference ?? "N/A"}
-          </dd>
-        </div>
-        <div className="flex items-center justify-between gap-layout-sm">
-          <dt className="font-medium uppercase tracking-[0.14em]">By</dt>
-          <dd className="min-w-0 truncate text-right text-foreground">
-            {deposit.recordedByStaffName
-              ? formatStaffDisplayName({
-                  fullName: deposit.recordedByStaffName,
-                })
-              : "N/A"}
-          </dd>
-        </div>
-        <div className="space-y-1">
-          <dt className="font-medium uppercase tracking-[0.14em]">Notes</dt>
-          <dd className="break-words text-foreground">
-            {deposit.notes ?? "N/A"}
-          </dd>
-        </div>
-      </dl>
-    </article>
-  );
-}
-
 export function RegisterSessionViewContent({
   actorStaffProfileId,
-  actorUserId,
+  canViewFinancialDetails = true,
   currency,
   isLoading,
   onAuthenticateForApproval,
@@ -3069,7 +3035,6 @@ export function RegisterSessionViewContent({
   onAuthenticateCloseoutReviewApproval,
   onCorrectOpeningFloat,
   onFinalizeCloseout,
-  onRecordDeposit,
   onReopenCloseout,
   onReviewCloseout,
   onResolveSyncReview,
@@ -3081,11 +3046,6 @@ export function RegisterSessionViewContent({
 }: RegisterSessionViewContentProps) {
   const navigate = useNavigate();
   const registerSession = registerSessionSnapshot?.registerSession ?? null;
-  const [amount, setAmount] = useState("");
-  const [notes, setNotes] = useState("");
-  const [reference, setReference] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
-  const [isRecordingDeposit, setIsRecordingDeposit] = useState(false);
   const [countedCash, setCountedCash] = useState("");
   const [closeoutNotes, setCloseoutNotes] = useState("");
   const [managerNotes, setManagerNotes] = useState("");
@@ -3134,18 +3094,6 @@ export function RegisterSessionViewContent({
           }),
         )),
   });
-  const [submissionKey, setSubmissionKey] = useState(() =>
-    buildDepositSubmissionKey(registerSession?._id ?? "session"),
-  );
-
-  useEffect(() => {
-    if (!registerSession?._id) {
-      return;
-    }
-
-    setSubmissionKey(buildDepositSubmissionKey(registerSession._id));
-  }, [registerSession?._id]);
-
   useEffect(() => {
     if (!registerSession?._id) {
       setCountedCash("");
@@ -3266,16 +3214,6 @@ export function RegisterSessionViewContent({
       };
     }, [registerSession, requiresReopenedCloseoutSubmitApproval, storeId]);
 
-  const applyCommandResult = (result: RegisterSessionDepositResult) => {
-    if (result.kind === "ok") {
-      setErrorMessage("");
-      return true;
-    }
-
-    setErrorMessage(result.error.message);
-    return false;
-  };
-
   const applyCloseoutCommandResult = (
     result: RegisterCloseoutCommandResult,
   ) => {
@@ -3292,49 +3230,6 @@ export function RegisterSessionViewContent({
     setCloseoutErrorMessage(result.error.message);
     return false;
   };
-
-  async function handleRecordDeposit() {
-    if (!registerSession?._id || !storeId) {
-      setErrorMessage(
-        "A store and register session are required before recording a deposit",
-      );
-      return;
-    }
-
-    const parsedAmount = Number(amount);
-
-    if (!amount.trim() || Number.isNaN(parsedAmount) || parsedAmount <= 0) {
-      setErrorMessage("Enter a deposit amount greater than zero");
-      return;
-    }
-
-    setErrorMessage("");
-    setIsRecordingDeposit(true);
-
-    try {
-      const result = await onRecordDeposit({
-        actorStaffProfileId,
-        actorUserId,
-        amount: parsedAmount,
-        notes: trimOptional(notes),
-        reference: trimOptional(reference),
-        registerSessionId: registerSession._id,
-        storeId,
-        submissionKey,
-      });
-
-      if (!applyCommandResult(result)) {
-        return;
-      }
-
-      setAmount("");
-      setNotes("");
-      setReference("");
-      setSubmissionKey(buildDepositSubmissionKey(registerSession._id));
-    } finally {
-      setIsRecordingDeposit(false);
-    }
-  }
 
   async function handleSubmitCloseout() {
     if (!registerSession?._id) {
@@ -3867,13 +3762,6 @@ export function RegisterSessionViewContent({
     hasPendingCashCorrections &&
     !needsCloseoutCorrection &&
     !isReopenedCloseoutCorrection;
-  const isDepositActionLocked =
-    Boolean(pendingCloseoutAction) ||
-    Boolean(hasPendingCloseoutApproval) ||
-    Boolean(hasPendingCashCorrections) ||
-    registerSession?.status === "closing" ||
-    registerSession?.status === "closeout_rejected" ||
-    registerSession?.status === "closed";
   const headerTitle = registerSession
     ? formatRegisterHeaderName(registerSession.registerNumber)
     : "Register detail";
@@ -4099,7 +3987,7 @@ export function RegisterSessionViewContent({
             Resolve pending cash-impacting sale voids or item adjustments before
             final closeout can complete.
           </p>
-          {pendingCashVoidText ? (
+          {canViewFinancialDetails && pendingCashVoidText ? (
             <p className="text-sm leading-6 text-muted-foreground">
               {pendingCashVoidText}
             </p>
@@ -4331,7 +4219,10 @@ export function RegisterSessionViewContent({
           }
           trailingContent={
             <div className="flex shrink-0 flex-wrap items-start justify-end gap-2">
-              {registerSession && orgUrlSlug && storeUrlSlug ? (
+              {canViewFinancialDetails &&
+              registerSession &&
+              orgUrlSlug &&
+              storeUrlSlug ? (
                 <Button
                   asChild
                   className="h-8 border-border bg-surface px-2.5 text-xs text-muted-foreground hover:bg-muted sm:h-9 sm:px-3 sm:text-sm"
@@ -4352,7 +4243,7 @@ export function RegisterSessionViewContent({
                   </Link>
                 </Button>
               ) : null}
-              {registerSession?.workflowTraceId ? (
+              {canViewFinancialDetails && registerSession?.workflowTraceId ? (
                 <Button
                   asChild
                   className="h-8 border-border bg-surface px-2.5 text-xs text-muted-foreground hover:bg-muted sm:h-9 sm:px-3 sm:text-sm"
@@ -4554,7 +4445,12 @@ export function RegisterSessionViewContent({
                             : "Expected cash"}
                         </span>
                         <span className="block font-numeric text-2xl tabular-nums text-foreground sm:text-3xl">
-                          {formatCurrency(currency, displayedExpectedCash)}
+                          <CashControlsFinancialValue
+                            amount={displayedExpectedCash}
+                            canView={canViewFinancialDetails}
+                            currency={currency}
+                            label="Expected cash"
+                          />
                         </span>
                       </dd>
                       <div className="mt-layout-md divide-y divide-border/70 rounded-md border border-border/70 bg-muted/10">
@@ -4582,10 +4478,12 @@ export function RegisterSessionViewContent({
                             Deposited
                           </dt>
                           <dd className="font-numeric tabular-nums text-sm text-foreground">
-                            {formatCurrency(
-                              currency,
-                              registerSession.totalDeposited,
-                            )}
+                            <CashControlsFinancialValue
+                              amount={registerSession.totalDeposited}
+                              canView={canViewFinancialDetails}
+                              currency={currency}
+                              label="Deposited cash"
+                            />
                           </dd>
                         </div>
                         <div className="flex items-center justify-between gap-layout-md px-3 py-2.5">
@@ -4595,7 +4493,12 @@ export function RegisterSessionViewContent({
                           <dd
                             className={`font-numeric tabular-nums text-sm ${getVarianceTone(displayedVariance)}`}
                           >
-                            {formatCurrency(currency, displayedVariance ?? 0)}
+                            <CashControlsFinancialValue
+                              amount={displayedVariance ?? 0}
+                              canView={canViewFinancialDetails}
+                              currency={currency}
+                              label="Variance"
+                            />
                           </dd>
                         </div>
                         {pendingCashVoidApprovedExpectedCash !== undefined ? (
@@ -4604,21 +4507,24 @@ export function RegisterSessionViewContent({
                               After adjustments
                             </dt>
                             <dd className="font-numeric tabular-nums text-sm text-foreground">
-                              {formatCurrency(
-                                currency,
-                                pendingCashVoidApprovedExpectedCash,
-                              )}
+                              <CashControlsFinancialValue
+                                amount={pendingCashVoidApprovedExpectedCash}
+                                canView={canViewFinancialDetails}
+                                currency={currency}
+                                label="Expected cash after adjustments"
+                              />
                             </dd>
                           </div>
                         ) : null}
                       </div>
-                      {pendingCashVoidText ? (
+                      {canViewFinancialDetails && pendingCashVoidText ? (
                         <p className="mt-layout-md border-t border-border/70 pt-layout-md text-xs leading-5 text-muted-foreground">
                           {pendingCashVoidText}
                         </p>
                       ) : null}
-                      {canCorrectOpeningFloat ||
-                      showOpeningFloatCorrectionUnavailable ? (
+                      {canViewFinancialDetails &&
+                      (canCorrectOpeningFloat ||
+                        showOpeningFloatCorrectionUnavailable) ? (
                         <div className="mt-layout-md border-t border-border/70 pt-layout-md">
                           {canCorrectOpeningFloat ? (
                             <Button
@@ -4645,6 +4551,380 @@ export function RegisterSessionViewContent({
                         </div>
                       ) : null}
                     </div>
+
+                    {!hasPendingCloseoutApproval ? (
+                      <div className="space-y-4 rounded-lg border border-border bg-surface-raised p-layout-md">
+                        <div className="space-y-2">
+                          <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                            Closeout workflow
+                          </p>
+                          <h2 className="font-display text-xl font-semibold text-foreground">
+                            {isRegisterCloseoutSyncReview
+                              ? "Closeout review pending"
+                              : "Count and close drawer"}
+                          </h2>
+                          <p className="text-sm text-muted-foreground">
+                            {isRegisterCloseoutSyncReview
+                              ? "Synced count is waiting for review."
+                              : "Submit the cash count, then resolve any variance approval before closing."}
+                          </p>
+                        </div>
+
+                        {isRegisterCloseoutSyncReview ? (
+                          <div className="rounded-lg border border-border bg-muted/20 p-4">
+                            <dl className="grid gap-3 text-sm sm:grid-cols-3">
+                              <div className="space-y-1">
+                                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                  Expected
+                                </dt>
+                                <dd className="font-numeric tabular-nums text-foreground">
+                                  {formatCurrency(currency, displayedExpectedCash)}
+                                </dd>
+                              </div>
+                              <div className="space-y-1">
+                                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                  Counted
+                                </dt>
+                                <dd className="font-numeric tabular-nums text-foreground">
+                                  {formatCurrency(currency, displayedCountedCash)}
+                                </dd>
+                              </div>
+                              <div className="space-y-1">
+                                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                  Variance
+                                </dt>
+                                <dd
+                                  className={`font-numeric tabular-nums ${getVarianceTone(displayedVariance ?? undefined)}`}
+                                >
+                                  {formatCurrency(currency, displayedVariance ?? 0)}
+                                </dd>
+                              </div>
+                            </dl>
+                          </div>
+                        ) : registerSession?.status === "closed" ||
+                          registerSession?.status === "closeout_rejected" ? (
+                          <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-4">
+                            <div className="flex items-center justify-between gap-3">
+                              <p className="text-sm font-medium text-foreground">
+                                {registerSession.status === "closeout_rejected"
+                                  ? "Closeout rejected"
+                                  : "Closeout complete"}
+                              </p>
+                              <Badge
+                                className="border-border bg-muted text-muted-foreground"
+                                size="sm"
+                                variant="outline"
+                              >
+                                {registerSession.status === "closeout_rejected"
+                                  ? "Rejected"
+                                  : "Closed"}
+                              </Badge>
+                            </div>
+                            {canViewFinancialDetails ? (
+                              <dl
+                                className={cn(
+                                  "grid gap-3 text-sm",
+                                  pendingCashVoidApprovedExpectedCash !==
+                                    undefined
+                                    ? "sm:grid-cols-4"
+                                    : "sm:grid-cols-3",
+                                )}
+                              >
+                                <div className="space-y-1">
+                                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                    {pendingCashVoidText
+                                      ? "Expected now"
+                                      : "Expected"}
+                                  </dt>
+                                  <dd className="font-numeric tabular-nums text-foreground">
+                                    {formatCurrency(currency, expectedCash)}
+                                  </dd>
+                                </div>
+                                {pendingCashVoidApprovedExpectedCash !==
+                                undefined ? (
+                                  <div className="space-y-1">
+                                    <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                      After adjustments
+                                    </dt>
+                                    <dd className="font-numeric tabular-nums text-foreground">
+                                      {formatCurrency(
+                                        currency,
+                                        pendingCashVoidApprovedExpectedCash,
+                                      )}
+                                    </dd>
+                                  </div>
+                                ) : null}
+                                <div className="space-y-1">
+                                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                    Counted
+                                  </dt>
+                                  <dd className="font-numeric tabular-nums text-foreground">
+                                    {formatCurrency(
+                                      currency,
+                                      registerSession.countedCash,
+                                    )}
+                                  </dd>
+                                </div>
+                                <div className="space-y-1">
+                                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                    Variance
+                                  </dt>
+                                  <dd
+                                    className={`font-numeric tabular-nums ${getVarianceTone(registerSession.variance)}`}
+                                  >
+                                    {formatCurrency(
+                                      currency,
+                                      registerSession.variance ?? 0,
+                                    )}
+                                  </dd>
+                                </div>
+                              </dl>
+                            ) : null}
+                            {canViewFinancialDetails && pendingCashVoidText ? (
+                              <p className="border-t border-border/70 pt-3 text-xs leading-5 text-muted-foreground">
+                                {pendingCashVoidText}
+                              </p>
+                            ) : null}
+                            <div className="space-y-3 border-t border-border/70 pt-3">
+                              <p className="text-sm leading-relaxed text-muted-foreground">
+                                {registerSession.status === "closeout_rejected"
+                                  ? "Manager approval is required to reopen this rejected closeout before a corrected count can be submitted."
+                                  : "Reopen the closeout to submit a corrected count. The saved closeout stays in the drawer history."}
+                              </p>
+                              <LoadingButton
+                                className="w-full justify-center"
+                                disabled={pendingCloseoutAction === "reopen"}
+                                isLoading={pendingCloseoutAction === "reopen"}
+                                onClick={() => void handleReopenClosedCloseout()}
+                                type="button"
+                                variant="outline"
+                              >
+                                <RotateCcw className="h-3.5 w-3.5" />
+                                Reopen closeout
+                              </LoadingButton>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="space-y-4">
+                            {registerSessionSnapshot?.closeoutReview ? (
+                              <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-4">
+                                <p className="text-sm font-medium text-foreground">
+                                  {isReopenedCloseoutCorrection
+                                    ? "Previous submitted closeout"
+                                    : "Submitted closeout"}
+                                </p>
+                                <dl className="flex flex-wrap gap-x-4 gap-y-3 text-sm">
+                                  <div className="min-w-[6rem] flex-1 space-y-1">
+                                    <dt className="text-[11px] uppercase leading-4 tracking-[0.14em] text-muted-foreground">
+                                      {pendingCashVoidText
+                                        ? "Expected now"
+                                        : "Expected"}
+                                    </dt>
+                                    <dd className="font-numeric tabular-nums text-foreground">
+                                      {formatCurrency(currency, expectedCash)}
+                                    </dd>
+                                  </div>
+                                  {pendingCashVoidApprovedExpectedCash !==
+                                  undefined ? (
+                                    <div className="min-w-[8.5rem] flex-1 space-y-1">
+                                      <dt className="text-[11px] uppercase leading-4 tracking-[0.14em] text-muted-foreground">
+                                        After adjustments
+                                      </dt>
+                                      <dd className="font-numeric tabular-nums text-foreground">
+                                        {formatCurrency(
+                                          currency,
+                                          pendingCashVoidApprovedExpectedCash,
+                                        )}
+                                      </dd>
+                                    </div>
+                                  ) : null}
+                                  <div className="min-w-[5.5rem] flex-1 space-y-1">
+                                    <dt className="text-[11px] uppercase leading-4 tracking-[0.14em] text-muted-foreground">
+                                      Counted
+                                    </dt>
+                                    <dd className="font-numeric tabular-nums text-foreground">
+                                      {formatCurrency(
+                                        currency,
+                                        registerSessionSnapshot.registerSession
+                                          .countedCash,
+                                      )}
+                                    </dd>
+                                  </div>
+                                  <div className="min-w-[5.5rem] flex-1 space-y-1">
+                                    <dt className="text-[11px] uppercase leading-4 tracking-[0.14em] text-muted-foreground">
+                                      Variance
+                                    </dt>
+                                    <dd
+                                      className={`font-numeric tabular-nums ${getVarianceTone(registerSessionSnapshot.closeoutReview.variance)}`}
+                                    >
+                                      {formatCurrency(
+                                        currency,
+                                        registerSessionSnapshot.closeoutReview
+                                          .variance,
+                                      )}
+                                    </dd>
+                                  </div>
+                                </dl>
+                                {pendingCashVoidText ? (
+                                  <p className="border-t border-border/70 pt-3 text-xs leading-5 text-muted-foreground">
+                                    {pendingCashVoidText}
+                                  </p>
+                                ) : null}
+                                <p className="text-sm text-muted-foreground">
+                                  Approval required:{" "}
+                                  {registerSessionSnapshot.closeoutReview
+                                    .requiresApproval
+                                    ? "Yes"
+                                    : "No"}
+                                </p>
+                                {formattedCloseoutReviewReason ? (
+                                  <p className="max-w-full overflow-hidden break-words text-sm leading-relaxed text-foreground">
+                                    {formattedCloseoutReviewReason}
+                                  </p>
+                                ) : null}
+                              </div>
+                            ) : null}
+
+                            {canFinalizeCloseout ? (
+                              <div className="space-y-3 rounded-lg border border-border bg-background p-4">
+                                <div className="space-y-1">
+                                  <p className="text-sm font-medium text-foreground">
+                                    Ready for final closeout
+                                  </p>
+                                  <p className="text-sm leading-6 text-muted-foreground">
+                                    Pending register corrections are resolved.
+                                    Finalize this submitted closeout against the
+                                    current expected cash.
+                                  </p>
+                                </div>
+                                <LoadingButton
+                                  className="w-full"
+                                  disabled={Boolean(pendingCloseoutAction)}
+                                  isLoading={pendingCloseoutAction === "finalize"}
+                                  onClick={() => void handleFinalizeCloseout()}
+                                  type="button"
+                                  variant="workflow"
+                                >
+                                  Finalize closeout
+                                </LoadingButton>
+                              </div>
+                            ) : null}
+
+                            {!canFinalizeCloseout && !isWaitingOnVoidReview ? (
+                              <>
+                                <label className="block space-y-2">
+                                  <span className="text-sm font-medium text-foreground">
+                                    Counted cash ({formattedCurrency})
+                                  </span>
+                                  <Input
+                                    aria-label="Closeout counted cash"
+                                    className="border-input bg-background"
+                                    inputMode="decimal"
+                                    onChange={(event) =>
+                                      setCountedCash(event.target.value)
+                                    }
+                                    pattern="[0-9]*[.]?[0-9]*"
+                                    type="text"
+                                    value={countedCash}
+                                  />
+                                </label>
+
+                                {canViewFinancialDetails ? (
+                                  <div className="rounded-lg border border-border bg-muted/20 p-4">
+                                    <dl
+                                      className={cn(
+                                        "grid gap-3 text-sm",
+                                        pendingCashVoidApprovedExpectedCash !==
+                                          undefined
+                                          ? "grid-cols-3"
+                                          : "grid-cols-2",
+                                      )}
+                                    >
+                                      <div className="space-y-1">
+                                        <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                          {pendingCashVoidText
+                                            ? "Expected now"
+                                            : "Expected"}
+                                        </dt>
+                                        <dd className="font-numeric tabular-nums text-foreground">
+                                          {formatCurrency(currency, expectedCash)}
+                                        </dd>
+                                      </div>
+                                      {pendingCashVoidApprovedExpectedCash !==
+                                      undefined ? (
+                                        <div className="space-y-1">
+                                          <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                            After adjustments
+                                          </dt>
+                                          <dd className="font-numeric tabular-nums text-foreground">
+                                            {formatCurrency(
+                                              currency,
+                                              pendingCashVoidApprovedExpectedCash,
+                                            )}
+                                          </dd>
+                                        </div>
+                                      ) : null}
+                                      <div className="space-y-1">
+                                        <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                                          Draft variance
+                                        </dt>
+                                        <dd
+                                          className={`font-numeric tabular-nums ${getVarianceTone(draftVariance ?? undefined)}`}
+                                        >
+                                          {draftVariance === null
+                                            ? "Pending count"
+                                            : formatCurrency(
+                                                currency,
+                                                draftVariance,
+                                              )}
+                                        </dd>
+                                      </div>
+                                    </dl>
+                                    {pendingCashVoidText ? (
+                                      <p className="mt-4 border-t border-border pt-3 text-xs leading-5 text-muted-foreground">
+                                        {pendingCashVoidText}
+                                      </p>
+                                    ) : null}
+                                  </div>
+                                ) : null}
+
+                                <label className="block space-y-2">
+                                  <span className="text-sm font-medium text-foreground">
+                                    Closeout notes
+                                  </span>
+                                  <Textarea
+                                    aria-label="Closeout notes"
+                                    className="min-h-[96px] border-input bg-background"
+                                    onChange={(event) =>
+                                      setCloseoutNotes(event.target.value)
+                                    }
+                                    placeholder="Add drawer notes if anything needs follow-up."
+                                    value={closeoutNotes}
+                                  />
+                                </label>
+
+                                <LoadingButton
+                                  className="w-full"
+                                  disabled={Boolean(pendingCloseoutAction)}
+                                  isLoading={pendingCloseoutAction === "submit"}
+                                  onClick={() => void handleSubmitCloseout()}
+                                  type="button"
+                                  variant="workflow"
+                                >
+                                  Submit closeout
+                                </LoadingButton>
+                              </>
+                            ) : null}
+                          </div>
+                        )}
+
+                        {closeoutErrorMessage ? (
+                          <p className="text-sm text-destructive" role="alert">
+                            {closeoutErrorMessage}
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : null}
 
                     <div className="rounded-lg border border-border bg-surface-raised p-layout-md">
                       <dt className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
@@ -4704,7 +4984,7 @@ export function RegisterSessionViewContent({
                     </div>
                   </dl>
 
-                  {closeoutFollowUpMessage ? (
+                  {canViewFinancialDetails && closeoutFollowUpMessage ? (
                     <div className="mt-layout-lg border-t border-border/70 pt-layout-lg">
                       <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
                         Manager follow-up
@@ -4718,7 +4998,7 @@ export function RegisterSessionViewContent({
 
                 <div className="flex flex-col gap-layout-md px-layout-md py-layout-md md:gap-layout-lg md:px-layout-lg md:py-layout-lg">
                   {pendingVoidApprovalPanel}
-                  {pendingCloseoutApprovalPanel}
+                  {canViewFinancialDetails ? pendingCloseoutApprovalPanel : null}
 
                   {shouldShowProminentCorrectionPanel ? (
                     <section
@@ -4990,6 +5270,8 @@ export function RegisterSessionViewContent({
                     </section>
                   ) : null}
 
+
+
                   <div
                     className={`order-2 flex flex-col items-start gap-layout-sm sm:flex-row sm:justify-between ${hasPendingCloseoutApproval ? "pt-4" : ""}`}
                   >
@@ -5240,538 +5522,6 @@ export function RegisterSessionViewContent({
             )}
           </section>
 
-          <div className="grid gap-layout-md md:gap-6 xl:grid-cols-[minmax(0,1fr)_418px]">
-            <section className="rounded-[calc(var(--radius)*1.25)] border border-border bg-surface px-layout-md py-layout-md shadow-surface md:px-layout-lg md:py-layout-lg">
-              <div className="space-y-layout-md">
-                <div className="space-y-1">
-                  <h2 className="font-display text-2xl font-semibold text-foreground">
-                    Deposit history
-                  </h2>
-                  <p className="text-sm text-muted-foreground">
-                    Safe drops recorded against this drawer, newest first.
-                  </p>
-                </div>
-
-                {!registerSessionSnapshot ? null : registerSessionSnapshot
-                    .deposits.length === 0 ? (
-                  <EmptyState
-                    description="Once a safe drop is recorded it will appear here with the staff name and reference"
-                    title="No deposits recorded"
-                  />
-                ) : (
-                  <>
-                    <div className="space-y-layout-sm md:hidden">
-                      {registerSessionSnapshot.deposits.map((deposit) => (
-                        <RegisterSessionDepositCard
-                          currency={currency}
-                          deposit={deposit}
-                          key={deposit._id}
-                        />
-                      ))}
-                    </div>
-                    <div className="hidden overflow-hidden rounded-lg border border-border bg-surface-raised md:block">
-                      <Table>
-                        <TableHeader>
-                          <TableRow className="border-b border-border hover:bg-transparent">
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Amount
-                            </TableHead>
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Recorded
-                            </TableHead>
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Reference
-                            </TableHead>
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              By
-                            </TableHead>
-                            <TableHead className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              Notes
-                            </TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {registerSessionSnapshot.deposits.map((deposit) => (
-                            <TableRow
-                              className="border-b border-border/70 transition-colors hover:bg-muted/40"
-                              key={deposit._id}
-                            >
-                              <TableCell className="font-numeric tabular-nums text-foreground">
-                                {formatCurrency(currency, deposit.amount)}
-                              </TableCell>
-                              <TableCell className="text-muted-foreground">
-                                {formatTimestamp(deposit.recordedAt)}
-                              </TableCell>
-                              <TableCell>
-                                {deposit.reference ?? "N/A"}
-                              </TableCell>
-                              <TableCell>
-                                {deposit.recordedByStaffName
-                                  ? formatStaffDisplayName({
-                                      fullName: deposit.recordedByStaffName,
-                                    })
-                                  : "N/A"}
-                              </TableCell>
-                              <TableCell>{deposit.notes ?? "N/A"}</TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  </>
-                )}
-              </div>
-            </section>
-
-            <aside className="space-y-layout-md rounded-[calc(var(--radius)*1.25)] border border-border bg-surface px-layout-md py-layout-md shadow-surface md:space-y-6 md:px-layout-lg md:py-layout-lg">
-              {!hasPendingCloseoutApproval ? (
-                <div className="space-y-4">
-                  <div className="space-y-2">
-                    <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-                      Closeout workflow
-                    </p>
-                    <h2 className="font-display text-xl font-semibold text-foreground">
-                      {isRegisterCloseoutSyncReview
-                        ? "Closeout review pending"
-                        : "Count and close drawer"}
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                      {isRegisterCloseoutSyncReview
-                        ? "Synced count is waiting for review."
-                        : "Submit the cash count, then resolve any variance approval before closing."}
-                    </p>
-                  </div>
-
-                  {isRegisterCloseoutSyncReview ? (
-                    <div className="rounded-lg border border-border bg-muted/20 p-4">
-                      <dl className="grid gap-3 text-sm sm:grid-cols-3">
-                        <div className="space-y-1">
-                          <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Expected
-                          </dt>
-                          <dd className="font-numeric tabular-nums text-foreground">
-                            {formatCurrency(currency, displayedExpectedCash)}
-                          </dd>
-                        </div>
-                        <div className="space-y-1">
-                          <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Counted
-                          </dt>
-                          <dd className="font-numeric tabular-nums text-foreground">
-                            {formatCurrency(currency, displayedCountedCash)}
-                          </dd>
-                        </div>
-                        <div className="space-y-1">
-                          <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Variance
-                          </dt>
-                          <dd
-                            className={`font-numeric tabular-nums ${getVarianceTone(displayedVariance ?? undefined)}`}
-                          >
-                            {formatCurrency(currency, displayedVariance ?? 0)}
-                          </dd>
-                        </div>
-                      </dl>
-                    </div>
-                  ) : registerSession?.status === "closed" ||
-                    registerSession?.status === "closeout_rejected" ? (
-                    <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-4">
-                      <div className="flex items-center justify-between gap-3">
-                        <p className="text-sm font-medium text-foreground">
-                          {registerSession.status === "closeout_rejected"
-                            ? "Closeout rejected"
-                            : "Closeout complete"}
-                        </p>
-                        <Badge
-                          className="border-border bg-muted text-muted-foreground"
-                          size="sm"
-                          variant="outline"
-                        >
-                          {registerSession.status === "closeout_rejected"
-                            ? "Rejected"
-                            : "Closed"}
-                        </Badge>
-                      </div>
-                      <dl
-                        className={cn(
-                          "grid gap-3 text-sm",
-                          pendingCashVoidApprovedExpectedCash !== undefined
-                            ? "sm:grid-cols-4"
-                            : "sm:grid-cols-3",
-                        )}
-                      >
-                        <div className="space-y-1">
-                          <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            {pendingCashVoidText
-                              ? "Expected now"
-                              : "Expected"}
-                          </dt>
-                          <dd className="font-numeric tabular-nums text-foreground">
-                            {formatCurrency(currency, expectedCash)}
-                          </dd>
-                        </div>
-                        {pendingCashVoidApprovedExpectedCash !== undefined ? (
-                          <div className="space-y-1">
-                            <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                              After adjustments
-                            </dt>
-                            <dd className="font-numeric tabular-nums text-foreground">
-                              {formatCurrency(
-                                currency,
-                                pendingCashVoidApprovedExpectedCash,
-                              )}
-                            </dd>
-                          </div>
-                        ) : null}
-                        <div className="space-y-1">
-                          <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Counted
-                          </dt>
-                          <dd className="font-numeric tabular-nums text-foreground">
-                            {formatCurrency(
-                              currency,
-                              registerSession.countedCash,
-                            )}
-                          </dd>
-                        </div>
-                        <div className="space-y-1">
-                          <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                            Variance
-                          </dt>
-                          <dd
-                            className={`font-numeric tabular-nums ${getVarianceTone(registerSession.variance)}`}
-                          >
-                            {formatCurrency(
-                              currency,
-                              registerSession.variance ?? 0,
-                            )}
-                          </dd>
-                        </div>
-                      </dl>
-                      {pendingCashVoidText ? (
-                        <p className="border-t border-border/70 pt-3 text-xs leading-5 text-muted-foreground">
-                          {pendingCashVoidText}
-                        </p>
-                      ) : null}
-                      <div className="space-y-3 border-t border-border/70 pt-3">
-                        <p className="text-sm leading-relaxed text-muted-foreground">
-                          {registerSession.status === "closeout_rejected"
-                            ? "Manager approval is required to reopen this rejected closeout before a corrected count can be submitted."
-                            : "Reopen the closeout to submit a corrected count. The saved closeout stays in the drawer history."}
-                        </p>
-                        <LoadingButton
-                          className="w-full justify-center"
-                          disabled={pendingCloseoutAction === "reopen"}
-                          isLoading={pendingCloseoutAction === "reopen"}
-                          onClick={() => void handleReopenClosedCloseout()}
-                          type="button"
-                          variant="outline"
-                        >
-                          <RotateCcw className="h-3.5 w-3.5" />
-                          Reopen closeout
-                        </LoadingButton>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="space-y-4">
-                      {registerSessionSnapshot?.closeoutReview ? (
-                        <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-4">
-                          <p className="text-sm font-medium text-foreground">
-                            {isReopenedCloseoutCorrection
-                              ? "Previous submitted closeout"
-                              : "Submitted closeout"}
-                          </p>
-                          <dl className="flex flex-wrap gap-x-4 gap-y-3 text-sm">
-                            <div className="min-w-[6rem] flex-1 space-y-1">
-                              <dt className="text-[11px] uppercase leading-4 tracking-[0.14em] text-muted-foreground">
-                                {pendingCashVoidText
-                                  ? "Expected now"
-                                  : "Expected"}
-                              </dt>
-                              <dd className="font-numeric tabular-nums text-foreground">
-                                {formatCurrency(currency, expectedCash)}
-                              </dd>
-                            </div>
-                            {pendingCashVoidApprovedExpectedCash !== undefined ? (
-                              <div className="min-w-[8.5rem] flex-1 space-y-1">
-                                <dt className="text-[11px] uppercase leading-4 tracking-[0.14em] text-muted-foreground">
-                                  After adjustments
-                                </dt>
-                                <dd className="font-numeric tabular-nums text-foreground">
-                                  {formatCurrency(
-                                    currency,
-                                    pendingCashVoidApprovedExpectedCash,
-                                  )}
-                                </dd>
-                              </div>
-                            ) : null}
-                            <div className="min-w-[5.5rem] flex-1 space-y-1">
-                              <dt className="text-[11px] uppercase leading-4 tracking-[0.14em] text-muted-foreground">
-                                Counted
-                              </dt>
-                              <dd className="font-numeric tabular-nums text-foreground">
-                                {formatCurrency(
-                                  currency,
-                                  registerSessionSnapshot.registerSession
-                                    .countedCash,
-                                )}
-                              </dd>
-                            </div>
-                            <div className="min-w-[5.5rem] flex-1 space-y-1">
-                              <dt className="text-[11px] uppercase leading-4 tracking-[0.14em] text-muted-foreground">
-                                Variance
-                              </dt>
-                              <dd
-                                className={`font-numeric tabular-nums ${getVarianceTone(registerSessionSnapshot.closeoutReview.variance)}`}
-                              >
-                                {formatCurrency(
-                                  currency,
-                                  registerSessionSnapshot.closeoutReview
-                                    .variance,
-                                )}
-                              </dd>
-                            </div>
-                          </dl>
-                          {pendingCashVoidText ? (
-                            <p className="border-t border-border/70 pt-3 text-xs leading-5 text-muted-foreground">
-                              {pendingCashVoidText}
-                            </p>
-                          ) : null}
-                          <p className="text-sm text-muted-foreground">
-                            Approval required:{" "}
-                            {registerSessionSnapshot.closeoutReview
-                              .requiresApproval
-                              ? "Yes"
-                              : "No"}
-                          </p>
-                          {formattedCloseoutReviewReason ? (
-                            <p className="max-w-full overflow-hidden break-words text-sm leading-relaxed text-foreground">
-                              {formattedCloseoutReviewReason}
-                            </p>
-                          ) : null}
-                        </div>
-                      ) : null}
-
-                      {canFinalizeCloseout ? (
-                        <div className="space-y-3 rounded-lg border border-border bg-background p-4">
-                          <div className="space-y-1">
-                            <p className="text-sm font-medium text-foreground">
-                              Ready for final closeout
-                            </p>
-                            <p className="text-sm leading-6 text-muted-foreground">
-                              Pending register corrections are resolved. Finalize
-                              this submitted closeout against the current
-                              expected cash.
-                            </p>
-                          </div>
-                          <LoadingButton
-                            className="w-full"
-                            disabled={Boolean(pendingCloseoutAction)}
-                            isLoading={pendingCloseoutAction === "finalize"}
-                            onClick={() => void handleFinalizeCloseout()}
-                            type="button"
-                            variant="workflow"
-                          >
-                            Finalize closeout
-                          </LoadingButton>
-                        </div>
-                      ) : null}
-
-                      {!canFinalizeCloseout && !isWaitingOnVoidReview ? (
-                        <>
-                          <label className="block space-y-2">
-                            <span className="text-sm font-medium text-foreground">
-                              Counted cash ({formattedCurrency})
-                            </span>
-                            <Input
-                              aria-label="Closeout counted cash"
-                              className="border-input bg-background"
-                              inputMode="decimal"
-                              onChange={(event) =>
-                                setCountedCash(event.target.value)
-                              }
-                              pattern="[0-9]*[.]?[0-9]*"
-                              type="text"
-                              value={countedCash}
-                            />
-                          </label>
-
-                          <div className="rounded-lg border border-border bg-muted/20 p-4">
-                            <dl
-                              className={cn(
-                                "grid gap-3 text-sm",
-                                pendingCashVoidApprovedExpectedCash !==
-                                  undefined
-                                  ? "grid-cols-3"
-                                  : "grid-cols-2",
-                              )}
-                            >
-                              <div className="space-y-1">
-                                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                                  {pendingCashVoidText
-                                    ? "Expected now"
-                                    : "Expected"}
-                                </dt>
-                                <dd className="font-numeric tabular-nums text-foreground">
-                                  {formatCurrency(currency, expectedCash)}
-                                </dd>
-                              </div>
-                              {pendingCashVoidApprovedExpectedCash !==
-                              undefined ? (
-                                <div className="space-y-1">
-                                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                                    After adjustments
-                                  </dt>
-                                  <dd className="font-numeric tabular-nums text-foreground">
-                                    {formatCurrency(
-                                      currency,
-                                      pendingCashVoidApprovedExpectedCash,
-                                    )}
-                                  </dd>
-                                </div>
-                              ) : null}
-                              <div className="space-y-1">
-                                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                                  Draft variance
-                                </dt>
-                                <dd
-                                  className={`font-numeric tabular-nums ${getVarianceTone(draftVariance ?? undefined)}`}
-                                >
-                                  {draftVariance === null
-                                    ? "Pending count"
-                                    : formatCurrency(currency, draftVariance)}
-                                </dd>
-                              </div>
-                            </dl>
-                            {pendingCashVoidText ? (
-                              <p className="mt-4 border-t border-border pt-3 text-xs leading-5 text-muted-foreground">
-                                {pendingCashVoidText}
-                              </p>
-                            ) : null}
-                          </div>
-
-                          <label className="block space-y-2">
-                            <span className="text-sm font-medium text-foreground">
-                              Closeout notes
-                            </span>
-                            <Textarea
-                              aria-label="Closeout notes"
-                              className="min-h-[96px] border-input bg-background"
-                              onChange={(event) =>
-                                setCloseoutNotes(event.target.value)
-                              }
-                              placeholder="Add drawer notes if anything needs follow-up."
-                              value={closeoutNotes}
-                            />
-                          </label>
-
-                          <LoadingButton
-                            className="w-full"
-                            disabled={Boolean(pendingCloseoutAction)}
-                            isLoading={pendingCloseoutAction === "submit"}
-                            onClick={() => void handleSubmitCloseout()}
-                            type="button"
-                            variant="workflow"
-                          >
-                            Submit closeout
-                          </LoadingButton>
-                        </>
-                      ) : null}
-                    </div>
-                  )}
-
-                  {closeoutErrorMessage ? (
-                    <p className="text-sm text-destructive" role="alert">
-                      {closeoutErrorMessage}
-                    </p>
-                  ) : null}
-                </div>
-              ) : null}
-
-              <div
-                className={
-                  hasPendingCloseoutApproval
-                    ? ""
-                    : "border-t border-border/70 pt-6"
-                }
-              >
-                <div className="space-y-1">
-                  <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
-                    Action
-                  </p>
-                  <h2 className="font-display text-xl font-semibold text-foreground">
-                    Record cash deposit
-                  </h2>
-                  <p className="text-sm text-muted-foreground">
-                    Capture the next safe drop for this register session.
-                  </p>
-                </div>
-
-                <div className="mt-4 space-y-4">
-                  <label className="block space-y-2">
-                    <span className="text-sm font-medium text-foreground">
-                      Amount
-                    </span>
-                    <Input
-                      aria-label="Deposit amount"
-                      className="border-input bg-background"
-                      disabled={isDepositActionLocked}
-                      min={0}
-                      onChange={(event) => setAmount(event.target.value)}
-                      step="1"
-                      type="number"
-                      value={amount}
-                    />
-                  </label>
-
-                  <label className="block space-y-2">
-                    <span className="text-sm font-medium text-foreground">
-                      Reference
-                    </span>
-                    <Input
-                      aria-label="Deposit reference"
-                      className="border-input bg-background"
-                      disabled={isDepositActionLocked}
-                      onChange={(event) => setReference(event.target.value)}
-                      placeholder="BANK-123"
-                      value={reference}
-                    />
-                  </label>
-
-                  <label className="block space-y-2">
-                    <span className="text-sm font-medium text-foreground">
-                      Notes
-                    </span>
-                    <Textarea
-                      aria-label="Deposit notes"
-                      className="min-h-[110px] border-input bg-background"
-                      disabled={isDepositActionLocked}
-                      onChange={(event) => setNotes(event.target.value)}
-                      placeholder="Optional handoff or safe-drop notes."
-                      value={notes}
-                    />
-                  </label>
-
-                  {errorMessage ? (
-                    <p className="text-sm text-destructive" role="alert">
-                      {errorMessage}
-                    </p>
-                  ) : null}
-
-                  <LoadingButton
-                    className="w-full"
-                    disabled={isRecordingDeposit || isDepositActionLocked}
-                    isLoading={isRecordingDeposit}
-                    onClick={() => void handleRecordDeposit()}
-                    type="button"
-                    variant={"workflow"}
-                  >
-                    Record deposit
-                  </LoadingButton>
-                </div>
-              </div>
-            </aside>
-          </div>
         </div>
       </FadeIn>
     </View>
@@ -5784,9 +5534,10 @@ export function RegisterSessionView() {
     canAccessProtectedSurface,
     canQueryProtectedData,
     hasFullAdminAccess,
+    hasFinancialDetailsAccess,
     isAuthenticated,
     isLoadingAccess,
-  } = useProtectedAdminPageState({ surface: "store_day" });
+  } = useProtectedAdminPageState({ surface: "cash_controls" });
   const canAccessSurface = canAccessProtectedSurface ?? hasFullAdminAccess;
   const { user } = useAuth();
   const params = useParams({ strict: false }) as
@@ -5818,16 +5569,17 @@ export function RegisterSessionView() {
         }
       : "skip",
   );
-  const actorStaffProfileId = useMemo(
+  const actorStaffProfile = useMemo(
     () =>
       activeStaffProfiles?.find(
         (staffProfile) =>
           staffProfile.linkedUserId === user?._id &&
           staffProfile.storeId === activeStore?._id &&
           staffProfile.status === "active",
-      )?._id,
+      ),
     [activeStaffProfiles, activeStore?._id, user?._id],
   );
+  const actorStaffProfileId = actorStaffProfile?._id;
   const recordRegisterSessionDeposit = useMutation(
     api.cashControls.deposits.recordRegisterSessionDeposit,
   );
@@ -6270,6 +6022,7 @@ export function RegisterSessionView() {
     <RegisterSessionViewContent
       actorStaffProfileId={actorStaffProfileId}
       actorUserId={user?._id}
+      canViewFinancialDetails={hasFinancialDetailsAccess}
       currency={activeStore.currency || "USD"}
       isLoading={
         registerSessionSnapshot === undefined ||
@@ -6304,7 +6057,7 @@ export function RegisterSessionActivityView() {
     hasFullAdminAccess,
     isAuthenticated,
     isLoadingAccess,
-  } = useProtectedAdminPageState({ surface: "store_day" });
+  } = useProtectedAdminPageState({ surface: "cash_controls" });
   const canAccessSurface = canAccessProtectedSurface ?? hasFullAdminAccess;
   const params = useParams({ strict: false }) as
     | {

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx
@@ -266,7 +266,7 @@ export function RegisterSessionsView() {
     hasFullAdminAccess,
     isAuthenticated,
     isLoadingAccess,
-  } = useProtectedAdminPageState({ surface: "store_day" });
+  } = useProtectedAdminPageState({ surface: "cash_controls" });
   const canAccessSurface = canAccessProtectedSurface ?? hasFullAdminAccess;
   const params = useParams({ strict: false }) as
     | {

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -1396,6 +1396,48 @@ describe("DailyCloseViewContent", () => {
     );
   });
 
+  it("shows summary comparison deltas only when comparison access is allowed", () => {
+    const snapshotWithPriorDay: DailyCloseSnapshot = {
+      ...readySnapshot,
+      priorDaySummary: {
+        ...baseSummary,
+        currentDayCashTotal: 90000,
+        paymentTotals: [
+          { amount: 90000, method: "cash", transactionCount: 4 },
+          { amount: 1420, method: "card", transactionCount: 2 },
+          { amount: 5000, method: "mobile_money", transactionCount: 2 },
+        ],
+        totalSales: 251000,
+      },
+    };
+
+    const { rerender } = renderContent(snapshotWithPriorDay);
+
+    expect(screen.getAllByText(/vs prior day/i).length).toBeGreaterThan(0);
+
+    rerender(
+      <DailyCloseViewContent
+        canViewSummaryComparisons={false}
+        currency="GHS"
+        hasFinancialDetailsAccess
+        hasFullAdminAccess
+        isAuthenticated
+        isCompleting={false}
+        isLoadingAccess={false}
+        isLoadingSnapshot={false}
+        onComplete={vi.fn(async () => ok({ closeId: "close-1" }))}
+        orgUrlSlug="wigclub"
+        snapshot={snapshotWithPriorDay}
+        storeId={"store-1" as Id<"store">}
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.queryByText(/vs prior day/i)).not.toBeInTheDocument();
+    expect(screen.getByText("14 transactions")).toBeInTheDocument();
+    expect(screen.getByText("2 cash transactions")).toBeInTheDocument();
+  });
+
   it("redacts EOD Review financial details without manager access", async () => {
     const user = userEvent.setup();
     renderContent(blockedSnapshot, {
@@ -1955,6 +1997,44 @@ describe("DailyCloseViewContent", () => {
       dailyCloseId: "daily-close-1",
       reason: "Cash deposit corrected.",
     });
+  });
+
+  it("reopens completed close snapshots when broad access redacts the full close record", async () => {
+    const user = userEvent.setup();
+    const onReopen = vi.fn(async () => ok({ action: "reopened" }));
+
+    renderContent(
+      {
+        ...readySnapshot,
+        completedClose: {
+          dailyCloseId: "daily-close-1",
+          completedAt: Date.UTC(2026, 4, 7, 23, 15),
+          completedByStaffName: "Ama Mensah",
+          restrictedDetailsRedacted: true,
+        },
+        existingClose: null,
+        status: "completed",
+      },
+      { onReopen },
+    );
+
+    await user.type(
+      screen.getByLabelText("Reopen reason"),
+      "Cash deposit corrected.",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Reopen EOD Review" }),
+    );
+
+    expect(onReopen).toHaveBeenCalledWith({
+      dailyCloseId: "daily-close-1",
+      reason: "Cash deposit corrected.",
+    });
+    expect(
+      screen.queryByText(
+        "end of day review record unavailable. Refresh before reopening.",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("does not show reopen for superseded or already reopened close records", () => {

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -163,6 +163,7 @@ export type DailyCloseSnapshot = {
   blockers: DailyCloseItem[];
   carryForwardItems: DailyCloseItem[];
   completedClose?: {
+    dailyCloseId?: Id<"dailyClose"> | string;
     actorType?: "human" | "automation";
     automationDecisionReason?: string | null;
     automationPolicyVersion?: string | null;
@@ -302,6 +303,7 @@ type BucketConfig = {
 };
 
 type DailyCloseViewContentProps = {
+  canViewSummaryComparisons?: boolean;
   currency: string;
   hasFinancialDetailsAccess: boolean;
   hasFullAdminAccess: boolean;
@@ -1911,6 +1913,7 @@ function normalizeCompletedReportSnapshot(
     blockers: [],
     carryForwardItems: storedSnapshot.carryForwardItems ?? [],
     completedClose: {
+      dailyCloseId: snapshot.completedClose?.dailyCloseId,
       completedAt:
         storedSnapshot.closeMetadata.completedAt ??
         snapshot.completedClose?.completedAt,
@@ -2806,11 +2809,13 @@ function TransactionReportAction({
 
 export function DailyCloseReadOnlyReport({
   canViewFinancialDetails = true,
+  canViewSummaryComparisons = canViewFinancialDetails,
   currency,
   orgUrlSlug,
   snapshot,
   storeUrlSlug,
 }: {
+  canViewSummaryComparisons?: boolean;
   canViewFinancialDetails?: boolean;
   currency: string;
   orgUrlSlug: string;
@@ -2837,6 +2842,7 @@ export function DailyCloseReadOnlyReport({
   const otherPaymentTotals = getOtherPaymentTotals(displaySnapshot.summary);
   const priorDaySummary = displaySnapshot.priorDaySummary ?? undefined;
   const priorWindowLabel = getPriorWindowLabel(displaySnapshot.operatingDate);
+  const shouldShowSummaryComparisons = canViewSummaryComparisons;
 
   return (
     <PageWorkspace>
@@ -2887,6 +2893,7 @@ export function DailyCloseReadOnlyReport({
                 ? getSummaryAmount(priorDaySummary, "totalSales", "salesTotal")
                 : undefined,
               priorWindowLabel,
+              showComparison: shouldShowSummaryComparisons,
             })}
             label={salesMetricLabels.netSales}
             link={{
@@ -2933,6 +2940,7 @@ export function DailyCloseReadOnlyReport({
                   )
                 : undefined,
               priorWindowLabel,
+              showComparison: shouldShowSummaryComparisons,
             })}
             label={salesMetricLabels.cash}
             link={{
@@ -2968,6 +2976,7 @@ export function DailyCloseReadOnlyReport({
                   paymentTotal.method,
                 ),
                 priorWindowLabel,
+                showComparison: shouldShowSummaryComparisons,
               })}
               key={paymentTotal.method}
               label={formatPaymentMethodLabel(paymentTotal.method)}
@@ -3431,6 +3440,7 @@ function CompletionRail({
 }
 
 export function DailyCloseViewContent({
+  canViewSummaryComparisons,
   currency,
   hasFinancialDetailsAccess,
   hasFullAdminAccess,
@@ -3549,6 +3559,8 @@ export function DailyCloseViewContent({
   const priorWindowLabel = displaySnapshot
     ? getPriorWindowLabel(displaySnapshot.operatingDate)
     : "yesterday";
+  const shouldShowSummaryComparisons =
+    canViewSummaryComparisons ?? hasFullAdminAccess;
   const buckets = displaySnapshot ? getBucketConfigs(displaySnapshot) : [];
   const defaultBucketValue = displaySnapshot
     ? getDefaultBucketValue(displaySnapshot, status)
@@ -3619,7 +3631,8 @@ export function DailyCloseViewContent({
 
     setCommandMessage(null);
 
-    const dailyCloseId = snapshot.existingClose?._id;
+    const dailyCloseId =
+      snapshot.existingClose?._id ?? snapshot.completedClose?.dailyCloseId;
 
     if (!dailyCloseId) {
       setCommandMessage({
@@ -3850,6 +3863,7 @@ export function DailyCloseViewContent({
                     )
                   : undefined,
                 priorWindowLabel,
+                showComparison: shouldShowSummaryComparisons,
               })}
               label={salesMetricLabels?.netSales ?? "Net sales"}
               link={{
@@ -3896,6 +3910,7 @@ export function DailyCloseViewContent({
                     )
                   : undefined,
                 priorWindowLabel,
+                showComparison: shouldShowSummaryComparisons,
               })}
               label={salesMetricLabels?.cash ?? "Cash"}
               link={{
@@ -3931,6 +3946,7 @@ export function DailyCloseViewContent({
                     paymentTotal.method,
                   ),
                   priorWindowLabel,
+                  showComparison: shouldShowSummaryComparisons,
                 })}
                 key={paymentTotal.method}
                 label={formatPaymentMethodLabel(paymentTotal.method)}
@@ -4232,6 +4248,7 @@ function DailyCloseConnectedView({
   return (
     <DailyCloseViewContent
       currency={activeStore?.currency || "USD"}
+      canViewSummaryComparisons={hasFullAdminAccess}
       hasFinancialDetailsAccess={hasFinancialDetailsAccess}
       hasFullAdminAccess={canAccessSurface}
       isAuthenticated={isAuthenticated}

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1365,6 +1365,22 @@ describe("DailyOperationsViewContent", () => {
     expect(closeAutomationLink).toHaveClass("sm:ml-layout-md", "self-start");
   });
 
+  it("hides automation status evidence when full admin access is not active", () => {
+    renderContent(automationSnapshot, {
+      canViewAutomationStatuses: false,
+    });
+
+    expect(screen.queryByText("Athena automation")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Athena started Opening Handoff."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", {
+        name: "Open Opening Handoff automation source",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows Athena completion attribution for a closed store day", () => {
     renderContent({
       ...closedSnapshot,
@@ -2706,6 +2722,29 @@ describe("DailyOperationsView", () => {
     expect(
       screen.getByText("Athena started Opening Handoff."),
     ).toBeInTheDocument();
+  });
+
+  it("does not subscribe to automation statuses without full admin access", () => {
+    mockedHooks.useProtectedAdminPageState.mockReturnValue({
+      activeStore: { _id: "store-1", currency: "GHS" },
+      canAccessProtectedSurface: true,
+      canQueryProtectedData: true,
+      hasFinancialDetailsAccess: true,
+      hasFullAdminAccess: false,
+      isAuthenticated: true,
+      isLoadingAccess: false,
+    });
+    mockedHooks.useQuery.mockImplementation((_query, args) =>
+      args === "skip" ? undefined : operatingSnapshot,
+    );
+
+    render(<DailyOperationsView />);
+
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOperationsAutomationSnapshot,
+      "skip",
+    );
+    expect(screen.queryByText("Athena automation")).not.toBeInTheDocument();
   });
 
   it("hydrates analytics detail on initial load for an uncached week", () => {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -338,6 +338,7 @@ type DailyOperationsViewContentProps = {
   cachedWeekMetrics?: DailyOperationsSnapshot["weekMetrics"];
   cachedWeekStorePulse?: StorePulseSummary | null;
   currency: string;
+  canViewAutomationStatuses?: boolean;
   hasDetailSnapshot: boolean;
   hasFullAdminAccess: boolean;
   hasFinancialDetailsAccess: boolean;
@@ -3065,6 +3066,7 @@ export function DailyOperationsViewContent({
   cachedWeekAnalyticsFetchedAt,
   cachedWeekMetrics,
   cachedWeekStorePulse,
+  canViewAutomationStatuses,
   currency,
   hasDetailSnapshot,
   hasFullAdminAccess,
@@ -3095,6 +3097,8 @@ export function DailyOperationsViewContent({
   timelineSnapshot,
 }: DailyOperationsViewContentProps) {
   const [localTimelineSheetOpen, setLocalTimelineSheetOpen] = useState(false);
+  const shouldShowAutomationStatuses =
+    canViewAutomationStatuses ?? hasFullAdminAccess;
   const isMobile = useIsMobile();
   const isTimelineSheetOpen =
     controlledTimelineSheetOpen ?? localTimelineSheetOpen;
@@ -3332,7 +3336,7 @@ export function DailyOperationsViewContent({
                   </div>
                 </div>
 
-                {!isHistoricalDate ? (
+                {!isHistoricalDate && shouldShowAutomationStatuses ? (
                   <>
                     <AutomationStatusPanel
                       orgUrlSlug={orgUrlSlug}
@@ -3937,7 +3941,9 @@ function DailyOperationsConnectedView({
   ) as DailyOperationsStoreRequestsSnapshot | undefined;
   const automationSnapshot = useExpectedDailyOperationsQuery(
     getDailyOperationsAutomationSnapshot ?? getDailyOperationsSnapshot,
-    getDailyOperationsAutomationSnapshot && canQueryProtectedData
+    getDailyOperationsAutomationSnapshot &&
+      canQueryProtectedData &&
+      hasFullAdminAccess
       ? snapshotArgs
       : "skip",
   ) as DailyOperationsAutomationSnapshot | undefined;
@@ -4208,6 +4214,7 @@ function DailyOperationsConnectedView({
         cachedDaySnapshotEntry?.hasDetail === true
       }
       hasFullAdminAccess={canAccessSurface}
+      canViewAutomationStatuses={hasFullAdminAccess}
       hasFinancialDetailsAccess={hasFinancialDetailsAccess}
       isAuthenticated={isAuthenticated}
       isLoadingAccess={isLoadingAccess}

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
@@ -41,6 +41,19 @@ vi.mock("convex/react", () => ({
   useQuery: (...args: unknown[]) => useQueryMock(...args),
 }));
 
+vi.mock("~/convex/_generated/api", () => ({
+  api: {
+    inventory: {
+      pos: {
+        getTodaySummary: "getTodaySummary",
+      },
+      storeSchedule: {
+        getStoreScheduleSummary: "getStoreScheduleSummary",
+      },
+    },
+  },
+}));
+
 vi.mock("recharts", () => ({
   Area: () => <path data-testid="store-pulse-area" />,
   AreaChart: ({ children }: { children?: React.ReactNode }) => (
@@ -143,79 +156,96 @@ describe("PointOfSaleView", () => {
       terminalSeed: null,
       source: "live",
     });
-    useQueryMock.mockReturnValue({
-      averageTransaction: 6_250,
-      date: "2026-06-20",
-      operatorSnapshot: {
-        busiestHour: {
-          hour: 14,
-          label: "2 PM",
-          totalSales: 12_500,
-          transactionCount: 2,
-        },
-        comparison: {
-          averageTransactionDeltaPercent: 25,
-          currentAverageTransaction: 6_250,
-          currentItemsSold: 3,
-          currentSales: 12_500,
-          currentTransactions: 2,
-          itemsSoldDeltaPercent: 50,
-          salesDeltaPercent: 25,
-          transactionDeltaPercent: 0,
-          yesterdayAverageTransaction: 5_000,
-          yesterdayItemsSold: 2,
-          yesterdaySales: 10_000,
-          yesterdayTransactions: 2,
-        },
-        historyDays: 14,
-        isLimited: false,
-        paymentMix: [
-          {
-            count: 1,
-            label: "Cash",
-            method: "cash",
-            share: 60,
-            total: 7_500,
+    useQueryMock.mockImplementation((query) => {
+      if (query === "getStoreScheduleSummary") {
+        return {
+          context: {
+            nextWindow: {
+              localDate: "2026-07-08",
+              localStartLabel: "09:00",
+            },
+            timezone: "Africa/Accra",
           },
-          {
-            count: 1,
-            label: "Card",
-            method: "card",
-            share: 40,
-            total: 5_000,
+          schedule: {
+            timezone: "Africa/Accra",
           },
-        ],
-        topItems: [
-          {
-            name: "Braiding hair",
-            productSku: "BRAID-1",
-            quantity: 2,
-            totalSales: 8_000,
-          },
-        ],
-        trend: [
-          {
-            averageTransaction: 0,
-            date: "2026-06-19",
-            label: "Jun 19",
-            totalItemsSold: 0,
-            totalSales: 0,
-            transactionCount: 0,
-          },
-          {
-            averageTransaction: 6_250,
-            date: "2026-06-20",
-            label: "Jun 20",
-            totalItemsSold: 3,
+        };
+      }
+
+      return {
+        averageTransaction: 6_250,
+        date: "2026-06-20",
+        operatorSnapshot: {
+          busiestHour: {
+            hour: 14,
+            label: "2 PM",
             totalSales: 12_500,
             transactionCount: 2,
           },
-        ],
-        usableHistoryDays: 1,
-      },
-      totalItemsSold: 3,
-      totalSales: 12_500,
-      totalTransactions: 2,
+          comparison: {
+            averageTransactionDeltaPercent: 25,
+            currentAverageTransaction: 6_250,
+            currentItemsSold: 3,
+            currentSales: 12_500,
+            currentTransactions: 2,
+            itemsSoldDeltaPercent: 50,
+            salesDeltaPercent: 25,
+            transactionDeltaPercent: 0,
+            yesterdayAverageTransaction: 5_000,
+            yesterdayItemsSold: 2,
+            yesterdaySales: 10_000,
+            yesterdayTransactions: 2,
+          },
+          historyDays: 14,
+          isLimited: false,
+          paymentMix: [
+            {
+              count: 1,
+              label: "Cash",
+              method: "cash",
+              share: 60,
+              total: 7_500,
+            },
+            {
+              count: 1,
+              label: "Card",
+              method: "card",
+              share: 40,
+              total: 5_000,
+            },
+          ],
+          topItems: [
+            {
+              name: "Braiding hair",
+              productSku: "BRAID-1",
+              quantity: 2,
+              totalSales: 8_000,
+            },
+          ],
+          trend: [
+            {
+              averageTransaction: 0,
+              date: "2026-06-19",
+              label: "Jun 19",
+              totalItemsSold: 0,
+              totalSales: 0,
+              transactionCount: 0,
+            },
+            {
+              averageTransaction: 6_250,
+              date: "2026-06-20",
+              label: "Jun 20",
+              totalItemsSold: 3,
+              totalSales: 12_500,
+              transactionCount: 2,
+            },
+          ],
+          usableHistoryDays: 1,
+        },
+        totalItemsSold: 3,
+        totalSales: 12_500,
+        totalTransactions: 2,
+      };
     });
   });
 
@@ -225,6 +255,12 @@ describe("PointOfSaleView", () => {
     expect(
       screen.getByRole("heading", { level: 1, name: "Point of Sale" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Store time")).toBeInTheDocument();
+    expect(screen.getByText("Next opening")).toBeInTheDocument();
+    expect(screen.getByText("Wed, Jul 8 9:00 AM")).toBeInTheDocument();
+    expect(useQueryMock).toHaveBeenCalledWith("getStoreScheduleSummary", {
+      storeId: "store-1",
+    });
   });
 
   it("prewarms register metadata without refreshing full availability from the POS landing page", () => {
@@ -287,7 +323,7 @@ describe("PointOfSaleView", () => {
     const { rerender } = render(<PointOfSaleView />);
 
     await user.click(screen.getByRole("tab", { name: "This month" }));
-    expect(useQueryMock).toHaveBeenLastCalledWith(expect.anything(), {
+    expect(useQueryMock).toHaveBeenCalledWith("getTodaySummary", {
       pulseWindow: "this_month",
       storeId: "store-1",
     });
@@ -301,7 +337,7 @@ describe("PointOfSaleView", () => {
 
     rerender(<PointOfSaleView />);
 
-    expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
+    expect(useQueryMock).toHaveBeenCalledWith("getTodaySummary", {
       pulseWindow: "today",
       storeId: "store-1",
     });
@@ -328,7 +364,7 @@ describe("PointOfSaleView", () => {
     expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(4);
   });
 
-  it("links POS users to terminal health from the POS landing page", () => {
+  it("links manager-level users to terminal health from the POS landing page", () => {
     render(<PointOfSaleView />);
 
     const link = screen.getByRole("link", { name: /Terminal Health/i });
@@ -353,7 +389,7 @@ describe("PointOfSaleView", () => {
     ).toBeInTheDocument();
   });
 
-  it("links POS-only users to POS settings from the POS landing page", () => {
+  it("hides manager-only POS launchers for POS-only sessions", () => {
     usePermissionsMock.mockReturnValue({
       canAccessPOS: () => true,
       hasFinancialDetailsAccess: false,
@@ -362,8 +398,21 @@ describe("PointOfSaleView", () => {
 
     render(<PointOfSaleView />);
 
-    const link = screen.getByRole("link", { name: /POS Settings/i });
+    expect(
+      screen.queryByRole("link", { name: /Product Lookup/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Terminal Health/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /POS Settings/i }),
+    ).not.toBeInTheDocument();
+  });
 
+  it("links manager-level users to POS settings from the POS landing page", () => {
+    render(<PointOfSaleView />);
+
+    const link = screen.getByRole("link", { name: /POS Settings/i });
     expect(link).toHaveAttribute("href", "/acme/store/downtown/pos/settings");
   });
 

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "convex/react";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { ComponentType, ReactNode } from "react";
+import { motion, useReducedMotion } from "framer-motion";
 import View from "../View";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { api } from "~/convex/_generated/api";
@@ -35,6 +36,21 @@ import {
   type POSStorePulseWindow,
 } from "./sales-pulse/POSSalesPulseView";
 
+type StoreScheduleWindowSummary = {
+  localDate: string;
+  localStartLabel: string;
+};
+
+type StoreScheduleSummaryResult = {
+  context?: {
+    nextWindow?: StoreScheduleWindowSummary | null;
+    timezone: string | null;
+  } | null;
+  schedule?: {
+    timezone: string;
+  } | null;
+} | null;
+
 type FeatureLinkProps = {
   children: ReactNode;
   className?: string;
@@ -53,6 +69,142 @@ type FeatureLinkProps = {
 };
 
 const FeatureLink = Link as unknown as ComponentType<FeatureLinkProps>;
+
+function formatStoreLocalDateTime(now: Date, timezone: string) {
+  try {
+    const dateLabel = new Intl.DateTimeFormat("en-US", {
+      day: "numeric",
+      month: "long",
+      timeZone: timezone,
+      weekday: "long",
+    }).format(now);
+    const timeLabel = new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: timezone,
+      timeZoneName: "short",
+    }).format(now);
+
+    return `${dateLabel} ${timeLabel}`;
+  } catch {
+    return null;
+  }
+}
+
+function formatStoreHoursTimeLabel(value: string) {
+  const raw = value.trim();
+  const twentyFourHourMatch = raw.match(/^([01]?\d|2[0-3]):([0-5]\d)$/);
+
+  if (!twentyFourHourMatch) {
+    return raw;
+  }
+
+  const hour = Number(twentyFourHourMatch[1]);
+  const minute = twentyFourHourMatch[2];
+  const period = hour >= 12 ? "PM" : "AM";
+  const displayHour = hour % 12 || 12;
+
+  return `${displayHour}:${minute} ${period}`;
+}
+
+function formatStoreLocalDateLabel(localDate: string) {
+  const date = new Date(`${localDate}T00:00:00.000Z`);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    weekday: "short",
+  }).format(date);
+}
+
+function formatNextOpeningLabel(nextWindow?: StoreScheduleWindowSummary | null) {
+  if (!nextWindow?.localStartLabel) {
+    return null;
+  }
+
+  const timeLabel = formatStoreHoursTimeLabel(nextWindow.localStartLabel);
+  const dateLabel = formatStoreLocalDateLabel(nextWindow.localDate);
+
+  return dateLabel ? `${dateLabel} ${timeLabel}` : timeLabel;
+}
+
+function useMinuteNow() {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const scheduleNextTick = () => {
+      const delay = 60_000 - (Date.now() % 60_000);
+
+      return window.setTimeout(() => {
+        setNow(new Date());
+        timeoutId = scheduleNextTick();
+      }, delay);
+    };
+
+    let timeoutId = scheduleNextTick();
+
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  return now;
+}
+
+function StoreLocalTime({
+  scheduleSummary,
+}: {
+  scheduleSummary: StoreScheduleSummaryResult | undefined;
+}) {
+  const shouldReduceMotion = useReducedMotion();
+  const now = useMinuteNow();
+  const timezone =
+    scheduleSummary?.context?.timezone ?? scheduleSummary?.schedule?.timezone;
+  const formattedTime = useMemo(
+    () => (timezone ? formatStoreLocalDateTime(now, timezone) : null),
+    [now, timezone],
+  );
+  const nextOpeningLabel = useMemo(
+    () => formatNextOpeningLabel(scheduleSummary?.context?.nextWindow ?? null),
+    [scheduleSummary?.context?.nextWindow],
+  );
+
+  return (
+    <span className="inline-grid min-h-6 items-center align-top">
+      {timezone && formattedTime ? (
+        <motion.span
+          animate={{ opacity: 1, transform: "translateY(0px)" }}
+          className="inline-flex flex-wrap items-center gap-x-3 gap-y-1 text-sm leading-6 text-muted-foreground"
+          initial={
+            shouldReduceMotion
+              ? { opacity: 0, transform: "translateY(0px)" }
+              : { opacity: 0, transform: "translateY(6px)" }
+          }
+          transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
+        >
+          <span className="font-medium text-foreground/85">Store time</span>
+          <span className="font-numeric tabular-nums">{formattedTime}</span>
+          {nextOpeningLabel ? (
+            <>
+              <span className="text-border" aria-hidden="true">
+                /
+              </span>
+              <span className="font-medium text-foreground/85">
+                Next opening
+              </span>
+              <span className="font-numeric tabular-nums">
+                {nextOpeningLabel}
+              </span>
+            </>
+          ) : null}
+        </motion.span>
+      ) : null}
+    </span>
+  );
+}
 
 export default function PointOfSaleView() {
   const { activeStore } = useGetActiveStore();
@@ -79,7 +231,8 @@ export default function PointOfSaleView() {
     refreshAvailabilitySnapshot: false,
     storeId: snapshotStoreId,
   });
-  const { canAccessPOS, hasFullAdminAccess } = usePermissions();
+  const { canAccessPOS, hasFinancialDetailsAccess, hasFullAdminAccess } =
+    usePermissions();
   const visibleStorePulseWindow = hasFullAdminAccess
     ? storePulseWindow
     : "today";
@@ -89,6 +242,10 @@ export default function PointOfSaleView() {
       ? { pulseWindow: visibleStorePulseWindow, storeId: snapshotStoreId }
       : "skip",
   );
+  const storeScheduleSummary = useQuery(
+    api.inventory.storeSchedule.getStoreScheduleSummary,
+    snapshotStoreId ? { storeId: snapshotStoreId } : "skip",
+  ) as StoreScheduleSummaryResult | undefined;
 
   // Currency formatter
   const currencyFormatter = useGetCurrencyFormatter();
@@ -141,7 +298,7 @@ export default function PointOfSaleView() {
       href: "/$orgUrlSlug/store/$storeUrlSlug/products" as const,
       params: liveLinkParams,
       color: "bg-green-500",
-      available: Boolean(liveLinkParams),
+      available: hasFinancialDetailsAccess && Boolean(liveLinkParams),
     },
 
     {
@@ -170,7 +327,8 @@ export default function PointOfSaleView() {
       href: "/$orgUrlSlug/store/$storeUrlSlug/pos/terminals" as const,
       params: liveLinkParams,
       color: "bg-emerald-600",
-      available: canAccessPOS() && Boolean(liveLinkParams),
+      available:
+        canAccessPOS() && hasFinancialDetailsAccess && Boolean(liveLinkParams),
     },
     {
       title: "Customers",
@@ -188,7 +346,8 @@ export default function PointOfSaleView() {
       href: "/$orgUrlSlug/store/$storeUrlSlug/pos/settings" as const,
       params: liveLinkParams,
       color: "bg-gray-500",
-      available: canAccessPOS() && Boolean(liveLinkParams),
+      available:
+        canAccessPOS() && hasFinancialDetailsAccess && Boolean(liveLinkParams),
     },
   ];
 
@@ -196,7 +355,12 @@ export default function PointOfSaleView() {
     <View hideBorder hideHeaderBottomBorder>
       <FadeIn className="container mx-auto py-layout-xl">
         <PageWorkspace>
-          <PageLevelHeader title="Point of Sale" />
+          <PageLevelHeader
+            title="Point of Sale"
+            description={
+              <StoreLocalTime scheduleSummary={storeScheduleSummary} />
+            }
+          />
 
           {/* POS Features Grid */}
           <div>

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -3783,9 +3783,9 @@ describe("POSRegisterView", () => {
       "href",
       "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/drawer-1?o=%252F",
     );
-    expect(screen.getByText("Expected")).toBeInTheDocument();
-    expect(screen.getByText("GH₵50")).toBeInTheDocument();
-    expect(screen.getByText("GH₵-5")).toBeInTheDocument();
+    expect(screen.queryByText("Expected")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵50")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵-5")).not.toBeInTheDocument();
     expect(screen.getByLabelText(/counted cash/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/closeout notes/i)).not.toBeRequired();
     expect(
@@ -3873,9 +3873,9 @@ describe("POSRegisterView", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Cloud session")).toBeInTheDocument();
     expect(screen.getByText("8980ZC")).toBeInTheDocument();
-    expect(screen.getByText("GH₵8,681")).toBeInTheDocument();
-    expect(screen.getByText("GH₵3,000")).toBeInTheDocument();
-    expect(screen.getByText("GH₵-5,681")).toBeInTheDocument();
+    expect(screen.queryByText("GH₵8,681")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵3,000")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵-5,681")).not.toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /cash controls/i }),
     ).toHaveAttribute(

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -64,6 +64,7 @@ describe("RegisterDrawerGate", () => {
 
   it("shows pesewa-level submitted closeout variances while whole cedi counts stay compact", () => {
     renderGate({
+      canViewCloseoutFinancials: true,
       closeoutSubmittedCountedCash: 10000,
       closeoutSubmittedVariance: 2,
       expectedCash: 10002,
@@ -78,6 +79,7 @@ describe("RegisterDrawerGate", () => {
 
   it("does not render a reopen action when no reopen handler is available", () => {
     renderGate({
+      canViewCloseoutFinancials: true,
       closeoutSubmittedCountedCash: 12500,
       closeoutSubmittedVariance: 2500,
       expectedCash: 10000,
@@ -95,6 +97,7 @@ describe("RegisterDrawerGate", () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     renderGate({
+      canViewCloseoutFinancials: true,
       closeoutSecondaryActionLabel: "Open replacement drawer",
       closeoutSubmittedCountedCash: 12500,
       closeoutSubmittedVariance: 2500,
@@ -117,6 +120,7 @@ describe("RegisterDrawerGate", () => {
 
   it("hides submitted closeout sign-out when no staff is signed in", () => {
     renderGate({
+      canViewCloseoutFinancials: true,
       closeoutSubmittedCountedCash: 780_000,
       closeoutSubmittedVariance: 40_000,
       expectedCash: 740_000,
@@ -134,6 +138,7 @@ describe("RegisterDrawerGate", () => {
 
   it("shows synced zero-variance closeouts as submitted instead of rendering the closeout form", () => {
     renderGate({
+      canViewCloseoutFinancials: true,
       closeoutSubmittedCountedCash: 10000,
       closeoutSubmittedReason: "pending_sync",
       closeoutSubmittedVariance: 0,
@@ -158,6 +163,7 @@ describe("RegisterDrawerGate", () => {
 
   it("shows pesewa-level draft closeout variances while whole cedi expected cash stays compact", () => {
     renderGate({
+      canViewCloseoutFinancials: true,
       closeoutCountedCash: "100.00",
       closeoutDraftVariance: -2,
       expectedCash: 10002,
@@ -168,8 +174,29 @@ describe("RegisterDrawerGate", () => {
     expect(screen.getByText("GH₵-0.02")).toHaveClass("text-danger");
   });
 
+  it("hides draft closeout financials from non-manager cashiers", () => {
+    renderGate({
+      canViewCloseoutFinancials: false,
+      closeoutCountedCash: "100.00",
+      closeoutDraftVariance: -2,
+      expectedCash: 10002,
+      mode: "closeoutBlocked",
+    });
+
+    expect(screen.queryByText("Expected")).not.toBeInTheDocument();
+    expect(screen.queryByText("Draft variance")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pending count")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵100.02")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵-0.02")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Counted cash (GH₵)")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Submit closeout" }),
+    ).toBeInTheDocument();
+  });
+
   it("calls out pending cash voids in the closeout expected cash context", () => {
     renderGate({
+      canViewCloseoutFinancials: true,
       closeoutCountedCash: "6100.00",
       closeoutDraftVariance: 0,
       expectedCash: 610000,

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -326,6 +326,8 @@ export function RegisterDrawerGate({
     const isSubmittedCloseout = Boolean(closeoutSubmittedReason);
     const isManagerReviewCloseout =
       closeoutSubmittedReason === "manager_review";
+    const canViewCloseoutFinancials =
+      drawerGate.canViewCloseoutFinancials === true;
     const closeoutRegisterLabel = formatRegisterGateLabel({
       registerLabel: drawerGate.registerLabel,
       registerNumber: drawerGate.registerNumber,
@@ -370,66 +372,68 @@ export function RegisterDrawerGate({
               </div>
             </div>
 
-            <div className="rounded-lg border border-warning/30 bg-warning/10 p-5">
-              <dl
-                className={`grid gap-4 text-sm ${
-                  pendingCashVoidApprovedExpectedCash !== undefined
-                    ? "sm:grid-cols-4"
-                    : "sm:grid-cols-3"
-                }`}
-              >
-                <div className="space-y-1">
-                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                    {pendingCashVoidText ? "Expected now" : "Expected"}
-                  </dt>
-                  <dd className="font-mono text-foreground">
-                    {formatCurrency(currency, drawerGate.expectedCash)}
-                  </dd>
-                </div>
-                {pendingCashVoidApprovedExpectedCash !== undefined ? (
+            {canViewCloseoutFinancials ? (
+              <div className="rounded-lg border border-warning/30 bg-warning/10 p-5">
+                <dl
+                  className={`grid gap-4 text-sm ${
+                    pendingCashVoidApprovedExpectedCash !== undefined
+                      ? "sm:grid-cols-4"
+                      : "sm:grid-cols-3"
+                  }`}
+                >
                   <div className="space-y-1">
                     <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                      After adjustments
+                      {pendingCashVoidText ? "Expected now" : "Expected"}
+                    </dt>
+                    <dd className="font-mono text-foreground">
+                      {formatCurrency(currency, drawerGate.expectedCash)}
+                    </dd>
+                  </div>
+                  {pendingCashVoidApprovedExpectedCash !== undefined ? (
+                    <div className="space-y-1">
+                      <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                        After adjustments
+                      </dt>
+                      <dd className="font-mono text-foreground">
+                        {formatCurrency(
+                          currency,
+                          pendingCashVoidApprovedExpectedCash,
+                        )}
+                      </dd>
+                    </div>
+                  ) : null}
+                  <div className="space-y-1">
+                    <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                      Counted
                     </dt>
                     <dd className="font-mono text-foreground">
                       {formatCurrency(
                         currency,
-                        pendingCashVoidApprovedExpectedCash,
+                        drawerGate.closeoutSubmittedCountedCash,
                       )}
                     </dd>
                   </div>
+                  <div className="space-y-1">
+                    <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                      Variance
+                    </dt>
+                    <dd
+                      className={`font-mono ${getVarianceTone(drawerGate.closeoutSubmittedVariance)}`}
+                    >
+                      {formatCurrency(
+                        currency,
+                        drawerGate.closeoutSubmittedVariance,
+                      )}
+                    </dd>
+                  </div>
+                </dl>
+                {pendingCashVoidText ? (
+                  <p className="mt-4 border-t border-warning/25 pt-3 text-xs leading-5 text-muted-foreground">
+                    {pendingCashVoidText}
+                  </p>
                 ) : null}
-                <div className="space-y-1">
-                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                    Counted
-                  </dt>
-                  <dd className="font-mono text-foreground">
-                    {formatCurrency(
-                      currency,
-                      drawerGate.closeoutSubmittedCountedCash,
-                    )}
-                  </dd>
-                </div>
-                <div className="space-y-1">
-                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                    Variance
-                  </dt>
-                  <dd
-                    className={`font-mono ${getVarianceTone(drawerGate.closeoutSubmittedVariance)}`}
-                  >
-                    {formatCurrency(
-                      currency,
-                      drawerGate.closeoutSubmittedVariance,
-                    )}
-                  </dd>
-                </div>
-              </dl>
-              {pendingCashVoidText ? (
-                <p className="mt-4 border-t border-warning/25 pt-3 text-xs leading-5 text-muted-foreground">
-                  {pendingCashVoidText}
-                </p>
-              ) : null}
-            </div>
+              </div>
+            ) : null}
 
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
               {drawerGate.onSubmit ? (
@@ -506,57 +510,59 @@ export function RegisterDrawerGate({
             </div>
 
             <form className="mt-8 space-y-5" onSubmit={handleCloseoutSubmit}>
-              <div className="rounded-lg border border-border bg-surface p-4">
-                <dl
-                  className={`grid gap-3 text-sm ${
-                    pendingCashVoidApprovedExpectedCash !== undefined
-                      ? "grid-cols-3"
-                      : "grid-cols-2"
-                  }`}
-                >
-                  <div className="space-y-1">
-                    <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                      {pendingCashVoidText ? "Expected now" : "Expected"}
-                    </dt>
-                    <dd className="font-mono text-foreground">
-                      {formatCurrency(currency, drawerGate.expectedCash)}
-                    </dd>
-                  </div>
-                  {pendingCashVoidApprovedExpectedCash !== undefined ? (
+              {canViewCloseoutFinancials ? (
+                <div className="rounded-lg border border-border bg-surface p-4">
+                  <dl
+                    className={`grid gap-3 text-sm ${
+                      pendingCashVoidApprovedExpectedCash !== undefined
+                        ? "grid-cols-3"
+                        : "grid-cols-2"
+                    }`}
+                  >
                     <div className="space-y-1">
                       <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                        After adjustments
+                        {pendingCashVoidText ? "Expected now" : "Expected"}
                       </dt>
                       <dd className="font-mono text-foreground">
-                        {formatCurrency(
-                          currency,
-                          pendingCashVoidApprovedExpectedCash,
-                        )}
+                        {formatCurrency(currency, drawerGate.expectedCash)}
                       </dd>
                     </div>
+                    {pendingCashVoidApprovedExpectedCash !== undefined ? (
+                      <div className="space-y-1">
+                        <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                          After adjustments
+                        </dt>
+                        <dd className="font-mono text-foreground">
+                          {formatCurrency(
+                            currency,
+                            pendingCashVoidApprovedExpectedCash,
+                          )}
+                        </dd>
+                      </div>
+                    ) : null}
+                    <div className="space-y-1">
+                      <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                        Draft variance
+                      </dt>
+                      <dd
+                        className={`font-mono ${getVarianceTone(drawerGate.closeoutDraftVariance)}`}
+                      >
+                        {drawerGate.closeoutDraftVariance === undefined
+                          ? "Pending count"
+                          : formatCurrency(
+                            currency,
+                            drawerGate.closeoutDraftVariance,
+                          )}
+                      </dd>
+                    </div>
+                  </dl>
+                  {pendingCashVoidText ? (
+                    <p className="mt-4 border-t border-border pt-3 text-xs leading-5 text-muted-foreground">
+                      {pendingCashVoidText}
+                    </p>
                   ) : null}
-                  <div className="space-y-1">
-                    <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                      Draft variance
-                    </dt>
-                    <dd
-                      className={`font-mono ${getVarianceTone(drawerGate.closeoutDraftVariance)}`}
-                    >
-                      {drawerGate.closeoutDraftVariance === undefined
-                        ? "Pending count"
-                        : formatCurrency(
-                          currency,
-                          drawerGate.closeoutDraftVariance,
-                        )}
-                    </dd>
-                  </div>
-                </dl>
-                {pendingCashVoidText ? (
-                  <p className="mt-4 border-t border-border pt-3 text-xs leading-5 text-muted-foreground">
-                    {pendingCashVoidText}
-                  </p>
-                ) : null}
-              </div>
+                </div>
+              ) : null}
 
               <label className="block space-y-2">
                 <span className="text-sm font-medium text-foreground">

--- a/packages/athena-webapp/src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
@@ -309,7 +309,7 @@ describe("POSStorePulseSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides financial sales cards when full admin access is not active", () => {
+  it("hides manager-only sales cards when full admin access is not active", () => {
     renderStorePulse({ hasFullAdminAccess: false });
 
     expect(screen.queryByText("Manager only")).not.toBeInTheDocument();
@@ -323,7 +323,7 @@ describe("POSStorePulseSection", () => {
     expect(screen.queryByText("Sales")).not.toBeInTheDocument();
     expect(screen.queryByText("Average sale")).not.toBeInTheDocument();
     expect(screen.getByText("Transactions")).toBeInTheDocument();
-    expect(screen.getByText("Items sold")).toBeInTheDocument();
+    expect(screen.queryByText("Items sold")).not.toBeInTheDocument();
     expect(screen.queryByText(/vs yesterday/)).not.toBeInTheDocument();
     expect(screen.queryByText("Sales trend")).not.toBeInTheDocument();
     expect(screen.queryByText("Top items")).not.toBeInTheDocument();
@@ -349,7 +349,7 @@ describe("POSStorePulseSection", () => {
     expect(screen.queryByText("Sales")).not.toBeInTheDocument();
     expect(screen.queryByText("Average sale")).not.toBeInTheDocument();
     expect(screen.getByText("Transactions")).toBeInTheDocument();
-    expect(screen.getByText("Items sold")).toBeInTheDocument();
+    expect(screen.queryByText("Items sold")).not.toBeInTheDocument();
     expect(screen.queryByText("Sales trend")).not.toBeInTheDocument();
     expect(screen.queryByText("Top items")).not.toBeInTheDocument();
     expect(screen.queryByText("How customers paid")).not.toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   registerTerminalMutation: vi.fn(),
   rotateRecoveryCode: vi.fn(),
   revokeRecoveryCode: vi.fn(),
+  updateRegisterCloseoutApprovalPolicy: vi.fn(),
   updateEodAutoCompletePolicy: vi.fn(),
   updateOpeningAutoStartPolicy: vi.fn(),
   unlockRecoveryCode: vi.fn(),
@@ -86,6 +87,8 @@ vi.mock("~/convex/_generated/api", () => ({
       dailyOperationsAutomation: {
         getEodAutoCompletePolicy: "getEodAutoCompletePolicy",
         getOpeningAutoStartPolicy: "getOpeningAutoStartPolicy",
+        getRegisterCloseoutApprovalPolicy: "getRegisterCloseoutApprovalPolicy",
+        updateRegisterCloseoutApprovalPolicy: "updateRegisterCloseoutApprovalPolicy",
         updateEodAutoCompletePolicy: "updateEodAutoCompletePolicy",
         updateOpeningAutoStartPolicy: "updateOpeningAutoStartPolicy",
       },
@@ -290,12 +293,18 @@ describe("registerAndProvisionPosTerminal", () => {
       maxVoidedSaleTotal: 2500,
       mode: "enabled",
     });
+    mocks.updateRegisterCloseoutApprovalPolicy.mockResolvedValue({
+      varianceApprovalThreshold: 7500,
+    });
     mocks.useMutation.mockImplementation((ref) => {
       if (ref === "updateOpeningAutoStartPolicy") {
         return mocks.updateOpeningAutoStartPolicy;
       }
       if (ref === "updateEodAutoCompletePolicy") {
         return mocks.updateEodAutoCompletePolicy;
+      }
+      if (ref === "updateRegisterCloseoutApprovalPolicy") {
+        return mocks.updateRegisterCloseoutApprovalPolicy;
       }
       if (ref === "rotateRecoveryCode") return mocks.rotateRecoveryCode;
       if (ref === "revokeRecoveryCode") return mocks.revokeRecoveryCode;
@@ -336,6 +345,13 @@ describe("registerAndProvisionPosTerminal", () => {
               maxVoidedSaleTotal: 2500,
               mode: "dry_run",
               operatingTimezoneOffsetMinutes: -120,
+            }
+        : ref === "getRegisterCloseoutApprovalPolicy"
+          ? {
+              requireManagerSignoffForAnyVariance: false,
+              requireManagerSignoffForOvers: false,
+              requireManagerSignoffForShorts: false,
+              varianceApprovalThreshold: 5000,
             }
         : ref === "getStoreScheduleSummary"
           ? {
@@ -688,6 +704,47 @@ describe("registerAndProvisionPosTerminal", () => {
     expect(mocks.useQuery).toHaveBeenCalledWith("getEodAutoCompletePolicy", {
       storeId: "store-1",
     });
+  });
+
+  it("lets full admins set the register closeout approval threshold", async () => {
+    const user = userEvent.setup();
+
+    await renderPOSSettingsView();
+
+    expect(
+      await screen.findByText("Closeout approval policy"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Set when register cash variances require manager review before final closeout.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Closeout variance threshold (GH₵)"),
+    ).toHaveValue(50);
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      "getRegisterCloseoutApprovalPolicy",
+      {
+        storeId: "store-1",
+      },
+    );
+
+    fireEvent.change(
+      screen.getByLabelText("Closeout variance threshold (GH₵)"),
+      {
+        target: { value: "75" },
+      },
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Save closeout approval policy" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.updateRegisterCloseoutApprovalPolicy).toHaveBeenCalledWith({
+        storeId: "store-1",
+        varianceApprovalThreshold: 7500,
+      }),
+    );
   });
 
   it("saves the EOD completion automation policy with thresholds", async () => {

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -411,6 +411,13 @@ type EodAutoCompletePolicy = {
   operatingTimezoneOffsetMinutes?: number | null;
 };
 
+type RegisterCloseoutApprovalPolicy = {
+  requireManagerSignoffForAnyVariance?: boolean | null;
+  requireManagerSignoffForOvers?: boolean | null;
+  requireManagerSignoffForShorts?: boolean | null;
+  varianceApprovalThreshold?: number | null;
+};
+
 type UpdateEodAutoCompletePolicy = (args: {
   cleanDayAutoCompleteEnabled: boolean;
   localCompletionWindowMinutes: number;
@@ -420,6 +427,11 @@ type UpdateEodAutoCompletePolicy = (args: {
   mode: AutomationPolicyMode;
   operatingTimezoneOffsetMinutes?: number;
   storeId: Id<"store">;
+}) => Promise<unknown>;
+
+type UpdateRegisterCloseoutApprovalPolicy = (args: {
+  storeId: Id<"store">;
+  varianceApprovalThreshold: number;
 }) => Promise<unknown>;
 
 type UpdateOpeningAutoStartPolicy = (args: {
@@ -658,6 +670,175 @@ function StoreHoursTimingReadout({
             Open Store Hours
           </HealthLink>
         ) : null}
+      </div>
+    </section>
+  );
+}
+
+function RegisterCloseoutApprovalPolicyAdminPanel({
+  currency,
+  storeId,
+}: {
+  currency: string;
+  storeId?: Id<"store"> | null;
+}) {
+  const { hasFullAdminAccess, isLoading } = usePermissions();
+  const policy = useQuery(
+    api.operations.dailyOperationsAutomation.getRegisterCloseoutApprovalPolicy,
+    !isLoading && hasFullAdminAccess && storeId
+      ? { storeId }
+      : "skip",
+  ) as RegisterCloseoutApprovalPolicy | null | undefined;
+  const updateRegisterCloseoutApprovalPolicy = useMutation(
+    api.operations.dailyOperationsAutomation.updateRegisterCloseoutApprovalPolicy,
+  ) as unknown as UpdateRegisterCloseoutApprovalPolicy;
+  const [varianceApprovalThreshold, setVarianceApprovalThreshold] =
+    useState("50");
+  const [isSaving, setIsSaving] = useState(false);
+  const [message, setMessage] = useState<{
+    kind: "error" | "success";
+    text: string;
+  } | null>(null);
+  const currencySymbol = currencyDisplaySymbol(currency);
+  const parsedVarianceApprovalThreshold = parseNonNegativeMoneyInput(
+    varianceApprovalThreshold,
+  );
+  const canSave =
+    Boolean(storeId) &&
+    parsedVarianceApprovalThreshold !== null &&
+    !isSaving;
+
+  useEffect(() => {
+    if (policy?.varianceApprovalThreshold == null) {
+      return;
+    }
+
+    setVarianceApprovalThreshold(
+      formatMinorUnitInputValue(policy.varianceApprovalThreshold),
+    );
+  }, [policy?.varianceApprovalThreshold]);
+
+  if (isLoading || !hasFullAdminAccess) {
+    return null;
+  }
+
+  const handleSave = async () => {
+    if (!storeId) {
+      setMessage({
+        kind: "error",
+        text: "Select a store before saving closeout approval policy.",
+      });
+      return;
+    }
+
+    if (parsedVarianceApprovalThreshold === null) {
+      setMessage({
+        kind: "error",
+        text: "Enter a valid closeout variance threshold.",
+      });
+      return;
+    }
+
+    setIsSaving(true);
+    setMessage(null);
+    try {
+      await updateRegisterCloseoutApprovalPolicy({
+        storeId,
+        varianceApprovalThreshold: parsedVarianceApprovalThreshold,
+      });
+      setMessage({
+        kind: "success",
+        text: "Closeout approval policy saved.",
+      });
+      toast.success("Closeout approval policy saved.");
+    } catch (error) {
+      console.error(error);
+      setMessage({
+        kind: "error",
+        text: "Closeout approval policy was not saved.",
+      });
+      toast.error("Closeout approval policy was not saved.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="grid gap-layout-xl border-b border-border py-layout-2xl lg:grid-cols-[17rem_minmax(0,1fr)]">
+      <div className="space-y-layout-sm">
+        <h2 className="text-2xl font-medium text-foreground">
+          Closeout approval policy
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Set when register cash variances require manager review before final
+          closeout.
+        </p>
+      </div>
+
+      <div className="space-y-layout-lg">
+        <div className="flex flex-wrap gap-layout-xs">
+          <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+            Manager review above threshold
+          </span>
+          {policy?.requireManagerSignoffForAnyVariance ? (
+            <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+              Any variance requires review
+            </span>
+          ) : null}
+          {policy?.requireManagerSignoffForOvers ? (
+            <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+              Overage review enabled
+            </span>
+          ) : null}
+          {policy?.requireManagerSignoffForShorts ? (
+            <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+              Shortage review enabled
+            </span>
+          ) : null}
+        </div>
+
+        <div className="max-w-[18rem] space-y-layout-xs">
+          <Label htmlFor="register-closeout-variance-threshold">
+            Closeout variance threshold ({currencySymbol})
+          </Label>
+          <Input
+            id="register-closeout-variance-threshold"
+            min={0}
+            onChange={(event) =>
+              setVarianceApprovalThreshold(event.target.value)
+            }
+            step="0.01"
+            type="number"
+            value={varianceApprovalThreshold}
+          />
+          <p className="text-sm leading-5 text-muted-foreground">
+            Variances greater than this amount require manager approval.
+          </p>
+        </div>
+
+        {message ? (
+          <div
+            className={
+              message.kind === "error"
+                ? "rounded-md border border-danger/20 bg-danger/10 px-layout-md py-layout-sm text-sm text-danger"
+                : "rounded-md border border-success/20 bg-success/10 px-layout-md py-layout-sm text-sm text-success"
+            }
+            role={message.kind === "error" ? "alert" : "status"}
+          >
+            {message.text}
+          </div>
+        ) : null}
+
+        <div className="border-t border-border pt-layout-md">
+          <LoadingButton
+            disabled={!canSave}
+            isLoading={isSaving}
+            onClick={handleSave}
+            variant="default"
+          >
+            Save closeout approval policy
+          </LoadingButton>
+        </div>
       </div>
     </section>
   );
@@ -2017,6 +2198,11 @@ export function POSSettingsView({
             orgUrlSlug={routeParams?.orgUrlSlug}
             storeId={activeStore?._id ?? null}
             storeUrlSlug={routeParams?.storeUrlSlug}
+          />
+
+          <RegisterCloseoutApprovalPolicyAdminPanel
+            currency={activeStore?.currency ?? "GHS"}
+            storeId={activeStore?._id ?? null}
           />
 
           <EodCompletionAutomationAdminPanel

--- a/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
+++ b/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
@@ -799,7 +799,7 @@ function StorePulseSkeleton({
 }) {
   const visibleLoadingMetrics = showFinancialSalesCards
     ? loadingMetrics
-    : loadingMetrics.slice(2);
+    : loadingMetrics.filter((metric) => metric.label === "Transactions");
 
   return (
     <div
@@ -995,21 +995,21 @@ export function StorePulseSummaryView({
                   label="Transactions"
                   value={totalTransactions}
                 />
-                <StorePulseMetric
-                  helper={
-                    canViewFinancialDetails
-                      ? copy.comparisonHelper
+                {canViewFinancialDetails ? (
+                  <StorePulseMetric
+                    helper={
+                      copy.comparisonHelper
                         ? formatComparisonHelper({
                             deltaPercent: comparison?.itemsSoldDeltaPercent,
                             priorValue: comparison?.yesterdayItemsSold,
                             priorWindowLabel: copy.comparisonHelper,
                           })
                         : "-"
-                      : undefined
-                  }
-                  label="Items sold"
-                  value={totalItemsSold}
-                />
+                    }
+                    label="Items sold"
+                    value={totalItemsSold}
+                  />
+                ) : null}
               </div>
             ) : null}
 

--- a/packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx
+++ b/packages/athena-webapp/src/components/traces/WorkflowTraceView.test.tsx
@@ -5,11 +5,16 @@ import type { Id } from "~/convex/_generated/dataModel";
 import { WorkflowTraceTimeline, WorkflowTraceView } from "./WorkflowTraceView";
 
 const mockedHooks = vi.hoisted(() => ({
+  useGetTerminal: vi.fn(),
   useQuery: vi.fn(),
 }));
 
 vi.mock("convex/react", () => ({
   useQuery: mockedHooks.useQuery,
+}));
+
+vi.mock("@/hooks/useGetTerminal", () => ({
+  useGetTerminal: mockedHooks.useGetTerminal,
 }));
 
 vi.mock("../common/PageHeader", () => ({
@@ -22,6 +27,9 @@ vi.mock("../common/PageHeader", () => ({
 describe("WorkflowTraceView", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
+    mockedHooks.useGetTerminal.mockReturnValue({
+      _id: "terminal-1",
+    });
   });
 
   afterEach(() => {
@@ -73,6 +81,11 @@ describe("WorkflowTraceView", () => {
       />,
     );
 
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(expect.anything(), {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      traceId: "repair_order:job-42",
+    });
     expect(screen.getAllByText("Succeeded").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Partial").length).toBeGreaterThan(0);
     const listItems = screen.getAllByRole("listitem");

--- a/packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx
+++ b/packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx
@@ -15,6 +15,7 @@ import {
 } from "../ui/tooltip";
 import { api } from "~/convex/_generated/api";
 import { capitalizeWords, getRelativeTime } from "~/src/lib/utils";
+import { useGetTerminal } from "@/hooks/useGetTerminal";
 
 export type WorkflowTraceHeaderModel = {
   health: string;
@@ -185,10 +186,12 @@ export function WorkflowTraceView({
   storeId: Id<"store">;
   traceId: string;
 }) {
+  const terminal = useGetTerminal();
   const workflowTrace = useQuery(
     api.workflowTraces.public.getWorkflowTraceViewById,
     {
       storeId,
+      terminalId: terminal?._id,
       traceId,
     },
   );

--- a/packages/athena-webapp/src/hooks/useProtectedAdminPageState.test.tsx
+++ b/packages/athena-webapp/src/hooks/useProtectedAdminPageState.test.tsx
@@ -62,4 +62,35 @@ describe("useProtectedAdminPageState", () => {
     expect(result.current.canQueryProtectedData).toBe(true);
     expect(result.current.hasFullAdminAccess).toBe(false);
   });
+
+  it("requires manager-level access for cash controls", () => {
+    mocks.usePermissions.mockReturnValue({
+      hasFinancialDetailsAccess: false,
+      hasFullAdminAccess: false,
+      hasStoreDaySurfaceAccess: true,
+      isLoading: false,
+    });
+
+    const denied = renderHook(() =>
+      useProtectedAdminPageState({ surface: "cash_controls" }),
+    );
+
+    expect(denied.result.current.canAccessProtectedSurface).toBe(false);
+    expect(denied.result.current.canQueryProtectedData).toBe(false);
+
+    mocks.usePermissions.mockReturnValue({
+      hasFinancialDetailsAccess: true,
+      hasFullAdminAccess: false,
+      hasStoreDaySurfaceAccess: true,
+      isLoading: false,
+    });
+
+    const elevated = renderHook(() =>
+      useProtectedAdminPageState({ surface: "cash_controls" }),
+    );
+
+    expect(elevated.result.current.canAccessProtectedSurface).toBe(true);
+    expect(elevated.result.current.canQueryProtectedData).toBe(true);
+    expect(elevated.result.current.hasFullAdminAccess).toBe(false);
+  });
 });

--- a/packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts
+++ b/packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts
@@ -2,7 +2,7 @@ import { useAuth } from "@/hooks/useAuth";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { usePermissions } from "@/hooks/usePermissions";
 
-type ProtectedSurfaceAccess = "full_admin" | "store_day";
+type ProtectedSurfaceAccess = "cash_controls" | "full_admin" | "store_day";
 
 export function useProtectedAdminPageState(
   options: { surface?: ProtectedSurfaceAccess } = {},
@@ -20,10 +20,13 @@ export function useProtectedAdminPageState(
   const fullAdminAccess = hasFullAdminAccess ?? canAccessOperations();
   const storeDaySurfaceAccess =
     hasStoreDaySurfaceAccess ?? canAccessOperations();
+  const cashControlsAccess = hasFinancialDetailsAccess ?? fullAdminAccess;
   const canAccessSurface =
-    options.surface === "store_day"
-      ? storeDaySurfaceAccess
-      : fullAdminAccess;
+    options.surface === "cash_controls"
+      ? cashControlsAccess
+      : options.surface === "store_day"
+        ? storeDaySurfaceAccess
+        : fullAdminAccess;
   const hasReadyAuthenticatedUser = Boolean(user);
   const isLoadingAccess = isLoadingPermissions || isLoadingUser || isLoadingStores;
   const canQueryProtectedData = Boolean(

--- a/packages/athena-webapp/src/lib/access/capabilities.test.ts
+++ b/packages/athena-webapp/src/lib/access/capabilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  canAccessCashControlsSurface,
   canAccessFullAdminSurface,
   canAccessStoreDaySurface,
   canViewFinancialDetails,
@@ -31,7 +32,7 @@ describe("surface capability access", () => {
     ).toBe(false);
   });
 
-  it("allows POS-only accounts to open store-day surfaces", () => {
+  it("keeps store-day surfaces manager-only", () => {
     expect(
       canAccessStoreDaySurface({
         role: "pos_only",
@@ -39,8 +40,20 @@ describe("surface capability access", () => {
       }),
     ).toBe(true);
     expect(canAccessStoreDaySurface({ role: "full_admin" })).toBe(true);
-    expect(canAccessStoreDaySurface({ role: "pos_only" })).toBe(true);
+    expect(canAccessStoreDaySurface({ role: "pos_only" })).toBe(false);
     expect(canAccessStoreDaySurface({ role: null })).toBe(false);
+  });
+
+  it("keeps cash controls manager-only", () => {
+    expect(canAccessCashControlsSurface({ role: "full_admin" })).toBe(true);
+    expect(
+      canAccessCashControlsSurface({
+        role: "pos_only",
+        activeManagerElevation: activeElevation,
+      }),
+    ).toBe(true);
+    expect(canAccessCashControlsSurface({ role: "pos_only" })).toBe(false);
+    expect(canAccessCashControlsSurface({ role: null })).toBe(false);
   });
 
   it("keeps excluded admin surfaces full-admin only", () => {
@@ -48,11 +61,11 @@ describe("surface capability access", () => {
       role: "pos_only" as const,
     };
 
-    expect(getSurfaceAccess("cash_controls", posOnly)).toBe(true);
-    expect(getSurfaceAccess("daily_operations", posOnly)).toBe(true);
-    expect(getSurfaceAccess("open_work", posOnly)).toBe(true);
-    expect(getSurfaceAccess("approvals", posOnly)).toBe(true);
-    expect(getSurfaceAccess("stock_adjustments", posOnly)).toBe(true);
+    expect(getSurfaceAccess("cash_controls", posOnly)).toBe(false);
+    expect(getSurfaceAccess("daily_operations", posOnly)).toBe(false);
+    expect(getSurfaceAccess("open_work", posOnly)).toBe(false);
+    expect(getSurfaceAccess("approvals", posOnly)).toBe(false);
+    expect(getSurfaceAccess("stock_adjustments", posOnly)).toBe(false);
 
     expect(getSurfaceAccess("procurement", posOnly)).toBe(false);
     expect(getSurfaceAccess("analytics", posOnly)).toBe(false);

--- a/packages/athena-webapp/src/lib/access/capabilities.ts
+++ b/packages/athena-webapp/src/lib/access/capabilities.ts
@@ -32,7 +32,6 @@ type SurfaceAccessContext = {
 };
 
 const STORE_DAY_SURFACES = new Set<SurfaceCapability>([
-  "cash_controls",
   "daily_operations",
   "open_work",
   "approvals",
@@ -49,24 +48,31 @@ export function canAccessStoreDaySurface({
   activeManagerElevation,
   role,
 }: SurfaceAccessContext): boolean {
-  return (
-    role === "pos_only" ||
-    canAccessFullAdminSurface({ role }) ||
-    Boolean(activeManagerElevation)
-  );
+  return canAccessFullAdminSurface({ role }) || Boolean(activeManagerElevation);
 }
 
-export function canViewFinancialDetails({
+export function canAccessCashControlsSurface({
   activeManagerElevation,
   role,
 }: SurfaceAccessContext): boolean {
   return canAccessFullAdminSurface({ role }) || Boolean(activeManagerElevation);
 }
 
+export function canViewFinancialDetails({
+  activeManagerElevation,
+  role,
+}: SurfaceAccessContext): boolean {
+  return canAccessCashControlsSurface({ activeManagerElevation, role });
+}
+
 export function getSurfaceAccess(
   surface: SurfaceCapability,
   context: SurfaceAccessContext,
 ): boolean {
+  if (surface === "cash_controls") {
+    return canAccessCashControlsSurface(context);
+  }
+
   if (STORE_DAY_SURFACES.has(surface)) {
     return canAccessStoreDaySurface(context);
   }

--- a/packages/athena-webapp/src/lib/moneyEntryAudit.test.ts
+++ b/packages/athena-webapp/src/lib/moneyEntryAudit.test.ts
@@ -23,12 +23,6 @@ const storefrontSourceRoot = join(storefrontRoot, "src");
 
 const reviewedRawParses: ReviewedRawParse[] = [
   {
-    file: "src/components/cash-controls/RegisterSessionView.tsx",
-    textIncludes: "parsedAmount = Number(amount)",
-    reason:
-      "Backend-owned conversion boundary: cash deposit mutation converts display amount with toPesewas.",
-  },
-  {
     file: "src/components/promo-codes/PromoCodePreview.tsx",
     textIncludes: "Number.parseFloat(discount)",
     reason: "Display-only preview formatting. V26-369 covers mutation persistence.",

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -260,6 +260,7 @@ export interface RegisterDrawerGateState {
     expectedCashAfterApproval?: number;
   } | null;
   canOpenCashControls?: boolean;
+  canViewCloseoutFinancials?: boolean;
   cashControlsRegisterSessionId?: Id<"registerSession">;
   canOpenDrawer?: boolean;
   hasSignedInStaff?: boolean;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -3623,6 +3623,7 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate?.closeoutDraftVariance).toBe(-200);
+    expect(result.current.drawerGate?.canViewCloseoutFinancials).toBe(true);
 
     await act(async () => {
       await result.current.drawerGate?.onSubmitCloseout?.();
@@ -4104,6 +4105,7 @@ describe("useRegisterViewModel", () => {
     );
 
     expect(result.current.drawerGate?.expectedCash).toBe(610000);
+    expect(result.current.drawerGate?.canViewCloseoutFinancials).toBe(false);
     expect(result.current.drawerGate?.pendingCashVoidApprovals).toEqual({
       cashAffectingCount: 1,
       cashAdjustmentCount: 0,

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -5443,6 +5443,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               expectedCash: activeCloseoutRegisterSession?.expectedCash,
               pendingCashVoidApprovals: activeCloseoutPendingCashVoidApprovals,
               canOpenCashControls: isCashierManager,
+              canViewCloseoutFinancials: isCashierManager,
               cashControlsRegisterSessionId:
                 activeCloseoutCloudRegisterSessionId ??
                 (activeCloseoutCloudRegisterSessionCode as

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings.index.tsx
@@ -1,19 +1,32 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { POSSettingsView } from "~/src/components/pos/settings/POSSettingsView";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 import { NotFoundView } from "~/src/components/states/not-found/NotFoundView";
+
+type NotFoundPayload = {
+  data?: {
+    org?: boolean;
+  };
+};
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/settings/"
 )({
-  component: POSSettingsView,
-  notFoundComponent: ({ data }) => {
-    const { orgUrlSlug, storeUrlSlug } = Route.useParams();
-    const { data: payload } = data as Record<string, any>;
-    const { org } = payload as Record<string, boolean>;
-
-    const entity = org ? "organization" : "store";
-    const name = org ? orgUrlSlug : storeUrlSlug;
-
-    return <NotFoundView entity={entity} entityIdentifier={name} />;
-  },
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <POSSettingsView />
+    </ProtectedRoute>
+  ),
+  notFoundComponent: SettingsNotFoundComponent,
 });
+
+function SettingsNotFoundComponent({ data }: { data?: unknown }) {
+  const { orgUrlSlug, storeUrlSlug } = Route.useParams();
+  const payload = data as NotFoundPayload | undefined;
+  const org = Boolean(payload?.data?.org);
+
+  const entity = org ? "organization" : "store";
+  const name = org ? orgUrlSlug : storeUrlSlug;
+
+  return <NotFoundView entity={entity} entityIdentifier={name} />;
+}

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals.index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { POSTerminalHealthView } from "~/src/components/pos/terminals/POSTerminalHealthView";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 import { NotFoundView } from "~/src/components/states/not-found/NotFoundView";
 
 type NotFoundPayload = {
@@ -23,6 +24,10 @@ function POSTerminalHealthNotFoundRoute({ data }: { data?: unknown }) {
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/"
 )({
-  component: POSTerminalHealthView,
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <POSTerminalHealthView />
+    </ProtectedRoute>
+  ),
   notFoundComponent: POSTerminalHealthNotFoundRoute,
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { POSTerminalDetailView } from "~/src/components/pos/terminals/POSTerminalDetailView";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 import { NotFoundView } from "~/src/components/states/not-found/NotFoundView";
 
 type NotFoundPayload = {
@@ -23,6 +24,10 @@ function POSTerminalDetailNotFoundRoute({ data }: { data?: unknown }) {
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId"
 )({
-  component: POSTerminalDetailView,
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <POSTerminalDetailView />
+    </ProtectedRoute>
+  ),
   notFoundComponent: POSTerminalDetailNotFoundRoute,
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit.tsx
@@ -1,8 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 import ProductView from "~/src/components/add-product/ProductView";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit"
 )({
-  component: ProductView,
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <ProductView />
+    </ProtectedRoute>
+  ),
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/index.tsx
@@ -1,8 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 import { ProductDetailView } from "~/src/components/product/ProductDetailView";
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/"
 )({
-  component: ProductDetailView,
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <ProductDetailView />
+    </ProtectedRoute>
+  ),
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived.tsx
@@ -1,8 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 import { ArchivedProducts } from "~/src/components/products/ArchivedProducts";
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/archived",
 )({
-  component: ArchivedProducts,
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <ArchivedProducts />
+    </ProtectedRoute>
+  ),
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/index.tsx
@@ -1,19 +1,32 @@
 import ComplimentaryProductsView from "~/src/components/products/complimentary/ComplimentaryProductsView";
 import { NotFoundView } from "@/components/states/not-found/NotFoundView";
 import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
+
+type NotFoundPayload = {
+  data?: {
+    org?: boolean;
+  };
+};
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/"
 )({
-  component: ComplimentaryProductsView,
-  notFoundComponent: ({ data }) => {
-    const { orgUrlSlug, storeUrlSlug } = Route.useParams();
-    const { data: d } = data as Record<string, any>;
-    const { org } = d as Record<string, boolean>;
-
-    const entity = org ? "organization" : "store";
-    const name = org ? orgUrlSlug : storeUrlSlug;
-
-    return <NotFoundView entity={entity} entityIdentifier={name} />;
-  },
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <ComplimentaryProductsView />
+    </ProtectedRoute>
+  ),
+  notFoundComponent: ComplimentaryProductsNotFoundComponent,
 });
+
+function ComplimentaryProductsNotFoundComponent({ data }: { data?: unknown }) {
+  const { orgUrlSlug, storeUrlSlug } = Route.useParams();
+  const payload = data as NotFoundPayload | undefined;
+  const org = Boolean(payload?.data?.org);
+
+  const entity = org ? "organization" : "store";
+  const name = org ? orgUrlSlug : storeUrlSlug;
+
+  return <NotFoundView entity={entity} entityIdentifier={name} />;
+}

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new.tsx
@@ -1,8 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 import { AddComplimentaryProduct } from "~/src/components/products/complimentary/AddComplimentaryProduct";
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/complimentary/new"
 )({
-  component: AddComplimentaryProduct,
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <AddComplimentaryProduct />
+    </ProtectedRoute>
+  ),
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/index.tsx
@@ -1,21 +1,33 @@
-import StoreProductsView from "~/src/components/products/StoreProductsView";
 import { NotFoundView } from "@/components/states/not-found/NotFoundView";
 import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 import ProductsView from "~/src/components/products/ProductsView";
+
+type NotFoundPayload = {
+  data?: {
+    org?: boolean;
+  };
+};
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/"
 )({
-  component: ProductsView,
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <ProductsView />
+    </ProtectedRoute>
+  ),
 
-  notFoundComponent: ({ data }) => {
-    const { orgUrlSlug, storeUrlSlug } = Route.useParams();
-    const { data: d } = data as Record<string, any>;
-    const { org } = d as Record<string, boolean>;
-
-    const entity = org ? "organization" : "store";
-    const name = org ? orgUrlSlug : storeUrlSlug;
-
-    return <NotFoundView entity={entity} entityIdentifier={name} />;
-  },
+  notFoundComponent: ProductsNotFoundComponent,
 });
+
+function ProductsNotFoundComponent({ data }: { data?: unknown }) {
+  const { orgUrlSlug, storeUrlSlug } = Route.useParams();
+  const payload = data as NotFoundPayload | undefined;
+  const org = Boolean(payload?.data?.org);
+
+  const entity = org ? "organization" : "store";
+  const name = org ? orgUrlSlug : storeUrlSlug;
+
+  return <NotFoundView entity={entity} entityIdentifier={name} />;
+}

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new.tsx
@@ -1,8 +1,13 @@
 import ProductView from "~/src/components/add-product/ProductView";
 import { createFileRoute } from "@tanstack/react-router";
+import { ProtectedRoute } from "~/src/components/ProtectedRoute";
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/new"
 )({
-  component: ProductView,
+  component: () => (
+    <ProtectedRoute requires="manager">
+      <ProductView />
+    </ProtectedRoute>
+  ),
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved.tsx
@@ -6,7 +6,7 @@ export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/products/unresolved"
 )({
   component: () => (
-    <ProtectedRoute requires="full_admin">
+    <ProtectedRoute requires="manager">
       <UnresolvedProducts />
     </ProtectedRoute>
   ),

--- a/scripts/harness-review.test.ts
+++ b/scripts/harness-review.test.ts
@@ -826,6 +826,11 @@ describe("runHarnessReview", () => {
               command: "bun run --filter '@athena/webapp' test:coverage",
               coverage: { mode: "full" },
             },
+            {
+              capability: "athena-webapp-typecheck",
+              command:
+                "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+            },
           ],
         },
         null,
@@ -863,7 +868,7 @@ describe("runHarnessReview", () => {
         capability: "athena-webapp-vitest",
         command: "@athena/webapp:test",
         providedBy: "local-pr-athena",
-        coveredCapabilities: ["athena-webapp-vitest"],
+        coveredCapabilities: ["athena-webapp-vitest", "athena-webapp-typecheck"],
         evidence: "artifacts/harness-delivery-runs/provider-evidence.json",
       })
     );
@@ -1420,6 +1425,92 @@ describe("runHarnessReview", () => {
       "@athena/webapp:test",
       "raw:bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
     ]);
+  });
+
+  it("skips athena webapp typecheck when local provider evidence covers it", async () => {
+    const rootDir = await createFixtureRepo();
+    const steps: string[] = [];
+    const logLines: string[] = [];
+
+    await write(
+      "packages/athena-webapp/docs/agent/validation-map.json",
+      JSON.stringify(
+        {
+          workspace: "@athena/webapp",
+          packageDir: "packages/athena-webapp",
+          surfaces: [
+            {
+              name: "shared-lib-or-utility-edits",
+              pathPrefixes: ["packages/athena-webapp/src/lib"],
+              commands: [
+                {
+                  kind: "raw",
+                  command:
+                    "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+                },
+              ],
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "artifacts/harness-delivery-runs/provider-evidence.json",
+      JSON.stringify(
+        {
+          schemaVersion: 1,
+          provider: "local-pr-athena",
+          capabilities: [
+            {
+              capability: "athena-webapp-typecheck",
+              command:
+                "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+            },
+          ],
+        },
+        null,
+        2
+      ),
+      rootDir
+    );
+    await write(
+      "packages/athena-webapp/src/lib/session.ts",
+      "export const session = true;\n",
+      rootDir
+    );
+
+    await runHarnessReview(rootDir, {
+      getChangedFiles: async () => ["packages/athena-webapp/src/lib/session.ts"],
+      providerEvidencePath: "artifacts/harness-delivery-runs/provider-evidence.json",
+      runHarnessCheck: async () => {
+        steps.push("harness:check");
+      },
+      runRawCommand: async (command) => {
+        steps.push(`raw:${command}`);
+      },
+      logger: {
+        log(line) {
+          logLines.push(line);
+        },
+        error() {},
+      },
+    });
+
+    expect(steps).toEqual(["harness:check"]);
+    expect(logLines).toContain(
+      JSON.stringify({
+        type: "provider_skipped",
+        status: "covered_by_provider",
+        capability: "athena-webapp-typecheck",
+        command: "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+        providedBy: "local-pr-athena",
+        coveredCapabilities: ["athena-webapp-typecheck"],
+        evidence: "artifacts/harness-delivery-runs/provider-evidence.json",
+      })
+    );
   });
 
   it("runs mapped storefront behavior scenarios for checkout-critical surfaces", async () => {

--- a/scripts/harness-review.ts
+++ b/scripts/harness-review.ts
@@ -62,7 +62,8 @@ type HarnessReviewOptions = {
 type LocalProviderCapability =
   | "harness-doc-freshness"
   | "root-script-tests"
-  | "athena-webapp-vitest";
+  | "athena-webapp-vitest"
+  | "athena-webapp-typecheck";
 
 type LocalProviderEvidenceCapability = {
   capability?: string;
@@ -220,6 +221,14 @@ function localCapabilityForCommand(
     return "athena-webapp-vitest";
   }
 
+  if (
+    command.kind === "raw" &&
+    command.command.trim() ===
+      "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json"
+  ) {
+    return "athena-webapp-typecheck";
+  }
+
   return null;
 }
 
@@ -345,7 +354,8 @@ function buildProviderSkip(
           (entry): entry is LocalProviderCapability =>
             entry === "harness-doc-freshness" ||
             entry === "root-script-tests" ||
-            entry === "athena-webapp-vitest"
+            entry === "athena-webapp-vitest" ||
+            entry === "athena-webapp-typecheck"
         ) ?? [],
     evidence: evidencePath,
   };

--- a/scripts/pr-athena-delivery-run.test.ts
+++ b/scripts/pr-athena-delivery-run.test.ts
@@ -277,6 +277,10 @@ describe("pr-athena delivery run wrapper", () => {
             command: "bun run --filter '@athena/webapp' test:coverage",
             coverage: { mode: "full" },
           },
+          {
+            capability: "athena-webapp-typecheck",
+            command: "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+          },
         ],
       });
     } finally {

--- a/scripts/pr-athena-delivery-run.ts
+++ b/scripts/pr-athena-delivery-run.ts
@@ -124,6 +124,10 @@ export async function writePrAthenaProviderEvidence(
             command: "bun run --filter '@athena/webapp' test:coverage",
             coverage: { mode: "full" },
           },
+          {
+            capability: "athena-webapp-typecheck",
+            command: "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+          },
         ],
       },
       null,

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -966,7 +966,19 @@ describe("repo harness ergonomics", () => {
       "bun scripts/harness-test.ts",
     );
     expect(packageJson.scripts?.["pr:athena:validate-provider"]).toContain(
+      "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+    );
+    expect(packageJson.scripts?.["pr:athena:validate-provider"]).toContain(
       "bun run test:coverage",
+    );
+    expect(
+      packageJson.scripts?.["pr:athena:validate-provider"]?.indexOf(
+        "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+      ),
+    ).toBeLessThan(
+      packageJson.scripts?.["pr:athena:validate-provider"]?.indexOf(
+        "bun run test:coverage",
+      ) ?? 0,
     );
     expect(packageJson.scripts?.["pr:athena:validate-provider"]).not.toContain(
       "bun run harness:test",


### PR DESCRIPTION
## Summary
- Gate cash controls, operations, products, POS diagnostics/settings, and workflow trace surfaces behind manager/full-admin access as requested.
- Rework register closeout surfaces so cashiers only see the actionable closeout input/CTA, while manager elevation restores financial details/admin controls.
- Add POS settings control for the register closeout approval threshold and disable the dev EOD daily report path.
- Add store time and next-opening IA polish on POS, plus move the Athena webapp typecheck earlier in pr:athena before coverage.

## Validation
- bun run pr:athena
- bun test scripts/harness-review.test.ts scripts/pr-athena-delivery-run.test.ts scripts/pre-push-review.test.ts
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json

Browser validation left to product review per request.