### PR TITLE
Hotfix terminal proof for payment method corrections

### DIFF
--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -1782,7 +1782,8 @@ describe("TransactionView", () => {
 
   it("queues async manager approval for payment corrections", async () => {
     const user = userEvent.setup();
-    const authMutation = vi.fn().mockResolvedValue({
+    const authMutation = vi.fn();
+    const terminalAuthMutation = vi.fn().mockResolvedValue({
       kind: "ok",
       data: {
         activeRoles: ["cashier"],
@@ -1832,6 +1833,8 @@ describe("TransactionView", () => {
       customerMutation,
       paymentMutation,
       approvalMutation,
+      vi.fn(),
+      terminalAuthMutation,
     );
     useParamsMock.mockReturnValue({ transactionId: "txn_13" });
     useQueryMock.mockReturnValue(baseTransaction);
@@ -1862,10 +1865,13 @@ describe("TransactionView", () => {
       ),
     ).not.toBeInTheDocument();
     expect(approvalMutation).not.toHaveBeenCalled();
-    expect(authMutation).toHaveBeenCalledWith({
+    expect(authMutation).not.toHaveBeenCalled();
+    expect(terminalAuthMutation).toHaveBeenCalledWith({
       allowedRoles: ["cashier", "manager"],
+      allowActiveSessionsOnOtherTerminals: true,
       pinHash: "hashed:1234",
       storeId: "store_1",
+      terminalId: "terminal_1",
       username: "manager",
     });
     expect(paymentMutation).toHaveBeenCalledWith({

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -908,7 +908,11 @@ export function TransactionView() {
       };
     }
 
-    if (pendingCorrection === "line_items" || pendingCorrection === "void") {
+    if (
+      pendingCorrection === "payment_method" ||
+      pendingCorrection === "line_items" ||
+      pendingCorrection === "void"
+    ) {
       if (!transaction?.terminalId) {
         return {
           kind: "user_error" as const,


### PR DESCRIPTION
## Summary

- authenticate transaction payment-method corrections against the transaction terminal
- pass the minted terminal-scoped staff proof to the correction mutation
- add regression coverage that distinguishes store-only auth from terminal auth

## Root cause

The payment correction backend requires terminal-scoped staff proof for requester attribution, but the transaction detail view used store-only staff authentication for payment corrections. That authentication path does not mint `posLocalStaffProof`, so submissions reached the backend without `staffProofToken`.

## Validation

- `bun run test -- src/components/pos/transactions/TransactionView.test.tsx` (57 passed)
- `bun run --filter @athena/webapp typecheck`
- `bun run graphify:rebuild`
- `bun run pr:athena`