### PR TITLE
[V26-1040]: Make pr:athena fail fast on harness contract drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,7 @@ packages/.claude/worktrees/
 
 graphify-out/cache/
 artifacts/harness-inferential-review/
+artifacts/harness-contract-preflight/
 artifacts/harness-scorecard/
 artifacts/harness-delivery-runs/
 artifacts/harness-behavior/trends/

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ The repo pins Bun via `package.json` (`bun@1.1.29` today), and GitHub Actions re
 
 `pre-commit:generated-artifacts` automatically runs `bun run harness:generate` and `bun run graphify:rebuild`, then stages the tracked generated harness docs and graphify outputs before the commit is finalized, so the pushed ref includes refreshed generated artifacts.
 `bun run pr:athena:prepare` starts with that same generated-artifact repair step, then blocks before the heavy validation ladder if unstaged or untracked files would prevent a reusable proof. Stage intended new files explicitly, or remove unrelated local files, before running the full gate.
+`bun run pr:athena:preflight` then aggregates validation-map coverage, live harness audit, audit-fixture consistency, and harness-script sibling-test policy before provider validation starts. Its failure report names the registry source, generated-doc repair, fixture and sibling-test files, and focused verification command.
 `bun run pr:athena:validate` runs the heavy validation ladder without recording proof, and `bun run pr:athena:record-proof` records the reusable pre-push proof for the current clean or staged-only tree.
 The default `bun run pr:athena` command runs the delivery-run wrapper, which composes those steps in order, writes same-tree provider evidence after the provider commands pass, writes the current local run ledger, and runs the scorecard against that ledger.
 `pre-push:review` starts with `bun run graphify:check`, then runs `bun run compound:check` and `bun run landed-report:check`, before the rest of the local validation suite. If tracked graphify artifacts are stale, the hook runs `bun run graphify:rebuild` once, reruns `bun run graphify:check`, and then stops so you can review and commit the repaired graphify artifacts before pushing again. `compound:check` is intentionally early so solution-doc policy failures are caught locally before the branch reaches CI. `landed-report:check` is equally early so stale report fingerprints from review-loop edits are caught before merge.
@@ -323,6 +324,7 @@ Local-only graphify artifacts:
 
 - `graphify-out/cache/`
 - `artifacts/harness-inferential-review/`
+- `artifacts/harness-contract-preflight/`
 - `artifacts/harness-scorecard/`
 - `artifacts/harness-behavior/trends/`
 - `artifacts/harness-behavior/videos/`

--- a/docs/solutions/workflow-issues/static-harness-contract-preflight-before-provider-validation-2026-07-13.md
+++ b/docs/solutions/workflow-issues/static-harness-contract-preflight-before-provider-validation-2026-07-13.md
@@ -17,7 +17,7 @@ tags:
   - preflight
   - pr-validation
   - diagnostics
-delivery_diff_fingerprint: 8cb155a2db0bcae069990177345dbfd21393cde481703f1dc7c15639dbc3c0f2
+delivery_diff_fingerprint: 23f2cf9c5523be0e32b5b6e1ce626dbfecdd67886d6d2d0197af1d67bc8059fd
 ---
 
 # Static Harness Contracts Must Fail Before Provider Validation

--- a/docs/solutions/workflow-issues/static-harness-contract-preflight-before-provider-validation-2026-07-13.md
+++ b/docs/solutions/workflow-issues/static-harness-contract-preflight-before-provider-validation-2026-07-13.md
@@ -1,0 +1,112 @@
+---
+title: Static Harness Contracts Must Fail Before Provider Validation
+date: 2026-07-13
+category: workflow-issues
+module: repository harness
+problem_type: workflow_issue
+component: development_workflow
+resolution_type: workflow_improvement
+severity: medium
+applies_when:
+  - "A validation registry generates maps or documentation consumed by later gates"
+  - "A heavy provider suite runs before deterministic repository-contract checks"
+  - "One registry edit can drift generated docs, audit fixtures, and sibling tests together"
+tags:
+  - harness
+  - fail-fast
+  - preflight
+  - pr-validation
+  - diagnostics
+delivery_diff_fingerprint: 8cb155a2db0bcae069990177345dbfd21393cde481703f1dc7c15639dbc3c0f2
+---
+
+# Static Harness Contracts Must Fail Before Provider Validation
+
+## Problem
+
+Athena's `pr:athena` gate previously entered the expensive provider-validation
+suite immediately after generated-artifact preparation. Deterministic harness
+contract failures were discovered later: changed-file validation-map gaps,
+registry paths missing from the audit fixture, and harness scripts changed
+without their sibling tests. A single registry edit could therefore require
+several full gate runs before all related repairs were visible.
+
+## Solution
+
+Give static repository contracts their own phase between preparation and
+provider validation:
+
+```text
+prepare -> static contract preflight -> provider validation -> review -> proof
+```
+
+The preflight should run independent checks with all-settled semantics so one
+failure does not hide another:
+
+- changed-file mapping coverage through the no-execution self-review sensor;
+- live registry, generated-map, and package-surface consistency through the
+  harness audit;
+- the real audit and registry tests, because fixture drift exists inside test
+  setup and cannot be detected by auditing the live repository alone; and
+- a narrowly exported sibling-test policy collector rather than the full
+  inferential-review suite.
+
+Aggregate those results into one human report and one machine artifact. Keep
+the existing later review ladder as defense in depth. The delivery-run ledger
+must record the preflight as a separate command span so a failed run proves
+that provider validation never started and proof was never recorded.
+
+For inferential review itself, print a concise blocking summary at the end of
+terminal output. Include the file, finding title, reason, concrete repair, and
+machine-artifact path so an agent does not need to open JSON before it can act.
+
+## Why This Matters
+
+Static contract checks are cheap, deterministic, and usually point directly to
+the repair. Running them first shortens feedback without weakening the gate.
+Aggregating independent findings prevents the sequential failure pattern where
+each repair exposes only the next stale fixture or policy violation.
+
+Narrow collectors also preserve diagnostic ownership. Calling an entire
+inferential suite merely to reuse one policy can misclassify unrelated findings
+and attach the wrong remediation. Export the smallest deterministic policy that
+the preflight actually owns; leave the full suite in its existing review phase.
+
+## Prevention
+
+- Add a distinct ledger phase whenever cheap static checks must prove an
+  expensive phase did not start.
+- Exercise the real fixture tests when the contract drift lives in test setup;
+  a live-repository audit cannot prove fixture completeness.
+- Test the combined failure state and the repaired pass state with real
+  detector-level fixtures, not only canned dependency outputs.
+- Fail closed when changed-file or sibling-policy evidence cannot be computed.
+- Keep terminal failure summaries actionable while retaining JSON artifacts
+  for automation and deeper inspection.
+- Do not remove the later merge-grade sensors merely because the preflight
+  repeats a cheap contract check.
+
+## Examples
+
+The focused sensor for this pattern is:
+
+```bash
+bun test scripts/harness-contract-preflight.test.ts \
+  scripts/pr-athena-delivery-run.test.ts \
+  scripts/harness-audit.test.ts \
+  scripts/harness-app-registry.test.ts \
+  scripts/harness-inferential-review.test.ts
+```
+
+A preflight failure should end with a repair contract naming
+`scripts/harness-app-registry.ts`, generated harness docs,
+`scripts/harness-app-registry.test.ts`, `scripts/harness-audit.test.ts`, and the
+focused verification command. An inferential-review failure should end with a
+terminal summary that contains `Why:` and `Fix:` lines plus the machine-output
+path.
+
+## Related
+
+- [Repo Validation Reruns Need Explicit Proof Or Parent Ownership](../harness/repo-validation-rerun-policy-2026-05-07.md)
+- [Repo Coverage Policy](../harness/repo-coverage-policy-2026-05-02.md)
+- [V26-1040](https://linear.app/v26-labs/issue/V26-1040/make-prathena-fail-fast-on-harness-contract-drift)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2501 files · ~0 words
+- 2503 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10158 nodes · 12385 edges · 2428 communities detected
+- 10170 nodes · 12399 edges · 2430 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2438,6 +2438,8 @@
 - [[_COMMUNITY_Community 2425|Community 2425]]
 - [[_COMMUNITY_Community 2426|Community 2426]]
 - [[_COMMUNITY_Community 2427|Community 2427]]
+- [[_COMMUNITY_Community 2428|Community 2428]]
+- [[_COMMUNITY_Community 2429|Community 2429]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2470,12 +2472,12 @@ Cohesion: 0.03
 Nodes (41): asRecord(), assertCanClearIndexedDbPosLocalStore(), buildEffectiveDrawerAuthorityState(), clearIndexedDbPosLocalStore(), compareIndexKeys(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId() (+33 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.05
-Nodes (78): appendDailyCloseCompletedReportingIngress(), approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildApprovalRequestsById(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx(), buildExpenseSessionsById() (+70 more)
+Cohesion: 0.06
+Nodes (86): buildFinding(), buildGitProcessEnv(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings() (+78 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.06
-Nodes (85): buildFinding(), buildGitProcessEnv(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings() (+77 more)
+Cohesion: 0.05
+Nodes (78): appendDailyCloseCompletedReportingIngress(), approvalBelongsToRange(), approvalRequestTypeLabel(), asCarryForwardItem(), buildApprovalRequestsById(), buildDailyCloseReportSnapshot(), buildDailyCloseSnapshotWithCtx(), buildExpenseSessionsById() (+70 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.06
@@ -4058,104 +4060,104 @@ Cohesion: 0.4
 Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
 
 ### Community 398 - "Community 398"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 400 - "Community 400"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 401 - "Community 401"
 Cohesion: 0.73
 Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 401 - "Community 401"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 402 - "Community 402"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 403 - "Community 403"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 404 - "Community 404"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 405 - "Community 405"
+### Community 404 - "Community 404"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 406 - "Community 406"
+### Community 405 - "Community 405"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 406 - "Community 406"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 408 - "Community 408"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 409 - "Community 409"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 410 - "Community 410"
+### Community 409 - "Community 409"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 411 - "Community 411"
+### Community 410 - "Community 410"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 412 - "Community 412"
+### Community 411 - "Community 411"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 413 - "Community 413"
+### Community 412 - "Community 412"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+
+### Community 413 - "Community 413"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 414 - "Community 414"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 415 - "Community 415"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 416 - "Community 416"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 417 - "Community 417"
+### Community 416 - "Community 416"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 418 - "Community 418"
+### Community 417 - "Community 417"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 418 - "Community 418"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 419 - "Community 419"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 421 - "Community 421"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 422 - "Community 422"
+### Community 421 - "Community 421"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 422 - "Community 422"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.53
@@ -4534,32 +4536,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 517 - "Community 517"
+Cohesion: 0.5
+Nodes (2): createSiblingPolicyFixture(), runGit()
+
+### Community 518 - "Community 518"
+Cohesion: 0.6
+Nodes (3): errorMessage(), formatHumanReport(), runHarnessContractPreflight()
+
+### Community 519 - "Community 519"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 518 - "Community 518"
+### Community 520 - "Community 520"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 519 - "Community 519"
+### Community 521 - "Community 521"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 520 - "Community 520"
+### Community 522 - "Community 522"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 521 - "Community 521"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 522 - "Community 522"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 523 - "Community 523"
-Cohesion: 0.67
-Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 524 - "Community 524"
 Cohesion: 0.5
@@ -4567,39 +4569,39 @@ Nodes (0):
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
+Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
 ### Community 526 - "Community 526"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 527 - "Community 527"
+Cohesion: 0.67
+Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
+
+### Community 528 - "Community 528"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 527 - "Community 527"
+### Community 529 - "Community 529"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
-### Community 528 - "Community 528"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 529 - "Community 529"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 530 - "Community 530"
-Cohesion: 0.67
-Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 531 - "Community 531"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 532 - "Community 532"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): isDisplayableMarker(), resolveHomepageSnapshotBootstrap()
 
 ### Community 533 - "Community 533"
-Cohesion: 0.67
-Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 534 - "Community 534"
 Cohesion: 0.5
@@ -4607,15 +4609,15 @@ Nodes (0):
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
+Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
 ### Community 536 - "Community 536"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 537 - "Community 537"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 538 - "Community 538"
 Cohesion: 0.5
@@ -4634,56 +4636,56 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 542 - "Community 542"
-Cohesion: 0.67
-Nodes (2): audit(), boundedText()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 543 - "Community 543"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 544 - "Community 544"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): audit(), boundedText()
 
 ### Community 545 - "Community 545"
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+
+### Community 546 - "Community 546"
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+
+### Community 547 - "Community 547"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 546 - "Community 546"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 547 - "Community 547"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 548 - "Community 548"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 549 - "Community 549"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 550 - "Community 550"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 551 - "Community 551"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 551 - "Community 551"
+### Community 552 - "Community 552"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 553 - "Community 553"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 552 - "Community 552"
+### Community 554 - "Community 554"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
-
-### Community 553 - "Community 553"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 554 - "Community 554"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 555 - "Community 555"
 Cohesion: 0.5
@@ -4691,103 +4693,103 @@ Nodes (0):
 
 ### Community 556 - "Community 556"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 557 - "Community 557"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 558 - "Community 558"
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+
+### Community 559 - "Community 559"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 558 - "Community 558"
+### Community 560 - "Community 560"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 559 - "Community 559"
+### Community 561 - "Community 561"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 560 - "Community 560"
+### Community 562 - "Community 562"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 561 - "Community 561"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 562 - "Community 562"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 563 - "Community 563"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 564 - "Community 564"
-Cohesion: 0.67
-Nodes (2): buildCtx(), buildQueryCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 565 - "Community 565"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 566 - "Community 566"
+Cohesion: 0.67
+Nodes (2): buildCtx(), buildQueryCtx()
+
+### Community 567 - "Community 567"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 567 - "Community 567"
+### Community 568 - "Community 568"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 569 - "Community 569"
 Cohesion: 0.67
 Nodes (2): buildRepository(), buildSession()
 
-### Community 568 - "Community 568"
+### Community 570 - "Community 570"
 Cohesion: 0.67
 Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
-### Community 569 - "Community 569"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 570 - "Community 570"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 571 - "Community 571"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 572 - "Community 572"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 573 - "Community 573"
 Cohesion: 0.83
 Nodes (3): actorRefWithCtx(), preflightReportingRunAccessWithCtx(), recordReportingDirectAccessDenialWithCtx()
 
-### Community 572 - "Community 572"
+### Community 574 - "Community 574"
 Cohesion: 0.83
 Nodes (3): assertMinor(), lineFact(), recognizeCommerceEvent()
 
-### Community 573 - "Community 573"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 574 - "Community 574"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 575 - "Community 575"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 576 - "Community 576"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 577 - "Community 577"
 Cohesion: 0.67
 Nodes (2): buildReportingRun(), createReportingRunWithCtx()
 
-### Community 576 - "Community 576"
-Cohesion: 0.67
-Nodes (2): getMetricContract(), validateMetricContractVersion()
-
-### Community 577 - "Community 577"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 578 - "Community 578"
 Cohesion: 0.67
-Nodes (2): completeCoverage(), emptyPresetContext()
+Nodes (2): getMetricContract(), validateMetricContractVersion()
 
 ### Community 579 - "Community 579"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 580 - "Community 580"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): completeCoverage(), emptyPresetContext()
 
 ### Community 581 - "Community 581"
 Cohesion: 0.5
@@ -4802,76 +4804,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 584 - "Community 584"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 585 - "Community 585"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 586 - "Community 586"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 585 - "Community 585"
+### Community 587 - "Community 587"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 586 - "Community 586"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 587 - "Community 587"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 588 - "Community 588"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 589 - "Community 589"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 590 - "Community 590"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 591 - "Community 591"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 592 - "Community 592"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 593 - "Community 593"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 594 - "Community 594"
-Cohesion: 0.83
-Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 595 - "Community 595"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 596 - "Community 596"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.83
+Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
 ### Community 597 - "Community 597"
-Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
-
-### Community 598 - "Community 598"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 598 - "Community 598"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
+
 ### Community 599 - "Community 599"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 600 - "Community 600"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 601 - "Community 601"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 602 - "Community 602"
 Cohesion: 0.5
@@ -4902,32 +4904,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 609 - "Community 609"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 610 - "Community 610"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 611 - "Community 611"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 612 - "Community 612"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 613 - "Community 613"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 614 - "Community 614"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 615 - "Community 615"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 616 - "Community 616"
 Cohesion: 0.5
@@ -4946,36 +4948,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 620 - "Community 620"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 621 - "Community 621"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 622 - "Community 622"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 623 - "Community 623"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 623 - "Community 623"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
 ### Community 624 - "Community 624"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 625 - "Community 625"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 626 - "Community 626"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
-Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 628 - "Community 628"
 Cohesion: 0.5
@@ -4983,39 +4985,39 @@ Nodes (0):
 
 ### Community 629 - "Community 629"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
 ### Community 630 - "Community 630"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 631 - "Community 631"
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
+
+### Community 632 - "Community 632"
 Cohesion: 0.67
 Nodes (2): coarseDevice(), emitLandingFunnelEvent()
 
-### Community 631 - "Community 631"
+### Community 633 - "Community 633"
 Cohesion: 0.83
 Nodes (3): getRecoveryHomePath(), isPublicRoutePath(), normalizePathname()
 
-### Community 632 - "Community 632"
+### Community 634 - "Community 634"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 633 - "Community 633"
+### Community 635 - "Community 635"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 634 - "Community 634"
+### Community 636 - "Community 636"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
-### Community 635 - "Community 635"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 636 - "Community 636"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 637 - "Community 637"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 638 - "Community 638"
 Cohesion: 0.5
@@ -5023,47 +5025,47 @@ Nodes (0):
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
-Nodes (2): buildPosLocalStoreFixtureSnapshot(), fixtureIntegrity()
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 640 - "Community 640"
-Cohesion: 0.83
-Nodes (3): completedEvent(), event(), item()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 641 - "Community 641"
 Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Nodes (2): buildPosLocalStoreFixtureSnapshot(), fixtureIntegrity()
 
 ### Community 642 - "Community 642"
-Cohesion: 0.67
-Nodes (2): assessPosLocalStoreClear(), hasValidClearInspectionCounts()
+Cohesion: 0.83
+Nodes (3): completedEvent(), event(), item()
 
 ### Community 643 - "Community 643"
-Cohesion: 0.83
-Nodes (3): isVersioned(), reconcileRegisterLifecycleServerAuthority(), sameAuthorityPayload()
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
 ### Community 644 - "Community 644"
 Cohesion: 0.67
-Nodes (2): applySnapshot(), toObservation()
+Nodes (2): assessPosLocalStoreClear(), hasValidClearInspectionCounts()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Nodes (3): isVersioned(), reconcileRegisterLifecycleServerAuthority(), sameAuthorityPayload()
 
 ### Community 646 - "Community 646"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applySnapshot(), toObservation()
 
 ### Community 647 - "Community 647"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 648 - "Community 648"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 649 - "Community 649"
-Cohesion: 0.83
-Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 650 - "Community 650"
 Cohesion: 0.5
@@ -5071,23 +5073,23 @@ Nodes (0):
 
 ### Community 651 - "Community 651"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
 ### Community 652 - "Community 652"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 653 - "Community 653"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 654 - "Community 654"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 655 - "Community 655"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.5
@@ -5114,67 +5116,67 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 662 - "Community 662"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 663 - "Community 663"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 664 - "Community 664"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 663 - "Community 663"
+### Community 665 - "Community 665"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 664 - "Community 664"
+### Community 666 - "Community 666"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 665 - "Community 665"
+### Community 667 - "Community 667"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 666 - "Community 666"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
-
-### Community 667 - "Community 667"
-Cohesion: 0.67
-Nodes (2): write(), writePublicQueryWithReturns()
 
 ### Community 668 - "Community 668"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 669 - "Community 669"
+Cohesion: 0.67
+Nodes (2): write(), writePublicQueryWithReturns()
+
+### Community 670 - "Community 670"
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+
+### Community 671 - "Community 671"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 670 - "Community 670"
+### Community 672 - "Community 672"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 671 - "Community 671"
+### Community 673 - "Community 673"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 672 - "Community 672"
+### Community 674 - "Community 674"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 673 - "Community 673"
+### Community 675 - "Community 675"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 674 - "Community 674"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 675 - "Community 675"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 676 - "Community 676"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 677 - "Community 677"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 678 - "Community 678"
@@ -5182,16 +5184,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 679 - "Community 679"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 680 - "Community 680"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 681 - "Community 681"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 682 - "Community 682"
 Cohesion: 0.67
@@ -5230,16 +5232,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 691 - "Community 691"
-Cohesion: 1.0
-Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 692 - "Community 692"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 693 - "Community 693"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
 
 ### Community 694 - "Community 694"
 Cohesion: 0.67
@@ -5258,32 +5260,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 698 - "Community 698"
-Cohesion: 1.0
-Nodes (2): closedRegisterReplayConflict(), repairConflict()
-
-### Community 699 - "Community 699"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
-
-### Community 700 - "Community 700"
-Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
-
-### Community 701 - "Community 701"
-Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
-
-### Community 702 - "Community 702"
-Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
-
-### Community 703 - "Community 703"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 704 - "Community 704"
+### Community 699 - "Community 699"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
+
+### Community 700 - "Community 700"
+Cohesion: 1.0
+Nodes (2): closedRegisterReplayConflict(), repairConflict()
+
+### Community 701 - "Community 701"
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
+
+### Community 702 - "Community 702"
+Cohesion: 1.0
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+
+### Community 703 - "Community 703"
+Cohesion: 1.0
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+
+### Community 704 - "Community 704"
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 705 - "Community 705"
 Cohesion: 0.67
@@ -5291,7 +5293,7 @@ Nodes (0):
 
 ### Community 706 - "Community 706"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 707 - "Community 707"
 Cohesion: 0.67
@@ -5302,20 +5304,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 709 - "Community 709"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 710 - "Community 710"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 711 - "Community 711"
 Cohesion: 1.0
 Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
 
-### Community 710 - "Community 710"
+### Community 712 - "Community 712"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 711 - "Community 711"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 712 - "Community 712"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 713 - "Community 713"
 Cohesion: 0.67
@@ -5330,16 +5332,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 716 - "Community 716"
-Cohesion: 1.0
-Nodes (2): evaluateAttention(), reason()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 717 - "Community 717"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 718 - "Community 718"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): evaluateAttention(), reason()
 
 ### Community 719 - "Community 719"
 Cohesion: 0.67
@@ -5354,32 +5356,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 722 - "Community 722"
-Cohesion: 1.0
-Nodes (2): buildDailyProjection(), integer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 723 - "Community 723"
-Cohesion: 1.0
-Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 724 - "Community 724"
 Cohesion: 1.0
-Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
+Nodes (2): buildDailyProjection(), integer()
 
 ### Community 725 - "Community 725"
 Cohesion: 1.0
-Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
+Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
 
 ### Community 726 - "Community 726"
 Cohesion: 1.0
-Nodes (2): reconcileProjection(), unitFor()
+Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
 
 ### Community 727 - "Community 727"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
 
 ### Community 728 - "Community 728"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reconcileProjection(), unitFor()
 
 ### Community 729 - "Community 729"
 Cohesion: 0.67
@@ -5398,56 +5400,56 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 733 - "Community 733"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 734 - "Community 734"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 735 - "Community 735"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 734 - "Community 734"
+### Community 736 - "Community 736"
 Cohesion: 1.0
 Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
-
-### Community 735 - "Community 735"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 736 - "Community 736"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 737 - "Community 737"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 738 - "Community 738"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
-
-### Community 739 - "Community 739"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
-
-### Community 740 - "Community 740"
-Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
-
-### Community 741 - "Community 741"
 Cohesion: 0.67
 Nodes (0):
 
+### Community 739 - "Community 739"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 740 - "Community 740"
+Cohesion: 1.0
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+
+### Community 741 - "Community 741"
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+
 ### Community 742 - "Community 742"
 Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 743 - "Community 743"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 744 - "Community 744"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 745 - "Community 745"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 746 - "Community 746"
 Cohesion: 0.67
@@ -5455,7 +5457,7 @@ Nodes (0):
 
 ### Community 747 - "Community 747"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 748 - "Community 748"
 Cohesion: 0.67
@@ -5466,16 +5468,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 750 - "Community 750"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 751 - "Community 751"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 752 - "Community 752"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 753 - "Community 753"
 Cohesion: 0.67
@@ -5495,7 +5497,7 @@ Nodes (0):
 
 ### Community 757 - "Community 757"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 758 - "Community 758"
 Cohesion: 0.67
@@ -5503,23 +5505,23 @@ Nodes (0):
 
 ### Community 759 - "Community 759"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 760 - "Community 760"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 761 - "Community 761"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 762 - "Community 762"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 763 - "Community 763"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 764 - "Community 764"
 Cohesion: 0.67
@@ -5527,39 +5529,39 @@ Nodes (0):
 
 ### Community 765 - "Community 765"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 766 - "Community 766"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 767 - "Community 767"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 768 - "Community 768"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 769 - "Community 769"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 770 - "Community 770"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 771 - "Community 771"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 772 - "Community 772"
 Cohesion: 1.0
 Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
-### Community 771 - "Community 771"
+### Community 773 - "Community 773"
 Cohesion: 1.0
 Nodes (2): buildTodaySummary(), renderStorePulse()
-
-### Community 772 - "Community 772"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 773 - "Community 773"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 774 - "Community 774"
 Cohesion: 0.67
@@ -5619,83 +5621,83 @@ Nodes (0):
 
 ### Community 788 - "Community 788"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 789 - "Community 789"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 790 - "Community 790"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 791 - "Community 791"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 792 - "Community 792"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 793 - "Community 793"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 794 - "Community 794"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 795 - "Community 795"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): TransactionsSkeleton()
 
 ### Community 796 - "Community 796"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 797 - "Community 797"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 798 - "Community 798"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 799 - "Community 799"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 800 - "Community 800"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (0):
 
 ### Community 801 - "Community 801"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 802 - "Community 802"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 803 - "Community 803"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 804 - "Community 804"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 805 - "Community 805"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 806 - "Community 806"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 807 - "Community 807"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 808 - "Community 808"
 Cohesion: 0.67
@@ -5723,7 +5725,7 @@ Nodes (0):
 
 ### Community 814 - "Community 814"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 815 - "Community 815"
 Cohesion: 0.67
@@ -5731,7 +5733,7 @@ Nodes (0):
 
 ### Community 816 - "Community 816"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 817 - "Community 817"
 Cohesion: 0.67
@@ -5758,32 +5760,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 823 - "Community 823"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 824 - "Community 824"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 825 - "Community 825"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getApprovalGuidance(), presentCommandToast()
 
 ### Community 826 - "Community 826"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 827 - "Community 827"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 828 - "Community 828"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 829 - "Community 829"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 830 - "Community 830"
 Cohesion: 0.67
@@ -5798,32 +5800,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 833 - "Community 833"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 834 - "Community 834"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 835 - "Community 835"
 Cohesion: 1.0
 Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
-### Community 834 - "Community 834"
+### Community 836 - "Community 836"
 Cohesion: 1.0
 Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
-### Community 835 - "Community 835"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 836 - "Community 836"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 837 - "Community 837"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 838 - "Community 838"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 839 - "Community 839"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 840 - "Community 840"
 Cohesion: 0.67
@@ -5846,44 +5848,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 845 - "Community 845"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 846 - "Community 846"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 847 - "Community 847"
 Cohesion: 1.0
 Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
-### Community 846 - "Community 846"
+### Community 848 - "Community 848"
 Cohesion: 1.0
 Nodes (2): collectSourceFiles(), findIllegalConvexImports()
-
-### Community 847 - "Community 847"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 848 - "Community 848"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 849 - "Community 849"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 850 - "Community 850"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
-
-### Community 851 - "Community 851"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
-
-### Community 852 - "Community 852"
-Cohesion: 0.67
-Nodes (1): hashPassword()
-
-### Community 853 - "Community 853"
 Cohesion: 0.67
 Nodes (0):
 
+### Community 851 - "Community 851"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 852 - "Community 852"
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+
+### Community 853 - "Community 853"
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
+
 ### Community 854 - "Community 854"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): hashPassword()
 
 ### Community 855 - "Community 855"
 Cohesion: 0.67
@@ -5891,39 +5893,39 @@ Nodes (0):
 
 ### Community 856 - "Community 856"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 857 - "Community 857"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 858 - "Community 858"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 859 - "Community 859"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 858 - "Community 858"
+### Community 860 - "Community 860"
 Cohesion: 1.0
 Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
-### Community 859 - "Community 859"
+### Community 861 - "Community 861"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 860 - "Community 860"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
-
-### Community 861 - "Community 861"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 862 - "Community 862"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 863 - "Community 863"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 864 - "Community 864"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 865 - "Community 865"
 Cohesion: 0.67
@@ -5934,32 +5936,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 867 - "Community 867"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 868 - "Community 868"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 869 - "Community 869"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 870 - "Community 870"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 871 - "Community 871"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 872 - "Community 872"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 873 - "Community 873"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 874 - "Community 874"
 Cohesion: 0.67
@@ -6022,8 +6024,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 889 - "Community 889"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 890 - "Community 890"
 Cohesion: 0.67
@@ -6031,11 +6033,11 @@ Nodes (0):
 
 ### Community 891 - "Community 891"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 892 - "Community 892"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 893 - "Community 893"
 Cohesion: 1.0
@@ -6046,12 +6048,12 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 895 - "Community 895"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 896 - "Community 896"
 Cohesion: 1.0
-Nodes (2): gitFixtureEnv(), runGit()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 897 - "Community 897"
 Cohesion: 0.67
@@ -6059,15 +6061,15 @@ Nodes (0):
 
 ### Community 898 - "Community 898"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): gitFixtureEnv(), runGit()
 
 ### Community 899 - "Community 899"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 900 - "Community 900"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 901 - "Community 901"
 Cohesion: 1.0
@@ -7367,7 +7369,7 @@ Nodes (0):
 
 ### Community 1225 - "Community 1225"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1226 - "Community 1226"
 Cohesion: 1.0
@@ -7375,7 +7377,7 @@ Nodes (0):
 
 ### Community 1227 - "Community 1227"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1228 - "Community 1228"
 Cohesion: 1.0
@@ -12177,442 +12179,450 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2428 - "Community 2428"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2429 - "Community 2429"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 899`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 901`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 902`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 903`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 904`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 905`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 906`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 907`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 908`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 909`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 910`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 911`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 912`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 913`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 914`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
+- **Thin community `Community 915`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 916`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
+- **Thin community `Community 917`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 918`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 919`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 920`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 921`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 922`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 923`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
+- **Thin community `Community 924`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 925`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 926`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 927`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 928`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 929`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 930`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 931`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 932`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 933`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 934`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
+- **Thin community `Community 935`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 936`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 937`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 938`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 939`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
+- **Thin community `Community 940`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
+- **Thin community `Community 941`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
+- **Thin community `Community 942`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 943`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 944`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 945`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 946`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 947`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 948`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 949`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 950`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 951`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
+- **Thin community `Community 952`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
+- **Thin community `Community 953`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 954`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 955`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 956`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 957`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 958`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 959`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 960`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 961`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
+- **Thin community `Community 962`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 963`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 964`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
+- **Thin community `Community 965`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
+- **Thin community `Community 966`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 967`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 968`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 969`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
+- **Thin community `Community 970`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 971`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 972`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 973`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 974`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 975`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 976`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 977`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 978`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `context()`, `access.test.ts`
+- **Thin community `Community 979`** (2 nodes): `context()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `current()`, `coverage.test.ts`
+- **Thin community `Community 980`** (2 nodes): `current()`, `coverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `context()`, `directAccess.test.ts`
+- **Thin community `Community 981`** (2 nodes): `context()`, `directAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `rows()`, `evidence.test.ts`
+- **Thin community `Community 982`** (2 nodes): `rows()`, `evidence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `context()`, `evidenceAccess.test.ts`
+- **Thin community `Community 983`** (2 nodes): `context()`, `evidenceAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
+- **Thin community `Community 984`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `context()`, `commerceEffects.test.ts`
+- **Thin community `Community 985`** (2 nodes): `context()`, `commerceEffects.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
+- **Thin community `Community 986`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
+- **Thin community `Community 987`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `processing.ts`, `processBoundedBatch()`
+- **Thin community `Community 988`** (2 nodes): `processing.ts`, `processBoundedBatch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
+- **Thin community `Community 989`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
+- **Thin community `Community 990`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
+- **Thin community `Community 991`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `reportingDestination()`, `destinations.ts`
+- **Thin community `Community 992`** (2 nodes): `reportingDestination()`, `destinations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
+- **Thin community `Community 993`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
+- **Thin community `Community 994`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
+- **Thin community `Community 995`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
+- **Thin community `Community 996`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
+- **Thin community `Community 997`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `settlement.ts`, `adaptSettlement()`
+- **Thin community `Community 998`** (2 nodes): `settlement.ts`, `adaptSettlement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
+- **Thin community `Community 999`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
+- **Thin community `Community 1000`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 1001`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 1002`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 1003`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 1004`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 1005`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 1006`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 1007`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 1008`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 1009`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 1010`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 1011`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 1012`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 1013`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 1014`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 1015`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 1016`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 1017`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 1018`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 1019`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 1020`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 1021`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 1022`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 1023`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 1024`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 1025`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 1026`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 1027`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 1028`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 1029`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
+- **Thin community `Community 1030`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 1031`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 1032`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 1033`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 1034`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 1035`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 1036`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 1037`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 1038`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 1039`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 1040`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 1041`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 1042`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 1043`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 1044`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 1045`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 1046`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 1047`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
+- **Thin community `Community 1048`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 1049`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
+- **Thin community `Community 1050`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 1051`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 1052`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 1053`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 1054`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 1055`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 1056`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1057`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 1058`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 1059`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 1060`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 1061`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 1062`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 1063`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 1064`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 1065`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 1066`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 1067`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 1068`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 1069`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 1070`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 1071`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 1072`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 1073`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 1074`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 1075`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 1076`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 1077`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 1078`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 1079`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 1080`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 1081`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 1082`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 1083`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 1084`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 1085`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 1086`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 1087`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 1088`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 1089`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 1090`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 1091`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 1092`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 1093`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 1094`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 1095`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 1096`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 1097`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 1098`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 1099`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 1100`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 1101`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 1102`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 1103`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 1104`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 1105`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 1106`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 1107`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 1108`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 1109`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 1110`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 1111`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 1112`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 1113`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 1114`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 1115`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 1116`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 1117`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -12648,2629 +12658,2629 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 1118`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 1119`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 1120`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 1121`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 1122`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 1123`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 1124`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 1125`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 1126`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 1127`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 1128`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 1129`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 1130`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 1131`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
+- **Thin community `Community 1132`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 1133`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 1134`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 1135`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 1136`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 1137`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 1138`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 1139`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 1140`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 1141`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 1142`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 1143`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 1144`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 1145`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
+- **Thin community `Community 1146`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
+- **Thin community `Community 1147`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
+- **Thin community `Community 1148`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
+- **Thin community `Community 1149`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
+- **Thin community `Community 1150`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
+- **Thin community `Community 1151`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 1152`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1153`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1154`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1155`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1156`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 1157`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 1158`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 1159`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 1160`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 1161`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 1162`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 1163`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 1164`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 1165`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 1166`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 1167`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 1168`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 1169`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 1170`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 1171`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 1172`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 1173`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 1174`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 1175`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 1176`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1177`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1178`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1179`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
+- **Thin community `Community 1180`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1181`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1182`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1183`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1184`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1185`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1186`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1187`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1188`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1189`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1190`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1191`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1192`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1193`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1194`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1195`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1196`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
+- **Thin community `Community 1197`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1198`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1199`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1200`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1201`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1202`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1203`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1204`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1205`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1206`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1207`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1208`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1209`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1210`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1211`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1212`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1213`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1214`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1215`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1216`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1217`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1218`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1219`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1220`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1221`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1222`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1223`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1224`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1225`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1226`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1227`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1228`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1229`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1230`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1231`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1232`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1233`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1234`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
+- **Thin community `Community 1235`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1236`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1237`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1238`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1239`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1240`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1241`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1242`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
+- **Thin community `Community 1243`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
+- **Thin community `Community 1244`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
+- **Thin community `Community 1245`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `posLocalStoreBoundedOperations.test.ts`, `poisonWholeStoreReads()`
+- **Thin community `Community 1246`** (2 nodes): `posLocalStoreBoundedOperations.test.ts`, `poisonWholeStoreReads()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
+- **Thin community `Community 1247`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
+- **Thin community `Community 1248`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
+- **Thin community `Community 1249`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
+- **Thin community `Community 1250`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
+- **Thin community `Community 1251`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
+- **Thin community `Community 1252`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1253`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1254`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
+- **Thin community `Community 1255`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1256`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1257`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1258`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1259`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1260`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1261`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
+- **Thin community `Community 1262`** (2 nodes): `registerUiState.ts`, `buildRegisterUpdateApplyBlockerState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1263`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1264`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1265`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1266`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1267`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1268`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1269`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1270`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1271`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1272`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1273`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1274`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `-public-layout.tsx`, `PublicLayout()`
+- **Thin community `Community 1275`** (2 nodes): `-public-layout.tsx`, `PublicLayout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1276`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1277`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1278`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1279`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1280`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1281`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1282`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1283`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1284`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1285`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1286`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1287`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1288`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1289`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1290`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1291`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
+- **Thin community `Community 1292`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
+- **Thin community `Community 1293`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
+- **Thin community `Community 1294`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1295`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
+- **Thin community `Community 1296`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1297`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `AuthenticatedLayout()`, `_authed.tsx`
+- **Thin community `Community 1298`** (2 nodes): `AuthenticatedLayout()`, `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1299`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1300`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `walkthrough.tsx`, `WalkthroughPage()`
+- **Thin community `Community 1301`** (2 nodes): `walkthrough.tsx`, `WalkthroughPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1302`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1303`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1304`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1305`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1306`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1307`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1308`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1309`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1310`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1311`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1312`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1313`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1314`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1315`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1316`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1317`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1318`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1319`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1320`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1321`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1322`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1323`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1324`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1325`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1326`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1327`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1328`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1329`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1330`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1331`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1332`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1333`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1334`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1335`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1336`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1337`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1338`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1339`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1340`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1341`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1342`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1343`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1344`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1345`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1346`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1347`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1348`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1349`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1350`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1351`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1352`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1353`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1354`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1355`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1356`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1357`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1358`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1359`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1360`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1361`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1362`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1363`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1364`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1365`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1366`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1367`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1368`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1369`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1370`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1371`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1372`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1373`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1374`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1375`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1376`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1377`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1378`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1379`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1380`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1381`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1382`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1383`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1384`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1385`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1386`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1387`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1388`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1389`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1390`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1391`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1392`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1393`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1394`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1395`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1396`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1397`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1398`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1399`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1400`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1401`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1402`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1403`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1404`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1405`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1406`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1407`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1408`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1409`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1410`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1411`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1412`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1413`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1414`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1415`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1416`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1417`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1418`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1419`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1420`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1421`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1422`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1423`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1424`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1425`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1426`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1427`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1428`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1429`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1430`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1431`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1432`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1433`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1434`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1435`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1436`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1437`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1438`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1439`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1440`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1441`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `api.js`
+- **Thin community `Community 1442`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1443`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1444`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `server.js`
+- **Thin community `Community 1445`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `app.ts`
+- **Thin community `Community 1446`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1447`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1448`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1449`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `auth.ts`
+- **Thin community `Community 1451`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1452`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1453`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `countries.ts`
+- **Thin community `Community 1455`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `email.ts`
+- **Thin community `Community 1456`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1457`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `payment.ts`
+- **Thin community `Community 1458`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `types.ts`
+- **Thin community `Community 1460`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1461`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1462`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `crons.ts`
+- **Thin community `Community 1463`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1464`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `internal.ts`
+- **Thin community `Community 1465`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1466`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1470`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1471`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `DailyManagerReport.tsx`
+- **Thin community `Community 1472`** (1 nodes): `DailyManagerReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1473`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1474`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1475`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1476`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1477`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1478`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1479`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
+- **Thin community `Community 1480`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1481`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `env.ts`
+- **Thin community `Community 1482`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1483`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `auth.ts`
+- **Thin community `Community 1484`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `colors.ts`
+- **Thin community `Community 1486`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `index.ts`
+- **Thin community `Community 1487`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1488`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1489`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1490`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `products.ts`
+- **Thin community `Community 1491`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `stores.ts`
+- **Thin community `Community 1493`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1495`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `bag.ts`
+- **Thin community `Community 1496`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `guest.ts`
+- **Thin community `Community 1497`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1498`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `index.ts`
+- **Thin community `Community 1499`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `me.ts`
+- **Thin community `Community 1500`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `offers.ts`
+- **Thin community `Community 1501`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1502`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1503`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1504`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1505`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1506`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1507`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1509`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1510`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `user.ts`
+- **Thin community `Community 1511`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1512`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `index.ts`
+- **Thin community `Community 1513`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1514`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `http.ts`
+- **Thin community `Community 1515`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `access.ts`
+- **Thin community `Community 1516`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1517`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1518`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1519`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `index.ts`
+- **Thin community `Community 1520`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `types.ts`
+- **Thin community `Community 1522`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1523`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `categories.ts`
+- **Thin community `Community 1525`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `colors.ts`
+- **Thin community `Community 1526`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1527`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1528`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1529`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1530`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1531`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `pos.ts`
+- **Thin community `Community 1532`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1533`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1534`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1535`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1536`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1537`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1538`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1539`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1540`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1541`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1543`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1544`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1545`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1546`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1547`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1548`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1550`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1551`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1552`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1553`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1554`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `types.ts`
+- **Thin community `Community 1555`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1556`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1557`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1558`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1559`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1560`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
+- **Thin community `Community 1561`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1562`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1563`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1564`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1565`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1566`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1567`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1568`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `dto.ts`
+- **Thin community `Community 1569`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1570`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1573`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `facts.ts`
+- **Thin community `Community 1574`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1575`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `types.ts`
+- **Thin community `Community 1576`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1577`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1578`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `customers.ts`
+- **Thin community `Community 1582`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1583`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `register.ts`
+- **Thin community `Community 1584`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `register.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1587`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `activation.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `attentionRules.test.ts`
+- **Thin community `Community 1589`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `commerceRecognition.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `activation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `customRangeRequests.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `attentionRules.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `export.test.ts`
+- **Thin community `Community 1592`** (1 nodes): `commerceRecognition.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `factFingerprint.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `customRangeRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `factIdentity.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `export.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `factFingerprint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `integrity.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `factIdentity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `corrections.test.ts`
+- **Thin community `Community 1597`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `corrections.ts`
+- **Thin community `Community 1598`** (1 nodes): `integrity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `deficitResolutionWork.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `corrections.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `types.ts`
+- **Thin community `Community 1600`** (1 nodes): `corrections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `authorizedPosBackfill.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `deficitResolutionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `backfillAuthorization.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `cutover.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `authorizedPosBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `inventoryRebuild.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `backfillAuthorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `legacyCompatibility.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `cutover.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `posCensusBackfill.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `inventoryRebuild.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `posSourceReconciliationGate.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `legacyCompatibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `processing.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `posCensusBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `runLedger.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `posSourceReconciliationGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `metricContracts.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `processing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `periods.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `runLedger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `projectionWork.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `metricContracts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `attention.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `periods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `currentInventory.test.ts`
+- **Thin community `Community 1614`** (1 nodes): `projectionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `customRange.test.ts`
+- **Thin community `Community 1615`** (1 nodes): `attention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `daily.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `currentInventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `dailyCloseTrust.test.ts`
+- **Thin community `Community 1617`** (1 nodes): `customRange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `factContributions.test.ts`
+- **Thin community `Community 1618`** (1 nodes): `daily.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `inventory.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `dailyCloseTrust.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `processor.test.ts`
+- **Thin community `Community 1620`** (1 nodes): `factContributions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `reconciliation.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `inventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `skuDay.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `processor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `skuInsights.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `reconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `storeIntraday.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `skuDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1625`** (1 nodes): `skuInsights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `destinations.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `storeIntraday.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `items.ts`
+- **Thin community `Community 1627`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `reportingReadModels.test.ts`
+- **Thin community `Community 1628`** (1 nodes): `destinations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `skuAttributionSequence.test.ts`
+- **Thin community `Community 1629`** (1 nodes): `items.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `types.ts`
+- **Thin community `Community 1630`** (1 nodes): `reportingReadModels.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `sourceAdapters.test.ts`
+- **Thin community `Community 1631`** (1 nodes): `skuAttributionSequence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `storeTimeAuthority.test.ts`
+- **Thin community `Community 1632`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `schema.ts`
+- **Thin community `Community 1633`** (1 nodes): `sourceAdapters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `automation.ts`
+- **Thin community `Community 1634`** (1 nodes): `storeTimeAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1635`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1636`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `index.ts`
+- **Thin community `Community 1637`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1638`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1639`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1640`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1641`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1642`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1643`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1644`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `category.ts`
+- **Thin community `Community 1645`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `color.ts`
+- **Thin community `Community 1646`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1647`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1648`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `index.ts`
+- **Thin community `Community 1649`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1650`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1651`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1652`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1653`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `organization.ts`
+- **Thin community `Community 1654`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1655`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `product.ts`
+- **Thin community `Community 1656`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1657`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1658`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1659`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `store.ts`
+- **Thin community `Community 1660`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1661`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `storeTimezone.ts`
+- **Thin community `Community 1662`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1663`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `landingFunnelEvent.ts`
+- **Thin community `Community 1664`** (1 nodes): `storeTimezone.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `walkthroughRequest.ts`
+- **Thin community `Community 1665`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `index.ts`
+- **Thin community `Community 1666`** (1 nodes): `landingFunnelEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1667`** (1 nodes): `walkthroughRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1668`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1669`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1670`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1671`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1672`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1673`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `index.ts`
+- **Thin community `Community 1674`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1675`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1676`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1677`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1678`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1679`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1680`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1681`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1682`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1683`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1684`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1685`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `customer.ts`
+- **Thin community `Community 1686`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1687`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1688`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1689`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1690`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `index.ts`
+- **Thin community `Community 1691`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `posLifecycleJournal.ts`
+- **Thin community `Community 1692`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1693`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1694`** (1 nodes): `posLifecycleJournal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1695`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1696`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1697`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1698`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1699`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1700`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
+- **Thin community `Community 1701`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `posRegisterMappingAuthority.ts`
+- **Thin community `Community 1702`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 1703`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 1704`** (1 nodes): `posRegisterMappingAuthority.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1705`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1706`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1707`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1708`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1709`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1710`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1711`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1712`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1713`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1714`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1716`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `index.ts`
+- **Thin community `Community 1717`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1718`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1719`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `facts.ts`
+- **Thin community `Community 1720`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `index.ts`
+- **Thin community `Community 1721`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `inventoryValuation.ts`
+- **Thin community `Community 1722`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `maintenance.ts`
+- **Thin community `Community 1723`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `projections.ts`
+- **Thin community `Community 1724`** (1 nodes): `inventoryValuation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `index.ts`
+- **Thin community `Community 1725`** (1 nodes): `maintenance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1726`** (1 nodes): `projections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1727`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1728`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1729`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1730`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1731`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `index.ts`
+- **Thin community `Community 1732`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1733`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1734`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1735`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1736`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1737`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1738`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `bag.ts`
+- **Thin community `Community 1739`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1740`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1741`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1742`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `guest.ts`
+- **Thin community `Community 1743`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `index.ts`
+- **Thin community `Community 1744`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `offer.ts`
+- **Thin community `Community 1745`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1746`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1747`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `review.ts`
+- **Thin community `Community 1748`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1749`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1750`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1751`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1752`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1753`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1754`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1755`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1756`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `bag.ts`
+- **Thin community `Community 1757`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1758`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `customer.ts`
+- **Thin community `Community 1759`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `guest.ts`
+- **Thin community `Community 1760`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1761`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1762`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1764`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1765`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1766`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1767`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `users.ts`
+- **Thin community `Community 1768`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `payment.ts`
+- **Thin community `Community 1769`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1770`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1771`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1772`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1774`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1775`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1776`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `index.ts`
+- **Thin community `Community 1777`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1778`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1779`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1780`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1781`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `auth.ts`
+- **Thin community `Community 1782`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1786`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1787`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1788`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1789`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `index.ts`
+- **Thin community `Community 1790`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1791`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 1792`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1793`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1794`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `reportingContract.ts`
+- **Thin community `Community 1795`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1796`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `reportingContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1798`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1799`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1800`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1801`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 1802`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1803`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 1804`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1805`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1806`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1807`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1808`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1809`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1811`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1812`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1813`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1816`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `CopyImagesView.test.tsx`
+- **Thin community `Community 1817`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `constants.ts`
+- **Thin community `Community 1818`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1819`** (1 nodes): `CopyImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1820`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1821`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `types.ts`
+- **Thin community `Community 1822`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `AnalyticsView.test.tsx`
+- **Thin community `Community 1823`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1824`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1825`** (1 nodes): `AnalyticsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1826`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1827`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1828`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1829`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1830`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1831`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1832`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1833`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1834`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1835`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1836`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1837`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1838`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1839`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1840`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1841`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1842`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1843`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `constants.ts`
+- **Thin community `Community 1844`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1845`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1846`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1847`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `data.ts`
+- **Thin community `Community 1848`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1849`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1850`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1851`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1852`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1853`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1854`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1855`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1856`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1857`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1858`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1859`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `constants.ts`
+- **Thin community `Community 1860`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1861`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1862`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1863`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `data.ts`
+- **Thin community `Community 1864`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1865`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1866`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1867`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1868`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1869`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1870`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1871`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1872`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1873`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1874`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1875`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `constants.ts`
+- **Thin community `Community 1876`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1877`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1878`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1879`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1880`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1881`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1882`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1883`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1884`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1885`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1886`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1887`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1888`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1889`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1890`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1891`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1892`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1893`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1894`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1895`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1896`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1897`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1898`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1899`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1900`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1901`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1902`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1903`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1904`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1905`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1906`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 1907`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1908`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1909`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1910`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1911`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1912`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1913`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `constants.ts`
+- **Thin community `Community 1914`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1915`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1916`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1917`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `data.ts`
+- **Thin community `Community 1918`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1919`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1920`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `constants.ts`
+- **Thin community `Community 1921`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1922`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1923`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1924`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1925`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `data.ts`
+- **Thin community `Community 1926`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1927`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `constants.ts`
+- **Thin community `Community 1928`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1929`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1930`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1931`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1932`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `data.ts`
+- **Thin community `Community 1933`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1934`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1935`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1936`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1937`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1938`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1939`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1940`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1941`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1942`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1943`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1944`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1945`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1946`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1947`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1948`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1949`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1950`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1951`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1952`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1953`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1954`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1955`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1956`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1957`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1958`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1959`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1960`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1961`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `types.ts`
+- **Thin community `Community 1962`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1963`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1964`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1965`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1966`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 1967`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1968`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 1969`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1970`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1971`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 1972`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1973`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1974`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1975`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1976`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1977`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1978`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1979`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1980`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `data.ts`
+- **Thin community `Community 1981`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1982`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1983`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1984`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1985`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1986`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1987`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1988`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1989`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1990`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1991`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1992`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1993`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `constants.ts`
+- **Thin community `Community 1994`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1995`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1996`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1997`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `data.ts`
+- **Thin community `Community 1998`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `types.ts`
+- **Thin community `Community 1999`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 2000`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 2001`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 2002`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 2003`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 2004`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `index.ts`
+- **Thin community `Community 2005`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `CustomRangeStatus.test.tsx`
+- **Thin community `Community 2006`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `InventoryMovementSummary.tsx`
+- **Thin community `Community 2007`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `ReportAttentionList.tsx`
+- **Thin community `Community 2008`** (1 nodes): `CustomRangeStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `ReportPeriodControl.test.tsx`
+- **Thin community `Community 2009`** (1 nodes): `InventoryMovementSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `ReportsInventoryView.test.tsx`
+- **Thin community `Community 2010`** (1 nodes): `ReportAttentionList.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `ReportsInventoryView.tsx`
+- **Thin community `Community 2011`** (1 nodes): `ReportPeriodControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `ReportsItemsView.test.tsx`
+- **Thin community `Community 2012`** (1 nodes): `ReportsInventoryView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `ReportsItemsView.tsx`
+- **Thin community `Community 2013`** (1 nodes): `ReportsInventoryView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `ReportsLayout.test.tsx`
+- **Thin community `Community 2014`** (1 nodes): `ReportsItemsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `ReportsOverviewView.test.tsx`
+- **Thin community `Community 2015`** (1 nodes): `ReportsItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `ReportsSkuDetailView.test.tsx`
+- **Thin community `Community 2016`** (1 nodes): `ReportsLayout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
+- **Thin community `Community 2017`** (1 nodes): `ReportsOverviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
+- **Thin community `Community 2018`** (1 nodes): `ReportsSkuDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
+- **Thin community `Community 2019`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `ReportsWorkspaceControls.tsx`
+- **Thin community `Community 2020`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `RevenueContribution.tsx`
+- **Thin community `Community 2021`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `reportPresentation.test.ts`
+- **Thin community `Community 2022`** (1 nodes): `ReportsWorkspaceControls.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2023`** (1 nodes): `RevenueContribution.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2024`** (1 nodes): `reportPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2025`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2026`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `index.tsx`
+- **Thin community `Community 2027`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2028`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2029`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2030`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2031`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2032`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2033`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2034`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2035`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 2036`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2037`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2038`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `index.tsx`
+- **Thin community `Community 2039`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2040`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2041`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2042`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `button.tsx`
+- **Thin community `Community 2043`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2044`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `card.tsx`
+- **Thin community `Community 2045`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2046`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2047`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `command.tsx`
+- **Thin community `Community 2048`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2049`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2050`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2051`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `form.tsx`
+- **Thin community `Community 2052`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2053`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2054`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `input.tsx`
+- **Thin community `Community 2055`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2056`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2057`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2058`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2059`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2060`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2061`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `select.tsx`
+- **Thin community `Community 2062`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2063`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2064`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2065`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `table.tsx`
+- **Thin community `Community 2066`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2067`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2068`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2069`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2070`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2071`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2072`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2073`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2074`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `constants.ts`
+- **Thin community `Community 2075`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2076`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2077`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2078`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `data.ts`
+- **Thin community `Community 2079`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2080`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2081`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2082`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2083`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2084`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2085`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2086`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2087`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2088`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2089`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `index.ts`
+- **Thin community `Community 2090`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2091`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2092`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2093`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2094`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2095`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2096`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2097`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2098`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2099`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2100`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2101`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2102`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2103`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2104`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2105`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `index.ts`
+- **Thin community `Community 2106`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2107`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2108`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2109`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2110`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `aws.ts`
+- **Thin community `Community 2111`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `constants.ts`
+- **Thin community `Community 2112`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `countries.ts`
+- **Thin community `Community 2113`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2114`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2115`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2116`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2117`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2118`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2119`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2120`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2121`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2122`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2123`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2124`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2125`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2125`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2126`** (1 nodes): `dto.ts`
+- **Thin community `Community 2126`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2127`** (1 nodes): `ports.ts`
+- **Thin community `Community 2127`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2128`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2128`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2129`** (1 nodes): `constants.ts`
+- **Thin community `Community 2129`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2130`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2130`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2131`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2131`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2132`** (1 nodes): `index.ts`
+- **Thin community `Community 2132`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2133`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2133`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2134`** (1 nodes): `types.ts`
+- **Thin community `Community 2134`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2135`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2135`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2136`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2136`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2137`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2137`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2138`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2138`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2139`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2139`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2140`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2140`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2141`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2141`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2142`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2142`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2143`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2143`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2144`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2144`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2145`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2145`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2146`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2146`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2147`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2147`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2148`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2148`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2149`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2149`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2150`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2150`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2151`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2151`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2152`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 2152`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2153`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2153`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2154`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2154`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2155`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2155`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2156`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2156`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2157`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2157`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2158`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2158`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2159`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2159`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2160`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2160`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2161`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2161`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2162`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2162`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2163`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2163`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2164`** (1 nodes): `index.ts`
+- **Thin community `Community 2164`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2165`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2165`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2166`** (1 nodes): `category.ts`
+- **Thin community `Community 2166`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2167`** (1 nodes): `product.ts`
+- **Thin community `Community 2167`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2168`** (1 nodes): `store.ts`
+- **Thin community `Community 2168`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2169`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2169`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2170`** (1 nodes): `user.ts`
+- **Thin community `Community 2170`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2171`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2171`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2172`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2172`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2173`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2173`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2174`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2174`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2175`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2175`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2176`** (1 nodes): `main.tsx`
+- **Thin community `Community 2176`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2177`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2177`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2178`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2178`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2179`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2179`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2180`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2180`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2181`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2181`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2182`** (1 nodes): `-index-route-view.tsx`
+- **Thin community `Community 2182`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2183`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2183`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2184`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2184`** (1 nodes): `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2185`** (1 nodes): `index.tsx`
+- **Thin community `Community 2185`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2186`** (1 nodes): `index.tsx`
+- **Thin community `Community 2186`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2187`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2188`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2188`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2189`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2189`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2190`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2190`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2191`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2191`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2192`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2192`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2193`** (1 nodes): `index.tsx`
+- **Thin community `Community 2193`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2194`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2194`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2195`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2195`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2196`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2196`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2197`** (1 nodes): `home.tsx`
+- **Thin community `Community 2197`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2198`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2198`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2199`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2199`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2200`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2200`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2201`** (1 nodes): `index.tsx`
+- **Thin community `Community 2201`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2202`** (1 nodes): `review.tsx`
+- **Thin community `Community 2202`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2203`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2203`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2204`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2204`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2205`** (1 nodes): `index.tsx`
+- **Thin community `Community 2205`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2206`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2206`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2207`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2207`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2208`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2208`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2209`** (1 nodes): `index.tsx`
+- **Thin community `Community 2209`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2210`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2210`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2211`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2211`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2212`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2212`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2213`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2213`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2214`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2214`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2215`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2215`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2216`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2216`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2217`** (1 nodes): `index.tsx`
+- **Thin community `Community 2217`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2218`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2218`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2219`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2219`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2220`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2220`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2221`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2221`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2222`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2222`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2223`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2223`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2224`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2224`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2225`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2225`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2226`** (1 nodes): `index.tsx`
+- **Thin community `Community 2226`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2227`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2227`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2228`** (1 nodes): `new.tsx`
+- **Thin community `Community 2228`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2229`** (1 nodes): `new.tsx`
+- **Thin community `Community 2229`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2230`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2230`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2231`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2231`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2232`** (1 nodes): `index.tsx`
+- **Thin community `Community 2232`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2233`** (1 nodes): `new.tsx`
+- **Thin community `Community 2233`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2234`** (1 nodes): `items.tsx`
+- **Thin community `Community 2234`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2235`** (1 nodes): `search.test.ts`
+- **Thin community `Community 2235`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2236`** (1 nodes): `storefront.tsx`
+- **Thin community `Community 2236`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2237`** (1 nodes): `index.tsx`
+- **Thin community `Community 2237`** (1 nodes): `search.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2238`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2238`** (1 nodes): `storefront.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2239`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2239`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2240`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2240`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2241`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2241`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2242`** (1 nodes): `index.tsx`
+- **Thin community `Community 2242`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2243`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2243`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2244`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2244`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2245`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2245`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2246`** (1 nodes): `index.tsx`
+- **Thin community `Community 2246`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2247`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2247`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2248`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2248`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2249`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2249`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2250`** (1 nodes): `app.tsx`
+- **Thin community `Community 2250`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2251`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2251`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2252`** (1 nodes): `index.tsx`
+- **Thin community `Community 2252`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2253`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2253`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2254`** (1 nodes): `landing.test.tsx`
+- **Thin community `Community 2254`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2255`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2255`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2256`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2256`** (1 nodes): `landing.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2257`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2257`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2258`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2258`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2259`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2259`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2260`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2260`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2261`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2261`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2262`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2262`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2263`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2263`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2264`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2264`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2265`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2265`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2266`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2266`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2267`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2267`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2268`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2268`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2269`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2269`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2270`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2270`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2271`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2271`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2272`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2272`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2273`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2273`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2274`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2274`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2275`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2275`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2276`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2276`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2277`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2277`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2278`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2278`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2279`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2279`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2280`** (1 nodes): `setup.ts`
+- **Thin community `Community 2280`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2281`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2281`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2282`** (1 nodes): `types.ts`
+- **Thin community `Community 2282`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2283`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2283`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2284`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2284`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2285`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2285`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2286`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2286`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2287`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2287`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2288`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2288`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2289`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2289`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2290`** (1 nodes): `types.ts`
+- **Thin community `Community 2290`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2291`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2291`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2292`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2292`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2293`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2293`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2294`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2294`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2295`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2295`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2296`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2296`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2297`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2297`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2298`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2298`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2299`** (1 nodes): `schema.ts`
+- **Thin community `Community 2299`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2300`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2300`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2301`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2301`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2302`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2302`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2303`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2303`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2304`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2304`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2305`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2305`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2306`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2306`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2307`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2307`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2308`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2308`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2309`** (1 nodes): `types.ts`
+- **Thin community `Community 2309`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2310`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2310`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2311`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2311`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2312`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2312`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2313`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2313`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2314`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2314`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2315`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2315`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2316`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2316`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2317`** (1 nodes): `constants.ts`
+- **Thin community `Community 2317`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2318`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2318`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2319`** (1 nodes): `About.tsx`
+- **Thin community `Community 2319`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2320`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2320`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2321`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2321`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2322`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2322`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2323`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2323`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2324`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2324`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2325`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2325`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2326`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2326`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2327`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2327`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2328`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2328`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2329`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2329`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2330`** (1 nodes): `types.ts`
+- **Thin community `Community 2330`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2331`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2331`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2332`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2332`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2333`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2333`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2334`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2334`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2335`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2335`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2336`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2336`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2337`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2337`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2338`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2339`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2340`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2341`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `button.tsx`
+- **Thin community `Community 2342`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `card.tsx`
+- **Thin community `Community 2343`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2344`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `command.tsx`
+- **Thin community `Community 2345`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2346`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2347`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2348`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `form.tsx`
+- **Thin community `Community 2349`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2350`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2351`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2351`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2352`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2353`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `input.tsx`
+- **Thin community `Community 2354`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `label.tsx`
+- **Thin community `Community 2355`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2356`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2357`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2358`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `index.ts`
+- **Thin community `Community 2359`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `types.ts`
+- **Thin community `Community 2360`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2361`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2362`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2362`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2363`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2364`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `select.tsx`
+- **Thin community `Community 2365`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2366`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2367`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `table.tsx`
+- **Thin community `Community 2368`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2369`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2370`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2371`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2372`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2373`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `config.ts`
+- **Thin community `Community 2374`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2375`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2376`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2377`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2378`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2379`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `constants.ts`
+- **Thin community `Community 2380`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `countries.ts`
+- **Thin community `Community 2381`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2382`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2383`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2384`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2385`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `index.ts`
+- **Thin community `Community 2386`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2387`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `store.ts`
+- **Thin community `Community 2388`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `bag.ts`
+- **Thin community `Community 2389`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2390`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `category.ts`
+- **Thin community `Community 2391`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `organization.ts`
+- **Thin community `Community 2392`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `product.ts`
+- **Thin community `Community 2393`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `store.ts`
+- **Thin community `Community 2394`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2395`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `user.ts`
+- **Thin community `Community 2396`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `states.ts`
+- **Thin community `Community 2397`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2398`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2399`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2400`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2401`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2402`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2403`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2404`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2405`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `index.tsx`
+- **Thin community `Community 2406`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2407`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2408`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2409`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2410`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2411`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2412`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2413`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `index.tsx`
+- **Thin community `Community 2414`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2415`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2416`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2417`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2418`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2419`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `index.js`
+- **Thin community `Community 2420`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2421`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2422`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2423`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2424`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2425`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2426`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2427`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2428`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2429`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -15281,9 +15291,9 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.03 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+- **Should `Community 2` be split into smaller, more focused modules?**
+  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,14 +7,14 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2501
-- Graph nodes: 10158
-- Graph edges: 12385
-- Communities: 2428
+- Code files discovered: 2503
+- Graph nodes: 10170
+- Graph edges: 12399
+- Communities: 2430
 
 ## Graph Hotspots
-- `dailyClose.ts` (87 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `harness-inferential-review.ts` (86 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `harness-inferential-review.ts` (88 edges, Community 1) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `dailyClose.ts` (87 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `posLocalStore.ts` (84 edges, Community 0) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 3) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (75 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `dailyClose.ts` (87 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
+- `dailyClose.ts` (87 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `posLocalStore.ts` (84 edges, Community 0) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 3) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (75 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "pr:athena": "bun run pr:athena:delivery-run",
     "pr:athena:delivery-run": "bun scripts/pr-athena-delivery-run.ts",
     "pr:athena:prepare": "bun run dependency:check && bun run pre-commit:generated-artifacts && bun scripts/pre-push-validation-proof.ts prepare-pr-athena",
+    "pr:athena:preflight": "bun scripts/harness-contract-preflight.ts",
     "pr:athena:validate": "bun run pr:athena:validate-provider && bun scripts/pr-athena-delivery-run.ts write-provider-evidence && bun run pr:athena:validate-review",
     "pr:athena:validate-provider": "bun run compound:check && bun run landed-report:check && bun run workflow:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' lint:frontend:changed && bun run architecture:check && bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json && bun run test:coverage",
     "pr:athena:validate-review": "bun run harness:review --base origin/main --repo-validation-provided-by pr:athena --provider-evidence artifacts/harness-delivery-runs/provider-evidence.json && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",

--- a/scripts/harness-contract-preflight.test.ts
+++ b/scripts/harness-contract-preflight.test.ts
@@ -207,6 +207,7 @@ describe("runHarnessContractPreflight", () => {
 
   it("passes through every default adapter on the current consistent tree", async () => {
     const result = await runHarnessContractPreflight(process.cwd(), {
+      baseRef: "HEAD",
       writeMachineOutput: false,
     });
 

--- a/scripts/harness-contract-preflight.test.ts
+++ b/scripts/harness-contract-preflight.test.ts
@@ -1,0 +1,292 @@
+import { spawnSync } from "node:child_process";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  runFocusedContractTests,
+  runHarnessContractPreflight,
+} from "./harness-contract-preflight";
+import { collectHarnessSiblingTestPolicyFindings } from "./harness-inferential-review";
+import { runHarnessSelfReview } from "./harness-self-review";
+
+function runGit(rootDir: string, args: string[]) {
+  const result = spawnSync("git", args, {
+    cwd: rootDir,
+    encoding: "utf8",
+    env: Object.fromEntries(
+      Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")),
+    ),
+  });
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `git ${args.join(" ")} failed`);
+  }
+}
+
+async function createSiblingPolicyFixture() {
+  const rootDir = await mkdtemp(
+    path.join(tmpdir(), "athena-harness-sibling-policy-"),
+  );
+  await mkdir(path.join(rootDir, "scripts"), { recursive: true });
+  await writeFile(
+    path.join(rootDir, "scripts/harness-app-registry.ts"),
+    "export const registry = ['baseline'];\n",
+  );
+  await writeFile(
+    path.join(rootDir, "scripts/harness-app-registry.test.ts"),
+    "export const registryTest = true;\n",
+  );
+  runGit(rootDir, ["init"]);
+  runGit(rootDir, ["config", "user.email", "codex@example.com"]);
+  runGit(rootDir, ["config", "user.name", "Codex Test"]);
+  runGit(rootDir, ["add", "."]);
+  runGit(rootDir, ["commit", "-m", "baseline"]);
+  runGit(rootDir, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+  await writeFile(
+    path.join(rootDir, "scripts/harness-app-registry.ts"),
+    "export const registry = ['baseline', 'new-surface'];\n",
+  );
+  return rootDir;
+}
+
+async function createRealAuditFixtureDrift() {
+  const rootDir = await mkdtemp(
+    path.join(tmpdir(), "athena-harness-audit-contract-"),
+  );
+  await cp(path.join(process.cwd(), "scripts"), path.join(rootDir, "scripts"), {
+    recursive: true,
+  });
+  await mkdir(path.join(rootDir, "packages/athena-webapp/scripts"), {
+    recursive: true,
+  });
+  await cp(
+    path.join(
+      process.cwd(),
+      "packages/athena-webapp/scripts/convex-lint-changed.sh",
+    ),
+    path.join(
+      rootDir,
+      "packages/athena-webapp/scripts/convex-lint-changed.sh",
+    ),
+  );
+  await symlink(path.join(process.cwd(), "node_modules"), path.join(rootDir, "node_modules"));
+
+  const registryPath = path.join(rootDir, "scripts/harness-app-registry.ts");
+  const baselineRegistry = await readFile(registryPath, "utf8");
+  const driftedRegistry = baselineRegistry.replace(
+    '          "src/assets",',
+    [
+      '          "src/assets",',
+      '          "docs/shared-demo-backend-coverage.md",',
+    ].join("\n"),
+  );
+  if (driftedRegistry === baselineRegistry) {
+    throw new Error("Unable to seed real harness audit fixture drift.");
+  }
+  await writeFile(registryPath, driftedRegistry);
+
+  return { rootDir, registryPath, baselineRegistry };
+}
+
+describe("runHarnessContractPreflight", () => {
+  it("aggregates mapping, audit fixture, and sibling-test findings in one run", async () => {
+    const result = await runHarnessContractPreflight("/repo", {
+      runSelfReview: async () => ({
+        blockers: [
+          "Harness review coverage gap: packages/athena-webapp/docs/shared-demo-backend-coverage.md is not covered by any validation mapping.",
+        ],
+      }),
+      runAudit: async () => undefined,
+      runContractTests: async () => {
+        throw new Error(
+          'Fixture drift: add "packages/athena-webapp/docs/shared-demo-backend-coverage.md" to the harness audit fixture.',
+        );
+      },
+      runSiblingTestPolicy: async () => [
+        {
+          id: "missing-harness-script-test-update-scripts-harness-app-registry-ts",
+          title: "Harness script changed without test update",
+          filePath: "scripts/harness-app-registry.ts",
+          rationale:
+            "The sibling test scripts/harness-app-registry.test.ts was not part of the same change.",
+          remediation:
+            "Update scripts/harness-app-registry.test.ts alongside the registry change.",
+        },
+      ],
+      writeMachineOutput: false,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings.map((finding) => finding.source)).toEqual([
+      "validation-map",
+      "contract-fixtures",
+      "sibling-test-policy",
+    ]);
+    expect(result.humanReport).toContain("scripts/harness-app-registry.ts");
+    expect(result.humanReport).toContain("scripts/harness-app-registry.test.ts");
+    expect(result.humanReport).toContain("scripts/harness-audit.test.ts");
+    expect(result.humanReport).toContain("bun run harness:generate");
+    expect(result.humanReport).toContain(
+      "bun test scripts/harness-contract-preflight.test.ts scripts/harness-review.test.ts scripts/harness-audit.test.ts scripts/harness-app-registry.test.ts scripts/harness-inferential-review.test.ts",
+    );
+  });
+
+  it("passes when every static harness contract is consistent", async () => {
+    const result = await runHarnessContractPreflight("/repo", {
+      runSelfReview: async () => ({ blockers: [] }),
+      runAudit: async () => undefined,
+      runContractTests: async () => undefined,
+      runSiblingTestPolicy: async () => [],
+      writeMachineOutput: false,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
+  });
+
+  it("fails closed when sibling-test policy evidence cannot be produced", async () => {
+    const result = await runHarnessContractPreflight("/repo", {
+      runSelfReview: async () => ({ blockers: [] }),
+      runAudit: async () => undefined,
+      runContractTests: async () => undefined,
+      runSiblingTestPolicy: async () => {
+        throw new Error(
+          "Base ref evidence is unavailable. Fetch origin/main and retry.",
+        );
+      },
+      writeMachineOutput: false,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.machine.findings).toEqual([
+      {
+        source: "sibling-test-policy",
+        message:
+          "Base ref evidence is unavailable. Fetch origin/main and retry.",
+      },
+    ]);
+  });
+
+  it("uses the real git diff to detect and clear sibling-test drift", async () => {
+    const rootDir = await createSiblingPolicyFixture();
+
+    try {
+      await expect(
+        collectHarnessSiblingTestPolicyFindings(rootDir),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          id: "missing-harness-script-test-update-scripts-harness-app-registry-ts",
+          filePath: "scripts/harness-app-registry.ts",
+        }),
+      ]);
+
+      await writeFile(
+        path.join(rootDir, "scripts/harness-app-registry.test.ts"),
+        "export const registryTest = 'new-surface';\n",
+      );
+
+      await expect(
+        collectHarnessSiblingTestPolicyFindings(rootDir),
+      ).resolves.toEqual([]);
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passes through every default adapter on the current consistent tree", async () => {
+    const result = await runHarnessContractPreflight(process.cwd(), {
+      writeMachineOutput: false,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.findings).toEqual([]);
+  });
+
+  it("surfaces and clears real harness-audit fixture drift", async () => {
+    const { rootDir, registryPath, baselineRegistry } =
+      await createRealAuditFixtureDrift();
+
+    try {
+      await expect(runFocusedContractTests(rootDir)).rejects.toThrow(
+        /Focused harness contract tests exited with code 1/,
+      );
+
+      await writeFile(registryPath, baselineRegistry);
+      await expect(runFocusedContractTests(rootDir)).resolves.toBeUndefined();
+    } finally {
+      await rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("aggregates three real contract failures, then passes after all are repaired", async () => {
+    const siblingRoot = await createSiblingPolicyFixture();
+    const auditFixture = await createRealAuditFixtureDrift();
+
+    try {
+      const runComposedPreflight = (mapped: boolean) =>
+        runHarnessContractPreflight(process.cwd(), {
+          runSelfReview: async () =>
+            runHarnessSelfReview(process.cwd(), {
+              baseRef: "origin/main",
+              getChangedFiles: async () => ({
+                baseFiles: [
+                  mapped
+                    ? "packages/athena-webapp/src/routes/index.tsx"
+                    : "packages/athena-webapp/unmapped-contract.ts",
+                ],
+                trackedFiles: [],
+                untrackedFiles: [],
+              }),
+              runHarnessCheck: async () => undefined,
+            }),
+          runAudit: async () => undefined,
+          runContractTests: async () =>
+            runFocusedContractTests(auditFixture.rootDir),
+          runSiblingTestPolicy: async () =>
+            collectHarnessSiblingTestPolicyFindings(siblingRoot),
+          writeMachineOutput: false,
+        });
+
+      const failed = await runComposedPreflight(false);
+      expect(failed.exitCode).toBe(1);
+      expect(failed.machine.findings.map((finding) => finding.source)).toEqual([
+        "validation-map",
+        "contract-fixtures",
+        "sibling-test-policy",
+      ]);
+      expect(failed.humanReport).toContain("unmapped-contract.ts");
+      expect(failed.humanReport).toContain("Focused harness contract tests exited");
+      expect(failed.humanReport).toContain("harness-app-registry.test.ts");
+
+      await writeFile(
+        auditFixture.registryPath,
+        auditFixture.baselineRegistry,
+      );
+      await writeFile(
+        path.join(siblingRoot, "scripts/harness-app-registry.test.ts"),
+        "export const registryTest = 'new-surface';\n",
+      );
+
+      const repaired = await runComposedPreflight(true);
+      expect(repaired.exitCode).toBe(0);
+      expect(repaired.machine.findings).toEqual([]);
+    } finally {
+      await Promise.all([
+        rm(siblingRoot, { recursive: true, force: true }),
+        rm(auditFixture.rootDir, { recursive: true, force: true }),
+      ]);
+    }
+  });
+});

--- a/scripts/harness-contract-preflight.ts
+++ b/scripts/harness-contract-preflight.ts
@@ -1,0 +1,214 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { runHarnessAudit } from "./harness-audit";
+import { runHarnessSelfReview } from "./harness-self-review";
+
+const DEFAULT_MACHINE_OUTPUT_PATH =
+  "artifacts/harness-contract-preflight/latest.json";
+const SIBLING_TEST_FINDING_PREFIX = "missing-harness-script-test-update-";
+
+type HarnessContractFindingSource =
+  | "validation-map"
+  | "harness-audit"
+  | "contract-fixtures"
+  | "sibling-test-policy";
+
+type HarnessContractFinding = {
+  source: HarnessContractFindingSource;
+  message: string;
+};
+
+type HarnessContractPreflightMachine = {
+  version: "1.0";
+  generatedAt: string;
+  status: "pass" | "fail";
+  findings: HarnessContractFinding[];
+};
+
+type HarnessContractPreflightOptions = {
+  nowIso?: () => string;
+  runSelfReview?: (rootDir: string) => Promise<{ blockers: string[] }>;
+  runAudit?: (rootDir: string) => Promise<void>;
+  runContractTests?: (rootDir: string) => Promise<void>;
+  runSiblingTestPolicy?: (rootDir: string) => Promise<
+    Array<{
+      id: string;
+      title: string;
+      filePath: string;
+      rationale: string;
+      remediation: string;
+    }>
+  >;
+  machineOutputPath?: string;
+  writeMachineOutput?: boolean;
+};
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function runFocusedContractTests(rootDir: string) {
+  const command = [
+    "bun",
+    "test",
+    "scripts/harness-audit.test.ts",
+    "scripts/harness-app-registry.test.ts",
+  ];
+  const process = Bun.spawn(command, {
+    cwd: rootDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "inherit",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(
+      [
+        `Focused harness contract tests exited with code ${exitCode}.`,
+        stdout.trim(),
+        stderr.trim(),
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+}
+
+function formatHumanReport(machine: HarnessContractPreflightMachine) {
+  if (machine.status === "pass") {
+    return "Harness contract preflight passed.";
+  }
+
+  const lines = [
+    `Harness contract preflight failed with ${machine.findings.length} finding(s).`,
+    "",
+  ];
+
+  for (const finding of machine.findings) {
+    lines.push(`[${finding.source}] ${finding.message}`);
+  }
+
+  lines.push(
+    "",
+    "Repair contract:",
+    "- Source of truth: scripts/harness-app-registry.ts",
+    "- Regenerate derived harness docs: bun run harness:generate",
+    "- Update the registry sibling test: scripts/harness-app-registry.test.ts",
+    "- Keep audit fixture paths current: scripts/harness-audit.test.ts",
+    "- Focused verification: bun test scripts/harness-contract-preflight.test.ts scripts/harness-review.test.ts scripts/harness-audit.test.ts scripts/harness-app-registry.test.ts scripts/harness-inferential-review.test.ts",
+  );
+
+  return lines.join("\n");
+}
+
+export async function runHarnessContractPreflight(
+  rootDir: string,
+  options: HarnessContractPreflightOptions = {},
+) {
+  const findings: HarnessContractFinding[] = [];
+  const runSelfReview =
+    options.runSelfReview ??
+    ((nextRootDir) =>
+      runHarnessSelfReview(nextRootDir, { baseRef: "origin/main" }));
+  const runAudit = options.runAudit ?? runHarnessAudit;
+  const runContractTests =
+    options.runContractTests ?? runFocusedContractTests;
+  const runSiblingTestPolicy =
+    options.runSiblingTestPolicy ??
+    (async (nextRootDir) => {
+      const { collectHarnessSiblingTestPolicyFindings } = await import(
+        "./harness-inferential-review"
+      );
+      return collectHarnessSiblingTestPolicyFindings(nextRootDir);
+    });
+
+  const [
+    selfReviewResult,
+    auditResult,
+    contractTestsResult,
+    inferentialResult,
+  ] =
+    await Promise.allSettled([
+      runSelfReview(rootDir),
+      runAudit(rootDir),
+      runContractTests(rootDir),
+      runSiblingTestPolicy(rootDir),
+    ]);
+
+  if (selfReviewResult.status === "fulfilled") {
+    for (const blocker of selfReviewResult.value.blockers) {
+      findings.push({ source: "validation-map", message: blocker });
+    }
+  } else {
+    findings.push({
+      source: "validation-map",
+      message: errorMessage(selfReviewResult.reason),
+    });
+  }
+
+  if (auditResult.status === "rejected") {
+    findings.push({
+      source: "harness-audit",
+      message: errorMessage(auditResult.reason),
+    });
+  }
+
+  if (contractTestsResult.status === "rejected") {
+    findings.push({
+      source: "contract-fixtures",
+      message: errorMessage(contractTestsResult.reason),
+    });
+  }
+
+  if (inferentialResult.status === "fulfilled") {
+    for (const finding of inferentialResult.value.filter((entry) =>
+      entry.id.startsWith(SIBLING_TEST_FINDING_PREFIX),
+    )) {
+      findings.push({
+        source: "sibling-test-policy",
+        message: `${finding.title} (${finding.filePath}): ${finding.rationale} ${finding.remediation}`,
+      });
+    }
+  } else {
+    findings.push({
+      source: "sibling-test-policy",
+      message: errorMessage(inferentialResult.reason),
+    });
+  }
+
+  const machine: HarnessContractPreflightMachine = {
+    version: "1.0",
+    generatedAt: (options.nowIso ?? (() => new Date().toISOString()))(),
+    status: findings.length === 0 ? "pass" : "fail",
+    findings,
+  };
+  const humanReport = formatHumanReport(machine);
+
+  if (options.writeMachineOutput ?? true) {
+    const outputPath = path.join(
+      rootDir,
+      options.machineOutputPath ?? DEFAULT_MACHINE_OUTPUT_PATH,
+    );
+    await mkdir(path.dirname(outputPath), { recursive: true });
+    await Bun.write(outputPath, `${JSON.stringify(machine, null, 2)}\n`);
+  }
+
+  return {
+    exitCode: machine.status === "pass" ? (0 as const) : (1 as const),
+    humanReport,
+    machine,
+  };
+}
+
+if (import.meta.main) {
+  const result = await runHarnessContractPreflight(process.cwd());
+  const logger = result.exitCode === 0 ? console.log : console.error;
+  logger(result.humanReport);
+  process.exit(result.exitCode);
+}

--- a/scripts/harness-contract-preflight.ts
+++ b/scripts/harness-contract-preflight.ts
@@ -27,6 +27,7 @@ type HarnessContractPreflightMachine = {
 };
 
 type HarnessContractPreflightOptions = {
+  baseRef?: string;
   nowIso?: () => string;
   runSelfReview?: (rootDir: string) => Promise<{ blockers: string[] }>;
   runAudit?: (rootDir: string) => Promise<void>;
@@ -112,10 +113,11 @@ export async function runHarnessContractPreflight(
   options: HarnessContractPreflightOptions = {},
 ) {
   const findings: HarnessContractFinding[] = [];
+  const baseRef = options.baseRef ?? "origin/main";
   const runSelfReview =
     options.runSelfReview ??
     ((nextRootDir) =>
-      runHarnessSelfReview(nextRootDir, { baseRef: "origin/main" }));
+      runHarnessSelfReview(nextRootDir, { baseRef }));
   const runAudit = options.runAudit ?? runHarnessAudit;
   const runContractTests =
     options.runContractTests ?? runFocusedContractTests;
@@ -125,7 +127,7 @@ export async function runHarnessContractPreflight(
       const { collectHarnessSiblingTestPolicyFindings } = await import(
         "./harness-inferential-review"
       );
-      return collectHarnessSiblingTestPolicyFindings(nextRootDir);
+      return collectHarnessSiblingTestPolicyFindings(nextRootDir, { baseRef });
     });
 
   const [

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  formatInferentialFailureDiagnostic,
   parseHarnessInferentialReviewArgs,
   runHarnessInferentialReview,
 } from "./harness-inferential-review";
@@ -208,6 +209,26 @@ describe("runHarnessInferentialReview", () => {
       filePath: "package.json",
     });
     expect(result.humanReport).toContain("Remediation:");
+    expect(
+      formatInferentialFailureDiagnostic(
+        result.machine,
+        result.machineOutputPath,
+      ),
+    ).toContain(
+      "[harness:inferential-review] BLOCKED: 1 finding(s), 0 runtime error(s).",
+    );
+    expect(
+      formatInferentialFailureDiagnostic(
+        result.machine,
+        result.machineOutputPath,
+      ),
+    ).toContain("Fix:");
+    expect(
+      formatInferentialFailureDiagnostic(
+        result.machine,
+        result.machineOutputPath,
+      ),
+    ).toContain("Machine details: artifacts/harness-inferential-review/latest.json");
   });
 
   it("fails when pr:athena omits harness review", async () => {
@@ -371,8 +392,9 @@ describe("runHarnessInferentialReview", () => {
         {
           scripts: {
             "pr:athena":
-              "bun run pr:athena:prepare && bun run pr:athena:validate && bun run pr:athena:record-proof",
+              "bun run pr:athena:prepare && bun run pr:athena:preflight && bun run pr:athena:validate && bun run pr:athena:record-proof",
             "pr:athena:prepare": "bun run pre-commit:generated-artifacts",
+            "pr:athena:preflight": "bun scripts/harness-contract-preflight.ts",
             "pr:athena:validate":
               "bun run harness:check && bun run harness:review --base origin/main --repo-validation-provided-by pr:athena && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",
             "pr:athena:record-proof":
@@ -405,6 +427,7 @@ describe("runHarnessInferentialReview", () => {
             "pr:athena": "bun run pr:athena:delivery-run",
             "pr:athena:delivery-run": "bun scripts/pr-athena-delivery-run.ts",
             "pr:athena:prepare": "bun run pre-commit:generated-artifacts",
+            "pr:athena:preflight": "bun scripts/harness-contract-preflight.ts",
             "pr:athena:validate":
               "bun run pr:athena:validate-provider && bun scripts/pr-athena-delivery-run.ts write-provider-evidence && bun run pr:athena:validate-review",
             "pr:athena:validate-provider": "bun run test:coverage",
@@ -821,6 +844,20 @@ describe("runHarnessInferentialReview", () => {
     expect(result.humanReport).toContain(
       "Confirm provider configuration and connectivity",
     );
+    expect(
+      formatInferentialFailureDiagnostic(
+        result.machine,
+        result.machineOutputPath,
+      ),
+    ).toContain(
+      "[harness:inferential-review] BLOCKED: 0 finding(s), 1 runtime error(s).",
+    );
+    expect(
+      formatInferentialFailureDiagnostic(
+        result.machine,
+        result.machineOutputPath,
+      ),
+    ).toContain("provider timeout");
   });
 
   it("records semantic shadow errors without making the command blocking", async () => {

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -380,6 +380,7 @@ function expandPackageScriptChain(
     childScripts.push(
       ...[
         "pr:athena:prepare",
+        "pr:athena:preflight",
         "pr:athena:validate",
         "pr:athena:record-proof",
         "pr:athena:scorecard",
@@ -535,6 +536,24 @@ async function collectHarnessScriptTestUpdateFindings(
   }
 
   return findings;
+}
+
+export async function collectHarnessSiblingTestPolicyFindings(
+  rootDir: string,
+  options: {
+    baseRef?: string;
+    getChangedFiles?: (
+      rootDir: string,
+      baseRef: string,
+    ) => Promise<string[]>;
+  } = {},
+) {
+  const baseRef = options.baseRef ?? DEFAULT_BASE_REF;
+  const changedFiles = await (
+    options.getChangedFiles ?? getChangedFilesForInferentialReview
+  )(rootDir, baseRef);
+
+  return collectHarnessScriptTestUpdateFindings(rootDir, changedFiles);
 }
 
 async function collectHarnessSafetySignalFindings(
@@ -2226,6 +2245,33 @@ function buildHumanReport(output: InferentialMachineOutput) {
   return lines.join("\n");
 }
 
+export function formatInferentialFailureDiagnostic(
+  output: InferentialMachineOutput,
+  machineOutputPath: string,
+) {
+  const lines = [
+    `[harness:inferential-review] BLOCKED: ${output.findings.length} finding(s), ${output.errors.length} runtime error(s).`,
+  ];
+
+  for (const finding of output.findings) {
+    lines.push(
+      `- [${finding.severity.toUpperCase()}] ${finding.filePath}: ${finding.title}`,
+      `  Why: ${finding.rationale}`,
+      `  Fix: ${finding.remediation}`,
+    );
+  }
+
+  for (const error of output.errors) {
+    lines.push(
+      `- [ERROR] ${error.code}: ${error.message}`,
+      `  Fix: ${error.remediation}`,
+    );
+  }
+
+  lines.push(`Machine details: ${machineOutputPath}`);
+  return lines.join("\n");
+}
+
 async function writeMachineOutput(
   rootDir: string,
   machineOutputPath: string,
@@ -2692,6 +2738,12 @@ if (import.meta.main) {
     console.log(`Machine output: ${result.machineOutputPath}`);
 
     if (result.exitCode !== 0) {
+      console.error(
+        formatInferentialFailureDiagnostic(
+          result.machine,
+          result.machineOutputPath,
+        ),
+      );
       process.exit(result.exitCode);
     }
   } catch (error) {

--- a/scripts/pr-athena-delivery-run.test.ts
+++ b/scripts/pr-athena-delivery-run.test.ts
@@ -32,7 +32,7 @@ function gitFixtureEnv() {
 }
 
 describe("pr-athena delivery run wrapper", () => {
-  it("runs prepare, validate, and record-proof phases while recording spans", async () => {
+  it("runs prepare, static preflight, validate, and record-proof phases while recording spans", async () => {
     const commands: string[][] = [];
     let tick = 0;
 
@@ -49,6 +49,7 @@ describe("pr-athena delivery run wrapper", () => {
     expect(result.exitCode).toBe(0);
     expect(commands).toEqual([
       ["bun", "run", "pr:athena:prepare"],
+      ["bun", "run", "pr:athena:preflight"],
       ["bun", "run", "pr:athena:validate"],
       ["bun", "run", "pr:athena:record-proof"],
       ["bun", "run", "pr:athena:scorecard"],
@@ -57,15 +58,47 @@ describe("pr-athena delivery run wrapper", () => {
       status: "pass",
       proofState: "proof_recorded",
       summary: {
-        commandCount: 4,
+        commandCount: 5,
         failedCommandCount: 0,
       },
       commandSpans: [
         { phase: "prepare", status: "pass", exitCode: 0 },
+        { phase: "preflight", status: "pass", exitCode: 0 },
         { phase: "validate", status: "pass", exitCode: 0 },
         { phase: "record-proof", status: "pass", exitCode: 0 },
         { phase: "scorecard", status: "pass", exitCode: 0 },
       ],
+    });
+  });
+
+  it("records a preflight failure before provider validation or proof recording", async () => {
+    const commands: string[][] = [];
+    let tick = 0;
+
+    const result = await runPrAthenaDeliveryRun("/repo", {
+      nowIso: () => `2026-06-18T12:00:0${tick}.000Z`,
+      monotonicMs: () => tick++ * 1000,
+      writeLedger: false,
+      runCommand: async (command) => {
+        commands.push(command);
+        return { exitCode: command.includes("pr:athena:preflight") ? 23 : 0 };
+      },
+    });
+
+    expect(result.exitCode).toBe(23);
+    expect(commands).toEqual([
+      ["bun", "run", "pr:athena:prepare"],
+      ["bun", "run", "pr:athena:preflight"],
+    ]);
+    expect(result.ledger).toMatchObject({
+      status: "blocked",
+      proofState: "proof_not_recorded",
+      blockedReason: "pr:athena:preflight exited with code 23",
+      commandSpans: [
+        { phase: "prepare", status: "pass", exitCode: 0 },
+        { phase: "preflight", status: "fail", exitCode: 23 },
+      ],
+      providerSkippedEvents: [],
     });
   });
 
@@ -142,6 +175,7 @@ describe("pr-athena delivery run wrapper", () => {
     expect(result.exitCode).toBe(42);
     expect(commands).toEqual([
       ["bun", "run", "pr:athena:prepare"],
+      ["bun", "run", "pr:athena:preflight"],
       ["bun", "run", "pr:athena:validate"],
     ]);
     expect(result.ledger).toMatchObject({
@@ -150,6 +184,7 @@ describe("pr-athena delivery run wrapper", () => {
       blockedReason: "pr:athena:validate exited with code 42",
       commandSpans: [
         { phase: "prepare", status: "pass", exitCode: 0 },
+        { phase: "preflight", status: "pass", exitCode: 0 },
         { phase: "validate", status: "fail", exitCode: 42 },
       ],
     });
@@ -172,6 +207,7 @@ describe("pr-athena delivery run wrapper", () => {
     expect(result.exitCode).toBe(1);
     expect(commands).toEqual([
       ["bun", "run", "pr:athena:prepare"],
+      ["bun", "run", "pr:athena:preflight"],
       ["bun", "run", "pr:athena:validate"],
       ["bun", "run", "pr:athena:record-proof"],
     ]);
@@ -181,6 +217,7 @@ describe("pr-athena delivery run wrapper", () => {
       blockedReason: "pr:athena:record-proof exited with code 1",
       commandSpans: [
         { phase: "prepare", status: "pass", exitCode: 0 },
+        { phase: "preflight", status: "pass", exitCode: 0 },
         { phase: "validate", status: "pass", exitCode: 0 },
         { phase: "record-proof", status: "fail", exitCode: 1 },
       ],
@@ -235,7 +272,7 @@ describe("pr-athena delivery run wrapper", () => {
       expect(latest).toMatchObject({
         status: "pass",
         proofState: "proof_recorded",
-        summary: { commandCount: 4 },
+        summary: { commandCount: 5 },
       });
     } finally {
       await rm(rootDir, { recursive: true, force: true });
@@ -320,6 +357,7 @@ describe("pr-athena delivery run wrapper", () => {
         blockedReason: "pr:athena:scorecard exited with code 7",
         commandSpans: [
           { phase: "prepare", status: "pass", exitCode: 0 },
+          { phase: "preflight", status: "pass", exitCode: 0 },
           { phase: "validate", status: "pass", exitCode: 0 },
           { phase: "record-proof", status: "pass", exitCode: 0 },
           { phase: "scorecard", status: "fail", exitCode: 7 },

--- a/scripts/pr-athena-delivery-run.ts
+++ b/scripts/pr-athena-delivery-run.ts
@@ -30,12 +30,13 @@ type PrAthenaDeliveryRunOptions = {
 };
 
 type PrAthenaPhase = {
-  phase: "prepare" | "validate" | "record-proof" | "scorecard";
+  phase: "prepare" | "preflight" | "validate" | "record-proof" | "scorecard";
   command: string[];
 };
 
 const PR_ATHENA_PHASES: PrAthenaPhase[] = [
   { phase: "prepare", command: ["bun", "run", "pr:athena:prepare"] },
+  { phase: "preflight", command: ["bun", "run", "pr:athena:preflight"] },
   { phase: "validate", command: ["bun", "run", "pr:athena:validate"] },
   { phase: "record-proof", command: ["bun", "run", "pr:athena:record-proof"] },
 ];

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -959,6 +959,9 @@ describe("repo harness ergonomics", () => {
     expect(packageJson.scripts?.["pr:athena:prepare"]).toContain(
       "bun scripts/pre-push-validation-proof.ts prepare-pr-athena",
     );
+    expect(packageJson.scripts?.["pr:athena:preflight"]).toBe(
+      "bun scripts/harness-contract-preflight.ts",
+    );
     expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
       "bun run pr:athena:validate-provider && bun scripts/pr-athena-delivery-run.ts write-provider-evidence && bun run pr:athena:validate-review",
     );


### PR DESCRIPTION
## Summary
- add a static harness-contract preflight between generated-artifact preparation and provider validation
- aggregate validation-map coverage, live audit, real audit/registry fixture tests, and sibling-test policy findings in one repair report
- surface concise terminal-first diagnostics for blocking `harness:inferential-review` findings and runtime errors
- record the preflight as its own delivery-run ledger span so failures prove provider validation and proof recording never started

## Why
A single harness registry change could previously require several full `pr:athena` runs: provider validation ran first, then later checks revealed a mapping gap, stale audit fixtures, and finally a missing sibling test. Cheap deterministic contract checks should report that entire failure class before the expensive provider suite.

## Validation
- `bun test scripts/harness-contract-preflight.test.ts scripts/pr-athena-delivery-run.test.ts scripts/harness-review.test.ts scripts/harness-audit.test.ts scripts/harness-app-registry.test.ts scripts/harness-inferential-review.test.ts scripts/pre-push-review.test.ts` (208 passed)
- real three-way detector fixture: mapping gap + audit-fixture drift + sibling-test drift, followed by repaired pass
- unanimous internal review: correctness, testing, standards
- `bun run pr:athena` (full gate passed; 499 root harness tests passed; proof recorded)
- `bun run graphify:check`
- `bun run compound:check`
- `git diff --check`

https://linear.app/v26-labs/issue/V26-1040/make-prathena-fail-fast-on-harness-contract-drift
