### PR TITLE
fix(pos): harden inventory visibility and sync replay

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -17,6 +17,9 @@ on:
 permissions:
   contents: read
 
+env:
+  NODE_OPTIONS: --max-old-space-size=4096
+
 jobs:
   harness-validation:
     name: Harness and Architecture Validation

--- a/docs/solutions/logic-errors/athena-legacy-import-onboarding-pos-visibility-2026-07-08.md
+++ b/docs/solutions/logic-errors/athena-legacy-import-onboarding-pos-visibility-2026-07-08.md
@@ -1,0 +1,75 @@
+---
+title: Athena Legacy Import Onboarding POS Visibility
+date: 2026-07-08
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "A legacy import row is finalized into trusted inventory and assigned real taxonomy, but the SKU does not appear in POS register search"
+  - "A hidden draft product can keep productSkuSearch.productIsVisible false after legacy taxonomy onboarding"
+root_cause: missing_workflow_step
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - inventory
+  - legacy-import
+  - catalog-search
+---
+
+# Athena Legacy Import Onboarding POS Visibility
+
+## Problem
+
+Legacy import products can start as hidden operational records. After a trusted import row is finalized and the product is assigned a normal Athena category/subcategory, the SKU must become visible in POS search.
+
+If onboarding leaves the product hidden or draft, `productSkuSearch.productIsVisible` keeps the trusted SKU out of register search even though the inventory row is ready for sale.
+
+## Symptoms
+
+- A finalized trusted legacy import SKU does not appear in POS register search after taxonomy onboarding.
+- The parent product has a normal category/subcategory but remains `isVisible: false` or `availability: "draft"`.
+- Refreshing search projections alone does not help when the parent product visibility flags are still hidden.
+
+## What Didn't Work
+
+- Completing the catalog taxonomy setup work item alone was not enough because it did not promote the product's sale-facing visibility fields.
+- Refreshing SKU search projections before fixing the parent product still preserved hidden product state in the projection.
+
+## Solution
+
+When product taxonomy moves out of the `legacy-import` category and finalized legacy import rows complete, promote the parent product to sale-facing visibility unless the current mutation explicitly requested `isVisible: false`.
+
+The repair path should:
+
+- promote eligible draft products to `availability: "live"`;
+- set hidden onboarded products to `isVisible: true`;
+- refresh every affected trusted SKU search projection;
+- leave rows still in legacy taxonomy hidden, but ensure `catalog_taxonomy_setup` work remains open.
+
+For already-onboarded rows, run the internal one-off repair after checking the dry-run output:
+
+```bash
+bunx convex run internal.inventory.catalogImport.repairOnboardedLegacyImportTrustedSkuVisibility '{"storeId":"<storeId>","dryRun":true,"limit":50}'
+bunx convex run internal.inventory.catalogImport.repairOnboardedLegacyImportTrustedSkuVisibility '{"storeId":"<storeId>","dryRun":false,"limit":50}'
+```
+
+Use the production deploy flag only after confirming the dry-run result.
+
+## Why This Works
+
+POS search intentionally hides normal catalog products when their parent product is hidden. Legacy import taxonomy is the temporary exception that lets operators review imported stock without exposing unfinished catalog items.
+
+Once a product leaves that legacy taxonomy, the exception no longer applies. Updating the parent product before refreshing affected SKU search projections makes the projection reflect the sale-ready state.
+
+## Prevention
+
+- Test taxonomy onboarding where a finalized active `inventoryImportProvisionalSku` row exists and the product starts hidden or draft.
+- Assert the product becomes live/visible when a normal Athena category/subcategory is assigned.
+- Assert `refreshProductSkuSearchForProduct` or the affected SKU projection refresh runs after the product visibility patch.
+- Test the repair path with multiple finalized trusted SKUs on the same product so every affected SKU projection refreshes while the product patch remains deduplicated.
+
+## Related Issues
+
+- [Athena POS Sale Inventory Review SKU Scope](./athena-pos-sale-inventory-review-sku-scope-2026-07-08.md)

--- a/docs/solutions/logic-errors/athena-pos-sale-inventory-review-sku-scope-2026-07-08.md
+++ b/docs/solutions/logic-errors/athena-pos-sale-inventory-review-sku-scope-2026-07-08.md
@@ -1,0 +1,68 @@
+---
+title: Athena POS Sale Inventory Review SKU Scope
+date: 2026-07-08
+category: logic-errors
+module: athena-webapp
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "A synced completed sale with one inventory review SKU can suppress sale inventory movements for unrelated SKUs"
+  - "Operators resolve an inventory review for the failed SKU while other valid sale SKU movements never appear"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - pos
+  - local-sync
+  - inventory
+  - stock-adjustments
+---
+
+# Athena POS Sale Inventory Review SKU Scope
+
+## Problem
+
+POS sale projection can preserve a completed transaction while routing some inventory demand to review. That review state is SKU-scoped; it is not the same as a hard projection conflict for the whole sale.
+
+If projection treats any reviewed inventory item as a transaction-level stock mutation blocker, valid SKUs in the same completed sale lose their sale movements and stock decrements. The review work item only asks operators to resolve the failed SKU, so the unrelated skipped movements have no obvious recovery path.
+
+## Symptoms
+
+- A mixed-SKU synced sale creates inventory review work for one SKU.
+- Other SKUs in the same sale do not receive sale inventory movements even though they have enough stock.
+- Retrying the already-projected sale does not backfill the missing eligible movements.
+
+## What Didn't Work
+
+- Treating reviewed inventory demand as a sale-wide mutation blocker preserved the transaction but skipped unrelated SKU movements.
+- Replaying an already-projected sale without movement idempotency risked duplicate stock decrements.
+- Revalidating ordinary projected sale retries against current stock could create false review work for sales already applied correctly.
+
+## Solution
+
+Keep hard conflicts and reviewed inventory skips separate:
+
+- Hard inventory conflicts still block all sale inventory mutation for the event.
+- Non-blocking reviewed inventory skips are SKU-scoped. Exclude only `skippedMutationItems` from sale movement aggregation.
+- Continue creating the `synced_sale_inventory_review` work item for skipped SKU demand.
+- Still project sale movements and SKU patches for trusted, eligible SKUs in the same completed transaction.
+- On replay of an already-projected sale, only use the reviewed-sale backfill path when the event has a resolved or explicitly reviewed inventory conflict.
+- Record sale inventory movements idempotently so a retry that backfills once does not decrement stock again.
+
+## Why This Works
+
+The projection can distinguish between demand that is unsafe to mutate and demand that is still trusted. Keeping that distinction at the SKU level lets Athena preserve the completed sale, keep review work focused on the bad line, and still maintain ledger accuracy for the good lines.
+
+The reviewed replay gate prevents normal retries from creating new operational review work after stock has changed for unrelated reasons. Idempotent sale movement recording lets the same retry safely run again after a successful backfill.
+
+## Prevention
+
+- Test mixed-SKU sales where one SKU creates review work and another SKU should still write a sale inventory movement.
+- Assert single-SKU review cases still write no movement for the reviewed SKU.
+- Assert hard inventory conflicts still suppress all movement, even if the sale record is preserved for review.
+- Test already-projected sale retries both with and without reviewed inventory conflict history.
+- Test the second retry after backfill and assert no duplicate movement or stock patch is recorded.
+
+## Related Issues
+
+- [Athena Legacy Import Onboarding POS Visibility](./athena-legacy-import-onboarding-pos-visibility-2026-07-08.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8875 nodes · 10821 edges · 2132 communities detected
+- 8880 nodes · 10831 edges · 2132 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2187,11 +2187,11 @@ Nodes (66): attentionSeverity(), automationRunClassification(), automationStatus
 
 ### Community 4 - "Community 4"
 Cohesion: 0.04
-Nodes (34): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatOperationalWorkTypeLabel(), getBucketCountClassName(), getDailyCloseSalesMetricLabels(), getDailyCloseStatus() (+26 more)
+Nodes (36): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), compareSummaryPaymentTotals(), formatOperationalWorkTypeLabel(), getBucketCountClassName(), getDailyCloseSalesMetricLabels() (+28 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.09
-Nodes (61): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal(), collectExistingSaleMappings() (+53 more)
+Nodes (62): applySaleInventoryMovements(), assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), capNonCashPaymentsToExpectedTotal() (+54 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.04
@@ -2202,12 +2202,12 @@ Cohesion: 0.05
 Nodes (33): asRecord(), assertCanClearIndexedDbPosLocalStore(), clearIndexedDbPosLocalStore(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), inspectIndexedDbStoresForClear() (+25 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.09
-Nodes (47): buildLocalSyncEventRecordInput(), canonicalize(), canonicalJson(), createLocalSyncIngestionService(), getLocalSyncCursorIdentity(), getLocalSyncScope(), ingestLocalEventsWithCtx(), isNonEmptyString() (+39 more)
+Cohesion: 0.08
+Nodes (56): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+48 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.08
-Nodes (53): buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch(), buildTrustedSkuFingerprint() (+45 more)
+Cohesion: 0.09
+Nodes (47): buildLocalSyncEventRecordInput(), canonicalize(), canonicalJson(), createLocalSyncIngestionService(), getLocalSyncCursorIdentity(), getLocalSyncScope(), ingestLocalEventsWithCtx(), isNonEmptyString() (+39 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.07
@@ -2354,16 +2354,16 @@ Cohesion: 0.16
 Nodes (25): acknowledgeTerminalRecoveryCommand(), arraysEqualAsSets(), buildExecutionId(), claimTerminalRecoveryCommand(), containsSecretLikeField(), getRuntimeAppUpdateEvidence(), hasRuntimeLocalReviewDetails(), isActiveCommand() (+17 more)
 
 ### Community 46 - "Community 46"
+Cohesion: 0.1
+Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
+
+### Community 47 - "Community 47"
 Cohesion: 0.15
 Nodes (20): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), linkedPendingCheckoutItemMatchesTrustedLine(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity() (+12 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.17
 Nodes (25): getRegisterCatalogPrice(), getRegisterCatalogProjectionPrice(), isActiveProvisionalImportSkuForStore(), isDraftAllowedInTrustedRegisterCatalog(), isLinkedPendingCheckoutAliasVisible(), isLinkedPendingCheckoutApprovedSkuVisible(), isPendingCheckoutItemVisible(), isTrustedRegisterCatalogProjection() (+17 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.1
-Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
 ### Community 49 - "Community 49"
 Cohesion: 0.12
@@ -2898,200 +2898,200 @@ Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
 ### Community 182 - "Community 182"
-Cohesion: 0.27
-Nodes (5): getLocalOperatingDate(), getLocalOperatingDateRange(), getReadinessDiagnosticRows(), getReadinessLoadingBlockers(), POSReadinessLoadingState()
-
-### Community 183 - "Community 183"
 Cohesion: 0.24
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 184 - "Community 184"
+### Community 183 - "Community 183"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 185 - "Community 185"
+### Community 184 - "Community 184"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 186 - "Community 186"
+### Community 185 - "Community 185"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 187 - "Community 187"
+### Community 186 - "Community 186"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 188 - "Community 188"
+### Community 187 - "Community 187"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 189 - "Community 189"
+### Community 188 - "Community 188"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 190 - "Community 190"
+### Community 189 - "Community 189"
 Cohesion: 0.31
 Nodes (7): architectureSolutionNote(), createFixtureRepo(), gitEnv(), nonFoundationalArchitectureSolutionNote(), runGit(), solutionNote(), write()
 
-### Community 191 - "Community 191"
+### Community 190 - "Community 190"
 Cohesion: 0.38
 Nodes (9): assertFrontendDependencyParity(), checkFrontendDependencyParity(), collectDependencyDeclarations(), collectFrontendDependencyFailures(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall() (+1 more)
 
-### Community 192 - "Community 192"
+### Community 191 - "Community 191"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 193 - "Community 193"
+### Community 192 - "Community 192"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 194 - "Community 194"
+### Community 193 - "Community 193"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.39
 Nodes (7): findActivePendingCheckoutLookupAliasByCode(), firstEvidenceTime(), normalizePendingCheckoutLookupCode(), resolvePendingCheckoutSku(), resolvePendingCheckoutSkuFromItem(), retirePendingCheckoutLookupAliasForItem(), upsertPendingCheckoutLookupAlias()
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.47
 Nodes (8): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isPendingCheckoutLookupAliasVisible(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
 
-### Community 199 - "Community 199"
+### Community 198 - "Community 198"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 200 - "Community 200"
+### Community 199 - "Community 199"
 Cohesion: 0.31
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 201 - "Community 201"
+### Community 200 - "Community 200"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 203 - "Community 203"
+### Community 202 - "Community 202"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 205 - "Community 205"
+### Community 204 - "Community 204"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 206 - "Community 206"
+### Community 205 - "Community 205"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 207 - "Community 207"
+### Community 206 - "Community 206"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 208 - "Community 208"
+### Community 207 - "Community 207"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 209 - "Community 209"
+### Community 208 - "Community 208"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 210 - "Community 210"
+### Community 209 - "Community 209"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 211 - "Community 211"
+### Community 210 - "Community 210"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 212 - "Community 212"
+### Community 211 - "Community 211"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 213 - "Community 213"
+### Community 212 - "Community 212"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 214 - "Community 214"
+### Community 213 - "Community 213"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 215 - "Community 215"
+### Community 214 - "Community 214"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 216 - "Community 216"
+### Community 215 - "Community 215"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 217 - "Community 217"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 218 - "Community 218"
+### Community 216 - "Community 216"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 219 - "Community 219"
+### Community 217 - "Community 217"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 220 - "Community 220"
+### Community 218 - "Community 218"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 219 - "Community 219"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 221 - "Community 221"
+### Community 220 - "Community 220"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 222 - "Community 222"
+### Community 221 - "Community 221"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 223 - "Community 223"
+### Community 222 - "Community 222"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 224 - "Community 224"
+### Community 223 - "Community 223"
 Cohesion: 0.32
 Nodes (4): createProductsQueryCtx(), createSkuMutationCtx(), pendingCheckoutEvidence(), pendingCheckoutItem()
 
-### Community 225 - "Community 225"
+### Community 224 - "Community 224"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 226 - "Community 226"
+### Community 225 - "Community 225"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 227 - "Community 227"
+### Community 226 - "Community 226"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 228 - "Community 228"
+### Community 227 - "Community 227"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 229 - "Community 229"
+### Community 228 - "Community 228"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 230 - "Community 230"
+### Community 229 - "Community 229"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
+
+### Community 230 - "Community 230"
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 231 - "Community 231"
 Cohesion: 0.25
@@ -3102,56 +3102,56 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 233 - "Community 233"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 234 - "Community 234"
 Cohesion: 0.36
 Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
-### Community 235 - "Community 235"
+### Community 234 - "Community 234"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 236 - "Community 236"
+### Community 235 - "Community 235"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 237 - "Community 237"
+### Community 236 - "Community 236"
 Cohesion: 0.29
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 238 - "Community 238"
+### Community 237 - "Community 237"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 239 - "Community 239"
+### Community 238 - "Community 238"
 Cohesion: 0.43
 Nodes (7): clearAthenaAuthSyncHandoff(), failAthenaAuthSyncHandoff(), getAthenaAuthSyncHandoffStatus(), normalizeAuthSyncRedirect(), parseHandoff(), readRawHandoff(), startAthenaAuthSyncHandoff()
 
-### Community 240 - "Community 240"
+### Community 239 - "Community 239"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 241 - "Community 241"
+### Community 240 - "Community 240"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 242 - "Community 242"
+### Community 241 - "Community 241"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 243 - "Community 243"
+### Community 242 - "Community 242"
 Cohesion: 0.29
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 244 - "Community 244"
+### Community 243 - "Community 243"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 245 - "Community 245"
+### Community 244 - "Community 244"
 Cohesion: 0.46
 Nodes (6): claimRuntimeHostForTerminal(), createRuntimeHostOwnerId(), getRemoteAssistRuntimeState(), getRuntimeHostClaimStorage(), PosRemoteAssistRuntimeHost(), releaseRuntimeHostClaim()
+
+### Community 245 - "Community 245"
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 246 - "Community 246"
 Cohesion: 0.39
@@ -3330,176 +3330,176 @@ Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
 ### Community 290 - "Community 290"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 291 - "Community 291"
 Cohesion: 0.52
 Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
-### Community 292 - "Community 292"
+### Community 291 - "Community 291"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 293 - "Community 293"
+### Community 292 - "Community 292"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 294 - "Community 294"
+### Community 293 - "Community 293"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
+
+### Community 294 - "Community 294"
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 297 - "Community 297"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 298 - "Community 298"
+### Community 297 - "Community 297"
 Cohesion: 0.43
 Nodes (4): createPackage(), installFixturePackages(), writeFixtureManifests(), writeJson()
 
-### Community 299 - "Community 299"
+### Community 298 - "Community 298"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 300 - "Community 300"
+### Community 299 - "Community 299"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 301 - "Community 301"
+### Community 300 - "Community 300"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 302 - "Community 302"
+### Community 301 - "Community 301"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 303 - "Community 303"
+### Community 302 - "Community 302"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 304 - "Community 304"
+### Community 303 - "Community 303"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 305 - "Community 305"
+### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 306 - "Community 306"
+### Community 305 - "Community 305"
 Cohesion: 0.53
 Nodes (4): createExpenseTransactionFromSessionHandler(), expenseItemHasTrustedAvailabilityHold(), expenseItemUsesTrustedInventory(), expenseTransactionError()
 
-### Community 307 - "Community 307"
+### Community 306 - "Community 306"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 308 - "Community 308"
+### Community 307 - "Community 307"
 Cohesion: 0.6
 Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
+
+### Community 308 - "Community 308"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 310 - "Community 310"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 311 - "Community 311"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 312 - "Community 312"
+### Community 311 - "Community 311"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 313 - "Community 313"
+### Community 312 - "Community 312"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 314 - "Community 314"
+### Community 313 - "Community 313"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 315 - "Community 315"
+### Community 314 - "Community 314"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 316 - "Community 316"
+### Community 315 - "Community 315"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 317 - "Community 317"
+### Community 316 - "Community 316"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 318 - "Community 318"
+### Community 317 - "Community 317"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 319 - "Community 319"
+### Community 318 - "Community 318"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 323 - "Community 323"
+### Community 322 - "Community 322"
 Cohesion: 0.4
 Nodes (2): moveBestSeller(), saveOrder()
 
-### Community 324 - "Community 324"
+### Community 323 - "Community 323"
 Cohesion: 0.4
 Nodes (2): moveFeaturedItem(), saveOrder()
 
-### Community 325 - "Community 325"
+### Community 324 - "Community 324"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 326 - "Community 326"
+### Community 325 - "Community 325"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 327 - "Community 327"
+### Community 326 - "Community 326"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 329 - "Community 329"
+### Community 328 - "Community 328"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 330 - "Community 330"
+### Community 329 - "Community 329"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 331 - "Community 331"
+### Community 330 - "Community 330"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 332 - "Community 332"
+### Community 331 - "Community 331"
 Cohesion: 0.47
 Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
+
+### Community 332 - "Community 332"
+Cohesion: 0.4
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 333 - "Community 333"
 Cohesion: 0.33
@@ -3695,79 +3695,79 @@ Nodes (0):
 
 ### Community 381 - "Community 381"
 Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 382 - "Community 382"
-Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 383 - "Community 383"
+### Community 382 - "Community 382"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 384 - "Community 384"
+### Community 383 - "Community 383"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 385 - "Community 385"
+### Community 384 - "Community 384"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 386 - "Community 386"
+### Community 385 - "Community 385"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 387 - "Community 387"
+### Community 386 - "Community 386"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 388 - "Community 388"
+### Community 387 - "Community 387"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 389 - "Community 389"
+### Community 388 - "Community 388"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
+
+### Community 389 - "Community 389"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 390 - "Community 390"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 391 - "Community 391"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 392 - "Community 392"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 393 - "Community 393"
+### Community 392 - "Community 392"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 394 - "Community 394"
+### Community 393 - "Community 393"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 395 - "Community 395"
+### Community 394 - "Community 394"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 396 - "Community 396"
+### Community 395 - "Community 395"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 397 - "Community 397"
+### Community 396 - "Community 396"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 398 - "Community 398"
+### Community 397 - "Community 397"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 399 - "Community 399"
+### Community 398 - "Community 398"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 399 - "Community 399"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 400 - "Community 400"
 Cohesion: 0.4
@@ -3782,12 +3782,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 403 - "Community 403"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 404 - "Community 404"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 404 - "Community 404"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 405 - "Community 405"
 Cohesion: 0.4
@@ -3798,20 +3798,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 407 - "Community 407"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 408 - "Community 408"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 409 - "Community 409"
+### Community 408 - "Community 408"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 410 - "Community 410"
+### Community 409 - "Community 409"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 410 - "Community 410"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 411 - "Community 411"
 Cohesion: 0.4
@@ -3834,76 +3834,76 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 416 - "Community 416"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 417 - "Community 417"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 417 - "Community 417"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 418 - "Community 418"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 420 - "Community 420"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 421 - "Community 421"
+### Community 420 - "Community 420"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 422 - "Community 422"
+### Community 421 - "Community 421"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 423 - "Community 423"
+### Community 422 - "Community 422"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 424 - "Community 424"
+### Community 423 - "Community 423"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 425 - "Community 425"
+### Community 424 - "Community 424"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 426 - "Community 426"
+### Community 425 - "Community 425"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 427 - "Community 427"
+### Community 426 - "Community 426"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 428 - "Community 428"
+### Community 427 - "Community 427"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 429 - "Community 429"
+### Community 428 - "Community 428"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 430 - "Community 430"
+### Community 429 - "Community 429"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 431 - "Community 431"
+### Community 430 - "Community 430"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 432 - "Community 432"
+### Community 431 - "Community 431"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 433 - "Community 433"
+### Community 432 - "Community 432"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 433 - "Community 433"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 434 - "Community 434"
 Cohesion: 0.4
@@ -3914,40 +3914,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 436 - "Community 436"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 438 - "Community 438"
+### Community 437 - "Community 437"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 439 - "Community 439"
+### Community 438 - "Community 438"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 440 - "Community 440"
+### Community 439 - "Community 439"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 441 - "Community 441"
+### Community 440 - "Community 440"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 442 - "Community 442"
+### Community 441 - "Community 441"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 443 - "Community 443"
+### Community 442 - "Community 442"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 444 - "Community 444"
+### Community 443 - "Community 443"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 444 - "Community 444"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.7
@@ -6435,11 +6435,11 @@ Nodes (0):
 
 ### Community 1066 - "Community 1066"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1067 - "Community 1067"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1068 - "Community 1068"
 Cohesion: 1.0
@@ -11212,1555 +11212,1555 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1020`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1021`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1022`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1023`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1024`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1025`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1026`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1027`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1028`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1029`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1030`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1031`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1032`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1033`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1034`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1035`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1036`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1037`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1038`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1039`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1040`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1041`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1042`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1043`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1044`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1045`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1046`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1047`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1048`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1049`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1050`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1051`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1052`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1053`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1054`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1055`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1056`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1057`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1058`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1059`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1060`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1061`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1062`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1063`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1064`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1065`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1066`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1067`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1068`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1069`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1070`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1071`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1072`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1073`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1074`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1075`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1076`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1077`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1078`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1079`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1080`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1081`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1082`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1083`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1084`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1085`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1086`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1087`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1088`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1089`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1090`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1091`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1092`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1093`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1094`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1095`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1096`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1097`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1098`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1099`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1100`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1101`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1102`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1103`** (2 nodes): `Index()`, `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1104`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1105`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1106`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1107`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1108`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1109`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1110`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1111`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1112`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1113`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1114`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1115`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1116`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1117`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1118`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1119`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1120`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1121`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1122`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1123`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1124`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1125`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1126`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1127`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1128`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1129`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1130`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1131`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1132`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1133`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1134`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1135`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1136`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1137`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1138`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1139`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1140`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1141`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1142`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1143`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1144`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1145`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1146`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1147`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1148`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1149`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1150`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1151`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1152`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1153`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1154`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1155`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1156`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1157`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1158`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1159`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1160`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1161`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1162`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1163`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1164`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1165`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1166`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1167`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1168`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1169`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1170`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1171`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1172`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1173`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1174`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1175`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1176`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1177`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1178`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1179`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1180`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1181`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1182`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1183`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1184`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1185`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1186`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1187`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1188`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1189`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1190`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1191`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1192`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1193`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1194`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1195`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1196`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1197`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1198`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1199`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1200`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1201`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1202`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1203`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1204`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1205`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1206`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1207`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1208`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1209`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1210`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1211`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1212`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1213`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1214`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1215`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1216`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1217`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1218`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1219`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1220`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1221`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1222`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1223`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1224`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1225`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1226`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1227`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1228`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1229`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1230`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1231`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1232`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1233`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1234`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1235`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1236`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1237`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1238`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1239`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1240`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1241`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1242`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1243`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1244`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1245`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1246`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1247`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1248`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1249`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1250`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1251`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1252`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1253`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1254`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1255`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1256`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1257`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1258`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1259`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1260`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1261`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `api.js`
+- **Thin community `Community 1262`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1263`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1264`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `server.js`
+- **Thin community `Community 1265`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `app.ts`
+- **Thin community `Community 1266`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1267`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1268`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1269`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1270`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `auth.ts`
+- **Thin community `Community 1271`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1272`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1273`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1274`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `countries.ts`
+- **Thin community `Community 1275`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `email.ts`
+- **Thin community `Community 1276`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1277`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `payment.ts`
+- **Thin community `Community 1278`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1279`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `types.ts`
+- **Thin community `Community 1280`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `crons.ts`
+- **Thin community `Community 1282`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `internal.ts`
+- **Thin community `Community 1284`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1288`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1289`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `DailyManagerReport.tsx`
+- **Thin community `Community 1291`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1292`** (1 nodes): `DailyManagerReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1293`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1294`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1295`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1296`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1297`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1298`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
+- **Thin community `Community 1299`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `env.ts`
+- **Thin community `Community 1300`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1301`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `auth.ts`
+- **Thin community `Community 1302`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1303`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `colors.ts`
+- **Thin community `Community 1304`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `index.ts`
+- **Thin community `Community 1305`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1306`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `products.ts`
+- **Thin community `Community 1307`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `stores.ts`
+- **Thin community `Community 1309`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `bag.ts`
+- **Thin community `Community 1311`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `guest.ts`
+- **Thin community `Community 1312`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1313`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `index.ts`
+- **Thin community `Community 1314`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `me.ts`
+- **Thin community `Community 1315`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `offers.ts`
+- **Thin community `Community 1316`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1317`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1318`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1319`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1320`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1321`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1322`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1323`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1324`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1325`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `user.ts`
+- **Thin community `Community 1326`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1327`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `index.ts`
+- **Thin community `Community 1328`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `http.ts`
+- **Thin community `Community 1330`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `access.ts`
+- **Thin community `Community 1331`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1333`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1334`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `index.ts`
+- **Thin community `Community 1335`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1336`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `types.ts`
+- **Thin community `Community 1337`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1338`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `categories.ts`
+- **Thin community `Community 1339`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `colors.ts`
+- **Thin community `Community 1340`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1341`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1342`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1343`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1344`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `pos.ts`
+- **Thin community `Community 1345`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1346`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1347`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1349`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1350`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1351`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1352`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1353`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1354`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1355`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1357`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1358`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1359`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1360`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1361`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `types.ts`
+- **Thin community `Community 1363`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1364`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1365`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1366`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1367`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1368`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1369`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
+- **Thin community `Community 1370`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1371`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1372`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1373`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1374`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1375`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `dto.ts`
+- **Thin community `Community 1376`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1377`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1378`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1379`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1380`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `types.ts`
+- **Thin community `Community 1381`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `facts.ts`
+- **Thin community `Community 1382`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `types.ts`
+- **Thin community `Community 1383`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1384`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1385`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `types.ts`
+- **Thin community `Community 1386`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1387`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `customers.ts`
+- **Thin community `Community 1388`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1389`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `register.ts`
+- **Thin community `Community 1390`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1391`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1392`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1393`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `schema.ts`
+- **Thin community `Community 1394`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `automation.ts`
+- **Thin community `Community 1395`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1396`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1397`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `index.ts`
+- **Thin community `Community 1398`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1399`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1400`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1401`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1402`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1403`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1404`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1405`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `category.ts`
+- **Thin community `Community 1406`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `color.ts`
+- **Thin community `Community 1407`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1408`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1409`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `index.ts`
+- **Thin community `Community 1410`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1411`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1412`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1413`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1414`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `organization.ts`
+- **Thin community `Community 1415`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1416`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `product.ts`
+- **Thin community `Community 1417`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1418`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1419`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1420`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `store.ts`
+- **Thin community `Community 1421`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1422`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1423`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `index.ts`
+- **Thin community `Community 1424`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1425`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1426`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1427`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1428`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1429`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1430`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1431`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `index.ts`
+- **Thin community `Community 1432`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1433`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1434`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1435`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1436`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1437`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1438`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1439`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1440`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1441`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1442`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1443`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `customer.ts`
+- **Thin community `Community 1444`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1445`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1446`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1447`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1448`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `index.ts`
+- **Thin community `Community 1449`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1450`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1451`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1452`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1453`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1454`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1455`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1456`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1457`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 1458`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 1459`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1460`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1461`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1462`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1463`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1464`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1465`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1466`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1467`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1468`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1469`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1471`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `index.ts`
+- **Thin community `Community 1472`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1473`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1474`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `index.ts`
+- **Thin community `Community 1475`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1476`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1477`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1478`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1479`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1480`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1481`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `index.ts`
+- **Thin community `Community 1482`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1483`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1484`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1485`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1486`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1487`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1488`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `bag.ts`
+- **Thin community `Community 1489`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1490`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1491`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1492`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `guest.ts`
+- **Thin community `Community 1493`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `index.ts`
+- **Thin community `Community 1494`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `offer.ts`
+- **Thin community `Community 1495`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1496`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1497`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `review.ts`
+- **Thin community `Community 1498`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1499`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1500`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1501`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1502`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1503`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1504`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1505`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `bag.ts`
+- **Thin community `Community 1507`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1508`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `customer.ts`
+- **Thin community `Community 1509`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `guest.ts`
+- **Thin community `Community 1510`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1512`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1513`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1514`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1515`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1516`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1517`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `users.ts`
+- **Thin community `Community 1518`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `payment.ts`
+- **Thin community `Community 1519`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1520`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1526`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `index.ts`
+- **Thin community `Community 1527`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1528`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1529`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1530`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1531`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `auth.ts`
+- **Thin community `Community 1532`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1533`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1534`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1535`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1536`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1537`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1538`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1539`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `index.ts`
+- **Thin community `Community 1540`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1541`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1542`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 1543`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1544`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1545`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1546`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1547`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1548`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1550`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1551`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 1552`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1553`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 1554`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1555`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1556`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1557`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1558`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1559`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1560`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1561`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1562`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1563`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 1564`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1565`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1566`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `constants.ts`
+- **Thin community `Community 1567`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1568`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1569`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1570`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `types.ts`
+- **Thin community `Community 1571`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1572`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1573`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1574`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1575`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1576`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1577`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1578`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1579`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1580`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1581`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1582`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1583`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1584`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1585`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1586`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1587`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1588`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1589`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1590`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1591`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `constants.ts`
+- **Thin community `Community 1592`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1593`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1594`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1595`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `data.ts`
+- **Thin community `Community 1596`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1597`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1598`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1599`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1600`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1601`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1602`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1603`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1604`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1605`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1607`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `constants.ts`
+- **Thin community `Community 1608`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1609`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1610`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1611`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `data.ts`
+- **Thin community `Community 1612`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1613`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1614`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1615`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1616`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1617`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1618`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1619`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1620`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1621`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1622`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1623`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `constants.ts`
+- **Thin community `Community 1624`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1625`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1626`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1627`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1628`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1629`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1630`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1631`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1632`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1633`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1634`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1635`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1637`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1638`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1639`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1640`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1641`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1642`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1643`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1644`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1645`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1646`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1647`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1648`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1649`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1650`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1651`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1653`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1654`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 1655`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1656`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1657`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1658`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1659`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1660`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1661`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `constants.ts`
+- **Thin community `Community 1662`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1663`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1664`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1665`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `data.ts`
+- **Thin community `Community 1666`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `constants.ts`
+- **Thin community `Community 1669`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1670`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1671`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1672`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1673`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `data.ts`
+- **Thin community `Community 1674`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1675`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `constants.ts`
+- **Thin community `Community 1676`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1677`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1678`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1679`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1680`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `data.ts`
+- **Thin community `Community 1681`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1682`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1683`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1684`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1685`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1686`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1687`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1688`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1689`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1690`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1691`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1692`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1693`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1694`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1695`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1696`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1697`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1698`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1699`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1700`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1701`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1702`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1703`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1704`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1705`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1706`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1707`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1708`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1709`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `types.ts`
+- **Thin community `Community 1710`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1711`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1712`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1713`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1714`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 1715`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1716`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 1717`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1718`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1719`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1720`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1721`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1722`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1723`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1724`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1725`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1726`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1727`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1728`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `data.ts`
+- **Thin community `Community 1729`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1730`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1731`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1732`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1733`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1734`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1735`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1736`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1737`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1738`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1739`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1740`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1741`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `constants.ts`
+- **Thin community `Community 1742`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1743`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1744`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1745`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `data.ts`
+- **Thin community `Community 1746`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `types.ts`
+- **Thin community `Community 1747`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1748`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1749`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1750`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1751`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1752`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `index.ts`
+- **Thin community `Community 1753`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1754`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1755`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1756`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1757`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `index.tsx`
+- **Thin community `Community 1758`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1759`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1760`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1761`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1762`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1763`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1764`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1765`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 1766`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1767`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 1768`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `index.tsx`
+- **Thin community `Community 1769`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1770`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1771`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1772`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `button.tsx`
+- **Thin community `Community 1773`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1774`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `card.tsx`
+- **Thin community `Community 1775`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1776`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1777`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `command.tsx`
+- **Thin community `Community 1778`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1779`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1780`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1781`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `form.tsx`
+- **Thin community `Community 1782`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1783`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1784`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `input.tsx`
+- **Thin community `Community 1785`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1786`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1787`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1788`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1789`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1790`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1791`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `select.tsx`
+- **Thin community `Community 1792`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1793`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1794`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1795`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1796`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,17 +8,17 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2205
-- Graph nodes: 8875
-- Graph edges: 10821
+- Graph nodes: 8880
+- Graph edges: 10831
 - Communities: 2132
 
 ## Graph Hotspots
 - `dailyClose.ts` (86 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (86 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `DailyCloseView.tsx` (71 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (69 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (66 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `usePosLocalSyncRuntime.ts` (64 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 - `posLocalStore.ts` (59 edges, Community 7) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `dailyClose.ts` (86 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `DailyCloseView.tsx` (71 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (69 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `projectLocalEvents.ts` (65 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (66 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 220) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 219) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 106) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/inventory/catalogImport.test.ts
+++ b/packages/athena-webapp/convex/inventory/catalogImport.test.ts
@@ -21,6 +21,7 @@ import {
   listInventoryImportReviewSkuContextWithCtx,
   listProductPageProvisionalSkuBinding,
   listProductPageProvisionalSkuBindingWithCtx,
+  repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx,
   saveInventoryImportReviewVersion,
   saveInventoryImportReviewVersionWithCtx,
   stageInventoryImportReviewRowsForPos,
@@ -1126,6 +1127,661 @@ describe("catalog import", () => {
           status: "committed",
         }),
       ]),
+    );
+  });
+
+  it("dry-runs onboarded legacy import trusted SKU visibility repair", async () => {
+    const { ctx, tables } = createMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "store-1",
+        },
+        {
+          _id: "category-legacy",
+          name: "Legacy import",
+          slug: "legacy-import",
+          storeId: "store-1",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-hidden-draft",
+          finalizedAt: 1_000,
+          productId: "product-hidden-draft",
+          productSkuId: "sku-hidden-draft",
+          status: "finalized",
+          storeId: "store-1",
+        },
+        {
+          _id: "provisional-legacy",
+          finalizedAt: 1_000,
+          productId: "product-legacy",
+          productSkuId: "sku-legacy",
+          status: "finalized",
+          storeId: "store-1",
+        },
+      ],
+      product: [
+        {
+          _id: "product-hidden-draft",
+          availability: "draft",
+          categoryId: "category-hair",
+          isVisible: false,
+          name: "Hidden Draft",
+          storeId: "store-1",
+          subcategoryId: "subcategory-hair",
+        },
+        {
+          _id: "product-legacy",
+          availability: "draft",
+          categoryId: "category-legacy",
+          isVisible: false,
+          name: "Still Legacy",
+          storeId: "store-1",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-hidden-draft",
+          productId: "product-hidden-draft",
+          sku: "SKU-HIDDEN-DRAFT",
+          storeId: "store-1",
+        },
+        {
+          _id: "sku-legacy",
+          productId: "product-legacy",
+          sku: "SKU-LEGACY",
+          storeId: "store-1",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-hair",
+          categoryId: "category-hair",
+          name: "Hair Oils",
+          slug: "hair-oils",
+          storeId: "store-1",
+        },
+        {
+          _id: "subcategory-legacy",
+          categoryId: "category-legacy",
+          name: "Imported inventory",
+          slug: "imported-inventory",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const result = await repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(
+      ctx,
+      {
+        dryRun: true,
+        limit: 10,
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      promotedToLive: 1,
+      refreshedSearchProjections: 0,
+      repairedProducts: 1,
+      scannedRows: 2,
+      skippedLegacyTaxonomy: 1,
+      taxonomyWorkItemsEnsured: 1,
+      visibleProducts: 1,
+    });
+    expect(result.repairedSkus).toEqual([
+      expect.objectContaining({
+        productId: "product-hidden-draft",
+        productName: "Hidden Draft",
+        productSkuId: "sku-hidden-draft",
+        sku: "SKU-HIDDEN-DRAFT",
+      }),
+    ]);
+    expect(result.taxonomyWorkItemSkus).toEqual([
+      expect.objectContaining({
+        productId: "product-legacy",
+        productName: "Still Legacy",
+        productSkuId: "sku-legacy",
+        sku: "SKU-LEGACY",
+      }),
+    ]);
+    expect(tables.product.get("product-hidden-draft")).toMatchObject({
+      availability: "draft",
+      isVisible: false,
+    });
+    expect(Array.from(tables.operationalWorkItem.values())).toEqual([]);
+    expect(mockedSkuSearch.upsertProductSkuSearchProjection).not.toHaveBeenCalled();
+  });
+
+  it("repairs onboarded legacy import trusted SKU visibility and draft status", async () => {
+    const { ctx, tables } = createMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "store-1",
+        },
+        {
+          _id: "category-legacy",
+          name: "Legacy import",
+          slug: "legacy-import",
+          storeId: "store-1",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-hidden-draft",
+          finalizedAt: 1_000,
+          productId: "product-hidden-draft",
+          productSkuId: "sku-hidden-draft",
+          status: "finalized",
+          storeId: "store-1",
+        },
+        {
+          _id: "provisional-visible-live",
+          finalizedAt: 1_100,
+          productId: "product-visible-live",
+          productSkuId: "sku-visible-live",
+          status: "active",
+          storeId: "store-1",
+        },
+        {
+          _id: "provisional-hidden-draft-other",
+          finalizedAt: 1_150,
+          productId: "product-hidden-draft",
+          productSkuId: "sku-hidden-draft-other",
+          status: "finalized",
+          storeId: "store-1",
+        },
+        {
+          _id: "provisional-other-store",
+          finalizedAt: 1_200,
+          productId: "product-other-store",
+          productSkuId: "sku-other-store",
+          status: "finalized",
+          storeId: "store-other",
+        },
+        {
+          _id: "provisional-legacy",
+          finalizedAt: 1_300,
+          productId: "product-legacy",
+          productSkuId: "sku-legacy",
+          status: "finalized",
+          storeId: "store-1",
+        },
+      ],
+      product: [
+        {
+          _id: "product-hidden-draft",
+          availability: "draft",
+          categoryId: "category-hair",
+          isVisible: false,
+          name: "Hidden Draft",
+          storeId: "store-1",
+          subcategoryId: "subcategory-hair",
+        },
+        {
+          _id: "product-visible-live",
+          availability: "live",
+          categoryId: "category-hair",
+          isVisible: true,
+          name: "Visible Live",
+          storeId: "store-1",
+          subcategoryId: "subcategory-hair",
+        },
+        {
+          _id: "product-other-store",
+          availability: "draft",
+          categoryId: "category-hair",
+          isVisible: false,
+          name: "Other Store",
+          storeId: "store-other",
+          subcategoryId: "subcategory-hair",
+        },
+        {
+          _id: "product-legacy",
+          availability: "draft",
+          categoryId: "category-legacy",
+          isVisible: false,
+          name: "Still Legacy",
+          organizationId: "org-1",
+          storeId: "store-1",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-hidden-draft",
+          productId: "product-hidden-draft",
+          sku: "SKU-HIDDEN-DRAFT",
+          storeId: "store-1",
+        },
+        {
+          _id: "sku-hidden-draft-other",
+          productId: "product-hidden-draft",
+          sku: "SKU-HIDDEN-DRAFT-OTHER",
+          storeId: "store-1",
+        },
+        {
+          _id: "sku-visible-live",
+          productId: "product-visible-live",
+          sku: "SKU-VISIBLE-LIVE",
+          storeId: "store-1",
+        },
+        {
+          _id: "sku-other-store",
+          productId: "product-other-store",
+          sku: "SKU-OTHER",
+          storeId: "store-other",
+        },
+        {
+          _id: "sku-legacy",
+          productId: "product-legacy",
+          sku: "SKU-LEGACY",
+          storeId: "store-1",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-hair",
+          categoryId: "category-hair",
+          name: "Hair Oils",
+          slug: "hair-oils",
+          storeId: "store-1",
+        },
+        {
+          _id: "subcategory-legacy",
+          categoryId: "category-legacy",
+          name: "Imported inventory",
+          slug: "imported-inventory",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const result = await repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(
+      ctx,
+      {
+        dryRun: false,
+        limit: 10,
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      dryRun: false,
+      promotedToLive: 1,
+      refreshedSearchProjections: 2,
+      repairedProducts: 1,
+      scannedRows: 4,
+      skippedLegacyTaxonomy: 1,
+      taxonomyWorkItemsEnsured: 1,
+      visibleProducts: 1,
+    });
+    expect(tables.product.get("product-hidden-draft")).toMatchObject({
+      availability: "live",
+      isVisible: true,
+    });
+    expect(tables.product.get("product-visible-live")).toMatchObject({
+      availability: "live",
+      isVisible: true,
+    });
+    expect(mockedSkuSearch.upsertProductSkuSearchProjection).toHaveBeenCalledWith(
+      ctx,
+      "sku-hidden-draft",
+    );
+    expect(
+      mockedSkuSearch.upsertProductSkuSearchProjection,
+    ).not.toHaveBeenCalledWith(ctx, "sku-visible-live");
+    expect(
+      mockedSkuSearch.upsertProductSkuSearchProjection,
+    ).toHaveBeenCalledWith(ctx, "sku-hidden-draft-other");
+    expect(Array.from(tables.operationalWorkItem.values())).toEqual([
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          categorySlug: "legacy-import",
+          productId: "product-legacy",
+          productSkuId: "sku-legacy",
+          provisionalSkuId: "provisional-legacy",
+          sku: "SKU-LEGACY",
+        }),
+        productId: "product-legacy",
+        productSkuId: "sku-legacy",
+        status: "open",
+        title: "Assign catalog category: Still Legacy",
+        type: "catalog_taxonomy_setup",
+      }),
+    ]);
+  });
+
+  it("scans finalized active rows without letting non-finalized rows consume the repair page", async () => {
+    const nonFinalizedRows = Array.from({ length: 3 }, (_, index) => ({
+      _id: `provisional-active-draft-${index + 1}`,
+      createdAt: index + 1,
+      productId: `product-active-draft-${index + 1}`,
+      productSkuId: `sku-active-draft-${index + 1}`,
+      status: "active",
+      storeId: "store-1",
+    }));
+    const { ctx, tables } = createMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "store-1",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        ...nonFinalizedRows,
+        {
+          _id: "provisional-finalized-active",
+          createdAt: 10,
+          finalizedAt: 1_500,
+          productId: "product-hidden-draft",
+          productSkuId: "sku-hidden-draft",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      product: [
+        {
+          _id: "product-hidden-draft",
+          availability: "draft",
+          categoryId: "category-hair",
+          isVisible: false,
+          name: "Hidden Draft",
+          storeId: "store-1",
+          subcategoryId: "subcategory-hair",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-hidden-draft",
+          productId: "product-hidden-draft",
+          sku: "SKU-HIDDEN-DRAFT",
+          storeId: "store-1",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-hair",
+          categoryId: "category-hair",
+          name: "Hair Oils",
+          slug: "hair-oils",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const result = await repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(
+      ctx,
+      {
+        dryRun: false,
+        limit: 1,
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result).toMatchObject({
+      promotedToLive: 1,
+      refreshedSearchProjections: 1,
+      repairedProducts: 1,
+      scannedRows: 1,
+      visibleProducts: 1,
+    });
+    expect(tables.product.get("product-hidden-draft")).toMatchObject({
+      availability: "live",
+      isVisible: true,
+    });
+    expect(mockedSkuSearch.upsertProductSkuSearchProjection).toHaveBeenCalledWith(
+      ctx,
+      "sku-hidden-draft",
+    );
+  });
+
+  it("returns a cursor so legacy visibility repair can advance past skipped rows", async () => {
+    const { ctx, tables } = createMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "store-1",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-clean",
+          finalizedAt: 100,
+          productId: "product-clean",
+          productSkuId: "sku-clean",
+          status: "active",
+          storeId: "store-1",
+        },
+        {
+          _id: "provisional-hidden-draft",
+          finalizedAt: 200,
+          productId: "product-hidden-draft",
+          productSkuId: "sku-hidden-draft",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      product: [
+        {
+          _id: "product-clean",
+          availability: "live",
+          categoryId: "category-hair",
+          isVisible: true,
+          name: "Clean Product",
+          storeId: "store-1",
+          subcategoryId: "subcategory-hair",
+        },
+        {
+          _id: "product-hidden-draft",
+          availability: "draft",
+          categoryId: "category-hair",
+          isVisible: false,
+          name: "Hidden Draft",
+          storeId: "store-1",
+          subcategoryId: "subcategory-hair",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-clean",
+          productId: "product-clean",
+          sku: "SKU-CLEAN",
+          storeId: "store-1",
+        },
+        {
+          _id: "sku-hidden-draft",
+          productId: "product-hidden-draft",
+          sku: "SKU-HIDDEN-DRAFT",
+          storeId: "store-1",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-hair",
+          categoryId: "category-hair",
+          name: "Hair Oils",
+          slug: "hair-oils",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const firstPage = await repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(
+      ctx,
+      {
+        dryRun: false,
+        limit: 1,
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(firstPage).toMatchObject({
+      refreshedSearchProjections: 0,
+      repairedProducts: 0,
+      scannedRows: 1,
+      truncated: true,
+      nextCursor: {
+        finalizedAt: 100,
+        scannedRowIds: ["provisional-clean"],
+        status: "active",
+      },
+    });
+
+    const secondPage =
+      await repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(ctx, {
+        cursor: firstPage.nextCursor,
+        dryRun: false,
+        limit: 1,
+        storeId: "store-1" as Id<"store">,
+      });
+
+    expect(secondPage).toMatchObject({
+      promotedToLive: 1,
+      refreshedSearchProjections: 1,
+      repairedProducts: 1,
+      scannedRows: 1,
+      truncated: false,
+      visibleProducts: 1,
+    });
+    expect(tables.product.get("product-hidden-draft")).toMatchObject({
+      availability: "live",
+      isVisible: true,
+    });
+    expect(mockedSkuSearch.upsertProductSkuSearchProjection).toHaveBeenCalledWith(
+      ctx,
+      "sku-hidden-draft",
+    );
+  });
+
+  it("continues through repair candidates that share a finalizedAt timestamp", async () => {
+    const { ctx, tables } = createMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "store-1",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-hidden-draft-1",
+          finalizedAt: 300,
+          productId: "product-hidden-draft-1",
+          productSkuId: "sku-hidden-draft-1",
+          status: "active",
+          storeId: "store-1",
+        },
+        {
+          _id: "provisional-hidden-draft-2",
+          finalizedAt: 300,
+          productId: "product-hidden-draft-2",
+          productSkuId: "sku-hidden-draft-2",
+          status: "active",
+          storeId: "store-1",
+        },
+      ],
+      product: [
+        {
+          _id: "product-hidden-draft-1",
+          availability: "draft",
+          categoryId: "category-hair",
+          isVisible: false,
+          name: "Hidden Draft 1",
+          storeId: "store-1",
+          subcategoryId: "subcategory-hair",
+        },
+        {
+          _id: "product-hidden-draft-2",
+          availability: "draft",
+          categoryId: "category-hair",
+          isVisible: false,
+          name: "Hidden Draft 2",
+          storeId: "store-1",
+          subcategoryId: "subcategory-hair",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-hidden-draft-1",
+          productId: "product-hidden-draft-1",
+          sku: "SKU-HIDDEN-DRAFT-1",
+          storeId: "store-1",
+        },
+        {
+          _id: "sku-hidden-draft-2",
+          productId: "product-hidden-draft-2",
+          sku: "SKU-HIDDEN-DRAFT-2",
+          storeId: "store-1",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-hair",
+          categoryId: "category-hair",
+          name: "Hair Oils",
+          slug: "hair-oils",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const firstPage = await repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(
+      ctx,
+      {
+        dryRun: false,
+        limit: 1,
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+    const secondPage =
+      await repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(ctx, {
+        cursor: firstPage.nextCursor,
+        dryRun: false,
+        limit: 1,
+        storeId: "store-1" as Id<"store">,
+      });
+
+    expect(firstPage.nextCursor).toMatchObject({
+      finalizedAt: 300,
+      scannedRowIds: ["provisional-hidden-draft-1"],
+      status: "active",
+    });
+    expect(secondPage).toMatchObject({
+      refreshedSearchProjections: 1,
+      repairedProducts: 1,
+      scannedRows: 1,
+      truncated: false,
+    });
+    expect(tables.product.get("product-hidden-draft-1")).toMatchObject({
+      availability: "live",
+      isVisible: true,
+    });
+    expect(tables.product.get("product-hidden-draft-2")).toMatchObject({
+      availability: "live",
+      isVisible: true,
+    });
+    expect(mockedSkuSearch.upsertProductSkuSearchProjection).toHaveBeenCalledWith(
+      ctx,
+      "sku-hidden-draft-1",
+    );
+    expect(mockedSkuSearch.upsertProductSkuSearchProjection).toHaveBeenCalledWith(
+      ctx,
+      "sku-hidden-draft-2",
     );
   });
 

--- a/packages/athena-webapp/convex/inventory/catalogImport.ts
+++ b/packages/athena-webapp/convex/inventory/catalogImport.ts
@@ -1,4 +1,5 @@
 import {
+  internalMutation,
   mutation,
   query,
   type MutationCtx,
@@ -42,12 +43,43 @@ const CATALOG_TAXONOMY_FINALIZATION_ROW_LIMIT = 25;
 const TRUSTED_FINALIZATION_ACTIVE_CHECKOUT_SESSION_LIMIT = 200;
 const DEFAULT_CATEGORY_SLUG = toSlug(DEFAULT_CATEGORY_NAME);
 const TRUSTED_FINALIZATION_CHECKOUT_SESSION_ITEM_LIMIT = 200;
+const LEGACY_IMPORT_TRUSTED_VISIBILITY_REPAIR_LIMIT = 200;
 
 type ProvisionalImportIdentity = {
   productId: Id<"product">;
   productSkuId: Id<"productSku">;
   sku?: string;
   barcode?: string;
+};
+
+type LegacyImportTrustedVisibilityRepairSku = {
+  productId: Id<"product">;
+  productName: string;
+  productSkuId: Id<"productSku">;
+  sku?: string;
+};
+
+type LegacyImportTrustedVisibilityRepairCursor = {
+  finalizedAt: number;
+  scannedRowIds: Array<Id<"inventoryImportProvisionalSku">>;
+  status: "active" | "finalized";
+};
+
+type LegacyImportTrustedVisibilityRepairResult = {
+  dryRun: boolean;
+  limit: number;
+  nextCursor?: LegacyImportTrustedVisibilityRepairCursor;
+  promotedToLive: number;
+  refreshedSearchProjections: number;
+  repairedProducts: number;
+  repairedSkus: LegacyImportTrustedVisibilityRepairSku[];
+  scannedRows: number;
+  skippedArchivedProducts: number;
+  skippedLegacyTaxonomy: number;
+  taxonomyWorkItemsEnsured: number;
+  taxonomyWorkItemSkus: LegacyImportTrustedVisibilityRepairSku[];
+  truncated: boolean;
+  visibleProducts: number;
 };
 
 const importStatusValidator = v.union(
@@ -101,6 +133,36 @@ const inventoryImportReviewVersionValidator = v.object({
   rowCount: v.number(),
   sourceFormat: importSourceFormatValidator,
   versionNumber: v.number(),
+});
+
+const legacyImportTrustedVisibilityRepairSkuValidator = v.object({
+  productId: v.id("product"),
+  productName: v.string(),
+  productSkuId: v.id("productSku"),
+  sku: v.optional(v.string()),
+});
+
+const legacyImportTrustedVisibilityRepairCursorValidator = v.object({
+  finalizedAt: v.number(),
+  scannedRowIds: v.array(v.id("inventoryImportProvisionalSku")),
+  status: v.union(v.literal("active"), v.literal("finalized")),
+});
+
+const legacyImportTrustedVisibilityRepairResultValidator = v.object({
+  dryRun: v.boolean(),
+  limit: v.number(),
+  nextCursor: v.optional(legacyImportTrustedVisibilityRepairCursorValidator),
+  promotedToLive: v.number(),
+  refreshedSearchProjections: v.number(),
+  repairedProducts: v.number(),
+  repairedSkus: v.array(legacyImportTrustedVisibilityRepairSkuValidator),
+  scannedRows: v.number(),
+  skippedArchivedProducts: v.number(),
+  skippedLegacyTaxonomy: v.number(),
+  taxonomyWorkItemsEnsured: v.number(),
+  taxonomyWorkItemSkus: v.array(legacyImportTrustedVisibilityRepairSkuValidator),
+  truncated: v.boolean(),
+  visibleProducts: v.number(),
 });
 
 const provisionalImportStageRowValidator = v.object({
@@ -1019,6 +1081,236 @@ export const finalizeTrustedInventoryFromProductPage = mutation({
     }
   },
 });
+
+export const repairOnboardedLegacyImportTrustedSkuVisibility = internalMutation({
+  args: {
+    cursor: v.optional(legacyImportTrustedVisibilityRepairCursorValidator),
+    dryRun: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
+    storeId: v.id("store"),
+  },
+  returns: legacyImportTrustedVisibilityRepairResultValidator,
+  async handler(ctx, args) {
+    return repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(ctx, {
+      cursor: args.cursor,
+      dryRun: args.dryRun ?? true,
+      limit: args.limit,
+      storeId: args.storeId,
+    });
+  },
+});
+
+export async function repairOnboardedLegacyImportTrustedSkuVisibilityWithCtx(
+  ctx: MutationCtx,
+  args: {
+    cursor?: LegacyImportTrustedVisibilityRepairCursor;
+    dryRun?: boolean;
+    limit?: number;
+    storeId: Id<"store">;
+  },
+): Promise<LegacyImportTrustedVisibilityRepairResult> {
+  const dryRun = args.dryRun ?? true;
+  const limit = normalizeLegacyImportTrustedVisibilityRepairLimit(args.limit);
+  const candidateRows = await listLegacyImportTrustedVisibilityRepairRows(ctx, {
+    cursor: args.cursor,
+    limit: limit + 1,
+    storeId: args.storeId,
+  });
+  const rows = candidateRows.slice(0, limit);
+  const lastScannedRow = rows.at(-1);
+  const nextCursor =
+    candidateRows.length > limit && lastScannedRow?.finalizedAt !== undefined
+      ? {
+          finalizedAt: lastScannedRow.finalizedAt,
+          scannedRowIds: [
+            ...(args.cursor?.status === lastScannedRow.status &&
+            args.cursor.finalizedAt === lastScannedRow.finalizedAt
+              ? args.cursor.scannedRowIds
+              : []),
+            ...rows
+              .filter(
+                (row) =>
+                  row.status === lastScannedRow.status &&
+                  row.finalizedAt === lastScannedRow.finalizedAt,
+              )
+              .map((row) => row._id),
+          ],
+          status: lastScannedRow.status as "active" | "finalized",
+        }
+      : undefined;
+  const repairedSkus: LegacyImportTrustedVisibilityRepairSku[] = [];
+  const taxonomyWorkItemSkus: LegacyImportTrustedVisibilityRepairSku[] = [];
+  const repairedProductIds = new Set<Id<"product">>();
+  let promotedToLive = 0;
+  let refreshedSearchProjections = 0;
+  let skippedArchivedProducts = 0;
+  let skippedLegacyTaxonomy = 0;
+  let taxonomyWorkItemsEnsured = 0;
+  let visibleProducts = 0;
+
+  for (const row of rows) {
+    if (!row.productId || !row.productSkuId || row.finalizedAt === undefined) {
+      continue;
+    }
+
+    const [product, productSku, taxonomyState] = await Promise.all([
+      ctx.db.get("product", row.productId),
+      ctx.db.get("productSku", row.productSkuId),
+      readProductTaxonomyStateWithCtx(ctx, {
+        productId: row.productId,
+        storeId: args.storeId,
+      }),
+    ]);
+
+    if (
+      !product ||
+      product.storeId !== args.storeId ||
+      !productSku ||
+      productSku.storeId !== args.storeId ||
+      productSku.productId !== product._id
+    ) {
+      continue;
+    }
+
+    if (product.availability === "archived") {
+      skippedArchivedProducts += 1;
+      continue;
+    }
+
+    if (!taxonomyState?.hasAthenaTaxonomy) {
+      skippedLegacyTaxonomy += 1;
+      taxonomyWorkItemSkus.push({
+        productId: product._id,
+        productName: product.name,
+        productSkuId: productSku._id,
+        ...(productSku.sku ? { sku: productSku.sku } : {}),
+      });
+      if (!dryRun) {
+        await ensureCatalogTaxonomySetupWorkForProductWithCtx(ctx, {
+          productId: product._id,
+          productSkuId: productSku._id,
+          provisionalSkuId: row._id,
+          storeId: args.storeId,
+        });
+        taxonomyWorkItemsEnsured += 1;
+      }
+      continue;
+    }
+
+    const shouldPromoteToLive = product.availability === "draft";
+    const shouldMakeVisible = product.isVisible === false;
+    const productAlreadyRepaired = repairedProductIds.has(product._id);
+    if (!shouldPromoteToLive && !shouldMakeVisible && !productAlreadyRepaired) {
+      continue;
+    }
+
+    repairedSkus.push({
+      productId: product._id,
+      productName: product.name,
+      productSkuId: productSku._id,
+      ...(productSku.sku ? { sku: productSku.sku } : {}),
+    });
+    if (shouldPromoteToLive) promotedToLive += 1;
+    if (shouldMakeVisible) visibleProducts += 1;
+
+    if (dryRun) {
+      continue;
+    }
+
+    if (!productAlreadyRepaired) {
+      await ctx.db.patch("product", product._id, {
+        ...(shouldPromoteToLive ? { availability: "live" as const } : {}),
+        ...(shouldMakeVisible ? { isVisible: true } : {}),
+      });
+      repairedProductIds.add(product._id);
+    }
+
+    await upsertProductSkuSearchProjection(ctx, productSku._id);
+    refreshedSearchProjections += 1;
+  }
+
+  return {
+    dryRun,
+    limit,
+    ...(nextCursor ? { nextCursor } : {}),
+    promotedToLive,
+    refreshedSearchProjections,
+    repairedProducts: new Set(repairedSkus.map((sku) => sku.productId)).size,
+    repairedSkus,
+    scannedRows: rows.length,
+    skippedArchivedProducts,
+    skippedLegacyTaxonomy,
+    taxonomyWorkItemsEnsured: dryRun
+      ? taxonomyWorkItemSkus.length
+      : taxonomyWorkItemsEnsured,
+    taxonomyWorkItemSkus,
+    truncated: Boolean(nextCursor),
+    visibleProducts,
+  };
+}
+
+function normalizeLegacyImportTrustedVisibilityRepairLimit(limit?: number) {
+  if (!Number.isFinite(limit) || limit === undefined) {
+    return LEGACY_IMPORT_TRUSTED_VISIBILITY_REPAIR_LIMIT;
+  }
+
+  return Math.max(
+    1,
+    Math.min(
+      LEGACY_IMPORT_TRUSTED_VISIBILITY_REPAIR_LIMIT,
+      Math.trunc(limit),
+    ),
+  );
+}
+
+async function listLegacyImportTrustedVisibilityRepairRows(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    cursor?: LegacyImportTrustedVisibilityRepairCursor;
+    limit: number;
+    storeId: Id<"store">;
+  },
+) {
+  const rows: Array<Doc<"inventoryImportProvisionalSku">> = [];
+  const statuses = ["active", "finalized"] as const;
+  const startStatusIndex = args.cursor
+    ? Math.max(0, statuses.indexOf(args.cursor.status))
+    : 0;
+
+  for (const status of statuses.slice(startStatusIndex)) {
+    if (rows.length >= args.limit) break;
+    const finalizedAtFloor =
+      args.cursor?.status === status ? args.cursor.finalizedAt - 1 : -1;
+    const scannedRowIds =
+      args.cursor?.status === status ? new Set(args.cursor.scannedRowIds) : null;
+
+    const statusRows = await ctx.db
+      .query("inventoryImportProvisionalSku")
+      .withIndex("by_storeId_status_finalizedAt", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("status", status)
+          .gt("finalizedAt", finalizedAtFloor),
+      )
+      .take((args.limit - rows.length) + (scannedRowIds?.size ?? 0));
+
+    rows.push(
+      ...statusRows
+        .filter((row) => {
+          if (!args.cursor || args.cursor.status !== status) return true;
+          if (row.finalizedAt === undefined) return false;
+          if (row.finalizedAt < args.cursor.finalizedAt) return false;
+          return !(
+            row.finalizedAt === args.cursor.finalizedAt &&
+            scannedRowIds?.has(row._id)
+          );
+        })
+        .slice(0, args.limit - rows.length),
+    );
+  }
+
+  return rows;
+}
 
 export async function listProductPageProvisionalSkuBindingWithCtx(
   ctx: Pick<QueryCtx | MutationCtx, "db">,

--- a/packages/athena-webapp/convex/inventory/products.sku.test.ts
+++ b/packages/athena-webapp/convex/inventory/products.sku.test.ts
@@ -1316,6 +1316,143 @@ describe("product archiving", () => {
     });
   });
 
+  it("makes onboarded trusted legacy import products visible in catalog search", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "storezzzz",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional001",
+          finalTrustedQuantity: 5,
+          finalizedAt: 1_000,
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "active",
+          storeId: "storezzzz",
+        },
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          categoryId: "category-legacy",
+          isVisible: false,
+          name: "Quick And Go Bonding Glue",
+          organizationId: "org0001",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-protectant",
+          categoryId: "category-hair",
+          name: "Heat Protectant",
+          slug: "heat-protectant",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(update)(ctx, {
+      categoryId: "category-hair" as Id<"category">,
+      id: "product001" as Id<"product">,
+      subcategoryId: "subcategory-protectant" as Id<"subcategory">,
+    });
+
+    expect(tables.product.get("product001")).toMatchObject({
+      categoryId: "category-hair",
+      isVisible: true,
+      subcategoryId: "subcategory-protectant",
+    });
+    expect(mocks.refreshProductSkuSearchForProduct).toHaveBeenCalledWith(
+      ctx,
+      "product001",
+    );
+  });
+
+  it("keeps onboarded trusted legacy import products hidden when explicitly requested", async () => {
+    const { ctx, tables } = createSkuMutationCtx({
+      category: [
+        {
+          _id: "category-hair",
+          name: "Hair Care",
+          slug: "hair-care",
+          storeId: "storezzzz",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional001",
+          finalTrustedQuantity: 5,
+          finalizedAt: 1_000,
+          productId: "product001",
+          productSkuId: "sku001",
+          status: "active",
+          storeId: "storezzzz",
+        },
+      ],
+      product: [
+        {
+          _id: "product001",
+          availability: "live",
+          categoryId: "category-legacy",
+          isVisible: false,
+          name: "Quick And Go Bonding Glue",
+          organizationId: "org0001",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-legacy",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku001",
+          productId: "product001",
+          storeId: "storezzzz",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-protectant",
+          categoryId: "category-hair",
+          name: "Heat Protectant",
+          slug: "heat-protectant",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    await getHandler(update)(ctx, {
+      categoryId: "category-hair" as Id<"category">,
+      id: "product001" as Id<"product">,
+      isVisible: false,
+      subcategoryId: "subcategory-protectant" as Id<"subcategory">,
+    });
+
+    expect(tables.product.get("product001")).toMatchObject({
+      categoryId: "category-hair",
+      isVisible: false,
+      subcategoryId: "subcategory-protectant",
+    });
+    expect(mocks.refreshProductSkuSearchForProduct).toHaveBeenCalledWith(
+      ctx,
+      "product001",
+    );
+  });
+
   it("rejects finalized legacy import review row saves when taxonomy remains legacy import", async () => {
     const { ctx, tables } = createSkuMutationCtx({
       category: [

--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -1096,10 +1096,18 @@ export const update = mutation({
     if (taxonomyChanged) {
       const productAfterPatch = await ctx.db.get("product", args.id);
       if (productAfterPatch) {
-        await completeFinalizedLegacyImportRowsForProductTaxonomyWithCtx(ctx, {
-          productId: productAfterPatch._id,
-          storeId: productAfterPatch.storeId,
-        });
+        const completedLegacyImportRows =
+          await completeFinalizedLegacyImportRowsForProductTaxonomyWithCtx(ctx, {
+            productId: productAfterPatch._id,
+            storeId: productAfterPatch.storeId,
+          });
+        if (
+          completedLegacyImportRows > 0 &&
+          args.isVisible !== false &&
+          productAfterPatch.isVisible === false
+        ) {
+          await ctx.db.patch("product", args.id, { isVisible: true });
+        }
         await completeCatalogTaxonomySetupWorkForProductWithCtx(ctx, {
           productId: productAfterPatch._id,
           storeId: productAfterPatch.storeId,

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -271,7 +271,7 @@ describe("createLocalSyncIngestionService", () => {
     expect(repository.createdPaymentAllocations).toHaveLength(2);
   });
 
-  it("returns inventory review work item mappings when a conflicted sale is retried", async () => {
+  it("returns inventory review work item mappings when a reviewed sale is retried", async () => {
     const repository = createFakeSyncRepository();
     const service = createLocalSyncIngestionService({
       repository,
@@ -322,7 +322,7 @@ describe("createLocalSyncIngestionService", () => {
       expect(result.data.accepted).toEqual([
         expect.objectContaining({
           localEventId: "event-sale-completed-1",
-          status: "conflicted",
+          status: "projected",
         }),
       ]);
       expect(result.data.mappings).toEqual(
@@ -338,14 +338,306 @@ describe("createLocalSyncIngestionService", () => {
           }),
         ]),
       );
-      expect(result.data.conflicts).toEqual([
-        expect.objectContaining({
-          conflictType: "inventory",
-          status: "needs_review",
-        }),
-      ]);
+      expect(result.data.conflicts).toEqual([]);
     }
     expect(repository.createdTransactions).toHaveLength(1);
+  });
+
+  it("projects eligible SKU inventory movement when another SKU needs review", async () => {
+    const repository = createFakeSyncRepository({
+      skus: [
+        {
+          _id: "sku-1",
+          storeId: "store-1",
+          productId: "product-1",
+          sku: "CAP-1",
+          price: 25,
+          quantityAvailable: 0,
+          inventoryCount: 0,
+          images: [],
+        },
+        {
+          _id: "sku-2",
+          storeId: "store-1",
+          productId: "product-2",
+          sku: "BRUSH-1",
+          price: 15,
+          quantityAvailable: 4,
+          inventoryCount: 4,
+          images: [],
+        },
+      ],
+    });
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+    const sale = buildSaleCompletedEvent({
+      sequence: 1,
+      payload: {
+        ...buildSaleCompletedEvent({ sequence: 1 }).payload,
+        totals: {
+          subtotal: 55,
+          tax: 0,
+          total: 55,
+        },
+        items: [
+          {
+            localTransactionItemId: "local-blocked-line-1",
+            productId: "product-1" as never,
+            productSkuId: "sku-1" as never,
+            productName: "Wig Cap",
+            productSku: "CAP-1",
+            quantity: 1,
+            unitPrice: 25,
+          },
+          {
+            localTransactionItemId: "local-eligible-line-1",
+            productId: "product-2" as never,
+            productSkuId: "sku-2" as never,
+            productName: "Edge Brush",
+            productSku: "BRUSH-1",
+            quantity: 2,
+            unitPrice: 15,
+          },
+        ],
+        payments: [
+          {
+            localPaymentId: "local-payment-1",
+            method: "cash",
+            amount: 55,
+            timestamp: 21,
+          },
+        ],
+      },
+    });
+
+    const result = await service.ingestBatch(buildBatch({ events: [sale] }));
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") {
+      throw new Error("Expected ok result");
+    }
+    expect(result.data.accepted).toEqual([
+      expect.objectContaining({
+        localEventId: "event-sale-completed-1",
+        status: "projected",
+      }),
+    ]);
+    expect(result.data.conflicts).toEqual([]);
+    expect(repository.createdServiceWorkItems).toEqual([
+      expect.objectContaining({
+        type: "synced_sale_inventory_review",
+        metadata: expect.objectContaining({
+          primaryProductSkuId: "sku-1",
+          skippedMutationItems: [
+            expect.objectContaining({
+              productSkuId: "sku-1",
+              reason: "stock_shortfall",
+              requestedQuantity: 1,
+            }),
+          ],
+        }),
+      }),
+    ]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([
+      expect.objectContaining({
+        productSkuId: "sku-2",
+        quantity: 2,
+        transactionNumber: "LR-001",
+      }),
+    ]);
+    expect(repository.productPatches).toEqual([
+      {
+        productSkuId: "sku-2",
+        patch: {
+          inventoryCount: 2,
+          quantityAvailable: 2,
+        },
+      },
+    ]);
+  });
+
+  it("backfills eligible SKU movement when an already-projected reviewed sale retries", async () => {
+    const repository = createFakeSyncRepository({
+      skus: [
+        {
+          _id: "sku-1",
+          storeId: "store-1",
+          productId: "product-1",
+          sku: "CAP-1",
+          price: 25,
+          quantityAvailable: 0,
+          inventoryCount: 0,
+          images: [],
+        },
+        {
+          _id: "sku-2",
+          storeId: "store-1",
+          productId: "product-2",
+          sku: "BRUSH-1",
+          price: 15,
+          quantityAvailable: 4,
+          inventoryCount: 4,
+          images: [],
+        },
+      ],
+    });
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 200,
+    });
+    const sale = buildSaleCompletedEvent({
+      sequence: 1,
+      payload: {
+        ...buildSaleCompletedEvent({ sequence: 1 }).payload,
+        totals: {
+          subtotal: 55,
+          tax: 0,
+          total: 55,
+        },
+        items: [
+          {
+            localTransactionItemId: "local-blocked-line-1",
+            productId: "product-1" as never,
+            productSkuId: "sku-1" as never,
+            productName: "Wig Cap",
+            productSku: "CAP-1",
+            quantity: 1,
+            unitPrice: 25,
+          },
+          {
+            localTransactionItemId: "local-eligible-line-1",
+            productId: "product-2" as never,
+            productSkuId: "sku-2" as never,
+            productName: "Edge Brush",
+            productSku: "BRUSH-1",
+            quantity: 2,
+            unitPrice: 15,
+          },
+        ],
+        payments: [
+          {
+            localPaymentId: "local-payment-1",
+            method: "cash",
+            amount: 55,
+            timestamp: 21,
+          },
+        ],
+      },
+    });
+    const salePayload = sale.payload as PosLocalSalePayload;
+    repository.events.push({
+      _id: "sync-event-existing",
+      acceptedAt: 100,
+      eventType: "sale_completed",
+      localEventId: sale.localEventId,
+      localRegisterSessionId: sale.localRegisterSessionId ?? "",
+      occurredAt: sale.occurredAt,
+      payload: {
+        ...salePayload,
+        receiptNumber: salePayload.localReceiptNumber,
+      },
+      projectedAt: 100,
+      sequence: sale.sequence,
+      staffProfileId: sale.staffProfileId as never,
+      status: "projected",
+      storeId: "store-1" as never,
+      submittedAt: 100,
+      syncScope: "pos",
+      terminalId: "terminal-1" as never,
+    });
+    repository.mappings.push({
+      _id: "mapping-transaction-existing",
+      cloudId: "transaction-existing" as never,
+      cloudTable: "posTransaction",
+      createdAt: 100,
+      localEventId: sale.localEventId,
+      localId: salePayload.localTransactionId,
+      localIdKind: "transaction",
+      localRegisterSessionId: sale.localRegisterSessionId ?? "",
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+    });
+    repository.conflicts.push({
+      _id: "conflict-reviewed-inventory",
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      localRegisterSessionId: sale.localRegisterSessionId ?? "",
+      localEventId: sale.localEventId,
+      sequence: sale.sequence,
+      conflictType: "inventory",
+      status: "resolved",
+      summary: "Inventory needs manager review for a synced offline sale.",
+      details: {
+        localTransactionId: salePayload.localTransactionId,
+        productSkuId: "sku-1",
+        quantityAvailable: 0,
+        requestedQuantity: 1,
+      },
+      createdAt: 100,
+      resolvedAt: 150,
+    });
+
+    const retry = await service.ingestBatch(buildBatch({ events: [sale] }));
+
+    expect(retry.kind).toBe("ok");
+    if (retry.kind !== "ok") {
+      throw new Error("Expected ok result");
+    }
+    expect(retry.data.accepted).toEqual([
+      expect.objectContaining({
+        localEventId: "event-sale-completed-1",
+        status: "projected",
+      }),
+    ]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([
+      expect.objectContaining({
+        posTransactionId: "transaction-existing",
+        productSkuId: "sku-2",
+        quantity: 2,
+      }),
+    ]);
+    expect(repository.productPatches).toEqual([
+      {
+        productSkuId: "sku-2",
+        patch: {
+          inventoryCount: 2,
+          quantityAvailable: 2,
+        },
+      },
+    ]);
+
+    const secondRetry = await service.ingestBatch(buildBatch({ events: [sale] }));
+
+    expect(secondRetry.kind).toBe("ok");
+    if (secondRetry.kind !== "ok") {
+      throw new Error("Expected ok result");
+    }
+    expect(secondRetry.data.accepted).toEqual([
+      expect.objectContaining({
+        localEventId: "event-sale-completed-1",
+        status: "projected",
+      }),
+    ]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([
+      expect.objectContaining({
+        posTransactionId: "transaction-existing",
+        productSkuId: "sku-2",
+        quantity: 2,
+      }),
+    ]);
+    expect(repository.productPatches).toEqual([
+      {
+        productSkuId: "sku-2",
+        patch: {
+          inventoryCount: 2,
+          quantityAvailable: 2,
+        },
+      },
+    ]);
   });
 
   it("rejects and preserves a projected event when a duplicate local event id has changed data", async () => {
@@ -4244,6 +4536,16 @@ function createFakeSyncRepository(
       storeId: string;
       terminalId: string;
     };
+    skus: Array<{
+      _id: string;
+      storeId: string;
+      productId: string;
+      sku: string;
+      price: number;
+      quantityAvailable: number;
+      inventoryCount: number;
+      images: string[];
+    }>;
     consumedHoldQuantities: Map<string, number>;
     existingRegisterSession: {
       _id: string;
@@ -4267,11 +4569,14 @@ function createFakeSyncRepository(
   createdExpenseSessionItems: unknown[];
   createdExpenseTransactions: unknown[];
   createdExpenseTransactionItems: unknown[];
+  createdServiceWorkItems: unknown[];
   createdRegisterSessions: unknown[];
   createdTransactions: unknown[];
   events: LocalSyncEventRecord[];
   mappings: LocalSyncMappingRecord[];
+  productPatches: unknown[];
   registerSessionPatches: Array<{ registerSessionId: string; patch: unknown }>;
+  recordedSaleInventoryMovements: unknown[];
   roleChecks: Array<{
     allowedRoles: string[];
     staffProfileId: string;
@@ -4295,6 +4600,9 @@ function createFakeSyncRepository(
   const createdExpenseSessionItems: unknown[] = [];
   const createdExpenseTransactions: unknown[] = [];
   const createdExpenseTransactionItems: unknown[] = [];
+  const createdServiceWorkItems: unknown[] = [];
+  const productPatches: unknown[] = [];
+  const recordedSaleInventoryMovements: unknown[] = [];
   const registerSessionPatches: Array<{
     registerSessionId: string;
     patch: unknown;
@@ -4322,6 +4630,18 @@ function createFakeSyncRepository(
     storeId: "store-1",
     terminalId: "terminal-1",
   };
+  const skus = overrides.skus ?? [
+    {
+      _id: "sku-1",
+      storeId: "store-1",
+      productId: "product-1",
+      sku: "CAP-1",
+      price: 25,
+      quantityAvailable: 10,
+      inventoryCount: 10,
+      images: [],
+    },
+  ];
 
   return {
     conflicts,
@@ -4331,11 +4651,14 @@ function createFakeSyncRepository(
     createdExpenseSessionItems,
     createdExpenseTransactions,
     createdExpenseTransactionItems,
+    createdServiceWorkItems,
     createdRegisterSessions,
     createdTransactions,
     events,
     mappings,
+    productPatches,
     registerSessionPatches,
+    recordedSaleInventoryMovements,
     roleChecks,
     async getTerminal(terminalId) {
       return terminal && terminal._id === terminalId
@@ -4393,26 +4716,16 @@ function createFakeSyncRepository(
       } as never;
     },
     async getProduct(productId) {
-      return productId === "product-1"
+      const sku = skus.find((candidate) => candidate.productId === productId);
+      return sku
         ? ({
-            _id: "product-1",
-            storeId: "store-1",
+            _id: productId,
+            storeId: sku.storeId,
           } as never)
         : null;
     },
     async getProductSku(productSkuId) {
-      return productSkuId === "sku-1"
-        ? ({
-            _id: "sku-1",
-            storeId: "store-1",
-            productId: "product-1",
-            sku: "CAP-1",
-            price: 25,
-            quantityAvailable: 10,
-            inventoryCount: 10,
-            images: [],
-          } as never)
-        : null;
+      return (skus.find((candidate) => candidate._id === productSkuId) as never) ?? null;
     },
     async getPendingCheckoutItem(pendingCheckoutItemId) {
       const created = createdPendingCheckoutItems.find(
@@ -4774,8 +5087,10 @@ function createFakeSyncRepository(
     async recordPendingCheckoutItemSaleEvidence(input) {
       return this.getPendingCheckoutItem(input.pendingCheckoutItemId);
     },
-    async createServiceWorkItem() {
-      return `service-work-item-${nextId++}` as never;
+    async createServiceWorkItem(input) {
+      const id = `service-work-item-${nextId++}`;
+      createdServiceWorkItems.push({ _id: id, ...input });
+      return id as never;
     },
     async createServiceCase() {
       return `service-case-${nextId++}` as never;
@@ -4834,8 +5149,27 @@ function createFakeSyncRepository(
     async createTransactionServiceLine() {
       return `transaction-service-line-${nextId++}` as never;
     },
-    async patchProductSku() {},
-    async recordSaleInventoryMovement() {
+    async patchProductSku(productSkuId, patch) {
+      productPatches.push({ productSkuId, patch });
+    },
+    async recordSaleInventoryMovement(input) {
+      if (
+        recordedSaleInventoryMovements.some(
+          (movement) => {
+            const recordedMovement = movement as {
+              posTransactionId?: unknown;
+              productSkuId?: unknown;
+            };
+            return (
+              recordedMovement.posTransactionId === input.posTransactionId &&
+              recordedMovement.productSkuId === input.productSkuId
+            );
+          },
+        )
+      ) {
+        return "existing";
+      }
+      recordedSaleInventoryMovements.push(input);
       return "inserted";
     },
     async createPaymentAllocation(input) {

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
@@ -108,6 +108,7 @@ type IngestionDependencies = {
 const TERMINAL_NOT_PROVISIONED_MESSAGE =
   "This terminal is not provisioned for POS sync.";
 const TERMINAL_INGESTION_PROJECTION_OPTIONS = {
+  allowReviewedInventorySaleProjection: true,
   trustStoredStaffProof: true,
 } as const;
 
@@ -251,6 +252,45 @@ export function createLocalSyncIngestionService(
                   },
                 );
                 continue;
+              }
+
+              if (
+                existing.status === "projected" &&
+                retryParseResult.event.eventType === "sale_completed"
+              ) {
+                const acceptedAt = existing.acceptedAt ?? dependencies.now();
+                const projection = await projectLocalSyncEvent(
+                  dependencies.projectionRepository,
+                  {
+                    storeId: batch.storeId,
+                    terminalId: batch.terminalId,
+                    event: retryParseResult.event,
+                    syncEventId: existing._id,
+                    submittedByUserId: batch.submittedByUserId,
+                    now: acceptedAt,
+                    options: TERMINAL_INGESTION_PROJECTION_OPTIONS,
+                  },
+                );
+                if (
+                  projection.status === "projected" &&
+                  projection.conflicts.length === 0
+                ) {
+                  await dependencies.repository.patchEvent(existing._id, {
+                    projectedAt: dependencies.now(),
+                    submittedAt: batch.submittedAt,
+                  });
+                  accepted.push({
+                    localEventId: existing.localEventId,
+                    sequence: existing.sequence,
+                    status: "projected",
+                  });
+                  mappings.push(...projection.mappings);
+                  acceptedThroughSequence = advanceAcceptedThroughSequence(
+                    acceptedThroughSequence,
+                    existing,
+                  );
+                  continue;
+                }
               }
             }
 

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -1007,6 +1007,126 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
+  it("projects eligible SKU movements when another SKU in the sale needs inventory review", async () => {
+    const repository = createProjectionRepository({
+      skus: [
+        {
+          _id: "sku-1",
+          storeId: "store-1",
+          productId: "product-1",
+          sku: "CAP-1",
+          price: 25,
+          quantityAvailable: 0,
+          inventoryCount: 0,
+          images: [],
+        },
+        {
+          _id: "sku-2",
+          storeId: "store-1",
+          productId: "product-2",
+          sku: "BRUSH-1",
+          price: 15,
+          quantityAvailable: 4,
+          inventoryCount: 4,
+          images: [],
+        },
+      ],
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          items: [
+            {
+              localTransactionItemId: "local-blocked-line-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              productName: "Wig Cap",
+              productSku: "CAP-1",
+              quantity: 1,
+              unitPrice: 25,
+            },
+            {
+              localTransactionItemId: "local-eligible-line-1",
+              productId: "product-2" as never,
+              productSkuId: "sku-2" as never,
+              productName: "Edge Brush",
+              productSku: "BRUSH-1",
+              quantity: 2,
+              unitPrice: 15,
+            },
+          ],
+          totals: {
+            subtotal: 55,
+            tax: 0,
+            total: 55,
+          },
+          payments: [
+            {
+              localPaymentId: "local-payment-1",
+              method: "cash",
+              amount: 55,
+              timestamp: 21,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      submittedByUserId: "athena-user-1" as never,
+      now: 100,
+      options: {
+        allowReviewedInventorySaleProjection: true,
+      },
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.createdConflicts).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([
+      expect.objectContaining({
+        productSkuId: "sku-2",
+        quantity: 2,
+        transactionNumber: "LR-001",
+      }),
+    ]);
+    expect(repository.productPatches).toEqual([
+      {
+        productSkuId: "sku-2",
+        patch: {
+          inventoryCount: 2,
+          quantityAvailable: 2,
+        },
+      },
+    ]);
+    expect(repository.createdServiceWorkItems).toEqual([
+      expect.objectContaining({
+        type: "synced_sale_inventory_review",
+        metadata: expect.objectContaining({
+          primaryProductSkuId: "sku-1",
+          skippedMutationItems: [
+            expect.objectContaining({
+              productSkuId: "sku-1",
+              reason: "stock_shortfall",
+              requestedQuantity: 1,
+            }),
+          ],
+          trustedInventoryLines: expect.arrayContaining([
+            expect.objectContaining({
+              productSkuId: "sku-1",
+              quantity: 1,
+            }),
+            expect.objectContaining({
+              productSkuId: "sku-2",
+              quantity: 2,
+            }),
+          ]),
+        }),
+      }),
+    ]);
+  });
+
   it("routes only the finalized slice to inventory review when trusted same-SKU stock still fits", async () => {
     const repository = createProjectionRepository({
       sku: {
@@ -3895,6 +4015,202 @@ describe("projectLocalSyncEvent", () => {
     );
     expect(repository.createdTransactions).toEqual([]);
     expect(repository.createdServiceWorkItems).toHaveLength(1);
+  });
+
+  it("does not create inventory review work for ordinary projected sale retries", async () => {
+    const repository = createProjectionRepository({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        productId: "product-1",
+        sku: "CAP-1",
+        price: 25,
+        quantityAvailable: 0,
+        inventoryCount: 0,
+        images: [],
+      },
+    });
+    repository.mappings.push(
+      {
+        _id: "mapping-existing-transaction",
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event-sale-completed-1",
+        localIdKind: "transaction",
+        localId: "local-txn-1",
+        cloudTable: "posTransaction",
+        cloudId: "transaction-1",
+        createdAt: 1,
+      },
+      {
+        _id: "mapping-existing-receipt",
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event-sale-completed-1",
+        localIdKind: "receipt",
+        localId: "LR-001",
+        cloudTable: "posTransaction",
+        cloudId: "transaction-1",
+        createdAt: 1,
+      },
+    );
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent(),
+      syncEventId: "sync-event-1",
+      submittedByUserId: "athena-user-1" as never,
+      now: 100,
+      options: {
+        allowReviewedInventorySaleProjection: true,
+      },
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.createdConflicts).toEqual([]);
+    expect(repository.createdServiceWorkItems).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([]);
+    expect(repository.productPatches).toEqual([]);
+    expect(result.mappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          localIdKind: "transaction",
+          cloudId: "transaction-1",
+        }),
+      ]),
+    );
+  });
+
+  it("backfills stock movement for reviewed sale replay once inventory is available", async () => {
+    const repository = createProjectionRepository({
+      consumedHoldQuantities: new Map([["sku-1", 1]]),
+      existingPosSession: {
+        _id: "local-session-1",
+        registerSessionId: "register-session-1",
+        staffProfileId: "staff-1",
+        status: "completed",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        transactionId: "transaction-1",
+      },
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        productId: "product-1",
+        sku: "CAP-1",
+        price: 25,
+        quantityAvailable: 4,
+        inventoryCount: 4,
+        images: [],
+      },
+    });
+    repository.createdPosSessions.push({
+      _id: "pos-session-1",
+      completedAt: 20,
+      createdAt: 20,
+      expiresAt: 20,
+      inventoryHoldMode: "ledger",
+      payments: [
+        {
+          amount: 25,
+          method: "cash",
+          timestamp: 21,
+        },
+      ],
+      registerNumber: "1",
+      registerSessionId: "register-session-1",
+      sessionNumber: "local-session-1",
+      staffProfileId: "staff-1",
+      status: "completed",
+      storeId: "store-1",
+      subtotal: 25,
+      tax: 0,
+      terminalId: "terminal-1",
+      total: 25,
+      transactionId: "transaction-1",
+      updatedAt: 20,
+    });
+    repository.mappings.push(
+      {
+        _id: "mapping-existing-pos-session",
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event-sale-completed-1",
+        localIdKind: "posSession",
+        localId: "local-session-1",
+        cloudTable: "posSession",
+        cloudId: "pos-session-1",
+        createdAt: 1,
+      },
+      {
+        _id: "mapping-existing-transaction",
+        storeId: "store-1" as never,
+        terminalId: "terminal-1" as never,
+        localRegisterSessionId: "local-register-1",
+        localEventId: "event-sale-completed-1",
+        localIdKind: "transaction",
+        localId: "local-txn-1",
+        cloudTable: "posTransaction",
+        cloudId: "transaction-1",
+        createdAt: 1,
+      },
+    );
+    repository.createdConflicts.push({
+      _id: "conflict-reviewed-inventory",
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      localRegisterSessionId: "local-register-1",
+      localEventId: "event-sale-completed-1",
+      sequence: 2,
+      conflictType: "inventory",
+      status: "resolved",
+      summary: "Inventory needs manager review for a synced offline sale.",
+      details: {
+        localTransactionId: "local-txn-1",
+        productSkuId: "sku-1",
+        quantityAvailable: 0,
+        requestedQuantity: 1,
+      },
+      createdAt: 1,
+      resolvedAt: 50,
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent(),
+      syncEventId: "sync-event-1",
+      submittedByUserId: "athena-user-1" as never,
+      now: 100,
+      options: {
+        allowReviewedInventorySaleProjection: true,
+      },
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.createdServiceWorkItems).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([
+      expect.objectContaining({
+        posTransactionId: "transaction-1",
+        productSkuId: "sku-1",
+        quantity: 1,
+      }),
+    ]);
+    expect(repository.productPatches).toEqual([
+      {
+        productSkuId: "sku-1",
+        patch: {
+          inventoryCount: 3,
+          quantityAvailable: 3,
+        },
+      },
+    ]);
   });
 
   it("preserves a reviewed sale without reusing a duplicate local POS session", async () => {
@@ -7708,6 +8024,17 @@ function createProjectionRepository(
       inventoryCount: number;
       images: string[];
     };
+    skus: Array<{
+      _id: string;
+      storeId: string;
+      productId: string;
+      sku: string;
+      price: number;
+      netPrice?: number;
+      quantityAvailable: number;
+      inventoryCount: number;
+      images: string[];
+    }>;
     productStoreId: string;
     customerStoreId: string;
     serviceCatalog: {
@@ -7921,6 +8248,7 @@ function createProjectionRepository(
     inventoryCount: 10,
     images: [],
   };
+  const skus = overrides.skus ?? [sku];
   const registerSession =
     overrides.registerSession === null
       ? null
@@ -8048,15 +8376,16 @@ function createProjectionRepository(
       } as never;
     },
     async getProduct(productId) {
-      return productId === "product-1"
+      const productSku = skus.find((candidate) => candidate.productId === productId);
+      return productSku
         ? ({
-            _id: "product-1",
-            storeId: overrides.productStoreId ?? "store-1",
+            _id: productId,
+            storeId: overrides.productStoreId ?? productSku.storeId,
           } as never)
         : null;
     },
     async getProductSku(productSkuId) {
-      return productSkuId === "sku-1" ? (sku as never) : null;
+      return (skus.find((candidate) => candidate._id === productSkuId) as never) ?? null;
     },
     async getPendingCheckoutItem(pendingCheckoutItemId) {
       const created = createdPendingCheckoutItems.find(
@@ -8559,6 +8888,22 @@ function createProjectionRepository(
       productPatches.push({ productSkuId, patch });
     },
     async recordSaleInventoryMovement(input) {
+      if (
+        recordedSaleInventoryMovements.some(
+          (movement) => {
+            const recordedMovement = movement as {
+              posTransactionId?: unknown;
+              productSkuId?: unknown;
+            };
+            return (
+              recordedMovement.posTransactionId === input.posTransactionId &&
+              recordedMovement.productSkuId === input.productSkuId
+            );
+          },
+        )
+      ) {
+        return "existing";
+      }
       recordedSaleInventoryMovements.push(input);
       return "inserted";
     },

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1464,18 +1464,17 @@ async function resolveExistingSaleProjection(
       !reviewedConflictIds.has(conflict._id) &&
       !reviewedConflictIds.has(conflict.localEventId),
   );
-  const reviewedInventoryConflicts = eventConflicts.filter(
+  const hasReviewedInventoryConflict = eventConflicts.some(
     (conflict) =>
-      conflict.status === "needs_review" &&
       conflict.conflictType === "inventory" &&
-      (reviewedConflictIds.has(conflict._id) ||
+      (conflict.status !== "needs_review" ||
+        reviewedConflictIds.has(conflict._id) ||
         reviewedConflictIds.has(conflict.localEventId)),
   );
-
   if (
     args.options?.allowReviewedInventorySaleProjection === true &&
-    existingConflicts.length === 0 &&
-    reviewedInventoryConflicts.length > 0
+    hasReviewedInventoryConflict &&
+    existingConflicts.length === 0
   ) {
     const existingSaleInventoryProjection =
       await createSkippedInventoryReviewForExistingSale(repository, args, {
@@ -1524,11 +1523,24 @@ async function createSkippedInventoryReviewForExistingSale(
   if (inventoryValidation.conflict) {
     return conflictResult(inventoryValidation.conflict);
   }
-  if (inventoryValidation.stockMutationAllowed) {
-    return null;
-  }
 
-  await createSkippedInventoryReviewWorkItem(repository, args, {
+  if (!inventoryValidation.stockMutationAllowed) {
+    await createSkippedInventoryReviewWorkItem(repository, args, {
+      inventoryValidation,
+      linePoliciesByLocalId: validation.catalogValidation.linePoliciesByLocalId,
+      payload: validation.payload,
+      sale: {
+        receiptMapping: input.transactionMapping,
+        registerSessionId: sessionResolution.registerSession._id,
+        transactionId: input.transactionMapping.cloudId as Id<"posTransaction">,
+        transactionMapping: input.transactionMapping,
+      },
+      session: sessionResolution,
+      store: validation.store,
+    });
+  }
+  await applySaleInventoryMovements(repository, args, {
+    consumeExistingSessionHolds: true,
     inventoryValidation,
     linePoliciesByLocalId: validation.catalogValidation.linePoliciesByLocalId,
     payload: validation.payload,
@@ -2216,18 +2228,23 @@ async function persistSaleItemsAndInventory(
     saleSession,
   } = input;
   const itemMappings: LocalSyncMappingRecord[] = [];
+  const mutationQuantities = collectSaleSkuQuantities(
+    payload,
+    input.linePoliciesByLocalId,
+    inventoryValidation,
+  );
+  const shouldConsumeHolds =
+    inventoryValidation.conflict === null &&
+    (inventoryValidation.stockMutationAllowed || mutationQuantities.size > 0);
   const consumedHoldQuantities =
-    inventoryValidation.stockMutationAllowed &&
+    shouldConsumeHolds &&
     saleSession.reusedExistingSession &&
     saleSession.posSessionId
       ? await repository.consumeInventoryHoldsForSession({
           sessionId: saleSession.posSessionId,
-          items: trustedInventorySaleItems(
-            payload,
-            input.linePoliciesByLocalId,
-          ).map((item) => ({
-            productSkuId: item.productSkuId as Id<"productSku">,
-            quantity: item.quantity,
+          items: [...mutationQuantities].map(([productSkuId, quantity]) => ({
+            productSkuId,
+            quantity,
           })),
           now: args.event.occurredAt,
         })
@@ -2373,27 +2390,68 @@ async function persistSaleItemsAndInventory(
     if (reviewWorkItemMapping) {
       itemMappings.push(reviewWorkItemMapping);
     }
-    return itemMappings;
   }
 
-  for (const [productSkuId, requestedQuantity] of collectSaleSkuQuantities(
+  await applySaleInventoryMovements(repository, args, {
+    inventoryValidation,
+    linePoliciesByLocalId: input.linePoliciesByLocalId,
     payload,
+    sale,
+    session: input.session,
+    store: input.store,
+  });
+
+  return itemMappings;
+}
+
+async function applySaleInventoryMovements(
+  repository: SyncProjectionRepository,
+  args: SaleCompletedArgs,
+  input: {
+    consumeExistingSessionHolds?: boolean;
+    inventoryValidation: SaleInventoryValidation;
+    linePoliciesByLocalId: Map<string, SaleInventoryLinePolicy>;
+    payload: PosLocalSalePayload;
+    sale: PersistedSale;
+    session: SaleSessionResolution;
+    store: StoreRecord;
+  },
+) {
+  const mutationQuantities = collectSaleSkuQuantities(
+    input.payload,
     input.linePoliciesByLocalId,
-  )) {
+    input.inventoryValidation,
+  );
+  if (
+    input.consumeExistingSessionHolds === true &&
+    mutationQuantities.size > 0 &&
+    input.session.existingPosSession
+  ) {
+    await repository.consumeInventoryHoldsForSession({
+      sessionId: input.session.existingPosSession._id,
+      items: [...mutationQuantities].map(([productSkuId, quantity]) => ({
+        productSkuId,
+        quantity,
+      })),
+      now: args.event.occurredAt,
+    });
+  }
+
+  for (const [productSkuId, requestedQuantity] of mutationQuantities) {
     const sku = await repository.getProductSku(productSkuId);
     if (!sku) continue;
 
     const movementDisposition = await repository.recordSaleInventoryMovement({
       customerProfileId: input.session.existingPosSession?.customerProfileId,
       organizationId: input.store?.organizationId,
-      posTransactionId: sale.transactionId,
+      posTransactionId: input.sale.transactionId,
       productId: sku.productId,
       productSkuId,
       quantity: requestedQuantity,
-      registerSessionId: sale.registerSessionId,
+      registerSessionId: input.sale.registerSessionId,
       staffProfileId: args.event.staffProfileId,
       storeId: args.storeId,
-      transactionNumber: payload.receiptNumber,
+      transactionNumber: input.payload.receiptNumber,
     });
 
     if (movementDisposition === "inserted") {
@@ -2406,8 +2464,6 @@ async function persistSaleItemsAndInventory(
       });
     }
   }
-
-  return itemMappings;
 }
 
 async function createSkippedInventoryReviewWorkItem(
@@ -3187,8 +3243,16 @@ async function validateSaleInventory(
 function collectSaleSkuQuantities(
   payload: PosLocalSalePayload,
   linePoliciesByLocalId: Map<string, SaleInventoryLinePolicy>,
+  inventoryValidation?: SaleInventoryValidation,
 ) {
   const quantities = new Map<Id<"productSku">, number>();
+  if (inventoryValidation?.conflict) {
+    return quantities;
+  }
+  const skippedProductSkuIds = new Set(
+    inventoryValidation?.skippedMutationItems.map((item) => item.productSkuId) ??
+      [],
+  );
   for (const [index, item] of payload.items.entries()) {
     if (!isTrustedInventorySaleItem(item, linePoliciesByLocalId, index)) {
       continue;
@@ -3198,6 +3262,9 @@ function collectSaleSkuQuantities(
       continue;
     }
     const productSkuId = item.productSkuId as Id<"productSku">;
+    if (skippedProductSkuIds.has(productSkuId)) {
+      continue;
+    }
     quantities.set(
       productSkuId,
       (quantities.get(productSkuId) ?? 0) + item.quantity,

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -476,6 +476,11 @@ const schema = defineSchema({
     inventoryImportProvisionalSkuSchema,
   )
     .index("by_storeId_status", ["storeId", "status"])
+    .index("by_storeId_status_finalizedAt", [
+      "storeId",
+      "status",
+      "finalizedAt",
+    ])
     .index("by_storeId_status_saleEvidenceQuantity", [
       "storeId",
       "status",

--- a/packages/athena-webapp/playwright.config.ts
+++ b/packages/athena-webapp/playwright.config.ts
@@ -6,6 +6,10 @@ const convexUrl =
   process.env.VITE_CONVEX_URL || "https://playwright-athena.convex.cloud";
 const apiGatewayUrl =
   process.env.VITE_API_GATEWAY_URL || "https://playwright-athena.convex.site";
+const webServerTimeout = Number(
+  process.env.PLAYWRIGHT_WEB_SERVER_TIMEOUT_MS ||
+    (process.env.CI ? 300_000 : 120_000),
+);
 
 export default defineConfig({
   testDir: "./src/tests",
@@ -32,7 +36,7 @@ export default defineConfig({
     },
     url: baseURL,
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    timeout: webServerTimeout,
     stdout: "pipe",
     stderr: "pipe",
   },

--- a/packages/athena-webapp/playwright.prod.config.ts
+++ b/packages/athena-webapp/playwright.prod.config.ts
@@ -15,6 +15,10 @@ const apiGatewayUrl =
   process.env.ATHENA_PROD_CONVEX_SITE_URL ||
   process.env.VITE_API_GATEWAY_URL ||
   "https://colorless-cardinal-870.convex.site";
+const webServerTimeout = Number(
+  process.env.PLAYWRIGHT_WEB_SERVER_TIMEOUT_MS ||
+    (process.env.CI ? 300_000 : 120_000),
+);
 
 export default defineConfig({
   testDir: "./src/tests/prod",
@@ -52,7 +56,7 @@ export default defineConfig({
         },
         url: baseURL,
         reuseExistingServer: !process.env.CI,
-        timeout: 120_000,
+        timeout: webServerTimeout,
         stdout: "pipe",
         stderr: "pipe",
       }

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -2714,7 +2714,7 @@ describe("RegisterSessionViewContent", () => {
       storeId: "store-1",
       subject: {
         id: "session-1",
-        label: "Register 3",
+        label: "Register 3 closeout correction",
         type: "register_session",
       },
       username: "manager",
@@ -3252,7 +3252,7 @@ describe("RegisterSessionViewContent", () => {
       storeId: "store-1",
       subject: {
         id: "session-1",
-        label: "Register 3",
+        label: "Register 3 closeout correction",
         type: "register_session",
       },
       username: "manager",
@@ -3616,6 +3616,16 @@ describe("RegisterSessionViewContent", () => {
       "Opening cash was recounted.",
     );
     expect(screen.getByText("$10")).toBeInTheDocument();
+    expect(screen.getByText("Corrected amount ($)")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit" })).toHaveClass(
+      "bg-action-workflow",
+    );
+    expect(
+      screen
+        .getByRole("heading", { name: "Opening float correction" })
+        .compareDocumentPosition(screen.getByText("Linked transactions")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     await user.click(screen.getByRole("button", { name: "Submit" }));
     await user.click(
       screen.getByRole("button", { name: "Approve correction" }),
@@ -3628,7 +3638,7 @@ describe("RegisterSessionViewContent", () => {
       storeId: "store-1",
       subject: {
         id: "session-1",
-        label: "Register 3",
+        label: "Register 3 opening float correction",
         type: "register_session",
       },
       username: "manager",

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -535,6 +535,7 @@ type ReopenedCloseoutSubmitIntent = {
 type OpeningFloatCorrectionIntent = {
   correctedOpeningFloat: number;
   reason: string;
+  registerNumber?: string | null;
   registerSessionId: string;
 };
 
@@ -1112,6 +1113,14 @@ function formatRegisterHeaderName(registerNumber?: string | null) {
   }
 
   return `Register ${registerName}`;
+}
+
+function formatRegisterCloseoutSubjectLabel(registerNumber?: string | null) {
+  return `${formatRegisterHeaderName(registerNumber)} closeout correction`;
+}
+
+function formatRegisterOpeningFloatSubjectLabel(registerNumber?: string | null) {
+  return `${formatRegisterHeaderName(registerNumber)} opening float correction`;
 }
 
 function getVarianceTone(variance?: number) {
@@ -3166,7 +3175,9 @@ export function RegisterSessionViewContent({
       resolutionModes: [{ kind: "inline_manager_proof" }],
       subject: {
         id: registerSession._id,
-        label: registerSession.registerNumber ?? undefined,
+        label: formatRegisterCloseoutSubjectLabel(
+          registerSession.registerNumber,
+        ),
         type: "register_session",
       },
     };
@@ -3208,7 +3219,9 @@ export function RegisterSessionViewContent({
         resolutionModes: [{ kind: "inline_manager_proof" }],
         subject: {
           id: registerSession._id,
-          label: registerSession.registerNumber ?? undefined,
+          label: formatRegisterCloseoutSubjectLabel(
+            registerSession.registerNumber,
+          ),
           type: "register_session",
         },
       };
@@ -3392,6 +3405,7 @@ export function RegisterSessionViewContent({
     const intent = {
       correctedOpeningFloat: parsedOpeningFloat,
       reason: trimmedReason,
+      registerNumber: registerSession.registerNumber,
       registerSessionId: registerSession._id,
     };
 
@@ -3570,7 +3584,15 @@ export function RegisterSessionViewContent({
 
       if (isApprovalRequiredResult(commandResult)) {
         setOpeningFloatCorrectionInfo("");
-        setPendingOpeningFloatApproval(commandResult.approval);
+        setPendingOpeningFloatApproval({
+          ...commandResult.approval,
+          subject: {
+            ...commandResult.approval.subject,
+            label: formatRegisterOpeningFloatSubjectLabel(
+              intent.registerNumber,
+            ),
+          },
+        });
         return;
       }
 
@@ -5005,8 +5027,8 @@ export function RegisterSessionViewContent({
                       className={
                         isOpeningFloatCorrectionOpen ||
                         openingFloatCorrectionSuccess
-                          ? "order-3 space-y-4 rounded-lg border border-border bg-surface-raised p-layout-md"
-                          : "order-3 space-y-3 rounded-lg border border-border bg-muted/20 px-layout-md py-3"
+                          ? "order-1 space-y-4 rounded-lg border border-border bg-surface-raised p-layout-md"
+                          : "order-1 space-y-3 rounded-lg border border-border bg-muted/20 px-layout-md py-3"
                       }
                     >
                       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -5075,7 +5097,7 @@ export function RegisterSessionViewContent({
 
                           <label className="block space-y-2">
                             <span className="text-sm font-medium text-foreground">
-                              Corrected amount
+                              Corrected amount ({formattedCurrency})
                             </span>
                             <Input
                               aria-label="Corrected opening float"
@@ -5135,6 +5157,7 @@ export function RegisterSessionViewContent({
                                 void handleSubmitOpeningFloatCorrection()
                               }
                               type="button"
+                              variant="workflow"
                             >
                               Submit
                             </LoadingButton>

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.test.tsx
@@ -196,6 +196,9 @@ describe("CommandApprovalDialog", () => {
     expect(
       screen.getByRole("heading", { name: "Enter manager credentials" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Approve and continue" }),
+    ).toHaveClass("bg-action-workflow");
   });
 
   it("formats closeout variance approval copy as stored currency", () => {

--- a/packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx
+++ b/packages/athena-webapp/src/components/operations/CommandApprovalDialog.tsx
@@ -167,6 +167,7 @@ export function CommandApprovalDialog({
                 approval.copy.primaryActionLabel ?? "Approve and continue",
             }}
             getSuccessMessage={() => null}
+            submitButtonVariant="workflow"
             onAuthenticate={async (args) => {
               const proofResult = await onAuthenticateForApproval({
                 actionKey: approval.action.key,

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -1389,6 +1389,27 @@ describe("DailyCloseViewContent", () => {
       "/wigclub/store/osu/pos/transactions?o=%252Fwigclub%252Fstore%252Fosu%252Foperations%252Fdaily-close&operatingDate=2026-05-07&paymentMethod=card",
     );
     expect(
+      screen
+        .getByRole("link", { name: "Open transactions" })
+        .compareDocumentPosition(
+          screen.getByRole("link", { name: "Open cash transactions" }),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "Open cash transactions" })
+        .compareDocumentPosition(
+          screen.getByRole("link", { name: "Open Card transactions" }),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "Open Card transactions" })
+        .compareDocumentPosition(
+          screen.getByRole("link", { name: "Open Mobile Money transactions" }),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
       screen.getByRole("link", { name: "Open expense reports" }),
     ).toHaveAttribute(
       "href",

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -437,7 +437,31 @@ function formatPaymentMethodLabel(method: string) {
 function getOtherPaymentTotals(summary: DailyCloseSnapshot["summary"]) {
   return (summary.paymentTotals ?? [])
     .filter((paymentTotal) => paymentTotal.method.toLowerCase() !== "cash")
-    .sort((left, right) => right.amount - left.amount);
+    .sort(compareSummaryPaymentTotals);
+}
+
+function getPaymentMethodDisplayRank(method: string) {
+  switch (method.toLowerCase()) {
+    case "card":
+      return 0;
+    case "mobile_money":
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+function compareSummaryPaymentTotals(
+  left: { amount: number; method: string },
+  right: { amount: number; method: string },
+) {
+  const rankDelta =
+    getPaymentMethodDisplayRank(left.method) -
+    getPaymentMethodDisplayRank(right.method);
+
+  if (rankDelta !== 0) return rankDelta;
+
+  return right.amount - left.amount;
 }
 
 function getPaymentTotalAmount(

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1261,12 +1261,14 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.queryByRole("link", { name: "Open Open work" }),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: "Open Close history workspace" }),
-    ).toHaveAttribute(
+    const closeHistoryLink = screen.getByRole("link", {
+      name: "Open Close history workspace",
+    });
+    expect(closeHistoryLink).toHaveAttribute(
       "href",
       "/wigclub/store/osu/operations/daily-close-history?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
     );
+    expect(closeHistoryLink.querySelector(".lucide-history")).not.toBeNull();
     expect(
       screen.getByRole("link", { name: "Open Stock adjustments workspace" }),
     ).toHaveAttribute(
@@ -1288,6 +1290,49 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.queryByRole("link", { name: "Open Open work workspace" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("orders summary metrics by standard tender sequence before remaining cards", () => {
+    renderContent({
+      ...operatingSnapshot,
+      closeSummary: {
+        ...operatingSnapshot.closeSummary,
+        paymentTotals: [
+          { amount: 349100, method: "cash", transactionCount: 2 },
+          { amount: 1184000, method: "mobile_money", transactionCount: 2 },
+          { amount: 670000, method: "card", transactionCount: 1 },
+        ],
+      },
+      operatingDate: getCurrentLocalOperatingDate(),
+    });
+
+    expect(
+      screen
+        .getByRole("link", { name: "Open transactions" })
+        .compareDocumentPosition(
+          screen.getByRole("link", { name: "Open cash transactions" }),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "Open cash transactions" })
+        .compareDocumentPosition(
+          screen.getByRole("link", { name: "Open Card transactions" }),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "Open Card transactions" })
+        .compareDocumentPosition(
+          screen.getByRole("link", { name: "Open Mobile Money transactions" }),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "Open Mobile Money transactions" })
+        .compareDocumentPosition(screen.getByText("Carried-over cash")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("shows normalized automation status for the current store day", () => {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -14,7 +14,6 @@ import {
 import { useQuery } from "convex/react";
 import {
   ArrowUpRight,
-  Archive,
   Ban,
   Barcode,
   Bot,
@@ -24,6 +23,7 @@ import {
   ChevronRight,
   CircleAlert,
   Clock3,
+  History,
   PackageSearch,
   RefreshCw,
 } from "lucide-react";
@@ -99,7 +99,7 @@ type OperationsWorkspaceLink = {
 const SUPPORTING_OPERATIONS_WORKSPACE_LINKS: OperationsWorkspaceLink[] = [
   {
     description: "Review completed close records for prior store days.",
-    icon: Archive,
+    icon: History,
     label: "Close history",
     to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close-history",
   },
@@ -1081,7 +1081,31 @@ function getOtherPaymentTotals(
 ) {
   return (summary.paymentTotals ?? [])
     .filter((paymentTotal) => paymentTotal.method.toLowerCase() !== "cash")
-    .sort((left, right) => right.amount - left.amount);
+    .sort(compareSummaryPaymentTotals);
+}
+
+function getPaymentMethodDisplayRank(method: string) {
+  switch (method.toLowerCase()) {
+    case "card":
+      return 0;
+    case "mobile_money":
+      return 1;
+    default:
+      return 2;
+  }
+}
+
+function compareSummaryPaymentTotals(
+  left: { amount: number; method: string },
+  right: { amount: number; method: string },
+) {
+  const rankDelta =
+    getPaymentMethodDisplayRank(left.method) -
+    getPaymentMethodDisplayRank(right.method);
+
+  if (rankDelta !== 0) return rankDelta;
+
+  return right.amount - left.amount;
 }
 
 function getPaymentTotalAmount(

--- a/packages/athena-webapp/src/components/pos/ProductCard.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductCard.tsx
@@ -162,20 +162,7 @@ export function ProductCard({
           </div>
         )}
 
-        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          {/* Availability */}
-          <p className="text-xs text-muted-foreground">
-            {product.availabilityMessage ? (
-              product.availabilityMessage
-            ) : usesPendingCount ? (
-              "Count pending"
-            ) : (
-              <>
-                <b>{product.quantityAvailable ?? 0}</b> available
-              </>
-            )}
-          </p>
-
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-end">
           <div
             className="flex items-center rounded-md border border-border bg-background p-1.5 shadow-sm"
             onClick={(event) => event.stopPropagation()}

--- a/packages/athena-webapp/src/components/pos/ProductLookup.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductLookup.tsx
@@ -88,16 +88,9 @@ export function ProductLookup({
                               {product.length && `Length: ${product.length}"`}
                             </p>
                           )}
-                          <div className="flex items-center gap-2">
-                            <p className="text-sm font-semibold">
-                              {formatStoredAmount(formatter, product.price)}
-                            </p>
-                            {product.quantityAvailable && (
-                              <span className="text-xs text-muted-foreground">
-                                ({product.quantityAvailable} available)
-                              </span>
-                            )}
-                          </div>
+                          <p className="text-sm font-semibold">
+                            {formatStoredAmount(formatter, product.price)}
+                          </p>
                         </div>
 
                         <Button

--- a/packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx
+++ b/packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx
@@ -144,7 +144,7 @@ describe("SearchResultsSection", () => {
     expect(onQuickAddProduct).not.toHaveBeenCalled();
   });
 
-  it("keeps a missing-availability result visible with readiness copy but does not add it", () => {
+  it("keeps a missing-availability result disabled without availability copy", () => {
     const onAddProduct = vi.fn();
     renderSearchResults({
       onAddProduct,
@@ -160,10 +160,10 @@ describe("SearchResultsSection", () => {
     });
 
     expect(
-      screen.getByText(
+      screen.queryByText(
         "Availability not ready. Reconnect or refresh this terminal before selling this item.",
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Club").closest("[aria-disabled]")).toHaveAttribute(
       "aria-disabled",
       "true",
@@ -200,6 +200,20 @@ describe("SearchResultsSection", () => {
 
     expect(onAddProduct).toHaveBeenCalledWith(product, 3);
     expect(onClearSearch).toHaveBeenCalled();
+  });
+
+  it("does not render availability count labels for trusted product results", () => {
+    renderSearchResults({
+      products: [
+        buildProduct({
+          id: "sku-trusted",
+          name: "Eco Gel",
+          quantityAvailable: 12,
+        }),
+      ],
+    });
+
+    expect(screen.queryByText("12 available")).not.toBeInTheDocument();
   });
 
   it("emphasizes the product price without using action styling", () => {
@@ -250,7 +264,7 @@ describe("SearchResultsSection", () => {
     expect(sku).not.toHaveClass("bg-muted", "rounded", "px-2", "py-1");
   });
 
-  it("allows provisional import results to be added while trusted counts are pending", async () => {
+  it("allows provisional import results to be added without count labels", async () => {
     const user = userEvent.setup();
     const product = buildProduct({
       availabilityMessage: "Count pending",
@@ -268,7 +282,7 @@ describe("SearchResultsSection", () => {
       onAddProduct,
     });
 
-    expect(screen.getByText("Count pending")).toBeInTheDocument();
+    expect(screen.queryByText("Count pending")).not.toBeInTheDocument();
     const quantityInput = screen.getByRole("spinbutton", {
       name: /quantity for imported wig/i,
     });
@@ -301,7 +315,7 @@ describe("SearchResultsSection", () => {
     expect(screen.queryByText("NULL")).not.toBeInTheDocument();
   });
 
-  it("shows count pending for pending checkout results", async () => {
+  it("allows pending checkout results to be added without count labels", async () => {
     const user = userEvent.setup();
     const product = buildProduct({
       id: "pending-checkout-1",
@@ -317,7 +331,7 @@ describe("SearchResultsSection", () => {
       onAddProduct,
     });
 
-    expect(screen.getByText("Count pending")).toBeInTheDocument();
+    expect(screen.queryByText("Count pending")).not.toBeInTheDocument();
     expect(screen.queryByText("0 available")).not.toBeInTheDocument();
 
     const quantityInput = screen.getByRole("spinbutton", {
@@ -370,7 +384,7 @@ describe("SearchResultsSection", () => {
       onAddProduct,
     });
 
-    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.queryByText("0 available")).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /^add$/i }));
 
     expect(onAddProduct).toHaveBeenCalledWith(product, 1);

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
@@ -340,20 +340,19 @@ describe("POSRegisterOpeningGuard", () => {
       expect.stringContaining("bg-surface"),
     );
     expect(screen.getByText("POS")).toBeInTheDocument();
-    expect(screen.getByText("Preparing POS")).toBeInTheDocument();
-    expect(screen.getByText("Checking register readiness.")).toBeInTheDocument();
-    expect(screen.getByText("Waiting on")).toBeInTheDocument();
-    expect(screen.getByText("close snapshot")).toBeInTheDocument();
-    expect(screen.getByText("local register readiness")).toBeInTheDocument();
-    expect(screen.getByText("Opening snapshot")).toBeInTheDocument();
-    expect(screen.getByText("started")).toBeInTheDocument();
-    expect(screen.getByText("Close snapshot")).toBeInTheDocument();
-    expect(screen.getAllByText("loading").length).toBeGreaterThan(0);
-    expect(screen.getByText("Local read stage")).toBeInTheDocument();
-    expect(screen.getByText("reading_local_store")).toBeInTheDocument();
-    expect(screen.getByText("Local read key")).toBeInTheDocument();
+    expect(screen.getByText("Checking this register")).toBeInTheDocument();
     expect(
-      screen.getByText("store-1:2026-05-09:no-terminal"),
+      screen.getByText(
+        "Athena is confirming the store day and local register state before checkout opens.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Day close")).toBeInTheDocument();
+    expect(
+      screen.getByText("Checking whether the day is already closed."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Local register state")).toBeInTheDocument();
+    expect(
+      screen.getByText("Reading saved register state on this device."),
     ).toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
@@ -1,7 +1,14 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
-import { ArrowUpRight, CheckCircle2, Loader2, RefreshCw, Store } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowUpRight,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  Store,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { ComposedPageHeader } from "@/components/common/PageHeader";
@@ -38,6 +45,7 @@ import { logger } from "@/lib/logger";
 import { reloadWindow } from "@/lib/navigationUtils";
 
 type DailyOpeningSnapshot = {
+  operatingDate?: string;
   status?: "blocked" | "needs_attention" | "ready" | "started";
 };
 
@@ -46,6 +54,12 @@ type DailyCloseSnapshot = {
     lifecycleStatus?: "active" | "reopened" | "superseded";
   } | null;
   status?: "blocked" | "needs_review" | "carry_forward" | "ready" | "completed";
+};
+
+type ReadinessChecklistItem = {
+  label: string;
+  state: "checking" | "ready" | "attention";
+  value: string;
 };
 
 function getLocalOperatingDate(date = new Date()) {
@@ -208,7 +222,7 @@ export function POSRegisterOpeningGuard({
           status: "ready",
           source: "local_readiness",
           storeDayStatus: "started",
-        } satisfies LocalPosReadiness)
+      } satisfies LocalPosReadiness)
       : localReadiness;
 
   if (isLoadingStores && entryContext.status === "loading") {
@@ -287,7 +301,7 @@ function POSReadinessLoadingState({
   isLoadingStores: boolean;
   localReadiness: LocalPosReadiness;
   openingSnapshot?: DailyOpeningSnapshot;
-  operatingDate: string;
+  operatingDate?: string;
   storeId?: Id<"store">;
 }) {
   const blockers = getReadinessLoadingBlockers({
@@ -298,15 +312,16 @@ function POSReadinessLoadingState({
     openingSnapshot,
     storeId,
   });
-  const rows = getReadinessDiagnosticRows({
+  const checklist = getReadinessChecklistItems({
     closeSnapshot,
     entryContext,
     isLoadingStores,
     localReadiness,
     openingSnapshot,
-    operatingDate,
+    operatingDate: openingSnapshot?.operatingDate ?? operatingDate,
     storeId,
   });
+  const hasBlockers = blockers.length > 0;
 
   return (
     <View
@@ -330,44 +345,85 @@ function POSReadinessLoadingState({
       }
     >
       <FadeIn className="flex h-full min-h-0 items-center justify-center p-6">
-        <div className="flex w-full max-w-3xl flex-col items-center rounded-lg border border-border bg-surface px-10 py-12 text-center shadow-sm">
-          <div className="mb-6 flex h-[4.5rem] w-[4.5rem] items-center justify-center rounded-full bg-muted text-muted-foreground">
-            <Loader2 className="h-7 w-7 animate-spin" />
+        <div className="flex w-full max-w-2xl flex-col items-center rounded-lg border border-border/80 bg-surface px-8 py-10 text-center shadow-sm">
+          <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" />
           </div>
           <h2 className="text-xl font-medium text-foreground/80">
-            Preparing POS
+            Checking this register
           </h2>
           <p className="mt-3 max-w-lg text-base leading-7 text-muted-foreground">
-            Checking register readiness.
+            Athena is confirming the store day and local register state before
+            checkout opens.
           </p>
-          <div className="mt-8 w-full rounded-lg border border-border bg-muted/30 p-4 text-left">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Waiting on
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {blockers.map((blocker) => (
-                  <span
-                    className="rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-foreground"
-                    key={blocker}
-                  >
-                    {blocker}
-                  </span>
-                ))}
+          <div className="mt-8 w-full rounded-lg border border-border/80 bg-muted/20 p-4 text-left">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  Register checks
+                </p>
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                  This usually takes a moment.
+                </p>
               </div>
+              {hasBlockers ? (
+                <div className="flex flex-wrap justify-end gap-2">
+                  {blockers.map((blocker) => (
+                    <span
+                      className="rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-muted-foreground"
+                      key={blocker}
+                    >
+                      {blocker}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
             </div>
-            <div className="mt-5 grid gap-2 sm:grid-cols-2">
-              {rows.map((row) => (
+            <div className="mt-5 grid gap-2">
+              {checklist.map((item) => (
                 <div
-                  className="rounded-md border border-border/70 bg-surface px-3 py-2"
-                  key={row.label}
+                  className="flex items-start gap-3 rounded-md border border-border/70 bg-surface px-3 py-2.5"
+                  key={item.label}
                 >
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                    {row.label}
-                  </p>
-                  <p className="mt-1 break-words text-sm font-medium text-foreground">
-                    {row.value}
-                  </p>
+                  <span
+                    className={[
+                      "mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full",
+                      item.state === "ready"
+                        ? "bg-emerald-50 text-emerald-700"
+                        : item.state === "attention"
+                          ? "bg-amber-50 text-amber-700"
+                          : "bg-muted text-muted-foreground",
+                    ].join(" ")}
+                    title={getReadinessChecklistStateLabel(item.state)}
+                  >
+                    {item.state === "ready" ? (
+                      <CheckCircle2
+                        className="h-3.5 w-3.5"
+                        aria-hidden="true"
+                      />
+                    ) : item.state === "attention" ? (
+                      <AlertCircle
+                        className="h-3.5 w-3.5"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <Loader2
+                        className="h-3.5 w-3.5 animate-spin"
+                        aria-hidden="true"
+                      />
+                    )}
+                    <span className="sr-only">
+                      {getReadinessChecklistStateLabel(item.state)}
+                    </span>
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground">
+                      {item.label}
+                    </p>
+                    <p className="mt-0.5 text-sm leading-5 text-muted-foreground">
+                      {item.value}
+                    </p>
+                  </div>
                 </div>
               ))}
             </div>
@@ -419,10 +475,10 @@ function getReadinessLoadingBlockers({
     blockers.push("local register readiness");
   }
 
-  return blockers.length > 0 ? blockers : ["readiness evaluation"];
+  return blockers;
 }
 
-function getReadinessDiagnosticRows({
+function getReadinessChecklistItems({
   closeSnapshot,
   entryContext,
   isLoadingStores,
@@ -436,79 +492,135 @@ function getReadinessDiagnosticRows({
   isLoadingStores: boolean;
   localReadiness: LocalPosReadiness;
   openingSnapshot?: DailyOpeningSnapshot;
-  operatingDate: string;
+  operatingDate?: string;
   storeId?: Id<"store">;
-}) {
-  const terminalStatus =
-    entryContext.status === "ready"
-      ? `${entryContext.source}; seed ${entryContext.terminalSeed ? "present" : "missing"}`
-      : entryContext.status;
+}): ReadinessChecklistItem[] {
   const localLoadingDiagnostics =
     localReadiness.status === "loading" ? localReadiness.diagnostics : null;
+  const operatingDateLabel = formatOperatingDateLabel(operatingDate);
 
-  const rows = [
+  const items: ReadinessChecklistItem[] = [
     {
       label: "Store",
+      state: isLoadingStores ? "checking" : storeId ? "ready" : "attention",
       value: isLoadingStores
-        ? "loading"
+        ? "Looking up the active store."
         : storeId
-          ? `ready: ${storeId}`
-          : "missing",
+          ? "Active store found."
+          : "Active store is missing.",
     },
     {
-      label: "Terminal",
-      value: terminalStatus,
+      label: "Register setup",
+      state:
+        entryContext.status === "loading"
+          ? "checking"
+          : entryContext.status === "ready" && entryContext.terminalSeed
+            ? "ready"
+            : "attention",
+      value:
+        entryContext.status === "loading"
+          ? "Checking this device."
+          : entryContext.status === "ready" && entryContext.terminalSeed
+            ? "This device is connected to a register."
+            : "This device needs register setup.",
     },
     {
-      label: "Operating date",
-      value: operatingDate,
+      label: "Opening handoff",
+      state:
+        !storeId || !openingSnapshot
+          ? "checking"
+          : openingSnapshot.status === "started"
+            ? "ready"
+            : "attention",
+      value:
+        !storeId || !openingSnapshot
+          ? "Checking today's opening state."
+          : openingSnapshot.status === "started"
+            ? getStartedStoreDayMessage(operatingDateLabel)
+            : "Opening handoff still needs attention.",
     },
     {
-      label: "Opening snapshot",
-      value: storeId ? (openingSnapshot?.status ?? "loading") : "skipped",
+      label: "Day close",
+      state:
+        !storeId || (openingSnapshot?.status === "started" && !closeSnapshot)
+          ? "checking"
+          : closeSnapshot?.status === "completed" &&
+              closeSnapshot.existingClose?.lifecycleStatus !== "reopened"
+            ? "attention"
+            : "ready",
+      value:
+        !storeId
+          ? "Waiting for store details."
+          : openingSnapshot?.status === "started" && !closeSnapshot
+            ? "Checking whether the day is already closed."
+            : closeSnapshot?.status === "completed" &&
+                closeSnapshot.existingClose?.lifecycleStatus !== "reopened"
+              ? "Store day is closed."
+              : "No closed day is blocking this register.",
     },
     {
-      label: "Close snapshot",
-      value: storeId
-        ? (closeSnapshot?.status ??
-          (openingSnapshot?.status === "started" ? "loading" : "pending"))
-        : "skipped",
-    },
-    {
-      label: "Local readiness",
-      value: localReadiness.status,
+      label: "Local register state",
+      state:
+        localReadiness.status === "loading"
+          ? "checking"
+          : localReadiness.status === "ready"
+            ? "ready"
+            : "attention",
+      value:
+        localReadiness.status === "loading"
+          ? "Reading saved register state on this device."
+          : localReadiness.status === "ready"
+            ? "Local register state is available."
+            : localReadiness.message,
     },
   ];
 
   if (localLoadingDiagnostics) {
-    rows.push({
-      label: "Local read stage",
-      value: localLoadingDiagnostics.stage,
-    });
-
-    if (localLoadingDiagnostics.stateKey) {
-      rows.push({
-        label: "Local read key",
-        value: localLoadingDiagnostics.stateKey,
-      });
-    }
-
-    if (localLoadingDiagnostics.activeStateKey) {
-      rows.push({
-        label: "Active read key",
-        value: localLoadingDiagnostics.activeStateKey,
-      });
-    }
-
     if (localLoadingDiagnostics.startedAt) {
-      rows.push({
-        label: "Local read started",
-        value: new Date(localLoadingDiagnostics.startedAt).toLocaleTimeString(),
+      items.push({
+        label: "Started checking",
+        state: "checking",
+        value: new Date(
+          localLoadingDiagnostics.startedAt,
+        ).toLocaleTimeString(),
       });
     }
   }
 
-  return rows;
+  return items;
+}
+
+function getReadinessChecklistStateLabel(
+  state: ReadinessChecklistItem["state"],
+) {
+  if (state === "ready") return "Ready";
+  if (state === "attention") return "Review";
+  return "Checking";
+}
+
+function getStartedStoreDayMessage(operatingDateLabel: string | null) {
+  return operatingDateLabel
+    ? `Store day for ${operatingDateLabel} has started.`
+    : "Store day has started.";
+}
+
+function formatOperatingDateLabel(operatingDate?: string) {
+  if (!operatingDate) {
+    return null;
+  }
+
+  const date = new Date(`${operatingDate}T00:00:00.000Z`);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(date);
 }
 
 function StoreDayNotStartedState({

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -1796,7 +1796,11 @@ interface POSRegisterViewProps {
 
 export function POSRegisterView(props: POSRegisterViewProps) {
   return (
-    <SidebarProvider className="contents" defaultOpen={false}>
+    <SidebarProvider
+      className="contents"
+      defaultOpen={false}
+      persistOpenState={false}
+    >
       <POSRegisterViewContent {...props} />
     </SidebarProvider>
   );

--- a/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.test.tsx
@@ -84,6 +84,7 @@ describe("RegisterCheckoutPanel", () => {
       to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
       params: expect.any(Function),
       search: {
+        intent: "void",
         o: "%2Fwigclub%2Fstore%2Fwigclub%2Fpos%2Fregister%3Fo%3D%252Fwigclub%252Fstore%252Fwigclub%252Fpos",
       },
     });

--- a/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx
@@ -49,7 +49,7 @@ export function RegisterCheckoutPanel({
         storeUrlSlug: current.storeUrlSlug!,
         transactionId: completedTransactionId,
       }),
-      search: { o: getOrigin() },
+      search: { intent: "void", o: getOrigin() },
     });
   }, [completedTransactionId, navigate]);
 

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -44,6 +44,19 @@ function renderGate(overrides: Partial<RegisterDrawerGateState> = {}) {
 }
 
 describe("RegisterDrawerGate", () => {
+  it("uses workflow styling for opening float corrections", () => {
+    renderGate({
+      correctedOpeningFloat: "5",
+      correctionReason: "Opening count was corrected.",
+      expectedCash: 20500,
+      mode: "openingFloatCorrection",
+    });
+
+    expect(screen.getByRole("button", { name: "Save correction" })).toHaveClass(
+      "bg-action-workflow",
+    );
+  });
+
   it("blocks drawer opening unless the signed-in staff member is a cashier or manager", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -297,6 +297,7 @@ export function RegisterDrawerGate({
               disabled={Boolean(drawerGate.isCorrectingOpeningFloat)}
               isLoading={Boolean(drawerGate.isCorrectingOpeningFloat)}
               type="submit"
+              variant="workflow"
             >
               Save correction
             </LoadingButton>

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -23,6 +23,7 @@ const useQueryMock = vi.fn();
 const useMutationMock = vi.fn();
 const useActionMock = vi.fn();
 const useParamsMock = vi.fn();
+const useSearchMock = vi.fn();
 const useProtectedAdminPageStateMock = vi.fn();
 
 vi.mock("convex/react", () => ({
@@ -49,6 +50,7 @@ vi.mock("@tanstack/react-router", () => ({
     return <a href={href}>{children}</a>;
   },
   useParams: (...args: unknown[]) => useParamsMock(...args),
+  useSearch: (...args: unknown[]) => useSearchMock(...args),
 }));
 
 vi.mock("../../View", () => ({
@@ -417,15 +419,27 @@ vi.mock("../../ui/button", () => ({
   Button: ({
     asChild,
     children,
+    className,
+    variant,
     ...props
   }: {
     asChild?: boolean;
     children?: React.ReactNode;
+    variant?: "workflow";
   } & React.ButtonHTMLAttributes<HTMLButtonElement>) =>
     asChild ? (
       <>{children}</>
     ) : (
-      <button type="button" {...props}>
+      <button
+        className={[
+          className,
+          variant === "workflow" ? "bg-action-workflow" : undefined,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        type="button"
+        {...props}
+      >
         {children}
       </button>
     ),
@@ -524,6 +538,8 @@ describe("TransactionView", () => {
     useMutationMock.mockReturnValue(vi.fn());
     useQueryMock.mockReset();
     useParamsMock.mockReset();
+    useSearchMock.mockReset();
+    useSearchMock.mockReturnValue({});
     useProtectedAdminPageStateMock.mockReturnValue({
       activeStore: { _id: "store_1" },
       isAuthenticated: true,
@@ -884,7 +900,7 @@ describe("TransactionView", () => {
 
     expect(
       screen.getByRole("button", { name: "Customer attribution" }),
-    ).toBeInTheDocument();
+    ).toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Payment method" }),
     ).toBeInTheDocument();
@@ -928,6 +944,11 @@ describe("TransactionView", () => {
       screen.getByLabelText("Void reason"),
       "Duplicate sale recorded.",
     );
+    expect(screen.getByRole("button", { name: "Submit void" })).toHaveClass(
+      "border-danger/40",
+      "bg-danger/5",
+      "text-danger",
+    );
     await user.click(screen.getByRole("button", { name: "Submit void" }));
     await user.click(screen.getByRole("button", { name: "Confirm" }));
 
@@ -945,6 +966,20 @@ describe("TransactionView", () => {
       staffProofToken: "proof-token-1",
       transactionId: "txn_void",
     });
+  });
+
+  it("opens the void workflow from the route intent", () => {
+    mockTransactionMutations(vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn());
+    useParamsMock.mockReturnValue({ transactionId: "txn_void_intent" });
+    useSearchMock.mockReturnValue({ intent: "void" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    expect(
+      screen.getByRole("heading", { name: "Void completed sale" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Void reason")).toBeInTheDocument();
   });
 
   it("disables completed sale voids while a void approval request is pending", async () => {
@@ -1441,7 +1476,7 @@ describe("TransactionView", () => {
     expect(screen.queryByRole("button", { name: "Submit void" })).not.toBeInTheDocument();
   });
 
-  it("routes high-risk transaction corrections to safe guidance", async () => {
+  it("disables unavailable amount and discount correction routes", async () => {
     const user = userEvent.setup();
     useParamsMock.mockReturnValue({ transactionId: "txn_7" });
     useQueryMock.mockReturnValue(baseTransaction);
@@ -1449,13 +1484,16 @@ describe("TransactionView", () => {
     render(<TransactionView />);
 
     await user.click(screen.getByRole("button", { name: "Update" }));
-    await user.click(screen.getByRole("button", { name: "Amounts or totals" }));
 
     expect(
-      screen.getByText(
+      screen.getByRole("button", { name: "Amounts or totals" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Discounts" })).toBeDisabled();
+    expect(
+      screen.queryByText(
         "Use refund, exchange, or manager review for item, amount, total, or discount updates.",
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByLabelText("Payment method update reason"),
     ).not.toBeInTheDocument();
@@ -1474,6 +1512,9 @@ describe("TransactionView", () => {
       screen.getByLabelText("Updated payment method"),
       "card",
     );
+    expect(
+      screen.getByRole("button", { name: "Submit payment update" }),
+    ).toHaveClass("bg-action-workflow");
     await user.click(
       screen.getByRole("button", { name: "Submit payment update" }),
     );
@@ -1516,7 +1557,7 @@ describe("TransactionView", () => {
     );
   });
 
-  it("places customer reason errors under the customer reason input", async () => {
+  it("keeps customer attribution updates disabled", async () => {
     const user = userEvent.setup();
     useParamsMock.mockReturnValue({ transactionId: "txn_20" });
     useQueryMock.mockReturnValue(baseTransaction);
@@ -1524,20 +1565,13 @@ describe("TransactionView", () => {
     render(<TransactionView />);
 
     await user.click(screen.getByRole("button", { name: "Update" }));
-    await user.click(
+
+    expect(
       screen.getByRole("button", { name: "Customer attribution" }),
-    );
-    await user.click(
-      screen.getByRole("button", { name: "Submit customer update" }),
-    );
-
-    const reasonInput = screen.getByLabelText("Customer update reason");
-    const reasonError = screen.getByText("Add a reason for this update");
-    const formChildren = Array.from(reasonInput.parentElement?.children ?? []);
-
-    expect(formChildren.indexOf(reasonError)).toBe(
-      formChildren.indexOf(reasonInput) + 1,
-    );
+    ).toBeDisabled();
+    expect(
+      screen.queryByText("Customer attribution update"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps payment method selection errors with the payment method form", async () => {
@@ -1695,6 +1729,33 @@ describe("TransactionView", () => {
     expect(
       screen.queryByPlaceholderText("cash, card, mobile_money..."),
     ).not.toBeInTheDocument();
+  });
+
+  it("cancels the payment method correction workflow", async () => {
+    const user = userEvent.setup();
+    useParamsMock.mockReturnValue({ transactionId: "txn_payment_cancel" });
+    useQueryMock.mockReturnValue(baseTransaction);
+
+    render(<TransactionView />);
+
+    await user.click(screen.getByRole("button", { name: "Update" }));
+    await user.click(screen.getByRole("button", { name: "Payment method" }));
+    await user.selectOptions(
+      screen.getByLabelText("Updated payment method"),
+      "card",
+    );
+    await user.type(
+      screen.getByLabelText("Payment method update reason"),
+      "Wrong tender selected.",
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel payment update" }));
+
+    expect(
+      screen.queryByText("Same-amount payment method update"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Payment method" })).not.toHaveClass(
+      "bg-action-workflow",
+    );
   });
 
   it("filters the current payment method from correction options", async () => {
@@ -2367,6 +2428,9 @@ describe("TransactionView", () => {
       screen.getByLabelText("Item adjustment reason"),
       "Customer received one unit.",
     );
+    expect(
+      screen.getByRole("button", { name: "Submit item adjustment" }),
+    ).toHaveClass("bg-action-workflow");
     await user.click(
       screen.getByRole("button", { name: "Submit item adjustment" }),
     );

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Link, useParams } from "@tanstack/react-router";
+import { Link, useParams, useSearch } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 import {
@@ -68,6 +68,12 @@ type RouteParams =
       orgUrlSlug?: string;
       storeUrlSlug?: string;
       transactionId: string;
+    }
+  | undefined;
+
+type RouteSearch =
+  | {
+      intent?: string;
     }
   | undefined;
 
@@ -346,6 +352,9 @@ export function TransactionView() {
   const params = useParams({
     strict: false,
   }) as RouteParams;
+  const search = useSearch({
+    strict: false,
+  }) as RouteSearch;
   const transactionId = params?.transactionId;
   const [correctionPanelOpen, setCorrectionPanelOpen] = useState(false);
   const [selectedCorrection, setSelectedCorrection] = useState<
@@ -373,7 +382,9 @@ export function TransactionView() {
   >(null);
   const [correctionHistoryExpanded, setCorrectionHistoryExpanded] =
     useState(false);
-  const [voidPanelOpen, setVoidPanelOpen] = useState(false);
+  const [voidPanelOpen, setVoidPanelOpen] = useState(
+    search?.intent === "void",
+  );
   const [voidReason, setVoidReason] = useState("");
   const [voidError, setVoidError] = useState<string | null>(null);
   const [voidSubmitting, setVoidSubmitting] = useState(false);
@@ -954,6 +965,14 @@ export function TransactionView() {
 
   function cancelItemAdjustmentWorkflow() {
     resetItemAdjustmentWorkflow();
+    setCorrectionError(null);
+    setPendingCorrection(null);
+    setSelectedCorrection(null);
+  }
+
+  function cancelPaymentMethodWorkflow() {
+    setPaymentCorrectionReason("");
+    setPaymentMethodInput("");
     setCorrectionError(null);
     setPendingCorrection(null);
     setSelectedCorrection(null);
@@ -1683,10 +1702,11 @@ export function TransactionView() {
                     ) : null}
                     <div className="grid gap-2">
                       <Button
+                        className="border-danger/40 bg-danger/5 text-danger hover:bg-danger/10 hover:text-danger"
                         disabled={voidSubmitting}
                         onClick={requestVoidSubmit}
                         type="button"
-                        variant="destructive"
+                        variant="outline"
                       >
                         Submit void
                       </Button>
@@ -1779,13 +1799,10 @@ export function TransactionView() {
                         <Button
                           aria-label="Customer attribution"
                           className="h-auto justify-start whitespace-normal px-3 py-3 text-left"
-                          onClick={() => setSelectedCorrection("customer")}
+                          disabled
+                          onClick={() => undefined}
                           type="button"
-                          variant={
-                            selectedCorrection === "customer"
-                              ? "workflow-soft"
-                              : "outline"
-                          }
+                          variant="outline"
                         >
                           <span className="grid gap-1">
                             <span>Customer attribution</span>
@@ -1913,15 +1930,26 @@ export function TransactionView() {
                                 {correctionError}
                               </p>
                             ) : null}
-                            <Button
-                              disabled={correctionSubmitting}
-                              onClick={() =>
-                                requestCorrectionSubmit("payment_method")
-                              }
-                              type="button"
-                            >
-                              Submit payment update
-                            </Button>
+                            <div className="grid gap-2">
+                              <Button
+                                disabled={correctionSubmitting}
+                                onClick={() =>
+                                  requestCorrectionSubmit("payment_method")
+                                }
+                                type="button"
+                                variant="workflow"
+                              >
+                                Submit payment update
+                              </Button>
+                              <Button
+                                disabled={correctionSubmitting}
+                                onClick={cancelPaymentMethodWorkflow}
+                                type="button"
+                                variant="outline"
+                              >
+                                Cancel payment update
+                              </Button>
+                            </div>
                           </div>
                         ) : null}
                       </div>
@@ -1951,26 +1979,20 @@ export function TransactionView() {
                         <Button
                           aria-label="Amounts or totals"
                           className="h-auto justify-start whitespace-normal px-3 py-2.5 text-left"
-                          onClick={() => setSelectedCorrection("amounts")}
+                          disabled
+                          onClick={() => undefined}
                           type="button"
-                          variant={
-                            selectedCorrection === "amounts"
-                              ? "workflow-soft"
-                              : "outline"
-                          }
+                          variant="outline"
                         >
                           Amounts or totals
                         </Button>
                         <Button
                           aria-label="Discounts"
                           className="h-auto justify-start whitespace-normal px-3 py-2.5 text-left"
-                          onClick={() => setSelectedCorrection("discounts")}
+                          disabled
+                          onClick={() => undefined}
                           type="button"
-                          variant={
-                            selectedCorrection === "discounts"
-                              ? "workflow-soft"
-                              : "outline"
-                          }
+                          variant="outline"
                         >
                           Discounts
                         </Button>
@@ -2194,6 +2216,7 @@ export function TransactionView() {
                               requestCorrectionSubmit("line_items")
                             }
                             type="button"
+                            variant="workflow"
                           >
                             Submit item adjustment
                           </Button>

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.test.tsx
@@ -56,6 +56,9 @@ describe("StaffAuthenticationDialog", () => {
       screen.getByRole("heading", { name: "Confirm staff credentials" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Authenticate to continue.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue" })).toHaveClass(
+      "bg-action-workflow",
+    );
   });
 
   it("renders embedded presentation without requiring a Dialog provider", () => {

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
+import type { ButtonProps } from "@/components/ui/button";
 import { type NormalizedCommandResult } from "@/lib/errors/runCommand";
 import { presentCommandToast } from "@/lib/errors/presentCommandToast";
 import { hashPin } from "@/lib/security/pinHash";
@@ -78,6 +79,7 @@ export type StaffAuthenticationDialogProps = {
   open: boolean;
   presentation?: "dialog" | "inline" | "embedded";
   returnTriggerLabel?: string;
+  submitButtonVariant?: ButtonProps["variant"];
 };
 
 export function StaffAuthenticationDialog({
@@ -94,6 +96,7 @@ export function StaffAuthenticationDialog({
   open,
   presentation = "dialog",
   returnTriggerLabel,
+  submitButtonVariant = "workflow",
 }: StaffAuthenticationDialogProps) {
   const [mode, setMode] = useState<StaffAuthMode>("authenticate");
   const [username, setUsername] = useState("");
@@ -340,6 +343,7 @@ export function StaffAuthenticationDialog({
           onClick={handleSubmit}
           isLoading={isAuthenticating}
           disabled={!canSubmit || isAuthenticating}
+          variant={submitButtonVariant}
         >
           {activeCopy.submitLabel}
         </LoadingButton>

--- a/packages/athena-webapp/src/components/ui/sidebar.test.tsx
+++ b/packages/athena-webapp/src/components/ui/sidebar.test.tsx
@@ -1,15 +1,33 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   SidebarInset,
   SidebarMenuButton,
   SidebarProvider,
+  useSidebar,
 } from "@/components/ui/sidebar";
 
 vi.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => false,
 }));
+
+beforeEach(() => {
+  document.cookie = "sidebar_state=; path=/; max-age=0";
+});
+
+function SidebarToggleProbe() {
+  const { open, setOpen } = useSidebar();
+
+  return (
+    <>
+      <div data-testid="sidebar-open-state">{String(open)}</div>
+      <button type="button" onClick={() => setOpen(!open)}>
+        Toggle
+      </button>
+    </>
+  );
+}
 
 describe("SidebarMenuButton", () => {
   it("marks enabled menu buttons as Remote Assist controls", () => {
@@ -49,5 +67,45 @@ describe("SidebarInset", () => {
     );
 
     expect(screen.getByText("Workspace")).toHaveClass("bg-app-canvas");
+  });
+});
+
+describe("SidebarProvider", () => {
+  it("restores persisted sidebar state when no explicit default is provided", () => {
+    document.cookie = "sidebar_state=false; path=/";
+
+    render(
+      <SidebarProvider>
+        <SidebarToggleProbe />
+      </SidebarProvider>,
+    );
+
+    expect(screen.getByTestId("sidebar-open-state")).toHaveTextContent("false");
+  });
+
+  it("lets explicit defaults override persisted sidebar state", () => {
+    document.cookie = "sidebar_state=true; path=/";
+
+    render(
+      <SidebarProvider defaultOpen={false}>
+        <SidebarToggleProbe />
+      </SidebarProvider>,
+    );
+
+    expect(screen.getByTestId("sidebar-open-state")).toHaveTextContent("false");
+  });
+
+  it("does not persist automatic sidebar state changes when persistence is disabled", () => {
+    document.cookie = "sidebar_state=true; path=/";
+
+    render(
+      <SidebarProvider defaultOpen persistOpenState={false}>
+        <SidebarToggleProbe />
+      </SidebarProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
+
+    expect(document.cookie).toContain("sidebar_state=true");
   });
 });

--- a/packages/athena-webapp/src/components/ui/sidebar.tsx
+++ b/packages/athena-webapp/src/components/ui/sidebar.tsx
@@ -42,6 +42,23 @@ type SidebarContextProps = {
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null);
 
+function readPersistedSidebarOpenState() {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  const sidebarCookie = document.cookie
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .find((cookie) => cookie.startsWith(`${SIDEBAR_COOKIE_NAME}=`));
+
+  if (!sidebarCookie) {
+    return undefined;
+  }
+
+  return sidebarCookie.split("=")[1] === "true";
+}
+
 function useSidebar() {
   const context = React.useContext(SidebarContext);
   if (!context) {
@@ -59,13 +76,15 @@ const SidebarProvider = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
     defaultOpen?: boolean;
+    persistOpenState?: boolean;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
   }
 >(
   (
     {
-      defaultOpen = false,
+      defaultOpen,
+      persistOpenState = true,
       open: openProp,
       onOpenChange: setOpenProp,
       className,
@@ -80,7 +99,12 @@ const SidebarProvider = React.forwardRef<
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(defaultOpen);
+    const [_open, _setOpen] = React.useState(
+      () =>
+        defaultOpen ??
+        (persistOpenState ? readPersistedSidebarOpenState() : undefined) ??
+        true
+    );
     const open = openProp ?? _open;
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
@@ -91,10 +115,12 @@ const SidebarProvider = React.forwardRef<
           _setOpen(openState);
         }
 
-        // This sets the cookie to keep the sidebar state.
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+        if (persistOpenState) {
+          // This sets the cookie to keep the sidebar state.
+          document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+        }
       },
-      [setOpenProp, open]
+      [setOpenProp, open, persistOpenState]
     );
 
     // Helper to toggle the sidebar.

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -8258,10 +8258,53 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(result.current.drawerGate?.errorMessage).toBe(
-      "Opening float required. Enter an amount greater than 0.",
+      "Opening float required. Enter 0 or more.",
     );
     expect(mockOpenDrawer).not.toHaveBeenCalled();
     expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
+  it("allows a zero opening float when opening the drawer", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: { _id: "staff-1", firstName: "Ama", lastName: "Kusi" },
+      activeRegisterSession: null,
+      activeSession: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    act(() => {
+      result.current.drawerGate?.onOpeningFloatChange?.("0");
+    });
+
+    await act(async () => {
+      await result.current.drawerGate?.onSubmit?.();
+    });
+
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "register.opened",
+          payload: expect.objectContaining({
+            openingFloat: 0,
+          }),
+        }),
+      ),
+    );
+    expect(result.current.drawerGate?.errorMessage).not.toBe(
+      "Opening float required. Enter 0 or more.",
+    );
   });
 
   it("records a pending local drawer-open event after opening the drawer", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -3084,9 +3084,9 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     const parsedOpeningFloat = parseDisplayAmountInput(drawerOpeningFloat);
-    if (parsedOpeningFloat === undefined || parsedOpeningFloat <= 0) {
+    if (parsedOpeningFloat === undefined) {
       setDrawerErrorMessage(
-        "Opening float required. Enter an amount greater than 0.",
+        "Opening float required. Enter 0 or more.",
       );
       return;
     }

--- a/packages/athena-webapp/src/routes/-authed-layout.tsx
+++ b/packages/athena-webapp/src/routes/-authed-layout.tsx
@@ -590,7 +590,6 @@ function MobileSidebarRouteDismiss({ routeKey }: { routeKey: string }) {
 }
 
 export default function Layout() {
-  const [defaultOpen] = useState<boolean | null>(true);
   const [fullscreenOverride, setFullscreenOverride] = useState<boolean | null>(
     null,
   );
@@ -705,23 +704,6 @@ export default function Layout() {
     ? browserPathWithSearch
     : getRedirectPathWithSearch(pathname, browserPathWithSearch);
 
-  // useEffect(() => {
-  //   // Read the sidebar state from cookies
-  //   const cookies = document.cookie.split(";");
-  //   const sidebarCookie = cookies.find((cookie) =>
-  //     cookie.trim().startsWith("sidebar:state=")
-  //   );
-
-  //   if (sidebarCookie) {
-  //     const sidebarState = sidebarCookie.split("=")[1];
-  //     setDefaultOpen(sidebarState === "true");
-  //   } else {
-  //     // If no cookie exists, default to true (expanded)
-  //     setDefaultOpen(true);
-  //   }
-  // }, []);
-
-  // Don't render until we've read the cookie
   useEffect(() => {
     if (
       shouldRenderPosTerminalShell ||
@@ -765,12 +747,11 @@ export default function Layout() {
   }, [routeWantsFullscreen]);
 
   if (
-    defaultOpen === null ||
-    (!shouldRenderPosTerminalShell &&
+    !shouldRenderPosTerminalShell &&
       !shouldRenderPosSignInGate &&
       !shouldRenderPendingPosTerminalShell &&
       !isBlockedPosAppSession &&
-      (isLoading || user === null))
+      (isLoading || user === null)
   ) {
     return null; // or a loading spinner if you prefer
   }
@@ -824,7 +805,6 @@ export default function Layout() {
         <AppShellFullscreenContext.Provider value={{ setFullscreenOverride }}>
           <SidebarProvider
             className="fixed inset-0 h-svh !min-h-0 flex-col overflow-hidden bg-app-canvas"
-            defaultOpen={defaultOpen}
           >
             <MobileSidebarRouteDismiss routeKey={routeKey} />
             {isFullscreenActive ? null : (

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -256,6 +256,7 @@ function setViewportWidth(width: number) {
 describe("Authed layout", () => {
   beforeEach(() => {
     mocked.OutletComponent = null;
+    document.cookie = "sidebar_state=; path=/; max-age=0";
     window.history.replaceState({}, "", "/wigclub/store/wigclub/products");
     Object.defineProperty(window.navigator, "onLine", {
       configurable: true,

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId.tsx
@@ -1,20 +1,35 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 
 import TransactionView from "~/src/components/pos/transactions/TransactionView";
 import { NotFoundView } from "~/src/components/states/not-found/NotFoundView";
+
+const transactionSearchSchema = z.object({
+  intent: z.enum(["void"]).optional(),
+  o: z.string().optional(),
+});
+
+function TransactionNotFoundComponent({ data }: { data?: unknown }) {
+  const { orgUrlSlug, storeUrlSlug } = Route.useParams();
+  const payload =
+    data &&
+    typeof data === "object" &&
+    "data" in data &&
+    data.data &&
+    typeof data.data === "object"
+      ? (data.data as { org?: boolean })
+      : {};
+
+  const entity = payload.org ? "organization" : "store";
+  const name = payload.org ? orgUrlSlug : storeUrlSlug;
+
+  return <NotFoundView entity={entity} entityIdentifier={name} />;
+}
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId"
 )({
   component: TransactionView,
-  notFoundComponent: ({ data }) => {
-    const { orgUrlSlug, storeUrlSlug } = Route.useParams();
-    const { data: payload } = data as Record<string, any>;
-    const { org } = payload as Record<string, boolean>;
-
-    const entity = org ? "organization" : "store";
-    const name = org ? orgUrlSlug : storeUrlSlug;
-
-    return <NotFoundView entity={entity} entityIdentifier={name} />;
-  },
+  validateSearch: transactionSearchSchema,
+  notFoundComponent: TransactionNotFoundComponent,
 });


### PR DESCRIPTION
## Summary

This hardens POS inventory visibility and local sync replay so legacy trusted import rows, reviewed local sales, and register/cash-control approvals stay scoped to the SKU, store, and register session they actually belong to.

The import repair path now pages finalized trusted provisional rows through an indexed cursor, refreshes affected trusted SKU search rows without product-wide fanout, and preserves hidden SKU visibility during legacy taxonomy onboarding. Local POS replay now separates reviewed inventory conflicts from already-projected sales, keeps duplicate sale inventory movement idempotent, and carries register context through opening-float correction approval flows.

## Notes

- Adds focused Convex coverage for trusted import visibility repair, cursor continuation, SKU refresh scope, and hidden legacy SKU onboarding.
- Expands POS sync/replay coverage around reviewed sales, duplicate projection, and inventory movement idempotency.
- Adds solution notes for the two bug patterns and rebuilds Graphify output.

## Validation

- Unanimous local reviewer approvals: correctness, reliability, testing, TypeScript, performance, project standards, security.
- `bun run test -- convex/inventory/catalogImport.test.ts convex/inventory/products.sku.test.ts convex/pos/application/sync/ingestLocalEvents.test.ts convex/pos/application/sync/projectLocalEvents.test.ts`
- Full relevant webapp test slice: 17 files, 873 tests passed.
- Pre-push hook passed all 7 steps, including Graphify freshness, compound checks, architecture checks, TypeScript, production build, POS/offline/prod Playwright slices, runtime behavior harness, and inferential review.
- `bunx convex dev --once` applied the new dev index successfully.
- `bun run graphify:rebuild` completed successfully.
