### PR TITLE
fix(marketing): remove stale pre-launch privacy copy

### DIFF
--- a/packages/athena-webapp/src/routes/privacy.test.tsx
+++ b/packages/athena-webapp/src/routes/privacy.test.tsx
@@ -27,6 +27,7 @@ describe("walkthrough privacy route", () => {
   it("documents collection, access, retention, provider processing, and subject requests", () => {
     render(<PrivacyPage />);
 
+    expect(screen.queryByText(/pre-launch notice/i)).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 1, name: "Privacy and retention details" })).toBeVisible();
     expect(screen.getByRole("heading", { name: "Information collected" })).toBeVisible();
     expect(screen.getByRole("heading", { name: "How the information is used" })).toBeVisible();

--- a/packages/athena-webapp/src/routes/privacy.tsx
+++ b/packages/athena-webapp/src/routes/privacy.tsx
@@ -30,7 +30,7 @@ export function PrivacyPage() {
             Privacy and retention details
           </h1>
           <p className="mt-layout-md max-w-2xl text-base leading-7 text-muted-foreground">
-            This pre-launch notice explains how Athena handles the information collected through the walkthrough form.
+            This notice explains how Athena handles the information collected through the walkthrough form.
           </p>
         </header>
 


### PR DESCRIPTION
## Summary
- remove the stale pre-launch qualifier from the now-live walkthrough privacy notice
- add a regression assertion that the live notice does not use pre-launch copy

## Validation
- focused privacy route tests (3 passing)
- TypeScript check
- bun run pr:athena