### PR TITLE
fix(operations): polish daily operations workflow surfaces

### DIFF
--- a/docs/solutions/design-patterns/athena-daily-operations-canvas-status-bands-2026-07-09.md
+++ b/docs/solutions/design-patterns/athena-daily-operations-canvas-status-bands-2026-07-09.md
@@ -1,0 +1,130 @@
+---
+title: Daily Operations status bands should live on the canvas
+date: 2026-07-09
+category: design-patterns
+module: athena-webapp
+problem_type: design_pattern
+component: rails_view
+resolution_type: code_fix
+severity: medium
+applies_when:
+  - "Daily Operations or Opening Handoff shows automation status, completion evidence, or historical state notices"
+  - "A dense operations workspace mixes metrics, charts, workflow lanes, and review evidence"
+  - "A reusable analytical component needs a card and non-card presentation"
+tags: [daily-operations, opening-handoff, canvas-treatment, store-pulse, automation]
+related_components: [convex, graphify, operation-review-workspace]
+---
+
+# Daily Operations status bands should live on the canvas
+
+## Problem
+Daily Operations and Opening Handoff accumulated several operational evidence
+blocks: Athena automation status, EOD completion attribution, historical
+incomplete-close notices, workflow follow-up lanes, Store Pulse charts, top
+items, and payment mix. Rendering each as a card made the page feel crowded and
+made secondary evidence compete visually with the metrics and workflow cards.
+
+The layout also put some evidence too far from the context it explained. For
+example, EOD completion attribution appeared below Store Pulse analytics even
+though it describes the store-day state, and Opening Handoff automation appeared
+below the metric cards even though it explains how the workflow was started.
+
+## Solution
+Treat status and evidence bands as canvas content when they explain the whole
+store-day context. Keep actual work lanes and repeated work-item rows as cards.
+
+In practice:
+
+- Place Athena automation, historical incomplete-close notices, and EOD
+  completion attribution in the top operational stack before metric cards.
+- Remove rounded card chrome from those bands: no border, raised background, or
+  shadow. Use page-aligned padding such as `px-layout-md py-layout-sm` when a
+  band still needs readable text rhythm.
+- Add explicit variants to reusable analytical components instead of replacing
+  their default card behavior globally. `StorePulseTimeline`,
+  `TopItemsPanel`, `PaymentMethodsPanel`, and their loading states now support a
+  canvas presentation while POS Store Pulse keeps the default card presentation.
+- Keep workflow lanes carded. They are actionable repeated units, so the card
+  boundary still helps scanning.
+- Move shared workspace layout with extension points rather than special-casing
+  order inside each page. `OperationReviewWorkspace` gained `beforeMetrics` so
+  Opening Handoff can render automation evidence before metrics without
+  changing Daily Close behavior.
+
+Tests should pin both placement and chrome. Useful assertions include:
+
+```tsx
+expect(panel).not.toHaveClass(
+  "rounded-lg",
+  "border",
+  "bg-surface-raised",
+  "shadow-surface",
+);
+expect(
+  panel.compareDocumentPosition(screen.getByText("Net sales")) &
+    Node.DOCUMENT_POSITION_FOLLOWING,
+).toBeTruthy();
+```
+
+## Why This Matters
+Operators scan these pages to understand the state of a store day and decide
+which workflow owns the next action. Too many cards make evidence feel like a
+pile of competing objects. Canvas bands let page-level facts read as context,
+while cards remain reserved for repeated actionable work.
+
+Position matters as much as styling. Automation and completion evidence should
+sit near the controls and metrics that summarize the operating date. Store Pulse
+details belong below the weekly sales context. Follow-up lanes belong near the
+workflow area. Keeping each piece in the layer it explains reduces first-glance
+overload.
+
+## Prevention
+- Before adding a new Daily Operations or Opening Handoff evidence block, decide
+  whether it is page-level context, an analytical visualization, or an
+  actionable repeated work item.
+- Use canvas treatment for page-level context and cards for repeated lanes,
+  review items, and framed tools.
+- When adding a canvas variant, include loaded, empty, and loading states in the
+  variant so the page does not flash back to card treatment while data hydrates.
+- Add tests for both DOM order and class-level chrome, especially when moving a
+  band above metrics.
+- Keep default card behavior for other consumers unless the caller explicitly
+  opts into a canvas variant.
+
+## Examples
+Before:
+
+```tsx
+<div className="rounded-lg border border-success/25 bg-success/10 p-layout-md shadow-surface">
+  <p>Athena completed EOD Review under store policy.</p>
+</div>
+```
+
+After:
+
+```tsx
+<DailyOperationsCompletionAttributionNotice
+  carryForwardCount={snapshot.completedClose?.carryForwardCount}
+  completedClose={snapshot.completedClose}
+/>
+
+<div className="grid gap-layout-md ...">
+  <OperationsSummaryMetric label="Net sales" />
+</div>
+```
+
+The notice component owns the canvas styling:
+
+```tsx
+<div className="px-layout-md py-layout-sm text-sm leading-6">
+  <p className="font-medium text-success">
+    Athena completed EOD Review under store policy.
+  </p>
+</div>
+```
+
+## Related
+- `packages/athena-webapp/src/components/operations/DailyOperationsView.tsx`
+- `packages/athena-webapp/src/components/operations/DailyOpeningView.tsx`
+- `packages/athena-webapp/src/components/operations/OperationReviewWorkspace.tsx`
+- `packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 8895 nodes · 10849 edges · 2134 communities detected
+- 8898 nodes · 10855 edges · 2134 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2184,8 +2184,8 @@ Cohesion: 0.06
 Nodes (68): buildLegacyOperationalExplanation(), buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildStaticOperationalExplanation(), buildTerminalAppUpdatePresentation(), buildTerminalOperationalExplanationPresentation(), buildTerminalRecoveryPresentation() (+60 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.06
-Nodes (66): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildApprovalsLane(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents() (+58 more)
+Cohesion: 0.05
+Nodes (68): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildApprovalsLane(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents() (+60 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.04
@@ -2808,16 +2808,16 @@ Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 159 - "Community 159"
-Cohesion: 0.29
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 160 - "Community 160"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 161 - "Community 161"
+### Community 160 - "Community 160"
 Cohesion: 0.18
 Nodes (0):
+
+### Community 161 - "Community 161"
+Cohesion: 0.29
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 162 - "Community 162"
 Cohesion: 0.33
@@ -3540,100 +3540,100 @@ Cohesion: 0.4
 Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
 
 ### Community 342 - "Community 342"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 343 - "Community 343"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 344 - "Community 344"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 345 - "Community 345"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 345 - "Community 345"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 347 - "Community 347"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 348 - "Community 348"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 349 - "Community 349"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 350 - "Community 350"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 351 - "Community 351"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 352 - "Community 352"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 353 - "Community 353"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 354 - "Community 354"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 352 - "Community 352"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 353 - "Community 353"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 354 - "Community 354"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 355 - "Community 355"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 356 - "Community 356"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 357 - "Community 357"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 359 - "Community 359"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 360 - "Community 360"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 361 - "Community 361"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 363 - "Community 363"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 364 - "Community 364"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 364 - "Community 364"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 365 - "Community 365"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.53
@@ -13459,7 +13459,7 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,16 +8,16 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2207
-- Graph nodes: 8895
-- Graph edges: 10849
+- Graph nodes: 8898
+- Graph edges: 10855
 - Communities: 2134
 
 ## Graph Hotspots
 - `dailyClose.ts` (86 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (86 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `dailyOperations.ts` (74 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (71 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `projectLocalEvents.ts` (66 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `usePosLocalSyncRuntime.ts` (64 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 - `posLocalStore.ts` (59 edges, Community 7) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,8 +19,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `dailyClose.ts` (86 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 2) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `dailyOperations.ts` (74 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `DailyCloseView.tsx` (71 edges, Community 4) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `dailyOperations.ts` (71 edges, Community 3) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `projectLocalEvents.ts` (66 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -1509,6 +1509,87 @@ describe("daily operations overview read model", () => {
     });
   });
 
+  it("marks week metrics reopened when the completed close was superseded by reopening", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [
+          {
+            ...priorClose,
+            _id: "close-original",
+            completedAt: Date.UTC(2026, 4, 8, 22),
+            isCurrent: false,
+            lifecycleStatus: "superseded",
+            operatingDate: "2026-05-08",
+            reopenedAt: Date.UTC(2026, 4, 9, 8),
+            status: "completed",
+            supersededByDailyCloseId: "close-reopened",
+          },
+        ],
+        dailyOpening: [startedOpening],
+        store: [store],
+      }),
+      {
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-05-08",
+      ),
+    ).toMatchObject({
+      isClosed: false,
+      isReopened: true,
+    });
+  });
+
+  it("marks week metrics closed when a reopened close was completed again", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [
+          {
+            ...priorClose,
+            _id: "close-original",
+            completedAt: Date.UTC(2026, 4, 8, 22),
+            isCurrent: false,
+            lifecycleStatus: "superseded",
+            operatingDate: "2026-05-08",
+            reopenedAt: Date.UTC(2026, 4, 9, 8),
+            status: "completed",
+            supersededByDailyCloseId: "close-reclosed",
+          },
+          {
+            ...priorClose,
+            _id: "close-reclosed",
+            completedAt: Date.UTC(2026, 4, 9, 10),
+            isCurrent: false,
+            lifecycleStatus: "active",
+            operatingDate: "2026-05-08",
+            reopenedAt: Date.UTC(2026, 4, 9, 8),
+            reopenedFromDailyCloseId: "close-original",
+            status: "completed",
+          },
+        ],
+        dailyOpening: [startedOpening],
+        store: [store],
+      }),
+      {
+        operatingDate: "2026-05-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(
+      snapshot.weekMetrics.find(
+        (metric) => metric.operatingDate === "2026-05-08",
+      ),
+    ).toMatchObject({
+      isClosed: true,
+      isReopened: false,
+    });
+  });
+
   it("exposes prior-day metric when yesterday is outside the selected week", async () => {
     const snapshot = await buildDailyOperationsSnapshotWithCtx(
       buildCtx({

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -393,8 +393,11 @@ async function buildWeekMetricForDate(
       )
       .take(MAX_OPERATIONS_QUERY_LIMIT),
   ]);
-  const currentDailyClose =
-    dailyClose.find((close) => close.isCurrent) ?? dailyClose[0];
+  const currentDailyClose = selectEffectiveDailyClose(dailyClose);
+  const isReopened =
+    currentDailyClose?.lifecycleStatus === "reopened" ||
+    (currentDailyClose?.lifecycleStatus === "superseded" &&
+      typeof currentDailyClose.reopenedAt === "number");
   const currentDayCashTotal = completedTransactions.reduce(
     (sum, transaction) => sum + transactionCashDelta(transaction),
     0,
@@ -424,8 +427,8 @@ async function buildWeekMetricForDate(
     expenseTransactionCount: expenseTransactions.length,
     isClosed:
       currentDailyClose?.status === "completed" &&
-      currentDailyClose.lifecycleStatus !== "reopened",
-    isReopened: currentDailyClose?.lifecycleStatus === "reopened",
+      !isReopened,
+    isReopened,
     isSelected: args.isSelected,
     operatingDate: args.operatingDate,
     paymentTotals: buildPaymentTotals(completedTransactions),
@@ -459,6 +462,55 @@ async function buildWeekMetrics(
         storeId: args.storeId,
       }),
     ),
+  );
+}
+
+function dailyCloseSortTime(close: {
+  _creationTime?: number;
+  completedAt?: number;
+  createdAt?: number;
+  reopenedAt?: number;
+  updatedAt?: number;
+}) {
+  return Math.max(
+    close.completedAt ?? 0,
+    close.reopenedAt ?? 0,
+    close.updatedAt ?? 0,
+    close.createdAt ?? 0,
+    close._creationTime ?? 0,
+  );
+}
+
+function latestDailyClose<T extends { _creationTime?: number }>(
+  closes: T[],
+) {
+  return closes
+    .slice()
+    .sort((left, right) => dailyCloseSortTime(right) - dailyCloseSortTime(left))
+    .at(0);
+}
+
+function selectEffectiveDailyClose<
+  T extends {
+    _creationTime?: number;
+    completedAt?: number;
+    createdAt?: number;
+    isCurrent?: boolean;
+    lifecycleStatus?: string;
+    reopenedAt?: number;
+    updatedAt?: number;
+  },
+>(dailyClose: T[]) {
+  return (
+    dailyClose.find((close) => close.isCurrent) ??
+    latestDailyClose(
+      dailyClose.filter((close) => close.lifecycleStatus === "active"),
+    ) ??
+    latestDailyClose(
+      dailyClose.filter((close) => close.lifecycleStatus === "reopened"),
+    ) ??
+    latestDailyClose(dailyClose) ??
+    null
   );
 }
 
@@ -1657,7 +1709,7 @@ async function getDailyCloseRecordForDate(
     )
     .take(MAX_OPERATIONS_QUERY_LIMIT);
 
-  return dailyClose.find((close) => close.isCurrent) ?? dailyClose[0] ?? null;
+  return selectEffectiveDailyClose(dailyClose);
 }
 
 async function getDailyOpeningRecordForDate(

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -831,6 +831,21 @@ describe("DailyOpeningViewContent", () => {
 
     expect(screen.getByText("Store day started")).toBeInTheDocument();
     expect(screen.getByText("Athena started Opening Handoff.")).toBeInTheDocument();
+    const automationPanel = screen
+      .getByRole("heading", { name: "Athena automation" })
+      .closest("section");
+    expect(automationPanel).toHaveClass("px-layout-md", "py-layout-sm");
+    expect(automationPanel).not.toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
+    expect(automationPanel).not.toBeNull();
+    expect(
+      automationPanel!.compareDocumentPosition(screen.getByText("Prior close")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(screen.getByText("Started by")).toBeInTheDocument();
     expect(screen.getByText("Athena")).toBeInTheDocument();
     expect(screen.queryByText("Staff unavailable")).not.toBeInTheDocument();

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -741,7 +741,7 @@ function OpeningAutomationStatusPanel({
   if (!automationStatus) return null;
 
   return (
-    <section className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
+    <section className="px-layout-md py-layout-sm">
       <h3 className="flex items-center gap-layout-xs text-base font-medium text-foreground">
         <Bot aria-hidden="true" className="h-4 w-4" />
         Athena automation
@@ -1872,6 +1872,11 @@ export function DailyOpeningViewContent({
         ) : null
       }
       afterGrid={null}
+      beforeMetrics={
+        snapshot ? (
+          <OpeningAutomationStatusPanel automationStatus={automationStatus} />
+        ) : null
+      }
       description="Review prior close handoff, acknowledge carry-forward work, and confirm whether the store day can start."
       eyebrow="Store Ops"
       isLoading={isLoadingSnapshot || !snapshot}
@@ -1880,7 +1885,6 @@ export function DailyOpeningViewContent({
       main={
         snapshot ? (
           <div className="space-y-layout-lg">
-            <OpeningAutomationStatusPanel automationStatus={automationStatus} />
             {isStarted ? (
               <OpeningAutomationReviewPanel
                 currency={currency}

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1132,8 +1132,8 @@ describe("DailyOperationsViewContent", () => {
       screen.queryByRole("link", { name: "Start EOD Review" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Historical store-day view" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Historical store-day view" }),
+    ).not.toBeInTheDocument();
     const historicalEodReviewLink = screen.getByRole("link", {
       name: "Review EOD Review for Friday, May 8, 2026",
     });
@@ -1147,7 +1147,7 @@ describe("DailyOperationsViewContent", () => {
       "text-success",
       "hover:text-success",
     );
-    expect(screen.queryByText("Workflow status")).not.toBeInTheDocument();
+    expect(screen.queryByText("Store-day follow-up")).not.toBeInTheDocument();
     expect(screen.queryByText("Current day only")).not.toBeInTheDocument();
     expect(screen.queryByText("Needs attention")).not.toBeInTheDocument();
     expect(
@@ -1347,7 +1347,13 @@ describe("DailyOperationsViewContent", () => {
     const automationPanel = automationHeading.closest("section");
     const netSalesMetric = screen.getByText(/^(Today's net sales|Net sales)$/);
 
-    expect(automationPanel).toHaveClass("py-layout-sm", "rounded-md");
+    expect(automationPanel).toHaveClass("px-layout-md", "py-layout-sm");
+    expect(automationPanel).not.toHaveClass(
+      "rounded-md",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
     expect(automationHeading).toHaveClass(
       "text-sm",
       "font-medium",
@@ -1438,8 +1444,34 @@ describe("DailyOperationsViewContent", () => {
     } as DailyOperationsSnapshot);
 
     expect(
+      screen.getByRole("heading", { name: "Athena automation" }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByText("Athena completed EOD Review under store policy."),
     ).toBeInTheDocument();
+    const attributionNotice = screen
+      .getByText("Athena completed EOD Review under store policy.")
+      .closest("div");
+    expect(attributionNotice).not.toBeNull();
+    expect(attributionNotice).toHaveClass("py-layout-sm");
+    expect(attributionNotice).not.toHaveClass(
+      "px-layout-md",
+      "rounded-lg",
+      "border",
+      "bg-success/10",
+      "shadow-surface",
+    );
+    expect(
+      attributionNotice!.compareDocumentPosition(screen.getByText("Net sales")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("heading", { name: "Athena automation" })
+        .compareDocumentPosition(
+          screen.getByText("Athena completed EOD Review under store policy."),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(
       screen.getByText(
         "Policy checked low-risk review evidence before completion.",
@@ -1451,6 +1483,41 @@ describe("DailyOperationsViewContent", () => {
       ),
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/manager approved/i)).not.toBeInTheDocument();
+  });
+
+  it("omits generic historical view copy when Athena completion attribution is present", () => {
+    renderContent({
+      ...notOpenedSnapshot,
+      completedClose: {
+        actorType: "automation",
+        automationDecisionReason:
+          "EOD Review has only low-risk review evidence within policy thresholds.",
+        carryForwardCount: 1,
+        completedAt: Date.UTC(2026, 4, 8, 22),
+      },
+    } as DailyOperationsSnapshot);
+
+    const attributionNotice = screen
+      .getByText("Athena completed EOD Review under store policy.")
+      .closest("div");
+    const statusStack = attributionNotice?.closest("section");
+
+    expect(
+      screen.queryByRole("heading", { name: "Historical store-day view" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "This historical operating date is view-only. Workflow actions are available only on the current operating date.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(attributionNotice).not.toBeNull();
+    expect(statusStack).not.toBeNull();
+    expect(attributionNotice).toHaveClass("py-layout-sm");
+    expect(attributionNotice).not.toHaveClass("px-layout-md");
+    expect(
+      statusStack!.compareDocumentPosition(screen.getByText("Net sales")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("shows preserved carry-forward copy when the completed close has carry-forward", () => {
@@ -1533,10 +1600,16 @@ describe("DailyOperationsViewContent", () => {
 
     expect(within(storePulse).getByText("Sales trend")).toBeInTheDocument();
     expect(chart).toBeInTheDocument();
-    expect(chartContainer.parentElement).toHaveClass(
+    expect(chartContainer.parentElement).toHaveClass("py-8");
+    expect(chartContainer.parentElement).not.toHaveClass(
       "px-layout-sm",
-      "py-8",
       "sm:p-8",
+    );
+    expect(chartContainer.parentElement).not.toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
     );
     expect(chart).toHaveAttribute(
       "data-display-labels",
@@ -1548,6 +1621,37 @@ describe("DailyOperationsViewContent", () => {
     expect(chart).toHaveAttribute("data-margin-right", "72");
     expect(within(storePulse).getByText("Braiding Hair")).toBeInTheDocument();
     expect(within(storePulse).getByText("Top items")).toBeInTheDocument();
+    const topItemsPanel = within(storePulse)
+      .getByText("Braiding Hair")
+      .closest(".divide-y")?.parentElement;
+    const topItemRow = within(storePulse)
+      .getByText("Braiding Hair")
+      .closest(".grid");
+    const paymentPanel = within(storePulse)
+      .getByText("Cash")
+      .closest(".divide-y")?.parentElement;
+    const paymentRow = within(storePulse).getByText("Cash").closest(".grid");
+
+    expect(topItemsPanel).not.toBeNull();
+    expect(topItemRow).not.toBeNull();
+    expect(paymentPanel).not.toBeNull();
+    expect(paymentRow).not.toBeNull();
+    expect(topItemsPanel!).not.toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
+    expect(topItemRow!).toHaveClass("py-layout-sm");
+    expect(topItemRow!).not.toHaveClass("px-layout-md");
+    expect(paymentPanel!).not.toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
+    expect(paymentRow!).toHaveClass("py-layout-sm");
+    expect(paymentRow!).not.toHaveClass("px-layout-md");
     expect(
       within(storePulse).getByLabelText("Total items sold: 3"),
     ).toBeInTheDocument();
@@ -1568,6 +1672,37 @@ describe("DailyOperationsViewContent", () => {
     expect(
       within(storePulse).getByText("This week's completed POS sales."),
     ).toBeInTheDocument();
+  });
+
+  it("uses completed-day empty state copy for historical store pulse detail", () => {
+    vi.useRealTimers();
+    const storePulse = buildStorePulseSummary({ date: "2026-06-28" });
+    const operatorSnapshot = storePulse.operatorSnapshot!;
+
+    operatorSnapshot.topItems = [];
+    operatorSnapshot.paymentMix = [];
+    operatorSnapshot.comparison.currentItemsSold = 0;
+
+    renderContent({
+      ...operatingSnapshot,
+      operatingDate: "2026-06-28",
+      storePulse,
+    });
+
+    expect(screen.getByText("No item history")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No completed POS item movement was recorded for this day.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No payment mix")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No synced POS payment methods were recorded for this day.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No item history yet")).not.toBeInTheDocument();
+    expect(screen.queryByText("No payment mix yet")).not.toBeInTheDocument();
   });
 
   it("uses evenly spaced store pulse trend ticks on mobile", () => {
@@ -1645,7 +1780,7 @@ describe("DailyOperationsViewContent", () => {
       .closest("section");
     const timeline = screen.getByLabelText("Store-day timeline");
     const workflowSection = screen
-      .getByRole("heading", { name: "Workflow status" })
+      .getByRole("heading", { name: "Store-day follow-up" })
       .closest("section");
 
     expect(openingReview?.parentElement).toBe(timeline.parentElement);
@@ -1702,7 +1837,12 @@ describe("DailyOperationsViewContent", () => {
   it("keeps closed lifecycle state primary over stale skipped automation decisions", () => {
     renderContent(staleSkippedAutomationSnapshot);
 
-    expect(screen.getByText("Closed store-day record")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Review EOD Review for Friday, May 8, 2026",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Closed store-day record")).not.toBeInTheDocument();
     expect(screen.queryByText("Athena automation")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Athena checked EOD Review. No change was made."),
@@ -1759,7 +1899,14 @@ describe("DailyOperationsViewContent", () => {
         ],
       });
 
-      expect(screen.getByText("Closed store-day record")).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", {
+          name: "Review EOD Review for Friday, May 8, 2026",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Closed store-day record"),
+      ).not.toBeInTheDocument();
       expect(screen.queryByText("Athena automation")).not.toBeInTheDocument();
     },
   );
@@ -1783,15 +1930,33 @@ describe("DailyOperationsViewContent", () => {
     });
 
     const workflowSection = screen
-      .getByRole("heading", { name: "Workflow status" })
+      .getByRole("heading", { name: "Store-day follow-up" })
       .closest("section");
 
     expect(workflowSection).not.toBeNull();
     const workflow = within(workflowSection!);
+    const workflowShell = workflowSection!.lastElementChild;
 
+    expect(workflowShell).not.toHaveClass(
+      "rounded-md",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
     expect(workflow.queryByText("0")).not.toBeInTheDocument();
     expect(workflow.queryByText("2 registers")).not.toBeInTheDocument();
     expect(workflow.getByText("2 registers need attention.")).toBeInTheDocument();
+    expect(
+      workflow.getByRole("link", { name: "Open Registers" }).closest("article"),
+    ).toHaveClass("rounded-md", "border", "bg-background/60");
+    expect(
+      workflow.getByRole("link", { name: "Open Close history workspace" })
+        .parentElement?.parentElement,
+    ).toHaveClass("mt-layout-md");
+    expect(
+      workflow.getByRole("link", { name: "Open Close history workspace" })
+        .parentElement?.parentElement,
+    ).not.toHaveClass("border-t");
   });
 
   it("uses compact icons for workflow lanes that need attention or are blocked", () => {
@@ -1835,7 +2000,7 @@ describe("DailyOperationsViewContent", () => {
       weekMetrics: [
         {
           ...weekMetrics[0],
-          isClosed: false,
+          isClosed: true,
           isReopened: true,
           isSelected: true,
           operatingDate: getCurrentLocalOperatingDate(),
@@ -1960,23 +2125,23 @@ describe("DailyOperationsViewContent", () => {
       screen.queryByRole("link", { name: "Review EOD Review" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Historical store-day view" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Historical store-day view" }),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "This historical operating date is view-only. Workflow actions are available only on the current operating date.",
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("Needs attention")).not.toBeInTheDocument();
-    expect(screen.queryByText("Workflow status")).not.toBeInTheDocument();
+    expect(screen.queryByText("Store-day follow-up")).not.toBeInTheDocument();
   });
 
   it("links historical started store days to EOD Review even before close", () => {
     renderContent(operatingSnapshot);
 
     expect(
-      screen.getByRole("heading", { name: "Historical store-day view" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Historical store-day view" }),
+    ).not.toBeInTheDocument();
     const historicalEodReviewLink = screen.getByRole("link", {
       name: "Review EOD Review for Friday, May 8, 2026",
     });
@@ -1994,10 +2159,10 @@ describe("DailyOperationsViewContent", () => {
       screen.queryByRole("link", { name: "Review EOD Review" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(
+      screen.queryByText(
         "This historical operating date is view-only. Workflow actions are available only on the current operating date.",
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
   });
 
   it("keeps current-day opening actions available", () => {
@@ -2121,6 +2286,12 @@ describe("DailyOperationsViewContent", () => {
       screen.getByRole("heading", { name: "Incomplete store-day close" }),
     ).toBeInTheDocument();
     expect(
+      screen
+        .getByRole("heading", { name: "Incomplete store-day close" })
+        .compareDocumentPosition(screen.getByText("Net sales")) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
       screen.getByText(
         "This historical store day does not have a completed close.",
       ),
@@ -2143,6 +2314,14 @@ describe("DailyOperationsViewContent", () => {
       "text-danger",
       "hover:text-danger",
     );
+    expect(
+      screen.getByRole("heading", { name: "Incomplete store-day close" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This historical store day does not have a completed close.",
+      ),
+    ).toBeInTheDocument();
     view.unmount();
 
     renderContent(closedSnapshot);
@@ -2273,7 +2452,12 @@ describe("DailyOperationsViewContent", () => {
       screen.queryByRole("link", { name: "Review close blockers" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Historical store-day view" }),
+      screen.getByRole("heading", { name: "Incomplete store-day close" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This historical store day does not have a completed close.",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.queryByLabelText("Operator attention"),
@@ -2283,12 +2467,15 @@ describe("DailyOperationsViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps historical EOD Review links on the selected operating date", () => {
+  it("keeps historical EOD Review in the top action bar for closed dates", () => {
     renderContent(closedSnapshot);
 
     expect(
-      screen.getByRole("heading", { name: "Closed store-day record" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Closed store-day record" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Review EOD Review" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         "This operating date is closed. The saved The end of day review is available for this store-day record.",
@@ -2300,12 +2487,6 @@ describe("DailyOperationsViewContent", () => {
       ),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "Review EOD Review" }),
-    ).toHaveAttribute(
-      "href",
-      "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
-    );
-    expect(
       screen.getByRole("link", {
         name: "Review EOD Review for Friday, May 8, 2026",
       }),
@@ -2313,7 +2494,7 @@ describe("DailyOperationsViewContent", () => {
       "href",
       "/wigclub/store/osu/operations/daily-close?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
     );
-    expect(screen.queryByText("Workflow status")).not.toBeInTheDocument();
+    expect(screen.queryByText("Store-day follow-up")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Open EOD Review" }),
     ).not.toBeInTheDocument();
@@ -2328,7 +2509,9 @@ describe("DailyOperationsViewContent", () => {
     renderContent(closedSnapshot);
 
     expect(
-      screen.getByRole("link", { name: "Review EOD Review" }),
+      screen.getByRole("link", {
+        name: "Review EOD Review for Friday, May 8, 2026",
+      }),
     ).toBeInTheDocument();
     expect(screen.getByText("EOD Review completed.")).toBeInTheDocument();
     expect(
@@ -2736,8 +2919,8 @@ describe("DailyOperationsView", () => {
       }),
     );
     expect(
-      screen.getByRole("heading", { name: "Historical store-day view" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("heading", { name: "Historical store-day view" }),
+    ).not.toBeInTheDocument();
   });
 
   it("subscribes to automation statuses separately from the main snapshot", () => {
@@ -2843,11 +3026,19 @@ describe("DailyOperationsView", () => {
 
     const storePulse = screen.getByRole("region", { name: "Store pulse" });
 
-    expect(
-      within(storePulse).getByRole("button", {
-        name: "Load analytics for sales trend",
-      }),
-    ).toBeInTheDocument();
+    const salesTrendPreview = within(storePulse).getByRole("button", {
+      name: "Load analytics for sales trend",
+    });
+
+    expect(salesTrendPreview).toBeInTheDocument();
+    expect(salesTrendPreview).toHaveClass("py-8");
+    expect(salesTrendPreview).not.toHaveClass("p-8");
+    expect(salesTrendPreview).not.toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
     expect(
       within(storePulse).getByRole("heading", { name: "Sales trend" }),
     ).toBeInTheDocument();
@@ -2860,6 +3051,31 @@ describe("DailyOperationsView", () => {
     expect(
       within(storePulse).getByText("Store pulse detail loads with analytics."),
     ).toBeInTheDocument();
+    const topItemsPreview = within(storePulse).getByRole("button", {
+      name: "Load analytics for Top items",
+    });
+    const paymentPreview = within(storePulse).getByRole("button", {
+      name: "Load analytics for How customers paid",
+    });
+    expect(topItemsPreview).not.toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
+    const topItemsPreviewRow = topItemsPreview.querySelector(".grid");
+    const paymentPreviewRow = paymentPreview.querySelector(".grid");
+
+    expect(topItemsPreviewRow).not.toBeNull();
+    expect(topItemsPreviewRow!).not.toHaveClass("px-layout-md");
+    expect(paymentPreview).not.toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
+    expect(paymentPreviewRow).not.toBeNull();
+    expect(paymentPreviewRow!).not.toHaveClass("px-layout-md");
     expect(
       within(storePulse).getByRole("heading", { name: "Top items" }),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -1531,7 +1531,7 @@ function AutomationStatusPanel({
 
   if (variant === "compact") {
     return (
-      <section className="rounded-md border border-border bg-surface-raised px-layout-md py-layout-sm shadow-surface">
+      <section className="px-layout-md py-layout-sm">
         <div className="flex flex-col gap-layout-md">
           <h3 className="flex shrink-0 items-center gap-layout-xs text-sm font-medium text-foreground">
             <Bot aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
@@ -1696,8 +1696,12 @@ function DailyOperationsCompletionAttributionNotice({
   }
 
   return (
-    <div className="rounded-lg border border-success/25 bg-success/10 p-layout-md text-sm leading-6 shadow-surface">
-      <p className="font-medium text-success">
+    <div className="py-layout-sm text-sm leading-6">
+      <h3 className="flex items-center gap-layout-xs text-sm font-medium text-foreground">
+        <Bot aria-hidden="true" className="h-4 w-4 text-muted-foreground" />
+        Athena automation
+      </h3>
+      <p className="mt-layout-sm font-medium text-success">
         Athena completed EOD Review under store policy.
       </p>
       <p className="mt-1 text-muted-foreground">
@@ -1890,68 +1894,27 @@ function isPendingCheckoutReview(item: DailyOperationsReviewEvidence) {
 }
 
 function HistoricalWorkflowPanel({
-  orgUrlSlug,
   snapshot,
-  storeUrlSlug,
 }: {
-  orgUrlSlug: string;
   snapshot: DailyOperationsSnapshot;
-  storeUrlSlug: string;
 }) {
   const isClosed = snapshot.lifecycle.status === "closed";
-  const isHistoricalOperating = snapshot.lifecycle.status === "operating";
+  const isIncompleteStoreDay = shouldShowHistoricalEodReviewAction(snapshot);
+
+  if (isClosed || !isIncompleteStoreDay) return null;
 
   return (
     <section className="space-y-layout-md">
       <h3 className="text-base font-medium text-foreground">
-        {isClosed
-          ? "Closed store-day record"
-          : isHistoricalOperating
-            ? "Incomplete store-day close"
-            : "Historical store-day view"}
+        Incomplete store-day close
       </h3>
-      <div className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
-        {isClosed ? (
-          <Button
-            asChild
-            className={getPrimaryActionEmphasis("closed").className}
-            size="sm"
-            variant="outline"
-          >
-            <Link
-              params={buildParams(orgUrlSlug, storeUrlSlug)}
-              search={
-                getWorkflowSearch(
-                  "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
-                  snapshot.operatingDate,
-                ) as never
-              }
-              to="/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close"
-            >
-              Review EOD Review
-              <ArrowUpRight aria-hidden="true" className="h-4 w-4" />
-            </Link>
-          </Button>
-        ) : isHistoricalOperating ? (
-          <>
-            <p className="text-sm leading-6 text-foreground">
-              This historical store day does not have a completed close.
-            </p>
-            <p className="mt-layout-xs text-sm leading-6 text-muted-foreground">
-              Review EOD before treating this date as a closed store-day record.
-            </p>
-          </>
-        ) : (
-          <>
-            <p className="text-sm leading-6 text-foreground">
-              This historical operating date is view-only. Workflow actions are
-              available only on the current operating date.
-            </p>
-            <p className="mt-layout-xs text-sm leading-6 text-muted-foreground">
-              Metrics and timeline remain available for this historical day.
-            </p>
-          </>
-        )}
+      <div>
+        <p className="text-sm leading-6 text-foreground">
+          This historical store day does not have a completed close.
+        </p>
+        <p className="mt-layout-xs text-sm leading-6 text-muted-foreground">
+          Review EOD before treating this date as a closed store-day record.
+        </p>
       </div>
     </section>
   );
@@ -1973,6 +1936,10 @@ function DailyOperationsStorePulsePanel({
   snapshot: DailyOperationsSnapshot;
 }) {
   const storePulseSummary = buildWeekToDateStorePulseSummary(snapshot);
+  const emptyStateTimeContext =
+    snapshot.operatingDate === getLocalOperatingDate()
+      ? "current"
+      : "historical";
 
   return (
     <section className="space-y-layout-md">
@@ -1986,6 +1953,9 @@ function DailyOperationsStorePulsePanel({
           showPulseWindowFilter={false}
           showSummaryMetrics={false}
           summary={storePulseSummary}
+          detailVariant="canvas"
+          emptyStateTimeContext={emptyStateTimeContext}
+          timelineVariant="canvas"
           topItemsTitle={getTopItemsTitle(snapshot.operatingDate)}
         />
       ) : (
@@ -2485,6 +2455,8 @@ function DailyOperationsStorePulsePreview({
   operatingDate: string;
 }) {
   const topItemsTitle = getTopItemsTitle(operatingDate);
+  const emptyStateTimeContext =
+    operatingDate === getLocalOperatingDate() ? "current" : "historical";
   const selectedCachedStorePulse = buildCachedStorePulseForOperatingDate({
     operatingDate,
     selectedDayStorePulse: cachedSelectedStorePulse,
@@ -2513,6 +2485,7 @@ function DailyOperationsStorePulsePreview({
             currencyFormatter={currencyFormatter(currency)}
             pulseWindow="this_week"
             snapshot={selectedCachedStorePulseTrend!.operatorSnapshot!}
+            variant="canvas"
           />
         ) : (
           <section
@@ -2534,7 +2507,7 @@ function DailyOperationsStorePulsePreview({
             </div>
             <div
               aria-label="Load analytics for sales trend"
-              className="group relative cursor-pointer overflow-hidden rounded-lg border border-border bg-surface-raised p-8 shadow-surface transition-[box-shadow] duration-200 ease-out hover:shadow-sm focus:outline-none focus-visible:border-action-workflow-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-within:border-action-workflow-border focus-within:shadow-sm"
+              className="group relative cursor-pointer py-8 transition-[background-color] duration-200 ease-out hover:bg-surface/45 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               onClick={() => {
                 if (!isLoading) onRequest();
               }}
@@ -2583,6 +2556,8 @@ function DailyOperationsStorePulsePreview({
             <TopItemsPanel
               canViewFinancialDetails={hasFullAdminAccess}
               currencyFormatter={currencyFormatter(currency)}
+              emptyStateTimeContext={emptyStateTimeContext}
+              variant="canvas"
               snapshot={detailSnapshot}
               title={topItemsTitle}
             />
@@ -2593,12 +2568,17 @@ function DailyOperationsStorePulsePreview({
               onRequest={onRequest}
               rowCount={5}
               title={topItemsTitle}
+              variant="canvas"
             />
           )}
         </PageWorkspaceMain>
         <PageWorkspaceRail>
           {detailSnapshot ? (
-            <PaymentMethodsPanel snapshot={detailSnapshot} />
+            <PaymentMethodsPanel
+              emptyStateTimeContext={emptyStateTimeContext}
+              variant="canvas"
+              snapshot={detailSnapshot}
+            />
           ) : (
             <DailyOperationsStorePulsePreviewList
               description="Share of synced POS sales by payment method."
@@ -2606,6 +2586,7 @@ function DailyOperationsStorePulsePreview({
               onRequest={onRequest}
               rowCount={3}
               title="How customers paid"
+              variant="canvas"
             />
           )}
         </PageWorkspaceRail>
@@ -2620,13 +2601,24 @@ function DailyOperationsStorePulsePreviewList({
   onRequest,
   rowCount,
   title,
+  variant = "card",
 }: {
   description: string;
   isLoading?: boolean;
   onRequest: () => void;
   rowCount: number;
   title: string;
+  variant?: "card" | "canvas";
 }) {
+  const panelClassName =
+    variant === "canvas"
+      ? "group relative cursor-pointer transition-[background-color] duration-200 ease-out hover:bg-surface/45 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-within:bg-surface/45"
+      : "group relative cursor-pointer rounded-lg border border-border bg-surface-raised shadow-surface transition-[box-shadow] duration-200 ease-out hover:shadow-sm focus:outline-none focus-visible:border-action-workflow-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-within:border-action-workflow-border focus-within:shadow-sm";
+  const rowClassName =
+    variant === "canvas"
+      ? "grid gap-2 py-layout-sm sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center"
+      : "grid gap-2 px-layout-md py-layout-sm sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center";
+
   return (
     <section aria-label={`${title} preview`} className="space-y-layout-md">
       <div>
@@ -2635,7 +2627,7 @@ function DailyOperationsStorePulsePreviewList({
       </div>
       <div
         aria-label={`Load analytics for ${title}`}
-        className="group relative cursor-pointer rounded-lg border border-border bg-surface-raised shadow-surface transition-[box-shadow] duration-200 ease-out hover:shadow-sm focus:outline-none focus-visible:border-action-workflow-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-within:border-action-workflow-border focus-within:shadow-sm"
+        className={panelClassName}
         onClick={() => {
           if (!isLoading) onRequest();
         }}
@@ -2651,10 +2643,7 @@ function DailyOperationsStorePulsePreviewList({
         />
         <div className="divide-y divide-border/70">
           {Array.from({ length: rowCount }).map((_, index) => (
-            <div
-              className="grid gap-2 px-layout-md py-layout-sm sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center"
-              key={index}
-            >
+            <div className={rowClassName} key={index}>
               <span
                 aria-hidden="true"
                 className="h-6 w-6 rounded-sm bg-muted"
@@ -2709,7 +2698,7 @@ function SupportingWorkspaceLinks({
   return (
     <div
       aria-labelledby="supporting-workspaces-heading"
-      className="border-t border-border/70 px-layout-sm py-2"
+      className="mt-layout-md px-layout-sm py-2"
     >
       <h4 className="sr-only" id="supporting-workspaces-heading">
         Supporting workspaces
@@ -3003,13 +2992,13 @@ function WeekMetricsStrip({
                   <span className="text-xs font-medium uppercase tracking-wide">
                     {formatWeekdayLabel(metric.operatingDate)}
                   </span>
-                  {metric.isClosed ? (
-                    <span className="rounded-full bg-success/10 px-1.5 py-0.5 text-[10px] font-medium text-success">
-                      Closed
-                    </span>
-                  ) : metric.isReopened ? (
+                  {metric.isReopened ? (
                     <span className="rounded-full bg-warning/10 px-1.5 py-0.5 text-[10px] font-medium text-warning">
                       Reopened
+                    </span>
+                  ) : metric.isClosed ? (
+                    <span className="rounded-full bg-success/10 px-1.5 py-0.5 text-[10px] font-medium text-success">
+                      Closed
                     </span>
                   ) : null}
                 </div>
@@ -3174,6 +3163,12 @@ export function DailyOperationsViewContent({
   const isHistoricalDate = snapshot
     ? isHistoricalOperatingDate(snapshot.operatingDate)
     : false;
+  const shouldShowHistoricalWorkflowPanel =
+    isHistoricalDate && showHistoricalEodReviewAction;
+  const shouldShowTopStatusStack = snapshot
+    ? shouldShowHistoricalWorkflowPanel ||
+      snapshot.completedClose?.actorType === "automation"
+    : false;
   const primaryActionEmphasisStatus = snapshot
     ? getPrimaryActionEmphasisStatus({
         isHistoricalDate,
@@ -3226,7 +3221,7 @@ export function DailyOperationsViewContent({
   return (
     <View hideBorder hideHeaderBottomBorder scrollMode="page">
       <FadeIn className="container mx-auto w-full py-layout-lg md:py-layout-xl">
-        <PageWorkspace>
+        <PageWorkspace className="md:space-y-layout-3xl">
           <PageLevelHeader
             eyebrow="Store Ops"
             title="Daily Operations"
@@ -3234,8 +3229,8 @@ export function DailyOperationsViewContent({
           />
 
           {isLoadingSnapshot || !snapshot ? null : (
-            <PageWorkspace>
-              <section className="space-y-layout-2xl">
+            <PageWorkspace className="space-y-layout-2xl md:space-y-layout-3xl">
+              <section className="space-y-layout-2xl md:space-y-layout-3xl">
                 <div className="flex flex-col gap-layout-sm lg:flex-row lg:items-center lg:justify-between">
                   {pendingApprovalsLane ? (
                     <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center">
@@ -3376,8 +3371,21 @@ export function DailyOperationsViewContent({
                     ) : null}
                   </>
                 ) : null}
+                {shouldShowTopStatusStack ? (
+                  <section className="space-y-layout-md">
+                    {shouldShowHistoricalWorkflowPanel ? (
+                      <HistoricalWorkflowPanel snapshot={snapshot} />
+                    ) : null}
+                    <DailyOperationsCompletionAttributionNotice
+                      carryForwardCount={
+                        snapshot.completedClose?.carryForwardCount
+                      }
+                      completedClose={snapshot.completedClose}
+                    />
+                  </section>
+                ) : null}
 
-                <div className="grid gap-layout-sm [grid-template-columns:repeat(auto-fit,minmax(min(14rem,100%),1fr))]">
+                <div className="grid gap-layout-md [grid-template-columns:repeat(auto-fit,minmax(min(14rem,100%),1fr))] md:gap-layout-lg">
                   <OperationsSummaryMetric
                     helper={formatOperationsMetricHelper({
                       currentValue: snapshot.closeSummary.salesTotal,
@@ -3587,7 +3595,7 @@ export function DailyOperationsViewContent({
                 ) : null}
               </section>
 
-              <PageWorkspaceGrid>
+              <PageWorkspaceGrid className="gap-layout-2xl lg:gap-layout-3xl">
                 <PageWorkspaceMain className="xl:col-start-1 xl:row-start-1">
                   {requestStorePulseSnapshot ? (
                     <DailyOperationsStorePulsePreview
@@ -3610,12 +3618,6 @@ export function DailyOperationsViewContent({
                       snapshot={storePulseDetailSnapshot}
                     />
                   ) : null}
-                  <DailyOperationsCompletionAttributionNotice
-                    carryForwardCount={
-                      snapshot.completedClose?.carryForwardCount
-                    }
-                    completedClose={snapshot.completedClose}
-                  />
                 </PageWorkspaceMain>
 
                 <PageWorkspaceRail className="xl:col-start-2 xl:row-span-2 xl:row-start-1">
@@ -3681,22 +3683,16 @@ export function DailyOperationsViewContent({
                   ) : null}
                 </PageWorkspaceRail>
 
-                <PageWorkspaceMain className="xl:col-start-1 xl:row-start-2">
-                  {isHistoricalDate ? (
-                    <HistoricalWorkflowPanel
-                      orgUrlSlug={orgUrlSlug}
-                      snapshot={snapshot}
-                      storeUrlSlug={storeUrlSlug}
-                    />
-                  ) : (
+                {!isHistoricalDate ? (
+                  <PageWorkspaceMain className="xl:col-start-1 xl:row-start-2">
                     <section className="space-y-layout-sm">
                       <div>
                         <h3 className="text-sm font-medium text-foreground">
-                          Workflow status
+                          Store-day follow-up
                         </h3>
                       </div>
-                      <div className="overflow-hidden rounded-md border border-border bg-surface-raised shadow-surface">
-                        <div className="grid gap-layout-xs p-2 md:grid-cols-2 xl:grid-cols-3">
+                      <div>
+                        <div className="grid gap-layout-xs md:grid-cols-2 xl:grid-cols-3">
                           {actionableLanes.length > 0 ? (
                             actionableLanes.map((lane) => (
                               <LaneCard
@@ -3718,8 +3714,8 @@ export function DailyOperationsViewContent({
                         />
                       </div>
                     </section>
-                  )}
-                </PageWorkspaceMain>
+                  </PageWorkspaceMain>
+                ) : null}
               </PageWorkspaceGrid>
 
               <Sheet

--- a/packages/athena-webapp/src/components/operations/OperationReviewWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationReviewWorkspace.tsx
@@ -12,6 +12,7 @@ import {
 type OperationReviewWorkspaceProps = {
   actions?: ReactNode;
   afterGrid?: ReactNode;
+  beforeMetrics?: ReactNode;
   description: ReactNode;
   eyebrow: string;
   isLoading?: boolean;
@@ -28,6 +29,7 @@ type OperationReviewWorkspaceProps = {
 export function OperationReviewWorkspace({
   actions,
   afterGrid,
+  beforeMetrics,
   description,
   eyebrow,
   isLoading = false,
@@ -69,6 +71,8 @@ export function OperationReviewWorkspace({
                     </div>
                   ) : null}
                 </div>
+
+                {beforeMetrics}
 
                 <div className="grid gap-layout-lg md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5">
                   {metrics}

--- a/packages/athena-webapp/src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/sales-pulse/POSSalesPulseView.test.tsx
@@ -173,9 +173,27 @@ describe("POSStorePulseSection", () => {
     expect(screen.getAllByText("50%").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("Card")).toBeInTheDocument();
     expect(screen.getByText("Braiding Hair")).toBeInTheDocument();
+    expect(
+      screen.getByText("Braiding Hair").closest(".divide-y")?.parentElement,
+    ).toHaveClass("rounded-lg", "border", "bg-surface-raised", "shadow-surface");
+    expect(screen.getByText("Braiding Hair").closest(".grid")).toHaveClass(
+      "px-layout-md",
+    );
+    expect(screen.getByText("Cash").closest(".divide-y")?.parentElement).toHaveClass(
+      "rounded-lg",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
+    expect(screen.getByText("Cash").closest(".grid")).toHaveClass(
+      "px-layout-md",
+    );
     expect(screen.getByLabelText("Total items sold: 3")).toBeInTheDocument();
     expect(screen.getByText("2 units sold")).toBeInTheDocument();
     expect(screen.getByTestId("store-pulse-chart")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("store-pulse-chart-container").parentElement,
+    ).toHaveClass("rounded-lg", "border", "bg-surface-raised", "shadow-surface");
     expect(screen.getByTestId("store-pulse-area")).toBeInTheDocument();
     expect(screen.queryByText("Transaction review")).not.toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
+++ b/packages/athena-webapp/src/components/store-pulse/StorePulseSummaryView.tsx
@@ -94,6 +94,12 @@ export type StorePulseWindow =
   | "this_month"
   | "all_time";
 
+export type StorePulseEmptyStateTimeContext = "current" | "historical";
+
+export type StorePulseTimelineVariant = "card" | "canvas";
+
+export type StorePulseDetailVariant = "card" | "canvas";
+
 const storePulseWindowOptions: Array<{
   label: string;
   value: StorePulseWindow;
@@ -139,6 +145,7 @@ const salesPulseChartConfig = {
 const detailCardClassName =
   "overflow-hidden rounded-lg border border-border bg-surface-raised shadow-surface";
 const detailRowClassName = "px-layout-md py-layout-sm";
+const canvasDetailRowClassName = "py-layout-sm";
 const topItemsPageSize = 5;
 const salesTrendAxisInset = 72;
 const mobileSalesTrendTickCount = 3;
@@ -322,6 +329,7 @@ export function StorePulseTimeline({
   currencyFormatter,
   pulseWindow,
   snapshot,
+  variant = "card",
 }: {
   animationKey?: string;
   canViewFinancialDetails: boolean;
@@ -329,6 +337,7 @@ export function StorePulseTimeline({
   currencyFormatter: Intl.NumberFormat;
   pulseWindow: StorePulseWindow;
   snapshot: StorePulseOperatorSnapshot;
+  variant?: StorePulseTimelineVariant;
 }) {
   const isMobile = useIsMobile();
   const chartData = useMemo(
@@ -393,7 +402,13 @@ export function StorePulseTimeline({
           ) : null}
         </div>
       </div>
-      <div className="overflow-hidden rounded-lg border border-border bg-surface-raised px-layout-sm py-8 shadow-surface sm:p-8">
+      <div
+        className={
+          variant === "canvas"
+            ? "py-8"
+            : "overflow-hidden rounded-lg border border-border bg-surface-raised px-layout-sm py-8 shadow-surface sm:p-8"
+        }
+      >
         <ChartContainer
           config={salesPulseChartConfig}
           className="store-pulse-sales-trend-chart h-[22rem] w-full"
@@ -516,13 +531,17 @@ export function StorePulseTimeline({
 export function TopItemsPanel({
   canViewFinancialDetails,
   currencyFormatter,
+  emptyStateTimeContext = "current",
   snapshot,
   title = "Top items",
+  variant = "card",
 }: {
   canViewFinancialDetails: boolean;
   currencyFormatter: Intl.NumberFormat;
+  emptyStateTimeContext?: StorePulseEmptyStateTimeContext;
   snapshot: StorePulseOperatorSnapshot;
   title?: string;
+  variant?: StorePulseDetailVariant;
 }) {
   const [page, setPage] = useState(1);
   const topItemCount = snapshot.topItems.length;
@@ -535,6 +554,10 @@ export function TopItemsPanel({
     pageStartIndex + topItemsPageSize,
   );
   const totalItemsSold = snapshot.comparison.currentItemsSold;
+  const panelClassName =
+    variant === "canvas" ? "" : detailCardClassName;
+  const rowClassName =
+    variant === "canvas" ? canvasDetailRowClassName : detailRowClassName;
 
   return (
     <section className="space-y-layout-md">
@@ -558,8 +581,8 @@ export function TopItemsPanel({
       <div
         className={
           isPaginated
-            ? `${detailCardClassName} flex min-h-[23.5rem] flex-col`
-            : detailCardClassName
+            ? `${panelClassName} flex min-h-[23.5rem] flex-col`
+            : panelClassName
         }
       >
         {snapshot.topItems.length ? (
@@ -575,7 +598,7 @@ export function TopItemsPanel({
 
                 return (
                   <div
-                    className={`${detailRowClassName} grid gap-2 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center`}
+                    className={`${rowClassName} grid gap-2 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center`}
                     key={`${item.name}:${item.productSku ?? rank}`}
                   >
                     <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-border bg-surface text-xs font-medium text-muted-foreground">
@@ -618,8 +641,16 @@ export function TopItemsPanel({
           </>
         ) : (
           <EmptyState
-            description="Completed POS sales will populate item movement here."
-            title="No item history yet"
+            description={
+              emptyStateTimeContext === "historical"
+                ? "No completed POS item movement was recorded for this day."
+                : "Completed POS sales will populate item movement here."
+            }
+            title={
+              emptyStateTimeContext === "historical"
+                ? "No item history"
+                : "No item history yet"
+            }
           />
         )}
       </div>
@@ -628,14 +659,20 @@ export function TopItemsPanel({
 }
 
 export function PaymentMethodsPanel({
+  emptyStateTimeContext = "current",
   snapshot,
+  variant = "card",
 }: {
+  emptyStateTimeContext?: StorePulseEmptyStateTimeContext;
   snapshot: StorePulseOperatorSnapshot;
+  variant?: StorePulseDetailVariant;
 }) {
   const totalPaymentTransactions = snapshot.paymentMix.reduce(
     (total, payment) => total + payment.count,
     0,
   );
+  const rowClassName =
+    variant === "canvas" ? canvasDetailRowClassName : detailRowClassName;
 
   return (
     <section aria-label="Payment methods" className="space-y-layout-md">
@@ -647,7 +684,7 @@ export function PaymentMethodsPanel({
           Share of synced POS sales by payment method.
         </p>
       </div>
-      <div className={detailCardClassName}>
+      <div className={variant === "canvas" ? "" : detailCardClassName}>
         <div className="divide-y divide-border/70">
           {snapshot.paymentMix.length ? (
             snapshot.paymentMix.map((payment) => {
@@ -659,7 +696,7 @@ export function PaymentMethodsPanel({
 
               return (
                 <div
-                  className={`${detailRowClassName} grid gap-1`}
+                  className={`${rowClassName} grid gap-1`}
                   key={payment.method}
                 >
                   <div className="flex items-center justify-between gap-layout-sm text-sm">
@@ -688,8 +725,16 @@ export function PaymentMethodsPanel({
             })
           ) : (
             <EmptyState
-              description="Payment method shares will appear after completed sales sync."
-              title="No payment mix yet"
+              description={
+                emptyStateTimeContext === "historical"
+                  ? "No synced POS payment methods were recorded for this day."
+                  : "Payment method shares will appear after completed sales sync."
+              }
+              title={
+                emptyStateTimeContext === "historical"
+                  ? "No payment mix"
+                  : "No payment mix yet"
+              }
             />
           )}
         </div>
@@ -699,13 +744,21 @@ export function PaymentMethodsPanel({
 }
 
 function StorePulseRail({
+  detailVariant,
+  emptyStateTimeContext,
   snapshot,
 }: {
+  detailVariant?: StorePulseDetailVariant;
+  emptyStateTimeContext?: StorePulseEmptyStateTimeContext;
   snapshot: StorePulseOperatorSnapshot;
 }) {
   return (
     <PageWorkspaceRail>
-      <PaymentMethodsPanel snapshot={snapshot} />
+      <PaymentMethodsPanel
+        variant={detailVariant}
+        emptyStateTimeContext={emptyStateTimeContext}
+        snapshot={snapshot}
+      />
     </PageWorkspaceRail>
   );
 }
@@ -717,7 +770,11 @@ const loadingMetrics = [
   { helper: "-", label: "Items sold" },
 ] as const;
 
-function StorePulseChartSkeleton() {
+function StorePulseChartSkeleton({
+  variant = "card",
+}: {
+  variant?: StorePulseTimelineVariant;
+}) {
   return (
     <section aria-label="Sales trend loading" className="space-y-layout-sm">
       <div className="flex flex-col gap-layout-xs sm:flex-row sm:items-end sm:justify-between">
@@ -729,7 +786,13 @@ function StorePulseChartSkeleton() {
         </div>
         <Skeleton className="h-6 w-28 rounded-sm" />
       </div>
-      <div className="overflow-hidden rounded-lg border border-border bg-surface-raised p-8 shadow-surface">
+      <div
+        className={
+          variant === "canvas"
+            ? "py-8"
+            : "overflow-hidden rounded-lg border border-border bg-surface-raised p-8 shadow-surface"
+        }
+      >
         <div className="relative h-[22rem] w-full">
           <div className="absolute inset-y-0 left-0 flex w-16 flex-col justify-between py-1">
             {Array.from({ length: 5 }).map((_, index) => (
@@ -755,24 +818,29 @@ function StorePulseChartSkeleton() {
 
 function StorePulseDetailSkeleton({
   description,
+  variant = "card",
   rowCount,
   title,
 }: {
   description: string;
+  variant?: StorePulseDetailVariant;
   rowCount: number;
   title: string;
 }) {
+  const rowClassName =
+    variant === "canvas" ? canvasDetailRowClassName : detailRowClassName;
+
   return (
     <section aria-label={`${title} loading`} className="space-y-layout-md">
       <div>
         <h3 className="text-base font-medium text-foreground">{title}</h3>
         <p className="mt-1 text-sm text-muted-foreground">{description}</p>
       </div>
-      <div className={detailCardClassName}>
+      <div className={variant === "canvas" ? "" : detailCardClassName}>
         <div className="divide-y divide-border/70">
           {Array.from({ length: rowCount }).map((_, index) => (
             <div
-              className={`${detailRowClassName} grid gap-2 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center`}
+              className={`${rowClassName} grid gap-2 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center`}
               key={index}
             >
               <Skeleton className="h-6 w-6 rounded-sm" />
@@ -789,12 +857,16 @@ function StorePulseDetailSkeleton({
 }
 
 function StorePulseSkeleton({
+  detailVariant,
   showFinancialSalesCards,
   showSummaryMetrics,
+  timelineVariant,
   topItemsTitle = "Top items",
 }: {
+  detailVariant?: StorePulseDetailVariant;
   showFinancialSalesCards: boolean;
   showSummaryMetrics: boolean;
+  timelineVariant?: StorePulseTimelineVariant;
   topItemsTitle?: string;
 }) {
   const visibleLoadingMetrics = showFinancialSalesCards
@@ -820,7 +892,9 @@ function StorePulseSkeleton({
           </div>
         ) : null}
 
-        {showFinancialSalesCards ? <StorePulseChartSkeleton /> : null}
+        {showFinancialSalesCards ? (
+          <StorePulseChartSkeleton variant={timelineVariant} />
+        ) : null}
       </section>
 
       {showFinancialSalesCards ? (
@@ -828,6 +902,7 @@ function StorePulseSkeleton({
           <PageWorkspaceMain>
             <StorePulseDetailSkeleton
               description="Highest-volume items in the current history window."
+              variant={detailVariant}
               rowCount={5}
               title={topItemsTitle}
             />
@@ -836,6 +911,7 @@ function StorePulseSkeleton({
           <PageWorkspaceRail>
             <StorePulseDetailSkeleton
               description="Share of synced POS sales by payment method."
+              variant={detailVariant}
               rowCount={3}
               title="How customers paid"
             />
@@ -851,24 +927,30 @@ export function StorePulseSummaryView({
   chartAnimationKey,
   chartDescription,
   currencyFormatter,
+  detailVariant = "card",
+  emptyStateTimeContext = "current",
   onPulseWindowChange,
   pulseWindow,
   showDetailPanels = true,
   showPulseWindowFilter = true,
   showSummaryMetrics = true,
   summary,
+  timelineVariant = "card",
   topItemsTitle = "Top items",
 }: {
   canViewFinancialDetails: boolean;
   chartAnimationKey?: string;
   chartDescription?: string;
   currencyFormatter: Intl.NumberFormat;
+  detailVariant?: StorePulseDetailVariant;
+  emptyStateTimeContext?: StorePulseEmptyStateTimeContext;
   onPulseWindowChange: (pulseWindow: StorePulseWindow) => void;
   pulseWindow: StorePulseWindow;
   showDetailPanels?: boolean;
   showPulseWindowFilter?: boolean;
   showSummaryMetrics?: boolean;
   summary: StorePulseSummary | undefined;
+  timelineVariant?: StorePulseTimelineVariant;
   topItemsTitle?: string;
 }) {
   const snapshot = summary?.operatorSnapshot;
@@ -921,8 +1003,10 @@ export function StorePulseSummaryView({
 
       {!snapshot ? (
         <StorePulseSkeleton
+          detailVariant={detailVariant}
           showFinancialSalesCards={canViewFinancialDetails}
           showSummaryMetrics={showSummaryMetrics}
+          timelineVariant={timelineVariant}
           topItemsTitle={topItemsTitle}
         />
       ) : (
@@ -1021,6 +1105,7 @@ export function StorePulseSummaryView({
                 currencyFormatter={currencyFormatter}
                 pulseWindow={pulseWindow}
                 snapshot={snapshot}
+                variant={timelineVariant}
               />
             ) : null}
           </section>
@@ -1031,12 +1116,18 @@ export function StorePulseSummaryView({
                 <TopItemsPanel
                   canViewFinancialDetails={canViewFinancialDetails}
                   currencyFormatter={currencyFormatter}
+                  variant={detailVariant}
+                  emptyStateTimeContext={emptyStateTimeContext}
                   snapshot={snapshot}
                   title={topItemsTitle}
                 />
               </PageWorkspaceMain>
 
-              <StorePulseRail snapshot={snapshot} />
+              <StorePulseRail
+                detailVariant={detailVariant}
+                emptyStateTimeContext={emptyStateTimeContext}
+                snapshot={snapshot}
+              />
             </PageWorkspaceGrid>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary

Daily Operations now reads more like an operational canvas and less like a stack of nested cards. The review, automation, sales trend, top items, payment mix, and follow-up surfaces share the lighter canvas treatment, while workflow lanes keep their card affordance where it helps scanning.

This also fixes historical store-day state cues: week badges now derive reopened vs closed status from the same lifecycle logic used by the top EOD action, empty states use date-aware copy, and the generic historical view-only message has been removed unless a historical day has an incomplete close that needs action.

## What Changed

- Moved Athena automation/completion notices above the metric cards on Daily Operations and Opening Handoff, with shared canvas styling and an explicit `Athena automation` header where the message represents automation work.
- Added canvas variants for sales trends, top items, payment mix, loading, and empty states so page sections align without extra horizontal padding.
- Increased vertical rhythm between major Daily Operations sections and simplified redundant closed-day EOD review surfaces.
- Updated historical lifecycle handling so reopened/reclosed day badges reflect the actual selected operating date state.
- Added a solution note for the reusable canvas-status-band pattern.

## Validation

- Pre-push full suite passed: 443 webapp test files, 4,923 tests.
- Focused operations/POS impact suite passed: 12 files, 516 tests.
- Daily Operations component suite passed: 78 tests.
- Changed frontend lint, changed Convex lint, architecture lint, TypeScript, production build, graphify, and harness behavior scenarios passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5_Codex](https://img.shields.io/badge/GPT_5_Codex-000000)