### PR TITLE
feat(marketing): release Athena landing MVP

### DIFF
--- a/docs/plans/2026-07-11-001-feat-athena-product-page-plan.html
+++ b/docs/plans/2026-07-11-001-feat-athena-product-page-plan.html
@@ -127,6 +127,7 @@
 
       <section id="decisions">
         <h2>Key technical decisions</h2>
+        <div class="decision"><strong>MVP release precedes positioning sessions.</strong> The 2026-07-12 owner decision releases a restrained claims-only page with non-numeric product-shaped illustration. The five owner-operator sessions become a post-release learning gate; their frozen four-of-five rule decides what copy to retain, revise, or narrow without retroactively validating demand or unapproved proof.</div>
         <div class="decision"><strong>Public and operational entry are separate.</strong> Public rendering does not wait for auth or organization resolution; authenticated dispatch remains explicit at <code>/app</code>.</div>
         <div class="decision"><strong>Real product, public-safe evidence.</strong> Reuse Store Pulse semantics through sanitized fixtures and audited fallbacks rather than exposing store-scoped queries.</div>
         <div class="decision"><strong>Persistence defines success.</strong> A walkthrough is accepted when its Convex record is durable or the unchanged submission key is safely deduplicated; notification failure stays observable and retryable behind the boundary.</div>
@@ -153,12 +154,12 @@
       <section id="units">
         <h2>Implementation-unit digest</h2>
         <ol class="units">
-          <li><strong>Positioning and proof gate</strong><div class="deps">External dependency: five eligible owner-operators and product-owner review.</div>Pre-register the comprehension rubric, record every eligible response, map the core sequence plus one cross-channel and one small-team-control proof, maintain a freshness manifest, and pre-register the launch-review rubric.</li>
+          <li><strong>Post-MVP positioning and proof gate</strong><div class="deps">External dependency: five eligible owner-operators and product-owner review; not a prerequisite for the claims-only MVP.</div>Pre-register the comprehension rubric, record every eligible response, map the core sequence plus one cross-channel and one small-team-control proof, maintain a freshness manifest, and use the frozen result to retain, revise, or narrow the released copy.</li>
           <li><strong>Public and app route separation</strong><div class="deps">Runs in parallel with units 1 and 3.</div>Make <code>/</code> public, move authenticated dispatch to <code>/app</code>, redirect <code>/landing</code>, suppress public operational chrome, and keep process-root providers stable.</li>
           <li><strong>Walkthrough persistence</strong><div class="deps">Deployment requires an accountable recipient and operational owner.</div>Add owned HTTP ingress, immutable records/follow-ups, canonical same-key idempotency, budget-bounded fresh-key replay aliases, evidence-based budgets, ambiguity-safe notification attempts, internal-only resolution, and retention/redaction.</li>
           <li><strong>Walkthrough experience</strong><div class="deps">Depends on units 2 and 3.</div>Build the accessible <code>/walkthrough</code> form, retained failure state, retry identity, confirmation, and secondary sign-in.</li>
-          <li><strong>Product-proof system</strong><div class="deps">Depends on unit 1.</div>Create sanitized fixtures, audited assets, staged responsive evidence, static poster fallback, and reduced-motion parity.</li>
-          <li><strong>Product-page narrative</strong><div class="deps">Depends on units 1, 2, 4, and 5.</div>Compose the approved sales-to-stock story, two evidenced breadth moments, fixed crawler metadata, dedicated privacy-safe funnel ingress, and prospect-first conversion hierarchy.</li>
+          <li><strong>Product-proof system</strong><div class="deps">Audited screenshots or numeric proof depend on unit 1; the claims-only MVP uses non-numeric product-shaped illustration.</div>Create sanitized fixtures, audited assets, staged responsive evidence, static poster fallback, and reduced-motion parity.</li>
+          <li><strong>Product-page narrative</strong><div class="deps">The claims-only MVP depends on units 2 and 4; final validated copy and audited media also depend on units 1 and 5.</div>Compose the behavior-grounded sales-to-stock story, two evidenced breadth moments, fixed crawler metadata, dedicated privacy-safe funnel ingress, and prospect-first conversion hierarchy.</li>
           <li><strong>Integration and launch verification</strong><div class="deps">Depends on units 3 through 6.</div>Exercise anonymous, authenticated, backend, media, accessibility, mobile, and deep-link paths, then refresh generated artifacts and run merge-grade validation.</li>
         </ol>
       </section>
@@ -168,7 +169,7 @@
         <table>
           <thead><tr><th>Phase</th><th>Work</th><th>Gate</th></tr></thead>
           <tbody>
-            <tr><td>0</td><td>Pre-registered positioning validation and proof audit</td><td>Four of five comprehension pass; every retained connection has credible evidence. Market effectiveness remains a post-launch question.</td></tr>
+            <tr><td>0</td><td>Claims-only MVP release, followed by pre-registered positioning validation and proof audit</td><td>The release contains no synthetic metrics or unapproved screenshots; afterward, four of five comprehension pass governs which claims survive.</td></tr>
             <tr><td>1</td><td>Public/app routing and walkthrough persistence in parallel</td><td>Route ownership and durable command contracts are green.</td></tr>
             <tr><td>2</td><td>Walkthrough UI and sanitized proof system in parallel</td><td>All form and media states are covered.</td></tr>
             <tr><td>3</td><td>Page composition and integrated release proof</td><td>Browser, accessibility, authenticated continuity, Graphify, and <code>pr:athena</code> pass.</td></tr>

--- a/docs/plans/2026-07-11-001-feat-athena-product-page-plan.md
+++ b/docs/plans/2026-07-11-001-feat-athena-product-page-plan.md
@@ -190,6 +190,10 @@ flowchart TB
 
 The prose dependency fields below are authoritative if this diagram and the unit details ever diverge.
 
+## MVP release decision — 2026-07-12
+
+The product owner approved a restrained claims-only MVP before the five positioning sessions. For this MVP, U1 is a post-release learning gate rather than a prerequisite for U6: publish only claims grounded in current Athena behavior, use non-numeric product-shaped illustrations instead of unapproved screenshots or synthetic performance proof, keep the owner as the restocking decision-maker, and keep the walkthrough path fail-closed until production privacy and recipient configuration is complete. The five sessions still use the frozen 4-of-5 rule to decide what copy to retain, revise, or narrow after release. They do not retroactively establish demand or validate unapproved product proof.
+
 - U1. **Complete positioning validation and the product-proof audit**
 
 **Goal:** Establish the evidence gate that approves or redirects the lead message and maps every narrative stage and transition to truthful, publishable Athena proof.
@@ -449,7 +453,7 @@ The prose dependency fields below are authoritative if this diagram and the unit
 
 **Requirements:** R3, R5, R6, R7, R9, R10, R14, R16; F1, F2; AE2, AE4, AE6.
 
-**Dependencies:** U1.
+**Dependencies:** U1 for audited screenshots or numeric product proof. The claims-only MVP may use the approved non-numeric product-shaped illustration before U1 completes.
 
 **Files:**
 - Create: `packages/athena-webapp/src/components/landing/landingProductProofData.ts`
@@ -497,7 +501,7 @@ The prose dependency fields below are authoritative if this diagram and the unit
 
 **Requirements:** R1-R16; F1-F3; AE1-AE6.
 
-**Dependencies:** U1, U2, U4, U5.
+**Dependencies:** U2 and U4 for the claims-only MVP; U1 and the full U5 proof audit are required before adding final validated copy, screenshots, or numeric product proof.
 
 **Files:**
 - Modify: `packages/athena-webapp/src/components/landing/AthenaLandingPage.tsx`
@@ -515,7 +519,7 @@ The prose dependency fields below are authoritative if this diagram and the unit
 - Define the trust boundary as a short note adjacent to product proof: showcased data is sanitized or illustrative, and the public page does not load a business's protected operating records. Do not add generic compliance badges or unverified security assurances.
 - Keep “Request a walkthrough” primary and sign-in secondary in the hero and closing conversion without duplicating competing actions in every section.
 - Reuse Athena semantic tokens, display/numeric type roles, dark structural shell, quiet surfaces, and restrained motion; avoid decorative card grids and generic SaaS visual motifs.
-- Carry only copy approved by U1. Keep product captions operational and specific; avoid forecasting, profit, automation, and all-in-one overclaims.
+- For the claims-only MVP, carry only behavior-grounded copy approved by the product owner. After the sessions, U1 governs final validated copy and audited product media. Keep product captions operational and specific; avoid forecasting, profit, automation, and all-in-one overclaims.
 - Put crawler-visible product-page title, description, fixed-production-origin canonical, and audited Open Graph tags in the static HTML response; keep client route titles for browser navigation. `/landing` redirects and canonicalizes to `/`; `/walkthrough` receives a product-specific server `noindex` header and never reflects form values.
 - Use U3's dedicated global marketing-funnel HTTP ingress for browser-side page view, walkthrough CTA selection, and form start. Forbid form payloads, email, phone, business text, submission key, or another stable person identifier. Durable acceptance is appended server-side in the walkthrough transaction; document event meanings so aggregate review reconciles with stored requests.
 - Lazy-load below-fold media while preserving document order and semantic text equivalents.
@@ -542,7 +546,7 @@ The prose dependency fields below are authoritative if this diagram and the unit
 **Verification:**
 - A reviewer can explain the page as “see today's sales, compare history, understand what moved, review stock pressure, decide what to restock.”
 - The page feels broader than a POS without losing the sales-and-inventory entry promise.
-- Every product claim traces to U1 evidence or the origin requirements.
+- Every MVP claim traces to current product behavior and the origin requirements; final validated copy and audited media additionally trace to U1 evidence.
 
 - U7. **Verify the integrated public journey and launch boundary**
 
@@ -633,9 +637,9 @@ flowchart TB
 
 ## Phased Delivery
 
-### Phase 0 — Evidence gates
+### Phase 0 — MVP release boundary and post-release evidence gate
 
-- Complete U1 and obtain the positioning/proof decision before final copy or product media is approved.
+- Release the claims-only MVP from current product behavior without screenshots or synthetic metrics. Complete U1 before approving post-MVP final copy or audited product media.
 
 ### Phase 1 — Independent foundations
 
@@ -643,7 +647,7 @@ flowchart TB
 
 ### Phase 2 — Prospect surfaces
 
-- Implement U4 after U2/U3 and U5 after U1.
+- Implement U4 after U2/U3. Use the non-numeric MVP illustration immediately; complete the audited U5 media system after U1.
 
 ### Phase 3 — Narrative integration and release proof
 
@@ -653,7 +657,7 @@ flowchart TB
 
 ## Success Metrics
 
-- Four of five representative owner-operators explain the problem, Athena's role, and the connected-record difference without prompting before final copy approval.
+- After MVP release, four of five representative owner-operators explain the problem, Athena's role, and the connected-record difference without prompting before post-MVP final copy approval.
 - The five-person result is recorded as a comprehension gate, not market validation.
 - Anonymous `/` renders a useful hero, product proof, and conversion path without authentication, protected store data, rich media, or motion.
 - Every retained narrative stage and transition has audited product evidence.
@@ -669,7 +673,7 @@ flowchart TB
 
 | Risk | Mitigation |
 |------|------------|
-| Positioning research disproves the chosen hero | U1 reopens R2, R5, R7, and key decisions before U5/U6 continue. |
+| Positioning research disproves the released hero | U1 reopens R2, R5, R7, and key decisions; revise or narrow the next page version without treating the original MVP as validated. |
 | Current product surfaces do not visibly prove a narrative transition | Narrow the story in U1 rather than fabricating connective evidence. |
 | Sanitized media leaks account or customer details | Use a field-by-field media audit, production-owned fixtures, and no direct reuse of pitch screenshots without review. |
 | Root-route migration breaks post-login or internal home links | Centralize public/app entry paths, characterize current redirects first, and cover `/`, `/app`, `/login`, `/landing`, and deep links. |

--- a/docs/reports/athena-landing-launch-review.md
+++ b/docs/reports/athena-landing-launch-review.md
@@ -1,6 +1,6 @@
 # Athena landing launch review
 
-Status: **pre-registration incomplete — do not interpret launch performance yet**
+Status: **MVP release approved — observation fields still require freeze**
 
 Review owner: **unassigned**
 
@@ -8,9 +8,9 @@ Launch revision: **not set**
 
 Rubric freeze timestamp: **not set**
 
-This record separates positioning evidence from traffic quality, form usability, ingress reliability, notification delivery, and owner follow-up. It is a decision rubric, not a report of market demand. Insufficient or conflicting evidence must remain `inconclusive`.
+This record separates positioning evidence from traffic quality, form usability, ingress reliability, notification delivery, and owner follow-up. The 2026-07-12 release is an explicit learning MVP using claims supported by current Athena behavior and no synthetic performance proof. It is a decision rubric, not a report of market demand. Insufficient or conflicting evidence must remain `inconclusive`.
 
-## Freeze before launch
+## Freeze before interpreting launch traffic
 
 The named review owner must complete and freeze these fields before production traffic is included.
 
@@ -19,9 +19,9 @@ The named review owner must complete and freeze these fields before production t
 | Production launch timestamp | `[required]` |
 | Landing revision / deployment id | `[required]` |
 | Observation window | First seven complete calendar days after launch, excluding registered incidents |
-| Minimum usable non-bot page-view sample | `[product owner must set before launch]` |
-| Minimum durable accepted-request sample | `[product owner must set before launch]` |
-| Maximum acceptable owner follow-up latency | `[product/sales owner must set before launch]` |
+| Minimum usable non-bot page-view sample | `[product owner must set before interpreting traffic]` |
+| Minimum durable accepted-request sample | `[product owner must set before interpreting traffic]` |
+| Maximum acceptable owner follow-up latency | `[product/sales owner must set before interpreting traffic]` |
 | Accountable product owner | `[required]` |
 | Accountable walkthrough follow-up owner | `[required]` |
 | Data extractor / reviewer | `[required]` |
@@ -129,6 +129,6 @@ This review can guide positioning; it cannot, by itself, prove product-market fi
 | Qualified / not qualified / unknown | `[not observed]` |
 | Incident intervals excluded | `[none registered]` |
 | Primary diagnostic classification | `inconclusive — launch has not occurred` |
-| Positioning decision | `blocked` |
+| Positioning decision | `not yet eligible — MVP release is unaffected` |
 
-Review owner sign-off: `[blocked until owner, thresholds, launch revision, and evidence are present]`
+Review owner sign-off: `[required before interpreting launch traffic; not a release gate for the claims-only MVP]`

--- a/docs/reports/athena-landing-positioning-validation.md
+++ b/docs/reports/athena-landing-positioning-validation.md
@@ -1,6 +1,6 @@
 # Athena landing positioning validation
 
-Status: **blocked — research not yet run**
+Status: **post-MVP validation — research not yet run**
 
 Gate owner: **unassigned; product owner must be named before recruitment**
 
@@ -10,7 +10,7 @@ Research revision: `draft-1`
 
 Decision threshold: **at least four of exactly five valid sessions must pass**
 
-This record is the pre-registration and results ledger for Athena's landing-page comprehension gate. It is not customer research already performed, evidence of demand, or approval of final copy. No participant has been recruited or scored in this draft.
+This record is the pre-registration and results ledger for Athena's post-MVP landing-page comprehension study. On 2026-07-12 the product owner approved a restrained claims-only MVP before the five sessions. The sessions now decide which message to retain, revise, or narrow; they do not block the initial MVP release. No participant has been recruited or scored in this draft.
 
 ## Gate rules
 
@@ -112,9 +112,9 @@ Do not store participant names, contact details, business names, or other direct
 | Threshold met | `no — research has not run` |
 | Product-owner decision | `blocked` |
 
-Final copy and product-media approval remain blocked until this ledger contains exactly five valid completed sessions, the pass count is mechanically derived, and the named product owner records the decision below.
+Post-MVP final copy and audited product-media approval remain blocked until this ledger contains exactly five valid completed sessions, the pass count is mechanically derived, and the named product owner records the decision below. This does not block the released claims-only MVP, which contains no audited screenshots or synthetic performance proof.
 
-Product-owner decision: `[blocked — do not sign before the five-session gate is complete]`
+Product-owner decision: `[blocked for post-MVP copy/media approval — do not sign before the five-session gate is complete]`
 
 Decision date: `[blank]`
 

--- a/docs/solutions/design-patterns/claims-only-product-page-mvp-before-validation-2026-07-12.md
+++ b/docs/solutions/design-patterns/claims-only-product-page-mvp-before-validation-2026-07-12.md
@@ -1,0 +1,64 @@
+---
+title: Release a claims-only product-page MVP before positioning validation
+date: 2026-07-12
+category: design-patterns
+module: Athena public product page
+problem_type: design_pattern
+component: frontend_stimulus
+resolution_type: workflow_improvement
+severity: medium
+applies_when:
+  - A public product page must ship before planned customer positioning sessions are complete
+  - Existing product behavior supports useful claims but approved screenshots and market proof are not ready
+tags:
+  - landing-page
+  - product-positioning
+  - claims-only-mvp
+  - public-proof
+  - owner-led-retail
+delivery_diff_fingerprint: d75397a4a71fc0bc58dba86250fa415f2c3ef45a4b509d3aed09ce9950a87af3
+---
+
+# Release a claims-only product-page MVP before positioning validation
+
+## Problem
+
+A product page can be technically ready before its positioning research and screenshot audit are complete. Treating those unfinished inputs as permission to invent metrics, imply automation, or expose unaudited account data creates a trust problem; treating them as an absolute release blocker prevents a deliberately narrow MVP from generating useful real-world learning.
+
+## Solution
+
+Release a claims-only MVP whose public story is bounded by behavior already present in Athena:
+
+- State the operator outcome plainly: see today's sales, reach historical sales easily, understand which products moved, and decide what needs attention.
+- Use non-numeric product-shaped illustration for hierarchy and product feel. Do not present illustrative bars as measured business performance.
+- Keep the operator as the decision-maker. Athena surfaces operating facts; it does not claim to forecast demand or reorder stock automatically.
+- Limit breadth to evidenced adjacent strengths, such as connected sales channels and small-team accountability.
+- Keep all conversion routes functional and fail closed until the production origin, privacy contact, notification recipient, and replay-signing keys are configured.
+- Reclassify the planned owner-operator sessions as a post-release learning gate. Preserve the pre-registered four-of-five comprehension rule to decide which copy to retain, revise, or narrow.
+
+Tests should assert the core narrative, CTA paths, and prohibited overclaims. Static metadata should use the same restrained promise as the rendered page.
+
+## Why This Matters
+
+This separates three different kinds of truth. Current product behavior establishes which claims may ship. Public-safe artwork establishes how those claims can be shown without exposing customer data. Later positioning sessions establish whether representative operators understand the message. None of those signals is allowed to impersonate another.
+
+The result is a useful MVP that can be released early without converting unvalidated assumptions into synthetic proof.
+
+## Prevention
+
+- Search product code and approved requirements for evidence before writing each public claim.
+- Reject synthetic performance figures, unaudited screenshots, forecasting language, and automated-replenishment language at the copy and test layers.
+- Keep validation documents explicit about whether research is a pre-release gate or a post-release learning gate.
+- Verify desktop and mobile composition plus the complete walkthrough path before release.
+- Keep runtime and compile-time privacy contacts identical; an absent or invalid contact must disable anonymous intake.
+
+## Examples
+
+Prefer “See which products shaped the day” over “Know what will sell next.” Prefer a labeled, non-numeric “Store pulse” illustration over a dashboard populated with invented revenue, transaction, or growth figures. Prefer “Decide what needs your attention next” over “Athena automatically keeps you stocked.”
+
+## Related
+
+- `docs/plans/2026-07-11-001-feat-athena-product-page-plan.md`
+- `docs/reports/athena-landing-positioning-validation.md`
+- `docs/reports/athena-landing-launch-review.md`
+- `docs/operations/walkthrough-request-operations.md`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10026 nodes · 12206 edges · 2408 communities detected
+- 10025 nodes · 12205 edges · 2408 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3162,24 +3162,24 @@ Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 179 - "Community 179"
-Cohesion: 0.29
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 180 - "Community 180"
 Cohesion: 0.31
 Nodes (9): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), ensurePaymentAllocationReportingWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), matchesExistingAllocation(), matchesKeyedAllocation(), paymentAllocationReportingIdentity() (+1 more)
 
-### Community 181 - "Community 181"
+### Community 180 - "Community 180"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 182 - "Community 182"
+### Community 181 - "Community 181"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 183 - "Community 183"
+### Community 182 - "Community 182"
 Cohesion: 0.22
 Nodes (4): buildStoreIntradayProjection(), checkpointAtOrBefore(), persistedCheckpointAt(), safeAdd()
+
+### Community 183 - "Community 183"
+Cohesion: 0.29
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 184 - "Community 184"
 Cohesion: 0.33
@@ -3435,15 +3435,15 @@ Nodes (0):
 
 ### Community 247 - "Community 247"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 248 - "Community 248"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 249 - "Community 249"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 250 - "Community 250"
 Cohesion: 0.22
@@ -4010,104 +4010,104 @@ Cohesion: 0.4
 Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
 
 ### Community 391 - "Community 391"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 392 - "Community 392"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 393 - "Community 393"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 394 - "Community 394"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 394 - "Community 394"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 395 - "Community 395"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 396 - "Community 396"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 397 - "Community 397"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 397 - "Community 397"
+### Community 398 - "Community 398"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 398 - "Community 398"
+### Community 399 - "Community 399"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 399 - "Community 399"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 400 - "Community 400"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 401 - "Community 401"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 402 - "Community 402"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 403 - "Community 403"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 404 - "Community 404"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 402 - "Community 402"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 403 - "Community 403"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 404 - "Community 404"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 405 - "Community 405"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 406 - "Community 406"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 408 - "Community 408"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 409 - "Community 409"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 410 - "Community 410"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 411 - "Community 411"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 412 - "Community 412"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 414 - "Community 414"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 414 - "Community 414"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 415 - "Community 415"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 0.53
@@ -4178,112 +4178,112 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 433 - "Community 433"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 434 - "Community 434"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 435 - "Community 435"
+### Community 434 - "Community 434"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 436 - "Community 436"
+### Community 435 - "Community 435"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 437 - "Community 437"
+### Community 436 - "Community 436"
 Cohesion: 0.5
 Nodes (2): buildCtx(), createDb()
 
-### Community 438 - "Community 438"
+### Community 437 - "Community 437"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 439 - "Community 439"
+### Community 438 - "Community 438"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 440 - "Community 440"
+### Community 439 - "Community 439"
 Cohesion: 0.6
 Nodes (4): buildRegisterSessionAuthorityPatch(), initialRegisterSessionAuthorityRevision(), insertRegisterSessionWithAuthority(), patchRegisterSessionWithAuthority()
 
-### Community 441 - "Community 441"
+### Community 440 - "Community 440"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 442 - "Community 442"
+### Community 441 - "Community 441"
 Cohesion: 0.7
 Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
-### Community 443 - "Community 443"
+### Community 442 - "Community 442"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 444 - "Community 444"
+### Community 443 - "Community 443"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
+
+### Community 444 - "Community 444"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 447 - "Community 447"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 448 - "Community 448"
+### Community 447 - "Community 447"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 449 - "Community 449"
+### Community 448 - "Community 448"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 450 - "Community 450"
+### Community 449 - "Community 449"
 Cohesion: 0.7
 Nodes (4): canonicalReportingBusinessEventKey(), canonicalReportingFactIdentity(), canonicalReportingFactKey(), requiredIdentityPart()
 
-### Community 451 - "Community 451"
+### Community 450 - "Community 450"
 Cohesion: 0.6
 Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
 
-### Community 452 - "Community 452"
+### Community 451 - "Community 451"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 453 - "Community 453"
+### Community 452 - "Community 452"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 454 - "Community 454"
+### Community 453 - "Community 453"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 455 - "Community 455"
+### Community 454 - "Community 454"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 456 - "Community 456"
+### Community 455 - "Community 455"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 456 - "Community 456"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 458 - "Community 458"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 459 - "Community 459"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 459 - "Community 459"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 460 - "Community 460"
 Cohesion: 0.4
@@ -4294,20 +4294,20 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 462 - "Community 462"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 463 - "Community 463"
 Cohesion: 0.5
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 464 - "Community 464"
+### Community 463 - "Community 463"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 465 - "Community 465"
+### Community 464 - "Community 464"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 465 - "Community 465"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 466 - "Community 466"
 Cohesion: 0.4
@@ -4334,80 +4334,80 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 472 - "Community 472"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 473 - "Community 473"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 473 - "Community 473"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 474 - "Community 474"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 475 - "Community 475"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 476 - "Community 476"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 477 - "Community 477"
+### Community 476 - "Community 476"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 478 - "Community 478"
+### Community 477 - "Community 477"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 479 - "Community 479"
+### Community 478 - "Community 478"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 480 - "Community 480"
+### Community 479 - "Community 479"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 481 - "Community 481"
+### Community 480 - "Community 480"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 482 - "Community 482"
+### Community 481 - "Community 481"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 483 - "Community 483"
+### Community 482 - "Community 482"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 484 - "Community 484"
+### Community 483 - "Community 483"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 485 - "Community 485"
+### Community 484 - "Community 484"
 Cohesion: 0.8
 Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
-### Community 486 - "Community 486"
+### Community 485 - "Community 485"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 487 - "Community 487"
+### Community 486 - "Community 486"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 488 - "Community 488"
+### Community 487 - "Community 487"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 489 - "Community 489"
+### Community 488 - "Community 488"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 490 - "Community 490"
+### Community 489 - "Community 489"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
+
+### Community 490 - "Community 490"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 491 - "Community 491"
 Cohesion: 0.4
@@ -4418,40 +4418,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 493 - "Community 493"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 494 - "Community 494"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 495 - "Community 495"
+### Community 494 - "Community 494"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 496 - "Community 496"
+### Community 495 - "Community 495"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 497 - "Community 497"
+### Community 496 - "Community 496"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 498 - "Community 498"
+### Community 497 - "Community 497"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 499 - "Community 499"
+### Community 498 - "Community 498"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 500 - "Community 500"
+### Community 499 - "Community 499"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 501 - "Community 501"
+### Community 500 - "Community 500"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 501 - "Community 501"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.7
@@ -12860,1811 +12860,1811 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1259`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `Index()`, `-index-route-view.tsx`
+- **Thin community `Community 1260`** (2 nodes): `redirectLegacyLanding()`, `-legacy-landing-redirect.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `redirectLegacyLanding()`, `-legacy-landing-redirect.ts`
+- **Thin community `Community 1261`** (2 nodes): `-public-layout.tsx`, `PublicLayout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `-public-layout.tsx`, `PublicLayout()`
+- **Thin community `Community 1262`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1263`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1264`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1265`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1266`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1267`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1268`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1269`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1270`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1271`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1272`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1273`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1274`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1275`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1276`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1277`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1278`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
+- **Thin community `Community 1279`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
+- **Thin community `Community 1280`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
+- **Thin community `Community 1281`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1282`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
+- **Thin community `Community 1283`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1284`** (2 nodes): `AuthenticatedLayout()`, `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `AuthenticatedLayout()`, `_authed.tsx`
+- **Thin community `Community 1285`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1286`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1287`** (2 nodes): `walkthrough.tsx`, `WalkthroughPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `walkthrough.tsx`, `WalkthroughPage()`
+- **Thin community `Community 1288`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1289`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1290`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1291`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1292`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1293`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1294`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1295`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1296`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1297`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1298`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1299`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1300`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1301`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1302`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1303`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1304`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1305`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1306`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1307`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1308`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1309`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1310`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1311`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1312`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1313`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1314`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1315`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1316`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1317`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1318`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1319`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1320`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1321`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1322`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1323`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1324`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1325`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1326`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1327`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1328`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1329`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1330`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1331`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1332`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1333`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1334`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1335`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1336`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1337`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1338`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1339`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1340`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1341`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1342`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1343`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1344`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1345`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1346`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1347`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1348`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1349`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1350`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1351`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1352`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1353`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1354`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1355`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1356`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1357`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1358`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1359`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1360`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1361`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1362`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1363`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1364`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1365`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1366`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1367`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1368`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1369`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1370`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1371`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1372`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1373`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1374`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1375`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1376`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1377`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1378`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1379`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1380`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1381`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1382`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1383`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1384`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1385`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1386`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1387`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1388`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1389`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1390`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1391`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1392`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1393`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1394`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1395`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1396`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1397`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1398`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1399`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1400`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1401`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1402`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1403`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1404`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1405`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1406`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1407`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1408`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1409`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1410`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1411`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1412`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1413`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1414`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1415`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1416`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1417`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1418`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1419`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1420`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1421`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1422`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1423`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1424`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1425`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1426`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1427`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1428`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `api.js`
+- **Thin community `Community 1429`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1430`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1431`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `server.js`
+- **Thin community `Community 1432`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `app.ts`
+- **Thin community `Community 1433`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1434`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1435`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1436`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1437`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `auth.ts`
+- **Thin community `Community 1438`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1439`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1440`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1441`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `countries.ts`
+- **Thin community `Community 1442`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `email.ts`
+- **Thin community `Community 1443`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1444`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `payment.ts`
+- **Thin community `Community 1445`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1446`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `types.ts`
+- **Thin community `Community 1447`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1448`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1449`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `crons.ts`
+- **Thin community `Community 1450`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1451`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `internal.ts`
+- **Thin community `Community 1452`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1453`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1455`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1457`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1458`** (1 nodes): `DailyManagerReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `DailyManagerReport.tsx`
+- **Thin community `Community 1459`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1460`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1461`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1462`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1463`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1464`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1465`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1466`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
+- **Thin community `Community 1467`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1468`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `env.ts`
+- **Thin community `Community 1469`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1470`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `auth.ts`
+- **Thin community `Community 1471`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `colors.ts`
+- **Thin community `Community 1473`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `index.ts`
+- **Thin community `Community 1474`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1475`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1476`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1477`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `products.ts`
+- **Thin community `Community 1478`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `stores.ts`
+- **Thin community `Community 1480`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `bag.ts`
+- **Thin community `Community 1483`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `guest.ts`
+- **Thin community `Community 1484`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `index.ts`
+- **Thin community `Community 1486`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `me.ts`
+- **Thin community `Community 1487`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `offers.ts`
+- **Thin community `Community 1488`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1489`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1490`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1491`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1492`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1493`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1494`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1495`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1496`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1497`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `user.ts`
+- **Thin community `Community 1498`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1499`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `index.ts`
+- **Thin community `Community 1500`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1501`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `http.ts`
+- **Thin community `Community 1502`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `access.ts`
+- **Thin community `Community 1503`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `index.ts`
+- **Thin community `Community 1507`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `types.ts`
+- **Thin community `Community 1509`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1510`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `categories.ts`
+- **Thin community `Community 1512`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `colors.ts`
+- **Thin community `Community 1513`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1514`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1515`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1516`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1517`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1518`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `pos.ts`
+- **Thin community `Community 1519`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1520`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1521`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1523`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1526`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1527`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1528`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1529`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1530`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1531`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1532`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1533`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1534`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1535`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1536`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1537`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1538`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1539`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1540`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1541`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `types.ts`
+- **Thin community `Community 1542`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1543`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1544`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1545`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1546`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1547`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
+- **Thin community `Community 1548`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1550`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1551`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1552`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1553`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1554`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1555`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `dto.ts`
+- **Thin community `Community 1556`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1557`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1558`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1559`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1560`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1561`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `types.ts`
+- **Thin community `Community 1562`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `facts.ts`
+- **Thin community `Community 1563`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1564`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `types.ts`
+- **Thin community `Community 1565`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1566`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `types.ts`
+- **Thin community `Community 1567`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1568`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1569`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1570`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `customers.ts`
+- **Thin community `Community 1571`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `register.ts`
+- **Thin community `Community 1573`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1574`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1575`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `activation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `activation.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `attentionRules.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `attentionRules.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `commerceRecognition.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `commerceRecognition.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `customRangeRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `customRangeRequests.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `export.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `export.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `factFingerprint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `factFingerprint.test.ts`
+- **Thin community `Community 1582`** (1 nodes): `factIdentity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `factIdentity.test.ts`
+- **Thin community `Community 1583`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1584`** (1 nodes): `integrity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `integrity.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `corrections.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `corrections.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `corrections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `corrections.ts`
+- **Thin community `Community 1587`** (1 nodes): `deficitResolutionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `deficitResolutionWork.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `types.ts`
+- **Thin community `Community 1589`** (1 nodes): `cutover.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `cutover.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `inventoryRebuild.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `inventoryRebuild.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `legacyCompatibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `legacyCompatibility.test.ts`
+- **Thin community `Community 1592`** (1 nodes): `processing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `processing.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `runLedger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `runLedger.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `metricContracts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `metricContracts.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `periods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `periods.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `projectionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `projectionWork.test.ts`
+- **Thin community `Community 1597`** (1 nodes): `attention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `attention.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `currentInventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `currentInventory.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `customRange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `customRange.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `daily.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `daily.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `dailyCloseTrust.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `dailyCloseTrust.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `factContributions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `factContributions.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `inventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `inventory.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `processor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `processor.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `reconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `reconciliation.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `skuDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `skuDay.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `skuInsights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `skuInsights.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `storeIntraday.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `storeIntraday.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `destinations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `destinations.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `items.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `items.ts`
+- **Thin community `Community 1612`** (1 nodes): `reportingReadModels.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `reportingReadModels.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `types.ts`
+- **Thin community `Community 1614`** (1 nodes): `sourceAdapters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `sourceAdapters.test.ts`
+- **Thin community `Community 1615`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `schema.ts`
+- **Thin community `Community 1616`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `automation.ts`
+- **Thin community `Community 1617`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1618`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1619`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `index.ts`
+- **Thin community `Community 1620`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1621`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1622`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1623`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1624`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1625`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1626`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1627`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `category.ts`
+- **Thin community `Community 1628`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `color.ts`
+- **Thin community `Community 1629`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1630`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1631`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `index.ts`
+- **Thin community `Community 1632`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1633`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1634`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1635`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1636`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `organization.ts`
+- **Thin community `Community 1637`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1638`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `product.ts`
+- **Thin community `Community 1639`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1640`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1641`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1642`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `store.ts`
+- **Thin community `Community 1643`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1644`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1645`** (1 nodes): `landingFunnelEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `landingFunnelEvent.ts`
+- **Thin community `Community 1646`** (1 nodes): `walkthroughRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `walkthroughRequest.ts`
+- **Thin community `Community 1647`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `index.ts`
+- **Thin community `Community 1648`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1649`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1650`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1651`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1652`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1653`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1654`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1655`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `index.ts`
+- **Thin community `Community 1656`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1657`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1658`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1659`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1660`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1661`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1662`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1663`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1664`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1665`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1666`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1667`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `customer.ts`
+- **Thin community `Community 1668`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1669`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1670`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1671`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1672`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `index.ts`
+- **Thin community `Community 1673`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1674`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1675`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1676`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1677`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1678`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1679`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1680`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1681`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
+- **Thin community `Community 1682`** (1 nodes): `posRegisterMappingAuthority.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `posRegisterMappingAuthority.ts`
+- **Thin community `Community 1683`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 1684`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 1685`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1686`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1687`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1688`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1689`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1690`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1691`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1692`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1693`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1694`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1695`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1696`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1697`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `index.ts`
+- **Thin community `Community 1698`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1699`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1700`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `facts.ts`
+- **Thin community `Community 1701`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `index.ts`
+- **Thin community `Community 1702`** (1 nodes): `inventoryValuation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `inventoryValuation.ts`
+- **Thin community `Community 1703`** (1 nodes): `maintenance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `maintenance.ts`
+- **Thin community `Community 1704`** (1 nodes): `projections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `projections.ts`
+- **Thin community `Community 1705`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `index.ts`
+- **Thin community `Community 1706`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1707`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1708`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1709`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1710`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1711`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1712`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `index.ts`
+- **Thin community `Community 1713`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1714`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1715`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1716`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1717`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1718`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1719`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `bag.ts`
+- **Thin community `Community 1720`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1721`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1722`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1723`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `guest.ts`
+- **Thin community `Community 1724`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `index.ts`
+- **Thin community `Community 1725`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `offer.ts`
+- **Thin community `Community 1726`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1727`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1728`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `review.ts`
+- **Thin community `Community 1729`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1730`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1731`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1732`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1733`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1734`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1735`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1736`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `bag.ts`
+- **Thin community `Community 1738`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1739`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `customer.ts`
+- **Thin community `Community 1740`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `guest.ts`
+- **Thin community `Community 1741`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1742`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1743`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1744`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1745`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1746`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1747`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `users.ts`
+- **Thin community `Community 1749`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `payment.ts`
+- **Thin community `Community 1750`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1753`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1754`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1755`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1756`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1757`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `index.ts`
+- **Thin community `Community 1758`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1759`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1760`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1761`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1762`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `auth.ts`
+- **Thin community `Community 1763`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1764`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1765`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1766`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1767`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1768`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1769`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1770`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `index.ts`
+- **Thin community `Community 1771`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1772`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1774`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1775`** (1 nodes): `reportingContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `reportingContract.ts`
+- **Thin community `Community 1776`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1777`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1779`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1780`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1781`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1782`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 1783`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1784`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 1785`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1786`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1787`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1788`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1789`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1790`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1791`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1792`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1793`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1794`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 1795`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1796`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1797`** (1 nodes): `CopyImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `CopyImagesView.test.tsx`
+- **Thin community `Community 1798`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `constants.ts`
+- **Thin community `Community 1799`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1800`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1801`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1802`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `types.ts`
+- **Thin community `Community 1803`** (1 nodes): `AnalyticsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `AnalyticsView.test.tsx`
+- **Thin community `Community 1804`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1805`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1806`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1807`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1808`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1809`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1810`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1811`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1812`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1813`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1814`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1815`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1816`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1817`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1818`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1819`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1820`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1821`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1822`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1823`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1824`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `constants.ts`
+- **Thin community `Community 1825`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1826`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1827`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1828`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `data.ts`
+- **Thin community `Community 1829`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1830`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1831`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1832`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1833`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1834`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1835`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1836`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1837`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1838`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1839`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1840`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `constants.ts`
+- **Thin community `Community 1841`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1842`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1843`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1844`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `data.ts`
+- **Thin community `Community 1845`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1846`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1847`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1848`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1849`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1850`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1851`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1852`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1853`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1854`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1855`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1856`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `constants.ts`
+- **Thin community `Community 1857`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1858`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1859`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1860`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1861`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1862`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1863`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1864`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1865`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1866`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1867`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1868`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1869`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1870`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1871`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1872`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1873`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1874`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1875`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1876`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1877`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1878`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1879`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1880`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1881`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1882`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1883`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1884`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1885`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1886`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1887`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 1888`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1889`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1890`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1891`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1892`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1893`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1894`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `constants.ts`
+- **Thin community `Community 1895`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1896`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1897`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1898`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `data.ts`
+- **Thin community `Community 1899`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1900`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1901`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `constants.ts`
+- **Thin community `Community 1902`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1903`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1904`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1905`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1906`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `data.ts`
+- **Thin community `Community 1907`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1908`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `constants.ts`
+- **Thin community `Community 1909`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1910`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1911`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1912`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1913`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `data.ts`
+- **Thin community `Community 1914`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1915`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1916`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1917`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1918`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1919`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1920`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1921`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1922`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1923`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1924`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1925`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1926`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1927`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1928`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1929`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1930`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1931`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1932`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1933`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1934`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1935`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1936`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1937`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1938`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1939`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1940`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1941`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1942`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `types.ts`
+- **Thin community `Community 1943`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1944`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1945`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1946`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1947`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 1948`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1949`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 1950`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1951`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1952`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1953`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1954`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1955`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1956`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1957`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1958`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1959`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1960`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1961`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `data.ts`
+- **Thin community `Community 1962`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1963`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1964`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1965`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1966`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1967`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1968`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1969`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1970`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1971`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1972`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1973`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1974`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `constants.ts`
+- **Thin community `Community 1975`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1976`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1977`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1978`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `data.ts`
+- **Thin community `Community 1979`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `types.ts`
+- **Thin community `Community 1980`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1981`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1982`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1983`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1984`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1985`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `index.ts`
+- **Thin community `Community 1986`** (1 nodes): `CustomRangeStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `CustomRangeStatus.test.tsx`
+- **Thin community `Community 1987`** (1 nodes): `InventoryMovementSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `InventoryMovementSummary.tsx`
+- **Thin community `Community 1988`** (1 nodes): `ReportAttentionList.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `ReportAttentionList.tsx`
+- **Thin community `Community 1989`** (1 nodes): `ReportPeriodControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `ReportPeriodControl.test.tsx`
+- **Thin community `Community 1990`** (1 nodes): `ReportsInventoryView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `ReportsInventoryView.test.tsx`
+- **Thin community `Community 1991`** (1 nodes): `ReportsInventoryView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `ReportsInventoryView.tsx`
+- **Thin community `Community 1992`** (1 nodes): `ReportsItemsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `ReportsItemsView.test.tsx`
+- **Thin community `Community 1993`** (1 nodes): `ReportsItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `ReportsItemsView.tsx`
+- **Thin community `Community 1994`** (1 nodes): `ReportsLayout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `ReportsLayout.test.tsx`
+- **Thin community `Community 1995`** (1 nodes): `ReportsOverviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `ReportsOverviewView.test.tsx`
+- **Thin community `Community 1996`** (1 nodes): `ReportsSkuDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `ReportsSkuDetailView.test.tsx`
+- **Thin community `Community 1997`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
+- **Thin community `Community 1998`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
+- **Thin community `Community 1999`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
+- **Thin community `Community 2000`** (1 nodes): `ReportsWorkspaceControls.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `ReportsWorkspaceControls.tsx`
+- **Thin community `Community 2001`** (1 nodes): `RevenueContribution.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `RevenueContribution.tsx`
+- **Thin community `Community 2002`** (1 nodes): `reportPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `reportPresentation.test.ts`
+- **Thin community `Community 2003`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2004`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2005`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2006`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2007`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `index.tsx`
+- **Thin community `Community 2008`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2009`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2010`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2011`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2012`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2013`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2014`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2015`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2016`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 2017`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2018`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2019`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `index.tsx`
+- **Thin community `Community 2020`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2021`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2022`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2023`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `button.tsx`
+- **Thin community `Community 2024`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2025`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `card.tsx`
+- **Thin community `Community 2026`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2027`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2028`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `command.tsx`
+- **Thin community `Community 2029`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2030`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2031`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2032`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `form.tsx`
+- **Thin community `Community 2033`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2034`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2035`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `input.tsx`
+- **Thin community `Community 2036`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2037`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2038`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2039`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2040`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2041`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2042`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `select.tsx`
+- **Thin community `Community 2043`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2044`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2045`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2046`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `table.tsx`
+- **Thin community `Community 2047`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2048`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2049`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2050`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2051`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2052`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2053`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2054`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2055`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `constants.ts`
+- **Thin community `Community 2056`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2057`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2058`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2059`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `data.ts`
+- **Thin community `Community 2060`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2061`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2062`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2063`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2064`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2065`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2066`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2067`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2068`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2069`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2070`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `index.ts`
+- **Thin community `Community 2071`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2072`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2073`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2074`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2075`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2076`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2077`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2078`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2079`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2080`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2081`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2082`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2083`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2084`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2085`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2086`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `index.ts`
+- **Thin community `Community 2087`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2088`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `index.ts`
+- **Thin community `Community 2089`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2090`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2091`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `aws.ts`
+- **Thin community `Community 2092`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `constants.ts`
+- **Thin community `Community 2093`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `countries.ts`
+- **Thin community `Community 2094`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2095`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2096`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2097`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2098`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2099`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2100`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2101`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2102`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2103`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2104`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2105`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2106`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `dto.ts`
+- **Thin community `Community 2107`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2108`** (1 nodes): `ports.ts`
+- **Thin community `Community 2108`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2109`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `constants.ts`
+- **Thin community `Community 2110`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2111`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2112`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `index.ts`
+- **Thin community `Community 2113`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2114`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `types.ts`
+- **Thin community `Community 2115`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2116`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2117`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2118`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2119`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2120`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2121`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2122`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2123`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2124`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2125`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2125`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2126`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2126`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2127`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2127`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2128`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2128`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2129`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2129`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2130`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2130`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2131`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2131`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2132`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2132`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2133`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 2133`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2134`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2134`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2135`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2135`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2136`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2136`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2137`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2137`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2138`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2138`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2139`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2139`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2140`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2140`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2141`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2141`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2142`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2142`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2143`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2143`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2144`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2144`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2145`** (1 nodes): `index.ts`
+- **Thin community `Community 2145`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2146`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2146`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2147`** (1 nodes): `category.ts`
+- **Thin community `Community 2147`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2148`** (1 nodes): `product.ts`
+- **Thin community `Community 2148`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2149`** (1 nodes): `store.ts`
+- **Thin community `Community 2149`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2150`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2150`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2151`** (1 nodes): `user.ts`
+- **Thin community `Community 2151`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2152`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2152`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2153`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2153`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2154`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2154`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2155`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2155`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2156`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2156`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2157`** (1 nodes): `main.tsx`
+- **Thin community `Community 2157`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2158`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2158`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2159`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2159`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2160`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2160`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2161`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2161`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2162`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2162`** (1 nodes): `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2163`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2481
-- Graph nodes: 10026
-- Graph edges: 12206
+- Graph nodes: 10025
+- Graph edges: 12205
 - Communities: 2408
 
 ## Graph Hotspots

--- a/packages/athena-webapp/index.html
+++ b/packages/athena-webapp/index.html
@@ -6,7 +6,7 @@
     <title>Athena | Sales and inventory visibility for owner-led retail</title>
     <meta
       name="description"
-      content="See today's sales, sales history, product movement, and stock context in one clear operating view."
+      content="See today's sales, understand what moved, and keep the history behind your business close."
     />
     <link rel="canonical" href="https://athena.wigclub.store/" />
     <meta property="og:type" content="website" />
@@ -17,7 +17,7 @@
     />
     <meta
       property="og:description"
-      content="See today's sales, sales history, product movement, and stock context in one clear operating view."
+      content="See today's sales, understand what moved, and keep the history behind your business close."
     />
     <meta property="og:url" content="https://athena.wigclub.store/" />
   </head>

--- a/packages/athena-webapp/src/routes/-index-route-view.tsx
+++ b/packages/athena-webapp/src/routes/-index-route-view.tsx
@@ -1,7 +1,130 @@
-import { useEffect } from "react";
+import { Link } from "@tanstack/react-router";
+import { useEffect, type ReactNode } from "react";
+import {
+  ArrowRight,
+  BarChart3,
+  Boxes,
+  Check,
+  History,
+  PackageSearch,
+  Store,
+  Users,
+} from "lucide-react";
 
 import { emitLandingFunnelEvent } from "@/lib/marketing/landingFunnelClient";
+import { WALKTHROUGH_PATH } from "@/lib/navigation/appEntryRoutes";
 import { PublicLayout } from "./-public-layout";
+
+const trendBars = [34, 48, 42, 61, 54, 72, 66, 82, 75, 91, 84, 96];
+
+function ProductMoment() {
+  return (
+    <figure
+      className="relative mx-auto w-full max-w-2xl overflow-hidden rounded-xl border border-shell-foreground/15 bg-background text-foreground shadow-overlay"
+    >
+      <figcaption className="sr-only">
+        Illustration of Athena&apos;s sales overview, including sales activity, history, and products moving.
+      </figcaption>
+      <div className="flex items-center justify-between border-b border-border bg-surface px-layout-md py-layout-sm">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+            Store pulse
+          </p>
+          <p className="mt-1 text-sm font-medium">Today</p>
+        </div>
+        <span className="rounded-full bg-success/10 px-layout-sm py-layout-xs text-xs font-medium text-success">
+          Sales in view
+        </span>
+      </div>
+
+      <div className="grid gap-layout-lg p-layout-md sm:p-layout-lg">
+        <div className="grid grid-cols-3 gap-layout-sm">
+          {["Sales", "Transactions", "Items sold"].map((label) => (
+            <div key={label} className="border-l border-border pl-layout-sm sm:pl-layout-md">
+              <p className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                {label}
+              </p>
+              <div className="mt-layout-sm h-2 rounded-full bg-muted">
+                <div className="h-2 w-2/3 rounded-full bg-signal/75" />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid gap-layout-lg border-t border-border pt-layout-md sm:grid-cols-[1.35fr_0.65fr]">
+          <div>
+            <div className="flex items-center justify-between gap-layout-sm">
+              <p className="text-sm font-medium">Sales over time</p>
+              <span className="text-xs text-muted-foreground">History stays close</span>
+            </div>
+            <div className="mt-layout-md flex h-32 items-end gap-1.5" aria-hidden="true">
+              {trendBars.map((height, index) => (
+                <div
+                  key={`${height}-${index}`}
+                  className="flex-1 rounded-t-sm bg-signal/20 last:bg-signal"
+                  style={{ height: `${height}%` }}
+                />
+              ))}
+            </div>
+          </div>
+          <div className="space-y-layout-sm">
+            <p className="text-sm font-medium">Products moving</p>
+            {["Everyday essentials", "New arrivals", "Repeat favourites"].map(
+              (label, index) => (
+                <div key={label} className="flex items-center gap-layout-sm text-xs">
+                  <span className="flex h-6 w-6 items-center justify-center rounded-md bg-signal/10 font-numeric text-signal">
+                    {index + 1}
+                  </span>
+                  <span className="text-muted-foreground">{label}</span>
+                </div>
+              ),
+            )}
+          </div>
+        </div>
+      </div>
+    </figure>
+  );
+}
+
+function StorySection({
+  eyebrow,
+  title,
+  copy,
+  icon: Icon,
+  children,
+  reversed = false,
+}: {
+  eyebrow: string;
+  title: string;
+  copy: string;
+  icon: typeof History;
+  children: ReactNode;
+  reversed?: boolean;
+}) {
+  return (
+    <section className="border-t border-border/70 px-layout-md py-layout-3xl sm:px-layout-xl">
+      <div
+        className={`mx-auto grid w-full max-w-7xl items-center gap-layout-2xl lg:grid-cols-2 ${
+          reversed ? "lg:[&>*:first-child]:order-2" : ""
+        }`}
+      >
+        <div className="max-w-xl">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-signal/10 text-signal">
+            <Icon className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <p className="mt-layout-lg text-xs font-semibold uppercase tracking-[0.22em] text-signal">
+            {eyebrow}
+          </p>
+          <h2 className="mt-layout-sm font-display text-4xl font-light leading-[1.02] text-foreground sm:text-5xl">
+            {title}
+          </h2>
+          <p className="mt-layout-md text-lg leading-8 text-muted-foreground">{copy}</p>
+        </div>
+        {children}
+      </div>
+    </section>
+  );
+}
 
 export function Index() {
   useEffect(() => {
@@ -10,19 +133,131 @@ export function Index() {
 
   return (
     <PublicLayout trackWalkthroughCta>
-      <main className="mx-auto flex min-h-[calc(100svh-4rem)] w-full max-w-7xl items-center px-layout-md py-layout-3xl sm:px-layout-xl">
-        <div className="max-w-3xl space-y-layout-lg">
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-signal">
-            Athena for owner-led retail
-          </p>
-          <h1 className="font-display text-5xl font-light leading-[0.98] text-foreground sm:text-7xl">
-            See how the business is doing today.
-          </h1>
-          <p className="max-w-2xl text-lg leading-8 text-muted-foreground">
-            Athena brings sales history and the products behind each day into
-            one clear operating view.
-          </p>
-        </div>
+      <main>
+        <section className="relative overflow-hidden bg-shell px-layout-md py-layout-3xl text-shell-foreground sm:px-layout-xl lg:py-[7.5rem]">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_82%_18%,hsl(var(--signal)/0.22),transparent_34%)]" />
+          <div className="relative mx-auto grid w-full max-w-7xl items-center gap-layout-2xl lg:grid-cols-[0.86fr_1.14fr]">
+            <div className="max-w-2xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-shell-foreground/80">
+                Athena for owner-led retail
+              </p>
+              <h1 className="mt-layout-md font-display text-5xl font-light leading-[0.96] sm:text-7xl">
+                See today&apos;s sales. Know what needs attention.
+              </h1>
+              <p className="mt-layout-lg max-w-xl text-lg leading-8 text-shell-foreground/75 sm:text-xl">
+                Athena keeps each day&apos;s sales, the products behind them, and your business history in one clear operating view.
+              </p>
+              <div className="mt-layout-xl flex flex-col gap-layout-sm sm:flex-row sm:items-center">
+                <Link
+                  to={WALKTHROUGH_PATH}
+                  onClick={() => emitLandingFunnelEvent("walkthrough_cta")}
+                  className="inline-flex min-h-12 items-center justify-center rounded-md bg-signal px-layout-lg text-sm font-semibold text-signal-foreground transition-[background-color,transform] duration-standard ease-standard hover:bg-signal/90 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shell-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-shell"
+                >
+                  Request a walkthrough
+                  <ArrowRight className="ml-layout-sm h-4 w-4" aria-hidden="true" />
+                </Link>
+                <span className="text-sm text-shell-foreground/60">
+                  Built for a small team with a lot to keep in view.
+                </span>
+              </div>
+            </div>
+            <ProductMoment />
+          </div>
+        </section>
+
+        <StorySection
+          eyebrow="Sales history"
+          title="Today is only the beginning."
+          copy="Move from the current day into the history Athena has recorded without searching through notebooks, receipts, or memory. Compare periods and keep the business story close to the work."
+          icon={History}
+        >
+          <div className="grid gap-layout-sm border-y border-border py-layout-md">
+            {["Today", "This week", "This month", "All recorded sales"].map(
+              (period, index) => (
+                <div key={period} className="flex items-center gap-layout-md py-layout-sm">
+                  <span className="font-numeric text-xs text-muted-foreground">0{index + 1}</span>
+                  <span className="text-lg text-foreground">{period}</span>
+                  <span className="ml-auto h-px w-12 bg-signal/50 sm:w-24" aria-hidden="true" />
+                </div>
+              ),
+            )}
+          </div>
+        </StorySection>
+
+        <StorySection
+          eyebrow="Product movement"
+          title="See which products shaped the day."
+          copy="Sales totals tell you where the day landed. Product movement helps explain why. Athena keeps units, sales, and the products customers chose within the same view."
+          icon={PackageSearch}
+          reversed
+        >
+          <div className="space-y-layout-md rounded-xl border border-border bg-surface p-layout-lg shadow-surface">
+            {["Fast-moving products", "Products gaining attention", "Items to review"].map(
+              (label, index) => (
+                <div key={label} className="flex items-center gap-layout-md border-b border-border pb-layout-md last:border-0 last:pb-0">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-signal/10 text-signal">
+                    {index === 2 ? <Boxes className="h-5 w-5" /> : <BarChart3 className="h-5 w-5" />}
+                  </span>
+                  <div>
+                    <p className="font-medium text-foreground">{label}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">Ready for the owner&apos;s review</p>
+                  </div>
+                </div>
+              ),
+            )}
+          </div>
+        </StorySection>
+
+        <StorySection
+          eyebrow="Owner decision"
+          title="Decide what needs your attention next."
+          copy="Bring product movement beside current stock pressure, then make the call. Athena highlights the operating facts; you stay responsible for the restocking decision."
+          icon={Boxes}
+        >
+          <div className="rounded-xl bg-shell p-layout-lg text-shell-foreground shadow-overlay">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-shell-foreground/80">Owner review</p>
+            <div className="mt-layout-lg space-y-layout-md">
+              {["What moved", "What is under pressure", "What to act on"].map((label) => (
+                <div key={label} className="flex items-center gap-layout-sm border-b border-shell-foreground/10 pb-layout-md last:border-0 last:pb-0">
+                  <Check className="h-4 w-4 text-shell-foreground/80" aria-hidden="true" />
+                  <span>{label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </StorySection>
+
+        <section className="border-t border-border bg-surface px-layout-md py-layout-3xl sm:px-layout-xl">
+          <div className="mx-auto grid max-w-7xl gap-layout-xl lg:grid-cols-2">
+            <article className="border-l-2 border-signal pl-layout-lg">
+              <Store className="h-5 w-5 text-signal" aria-hidden="true" />
+              <h2 className="mt-layout-md font-display text-3xl font-light">In-person and online sales stay connected.</h2>
+              <p className="mt-layout-sm max-w-lg leading-7 text-muted-foreground">Keep the operating record together as customers buy in person or online.</p>
+            </article>
+            <article className="border-l-2 border-signal pl-layout-lg">
+              <Users className="h-5 w-5 text-signal" aria-hidden="true" />
+              <h2 className="mt-layout-md font-display text-3xl font-light">Give your team room to work.</h2>
+              <p className="mt-layout-sm max-w-lg leading-7 text-muted-foreground">Staff permissions, approvals, and activity records help the owner delegate without losing the thread.</p>
+            </article>
+          </div>
+        </section>
+
+        <section className="bg-shell px-layout-md py-layout-3xl text-shell-foreground sm:px-layout-xl">
+          <div className="mx-auto flex max-w-7xl flex-col gap-layout-xl lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-shell-foreground/80">Start with the day in front of you</p>
+              <h2 className="mt-layout-md font-display text-4xl font-light leading-tight sm:text-6xl">See the business clearly enough to act.</h2>
+            </div>
+            <Link
+              to={WALKTHROUGH_PATH}
+              onClick={() => emitLandingFunnelEvent("walkthrough_cta")}
+              className="inline-flex min-h-12 items-center justify-center rounded-md bg-signal px-layout-lg text-sm font-semibold text-signal-foreground transition-[background-color,transform] duration-standard ease-standard hover:bg-signal/90 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shell-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-shell"
+            >
+              Request a walkthrough
+              <ArrowRight className="ml-layout-sm h-4 w-4" aria-hidden="true" />
+            </Link>
+          </div>
+        </section>
       </main>
     </PublicLayout>
   );

--- a/packages/athena-webapp/src/routes/index.test.tsx
+++ b/packages/athena-webapp/src/routes/index.test.tsx
@@ -44,12 +44,25 @@ describe("Index route", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: /see how the business is doing today/i,
+        name: /see today's sales\. know what needs attention\./i,
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: /request a walkthrough/i }),
-    ).toHaveAttribute("href", "/walkthrough");
+      screen.getByRole("heading", { name: /today is only the beginning/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /see which products shaped the day/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /decide what needs your attention next/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/in-person and online sales stay connected/i)).toBeInTheDocument();
+    expect(screen.getByText(/give your team room to work/i)).toBeInTheDocument();
+    const walkthroughLinks = screen.getAllByRole("link", {
+      name: /request a walkthrough/i,
+    });
+    expect(walkthroughLinks).toHaveLength(3);
+    expect(walkthroughLinks[0]).toHaveAttribute("href", "/walkthrough");
     expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute(
       "href",
       "/login",
@@ -60,11 +73,12 @@ describe("Index route", () => {
     });
     expect(primaryNavigation.querySelectorAll("a")).toHaveLength(3);
 
-    await user.click(
-      screen.getByRole("link", { name: /request a walkthrough/i }),
-    );
+    await user.click(walkthroughLinks[0]);
     expect(mocked.emitLandingFunnelEvent).toHaveBeenCalledWith(
       "walkthrough_cta",
     );
+
+    expect(document.body).not.toHaveTextContent(/automatically reorder/i);
+    expect(document.body).not.toHaveTextContent(/recover.*paper history/i);
   });
 });

--- a/packages/athena-webapp/src/routes/index.tsx
+++ b/packages/athena-webapp/src/routes/index.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/")({
       },
       {
         name: "description",
-        content: "See today's sales and the history behind the business.",
+        content: "See today's sales, understand what moved, and keep the history behind your business close.",
       },
     ],
   }),

--- a/packages/athena-webapp/src/static-product-metadata.test.ts
+++ b/packages/athena-webapp/src/static-product-metadata.test.ts
@@ -19,7 +19,7 @@ describe("static product-page metadata", () => {
     expect(
       document.querySelector('meta[name="description"]')?.getAttribute("content"),
     ).toBe(
-      "See today's sales, sales history, product movement, and stock context in one clear operating view.",
+      "See today's sales, understand what moved, and keep the history behind your business close.",
     );
     expect(document.querySelectorAll('link[rel="canonical"]')).toHaveLength(1);
     expect(


### PR DESCRIPTION
## Summary
- replace the placeholder public root with a claims-only Athena product-page MVP
- lead with daily sales visibility, accessible history, product movement, and owner-led decisions
- connect the public page to the durable walkthrough path without synthetic metrics or unaudited screenshots
- move positioning sessions to a post-MVP learning gate and document the reusable release pattern

## Validation
- bun run pr:athena
- focused landing, metadata, walkthrough route, and form tests (12 passing)
- TypeScript check
- desktop and mobile Playwright review
- unanimous product-truth and frontend/accessibility reviewer approval

## Release
Production walkthrough configuration is prepared. After merge, deploy Convex production followed by the Athena frontend with the approved public privacy contact.