### PR TITLE
[V26-1040]: Include delivery artifacts before merge

### DIFF
--- a/.agents/skills/ce-landed-change-report/SKILL.md
+++ b/.agents/skills/ce-landed-change-report/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ce-landed-change-report
-description: Create a digestible standalone HTML report for a landed change, merged PR, release, or completed Linear issue, with mandatory subagent-gathered context from prior sessions and delivered code changes plus an interactive comprehension quiz. Use when the user asks for an HTML report, explainer, digest, walkthrough, learning artifact, comprehension quiz, or post-merge understanding aid for work that has landed or is ready to explain.
+description: Create a digestible standalone HTML report for a delivery candidate or landed change, with mandatory subagent-gathered context from prior sessions and delivered code changes plus an interactive comprehension quiz. Use when the user asks for an HTML report, explainer, digest, walkthrough, learning artifact, comprehension quiz, or delivery understanding aid for work that is ready to review or has landed.
 ---
 
 # Landed Change Report
 
-Create a reader-friendly HTML report that explains a landed change with context, intuition, code-level mechanics, validation evidence, and a quiz the reader must pass.
+Create a reader-friendly HTML report that explains a delivery candidate or landed change with context, intuition, code-level mechanics, validation evidence, and a quiz the reader must pass. The normal execute-workflow mode is a delivery candidate: generate and commit the report before merge, then leave it unchanged after merge.
 
 This skill is intentionally subagent-driven. Do not create the report from only the current conversation unless subagents are unavailable in the host environment.
 
@@ -27,14 +27,14 @@ Run that command after final code/workflow edits and before final report renderi
 
 The report must include:
 
-- title, merge/PR/issue metadata, and status pills
+- title, PR/issue/source metadata, candidate-or-landed status, and status pills
 - executive summary
 - problem/context in plain language
 - intuition or mental model
 - before/after flow or layer breakdown
 - key file table with why each file matters
 - what changed and what intentionally did not change
-- validation, review, and deployment/root-alignment evidence
+- validation and review evidence, plus accurate deployment/root-alignment status (`pending`, `deferred`, `not applicable`, or completed evidence)
 - next-time workflow or operational guidance
 - interactive quiz with grade/reset behavior, answer explanations, and a pass threshold
 - subagent evidence summary naming the subagents used and what each contributed
@@ -67,7 +67,7 @@ Use `references/subagent-prompts.md` for prompt templates.
 
 ## Workflow
 
-### 1. Resolve The Landed Change
+### 1. Resolve The Change And Status Mode
 
 Accept any of:
 
@@ -75,21 +75,26 @@ Accept any of:
 - merge commit SHA
 - Linear issue id
 - branch name
-- plain-language description of the landed work
+- plain-language description of the delivery candidate or landed work
 
-Resolve to the most concrete artifact available, preferring a merged PR or merge commit. Capture:
+Resolve to the most concrete artifact available. When invoked from `$execute`, prefer the open delivery PR and its candidate head so the report can be included in that same PR before merge. Use landed mode only when the source was already merged before this reporting workflow began. Capture:
 
-- PR title, URL, body, state, merge SHA, and merged time
+- status mode: `delivery candidate` or `landed`
+- PR title, URL, body, state, candidate head SHA, and base SHA
+- merge SHA and merged time only in landed mode
 - commit range and changed files
 - Linear parent and child issues when available
 - validation/check status
-- deploy or no-deploy finish line
-- root-alignment state when relevant
+- deploy status: pending, deferred, not applicable, or completed evidence
+- root-alignment status: pending, deferred, not applicable, or completed evidence
+
+In delivery-candidate mode, do not claim merged, deployed, Linear `Done`, or root-aligned. Label those events as pending, deferred, or not applicable. Do not refresh the report after merge merely to replace candidate metadata; the final chat handoff carries the merge SHA and post-merge root/deploy result.
 
 Useful commands:
 
 ```bash
 gh pr view <pr> --json url,title,body,state,mergedAt,mergeCommit,statusCheckRollup
+gh pr view <pr> --json url,title,body,state,headRefOid,baseRefOid,statusCheckRollup
 git show --stat --numstat --name-only <merge-sha>
 git show --format=fuller --no-ext-diff <merge-sha> -- <important files>
 git status --short --branch
@@ -131,7 +136,7 @@ The report should teach the reader how to think about the change, not just list 
 
 Use this narrative order:
 
-1. **What happened**: merged PR, issue, commit, deployment/root state.
+1. **What is being delivered**: candidate PR/head and pending finish line, or merged PR/commit and completed finish line in landed mode.
 2. **Why it mattered**: operator/customer/system risk or product need.
 3. **The mental model**: a simple analogy, flow, table, or layer map.
 4. **Before vs after**: what was duplicated, broken, unclear, or missing before; what is now authoritative.
@@ -217,8 +222,8 @@ Check manually:
 - every major claim traces back to git, PR, Linear, local files, or subagent evidence
 - no secrets are present
 - quiz pass threshold is visible and enforced in JavaScript
-- report states whether production deploy occurred
-- report states whether root/local alignment occurred when relevant
+- report states the accurate production-deploy status without predicting a pending event
+- report states the accurate root/local-alignment status without predicting a pending event
 - report mentions subagents used
 
 If code files changed as part of creating or updating this skill, follow repo rules for Graphify. Documentation-only reports do not require Graphify unless repo policy says otherwise.
@@ -230,7 +235,7 @@ Return:
 ```text
 === Landed Change Report Complete ===
 Path: docs/reports/<report>.html
-Source: <PR/merge SHA/Linear issue>
+Source: <candidate PR/head or merged PR/merge SHA/Linear issue>
 Subagents: <names/roles used>
 Quiz: <N questions, pass threshold>
 Validation: <commands/checks run>
@@ -244,6 +249,7 @@ Notes: <deploy/root/Linear status, untracked/tracked state>
 - Do not let subagents write the report. They gather evidence; the orchestrator owns synthesis.
 - Do not turn the report into a PR description. It is a teaching artifact.
 - Do not overstate validation; say exactly what ran and what passed.
-- Do not claim production deployment unless a real deploy command completed.
+- Do not claim merge, Linear `Done`, root alignment, or production deployment unless each event actually occurred.
+- In execute delivery-candidate mode, commit the report to the delivery branch before merge and do not generate or refresh it after merge.
 - Do not include sensitive runtime data or raw secrets.
 - Do not mutate Linear, GitHub, or production systems unless the user explicitly asks.

--- a/.agents/skills/execute/SKILL.md
+++ b/.agents/skills/execute/SKILL.md
@@ -30,7 +30,7 @@ Do not use this skill when:
 - When executing a coordinated batch of related tickets, delivery can mean all tickets land through one shared integration PR rather than one PR per ticket.
 - Delivery always includes remote merge and local fast-forward unless the user explicitly opts out, asks to rely on auto-merge, or permissions prevent it.
 - Delivery also means you leave the local repo tidy, back on `main`, and reflecting the merged remote state.
-- Delivery handoff includes a digestible landed-change report from `$ce-landed-change-report` for substantial or behavior-bearing work after the PR is actually merged.
+- For substantial or behavior-bearing work, the delivery PR includes a digestible landed-change report from `$ce-landed-change-report`; do not defer the report to a post-merge follow-up PR.
 - Do not stop at "PR open" or "ready for review" unless the user explicitly asked for that narrower handoff.
 - Only treat something as a blocker when it genuinely requires user input.
 - Document significant scope decisions in Linear as you work.
@@ -47,6 +47,7 @@ Do not use this skill when:
 - "The final suite passed, so test-first happened."
 - "The PR merged, so there is nothing left to teach the system."
 - "The PR merged, so the human reader does not need a digestible handoff."
+- "I'll merge first and add the landed-change report in a second PR."
 - "I noticed something adjacent, so I should silently expand this ticket."
 - "A vague improvement idea deserves a proactive ticket."
 
@@ -77,8 +78,9 @@ Use this resolution order before asking the user for context:
 - Merge target `main`; merge method `squash`; review loops run relevant reviewer subagents until unanimous approval with no numeric cap.
 - Merge is the default delivery posture. Do not stop at an open PR when auto-review and merge are on.
 - After merge, fast-forward the local root checkout to `origin/main`; do not leave the repo on a stale local `main`.
-- After merge, run repo-local `$ce-landed-change-report` for behavior changes, architecture/workflow changes, operator/customer-facing surfaces, cross-layer contracts, coordinated batches, or high-risk refactors. Use the merged PR URL, merge SHA, Linear issue context, and delivered diff as report inputs, and follow that skill's subagent requirements.
-- For large branches, satisfy `bun run landed-report:check` before merge by including a valid `docs/reports/**/*.html` report artifact with a current deliverable diff fingerprint. If reviewer-loop edits change the deliverable diff after report creation, regenerate the report before merge; refresh or annotate the report after merge when final merge details matter.
+- Before merge, run repo-local `$ce-landed-change-report` for behavior changes, architecture/workflow changes, operator/customer-facing surfaces, cross-layer contracts, coordinated batches, or high-risk refactors. Use the PR URL, candidate head SHA, Linear issue context, and delivered diff as report inputs, follow that skill's subagent requirements, and commit the report to the delivery branch.
+- Generate the report after implementation and primary validation have stabilized but before the final review-and-merge loop. Keep pre-merge status language accurate: identify the source as a delivery candidate and do not claim merge, deploy, Linear `Done`, or root alignment before those events happen.
+- Satisfy `bun run landed-report:check` before merge with a valid `docs/reports/**/*.html` artifact and current deliverable diff fingerprint. If reviewer-loop edits change the deliverable diff, regenerate the report and rerun its reviewer before merge. Do not generate or refresh the report after merge; any later user-requested correction is separate work, not delivery closeout.
 - In Athena, merge or arm auto-merge with `bun run github:pr-merge -- <pr-number-or-url> --method squash --delete-branch` or `bun run github:pr-merge -- <pr-number-or-url> --auto --method squash` instead of raw `gh pr merge`. The helper uses GitHub APIs directly, so it does not try to check out or update local `main` and is safe when `main` is already checked out in the root worktree.
 - Human approval is not required unless the user explicitly asks for it.
 - All PR checks must be green before the PR actually merges. If required checks are still pending after local gates pass, arm auto-merge instead of waiting and manually merging; if a check fails, investigate and fix it.
@@ -184,8 +186,21 @@ After opening the PR:
 - add the PR link to the Linear ticket
 - if it is a coordinated integration PR, add the same PR link to every included ticket
 - note final validation status and major scope decisions in Linear
+- decide whether the landed-change report applies using the delivery contract above
+- when it applies, generate and review the report with the PR URL and candidate head, commit it to this same delivery branch, rerun `bun run landed-report:check`, and push it before entering the final review-and-merge loop
 
-### 8. Run The Review + Merge Loop
+### 8. Complete Delivery Artifacts + Compound The Learning
+
+- Before the final review-and-merge loop, decide whether the work taught the system something reusable.
+- Use the repo-local `$ce-compound` skill when the repo has a `docs/solutions/` knowledge base and the learning is repo-specific. In Athena, do not hand-roll solution-note structure; the repo-local `ce-compound` template is the authoring contract enforced by `compound:check`.
+- Update a skill when the learning changes how agents should deliver work across repos.
+- Treat a `$ce-landed-change-report` as delivery handoff for human comprehension, not as a replacement for durable solution notes or skill updates.
+- Create a follow-up Linear issue when the learning is a concrete missing repo sensor, missing validation map coverage, missing reviewer, or tooling gap that should be implemented later; include the source evidence and why it is separate from the current task.
+- Record `No durable learning` only when the change is local, obvious, and unlikely to recur.
+- When the landed-change report applies, finish its required subagent evidence and report-review loop now, commit the approved report to the delivery branch, and keep its diff fingerprint current through later review edits.
+- Close completed subagents and clean up any worker-only worktrees before the final merge. Keep only the delivery worktree and branch needed by the open PR.
+
+### 9. Run The Review + Merge Loop
 
 - Run `$requesting-code-review`.
 - Treat any of the following as blocking:
@@ -204,31 +219,19 @@ After opening the PR:
 - The follow-up issue should capture the failing remote check, the local validations that passed, the root cause, and the local command, harness mapping, or coverage addition needed so the failure is caught before CI next time.
 - Link that follow-up issue from the current Linear ticket and the PR comment trail when it materially affects the handoff.
 - Keep looping relevant reviewer subagents until unanimous approval: every selected reviewer must report approval/no blocking findings, GitHub feedback must have no unresolved actionable blockers, and checks must be passing or auto-mergeable. There is no numeric iteration cap; stop only when the next fix is not clear, permissions/repo settings block progress, or genuine user input is required.
+- If a review-loop edit changes the deliverable diff, refresh the solution/report fingerprints, rerun the report reviewer when applicable, and keep those artifacts in this same PR.
+- After the review loop is unanimously green and the candidate head, telemetry, report, and compounding artifacts are final, post or refresh the merge-ready Linear comment with the PR URL, candidate head SHA, final telemetry, validation evidence, report path or skip reason, and compounding decision. Keep the ticket in the accurate pre-merge state so merge automation can move it to `Done`.
 - When local gates and review gates pass, mark the PR ready if needed and arm auto-merge with `bun run github:pr-merge -- <pr-number-or-url> --auto --method squash` unless the user explicitly asked you to wait through merge completion or repo settings reject auto-merge.
 - If auto-merge cannot be armed and all PR checks are already green, squash-merge into `main` with `bun run github:pr-merge -- <pr-number-or-url> --method squash --delete-branch`.
 - Treat the merge as incomplete until the remote merge is confirmed and the local root checkout fast-forwards to the merged `origin/main`.
 
-### 9. Compound The Learning
+### 10. Post-Merge: Align Root + Run Non-Deferred Production Deploys
 
-- Before final ticket closure, decide whether the work taught the system something reusable.
-- Use the repo-local `$ce-compound` skill when the repo has a `docs/solutions/` knowledge base and the learning is repo-specific. In Athena, do not hand-roll solution-note structure; the repo-local `ce-compound` template is the authoring contract enforced by `compound:check`.
-- Update a skill when the learning changes how agents should deliver work across repos.
-- Treat a `$ce-landed-change-report` as delivery handoff for human comprehension, not as a replacement for durable solution notes or skill updates.
-- Create a follow-up Linear issue when the learning is a concrete missing repo sensor, missing validation map coverage, missing reviewer, or tooling gap that should be implemented later; include the source evidence and why it is separate from the current ticket.
-- Record `No durable learning` only when the change is local, obvious, and unlikely to recur.
-- Include the compounding decision in the final Linear comment and handoff.
-
-### 10. Close The Loop
-
-- After merge, confirm the ticket has already moved to `Done` via merge automation.
-- If merge succeeded but Linear did not move to `Done`, update the ticket directly or document the automation mismatch in Linear before handoff.
-- Post a final Linear comment with the PR URL, merge SHA, final telemetry, validation evidence, and compounding decision.
-- For coordinated batches, confirm every included ticket reached `Done`, not just the ticket that happened to anchor the PR title.
-- After delivery, fetch `origin`, fast-forward the local root checkout's `main` branch to `origin/main`, switch back to `main`, and confirm the local checkout reflects the merged result.
-- Generate the `$ce-landed-change-report` after the merge SHA exists when the delivery changed behavior, architecture, workflow, operator/customer-facing surfaces, cross-layer contracts, or coordinated multiple tickets. Include the generated report path in the final handoff and, when useful, the final Linear comment.
-- Skip the report only when the user explicitly opts out, the change is purely mechanical/sensor-only/docs-only, or the handoff happens before an actual merge with auto-merge merely armed. If skipped, include the reason in the handoff.
-- Clean up the working tree and any temporary worktree or branch created for the ticket so the local repo is tidy before handoff.
-- For subagent batches, close each worker explicitly before handoff: wait for completion, review and merge or intentionally reject its diff, run the relevant focused validation, remove the worker worktree, delete the worker branch only after it is merged, and record any unresolved blocker in the parent ticket or PR.
-- If repeated blockers remain and the next fix is not clear, leave the issue in the most accurate state, post an unresolved-item checklist with the latest telemetry, and hand off the exact blocker.
+- Once the remote merge is confirmed, post-merge work is limited to aligning and cleaning the local root checkout and running the selected production deploys, except for either action the user or repo workflow explicitly deferred.
+- Fetch `origin`, fast-forward the root checkout's `main` branch to the exact merged `origin/main`, verify it is clean, then remove the merged delivery worktree and local branch as part of local alignment cleanup.
+- Inspect the merged diff and run the narrowest applicable local production deploy commands from the clean root checkout. If no deployable runtime surface changed, record that explicit no-deploy result. If deployment was deferred by the user or repo workflow, name the deferral accurately.
+- Do not generate or refresh landed-change reports, solution notes, skills, PR descriptions, or Linear closeout comments after merge. Those artifacts and decisions belong in the delivery PR before merge.
+- Include the merged PR, merge SHA, report path or skip reason, validation/review result, Linear state, root alignment, deploy result or deferral, and compounding decision in the final handoff.
+- If repeated blockers remain and the next fix is not clear, leave the task in the most accurate state and hand off the exact blocker.
 - If merge permissions or repo settings prevent merge, leave the ticket in `In Review` and document the exact blocker.
 - If `auto_review_and_merge = off`, stop at review-ready state and say it is awaiting manual review or merge.

--- a/docs/reports/2026-07-13-v26-1040-harness-contract-preflight-report.html
+++ b/docs/reports/2026-07-13-v26-1040-harness-contract-preflight-report.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="b5e11c9da45800fd7f0a2dc250b7e6b9a118efeaade7984bc3ca0eb40eeddbc9" data-athena-report-base="d3e9ca1956a538ef2152ecde0f02f80961699e14^" data-athena-report-head="d3e9ca1956a538ef2152ecde0f02f80961699e14">
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="f25282af8f200818fd13b3f20587d06c9702b3d58e0eda4aa99aaab5d548e0c2" data-athena-report-base="d3e9ca1956a538ef2152ecde0f02f80961699e14^" data-athena-report-head="d3e9ca1956a538ef2152ecde0f02f80961699e14" data-athena-policy-correction-pr="656" data-athena-policy-correction-status="delivery-candidate">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -78,7 +78,7 @@
       <header>
         <h1>Fail Fast on Harness Contract Drift</h1>
         <p class="lede">How V26-1040 moved deterministic repository-contract failures ahead of expensive provider validation while preserving every merge-grade gate.</p>
-        <div class="meta"><span class="pill">V26-1040 · Done</span><span class="pill">PR #655 · Merged</span><span class="pill">Merge d3e9ca19</span><span class="pill">All required checks green</span><span class="pill">No production deploy</span><span class="pill">Local main aligned</span></div>
+        <div class="meta"><span class="pill">V26-1040 · Done</span><span class="pill">PR #655 · Merged</span><span class="pill">Merge d3e9ca19</span><span class="pill">All required checks green</span><span class="pill">No production deploy</span><span class="pill">Local main aligned</span><span class="pill">Policy correction PR #656 · Delivery candidate</span></div>
       </header>
       <section class="panel"><h2>Executive Summary</h2>
 <p>PR #655 merged V26-1040 into main on 2026-07-13. pr:athena now runs a dedicated static contract preflight after generated-artifact preparation and before provider validation. One run can report mapping gaps, live audit failures, stale audit or registry fixtures, and missing sibling-test updates together.</p>
@@ -125,6 +125,11 @@ After:  prepare -&gt; preflight -&gt; validate -&gt; record-proof -&gt; scorecar
 <p>PR #655 merged as d3e9ca1956a538ef2152ecde0f02f80961699e14. Linear V26-1040 moved to Done through merge automation. The root checkout fast-forwarded to that exact origin/main commit and was clean before this report branch was created.</p>
 <p>No Athena, storefront, Convex, schema, API, permissions, data, or deployment configuration changed. Production deployment was intentionally not run because the merged diff contains repository-local harness tooling, tests, documentation, and generated Graphify artifacts only.</p>
 </section>
+<section class="panel"><h2>Delivery Policy Correction Candidate (PR #656)</h2>
+<p>This report exposed a sequencing flaw in the execute workflow: a required landed-change report was being generated only after the delivery PR had merged, which forced a second PR and meant the report was not actually included with delivery.</p>
+<p>PR #655 and V26-1040 are merged and closed. This report plus the execute-skill, regression-sensor, and solution-note corrections belong to separate PR #656, which is a delivery candidate and is not yet merged or root-aligned.</p>
+<p>If PR #656 lands, the repo-local execute skill will require applicable reports, compounding artifacts, report review, and the merge-ready Linear closeout record before merge, all on the same delivery branch. After merge, the only delivery actions will be aligning and cleaning local root and running the selected production deploys; either action may be explicitly deferred by the user or repo workflow. The focused harness regression test will preserve that boundary and its ordering.</p>
+</section>
 <section class="panel"><h2>Next-Time Guidance</h2>
 
 <ul>
@@ -145,6 +150,7 @@ After:  prepare -&gt; preflight -&gt; validate -&gt; record-proof -&gt; scorecar
 <tr><td><code>scripts/pr-athena-delivery-run.ts</code></td><td>Places preflight between preparation and validation so an early block prevents provider work and proof recording.</td></tr>
 <tr><td><code>scripts/harness-inferential-review.ts</code></td><td>Exports the narrow sibling-test detector and prints terminal-first Why/Fix diagnostics for blocking inferential results.</td></tr>
 <tr><td><code>docs/solutions/workflow-issues/static-harness-contract-preflight-before-provider-validation-2026-07-13.md</code></td><td>Captures the reusable static-preflight-before-expensive-sensors pattern for future delivery work.</td></tr>
+<tr><td><code>.agents/skills/execute/SKILL.md</code></td><td>PR #656 candidate update: requires reports and compounding artifacts in the delivery PR before merge and limits post-merge work to root alignment and non-deferred production deploys.</td></tr>
 <tr><td><code>package.json</code></td><td>Exposes pr:athena:preflight as the stable repository command used by the delivery wrapper.</td></tr></tbody>
   </table>
 </section>
@@ -264,13 +270,13 @@ After:  prepare -&gt; preflight -&gt; validate -&gt; record-proof -&gt; scorecar
 
 <div class="quiz-question" data-answer="1">
   <fieldset>
-    <legend>10. What was the final production and repository state?</legend>
+    <legend>10. What was the final production and repository state for PR #655 / V26-1040?</legend>
     <label><input type="radio" name="q10" value="0" /> PR open, production deployed, Linear In Review</label>
 <label><input type="radio" name="q10" value="1" /> PR merged, no deployable runtime surface, Linear Done, local main aligned</label>
 <label><input type="radio" name="q10" value="2" /> PR merged, full production deploy required, local main stale</label>
 <label><input type="radio" name="q10" value="3" /> Auto-merge armed but no merge SHA</label>
   </fieldset>
-  <div class="answer-detail">The harness-only change merged as d3e9ca19, required no runtime deployment, closed V26-1040, and root main was fast-forwarded.</div>
+  <div class="answer-detail">PR #655's harness-only change merged as d3e9ca19, required no runtime deployment, closed V26-1040, and root main was fast-forwarded. PR #656 is separately labeled as a delivery candidate in this report.</div>
 </div>
 
     <div class="quiz-actions">

--- a/docs/reports/2026-07-13-v26-1040-harness-contract-preflight-report.html
+++ b/docs/reports/2026-07-13-v26-1040-harness-contract-preflight-report.html
@@ -1,0 +1,338 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="b5e11c9da45800fd7f0a2dc250b7e6b9a118efeaade7984bc3ca0eb40eeddbc9" data-athena-report-base="d3e9ca1956a538ef2152ecde0f02f80961699e14^" data-athena-report-head="d3e9ca1956a538ef2152ecde0f02f80961699e14">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Fail Fast on Harness Contract Drift</title>
+    <style>
+      :root {
+        --ink: #1f2933;
+        --muted: #596674;
+        --line: #d9e2ec;
+        --paper: #ffffff;
+        --soft: #f6f8fb;
+        --accent: #1d4ed8;
+        --accent-soft: #dbeafe;
+        --good: #166534;
+        --bad: #b91c1c;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--soft);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      main { max-width: 1120px; margin: 0 auto; padding: 48px 24px 72px; }
+      header { border-bottom: 1px solid var(--line); margin-bottom: 28px; padding-bottom: 28px; }
+      h1, h2, h3 { line-height: 1.18; letter-spacing: 0; }
+      h1 { font-size: 42px; max-width: 880px; margin: 0 0 16px; }
+      h2 { font-size: 28px; margin: 0 0 16px; }
+      p { margin: 0 0 14px; }
+      .lede { color: var(--muted); font-size: 18px; max-width: 880px; }
+      .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 20px; }
+      .pill { border: 1px solid var(--line); border-radius: 999px; background: var(--paper); color: var(--muted); font-size: 13px; padding: 6px 10px; }
+      .panel { background: var(--paper); border: 1px solid var(--line); border-radius: 8px; margin: 18px 0; padding: 22px; }
+      code { background: #eef2f7; border: 1px solid #d8dee8; border-radius: 5px; padding: 1px 5px; }
+      pre { overflow: auto; background: #111827; color: #e5e7eb; border-radius: 8px; padding: 16px; }
+      pre code { background: transparent; border: 0; color: inherit; padding: 0; }
+      table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+      th, td { border-bottom: 1px solid var(--line); padding: 11px 12px; text-align: left; vertical-align: top; }
+      th { background: #eef2f7; color: var(--muted); font-size: 13px; text-transform: uppercase; }
+      tr:last-child td { border-bottom: 0; }
+      .quiz-question { border-top: 1px solid var(--line); padding: 18px 0; }
+      .quiz-question:first-child { border-top: 0; }
+      fieldset { border: 0; margin: 0; padding: 0; }
+      legend { font-weight: 700; margin-bottom: 10px; }
+      label { display: block; border: 1px solid var(--line); border-radius: 8px; background: #fbfdff; margin: 8px 0; padding: 10px 12px; cursor: pointer; }
+      @media (hover: hover) and (pointer: fine) {
+        label:hover { border-color: #b6c5d8; }
+      }
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 8px;
+        background: var(--accent);
+        color: #ffffff;
+        cursor: pointer;
+        font-weight: 700;
+        padding: 11px 16px;
+        transition: transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+      }
+      button:active { transform: scale(0.97); }
+      button.secondary { background: #475569; }
+      .quiz-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
+      #quizResult { font-weight: 700; }
+      .question-status { font-weight: 700; margin-top: 10px; }
+      .answer-detail { display: none; border-top: 1px dashed var(--line); color: var(--muted); margin-top: 10px; padding-top: 10px; }
+      .answer-detail.visible { display: block; }
+      .correct { border-color: #86efac !important; background: #f0fdf4 !important; }
+      .incorrect { border-color: #fecaca !important; background: #fef2f2 !important; }
+      @media (prefers-reduced-motion: reduce) { button { transition-duration: 0ms; } }
+      @media (max-width: 820px) { h1 { font-size: 32px; } main { padding: 32px 16px 56px; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Fail Fast on Harness Contract Drift</h1>
+        <p class="lede">How V26-1040 moved deterministic repository-contract failures ahead of expensive provider validation while preserving every merge-grade gate.</p>
+        <div class="meta"><span class="pill">V26-1040 · Done</span><span class="pill">PR #655 · Merged</span><span class="pill">Merge d3e9ca19</span><span class="pill">All required checks green</span><span class="pill">No production deploy</span><span class="pill">Local main aligned</span></div>
+      </header>
+      <section class="panel"><h2>Executive Summary</h2>
+<p>PR #655 merged V26-1040 into main on 2026-07-13. pr:athena now runs a dedicated static contract preflight after generated-artifact preparation and before provider validation. One run can report mapping gaps, live audit failures, stale audit or registry fixtures, and missing sibling-test updates together.</p>
+<p>The change does not weaken the existing review, proof, provider-evidence, or scorecard ladder. A consistent tree continues into the same heavy validation. A broken static contract stops early, records a blocked preflight span, and cannot claim provider evidence or proof.</p>
+</section>
+<section class="panel"><h2>Why This Mattered</h2>
+<p>Before this change, a registry edit could require several full pr:athena runs. The first run might expose an unmapped surface, the next stale harness-audit fixtures, and the next a registry script changed without its sibling test. Those failures were deterministic, but agents paid the cost of the large provider suite before seeing the complete repair contract.</p>
+<ul>
+<li>The target was earlier and more complete feedback, not fewer checks.</li>
+<li>Automatic edits to tests or fixtures remained out of scope because the harness should diagnose source-contract drift, not silently author intent.</li>
+<li>The user expanded the scope to make harness:inferential-review terminal output actionable without opening its JSON report.</li>
+</ul>
+</section>
+<section class="panel"><h2>Mental Model: A Circuit Breaker Before the Expensive Line</h2>
+<p>Think of pr:athena as a production line. Preparation updates generated inputs. The new preflight is a circuit breaker that checks whether the line&#x27;s wiring diagram, fixtures, and safety tests agree before expensive machinery starts. It gathers independent faults with all-settled semantics, then either opens the circuit with one repair list or lets the unchanged validation line proceed.</p>
+<pre><code>Before: prepare -&gt; validate -&gt; record-proof -&gt; scorecard
+After:  prepare -&gt; preflight -&gt; validate -&gt; record-proof -&gt; scorecard</code></pre>
+</section>
+<section class="panel"><h2>Before and After</h2>
+
+<ul>
+<li>Before: mapping, fixture, and sibling-test drift surfaced sequentially inside later review work after provider validation had begun.</li>
+<li>After: runHarnessContractPreflight executes four independent detectors concurrently and aggregates every deterministic finding into one result.</li>
+<li>Before: inferential failures required digging through the detailed report or machine artifact to understand the actionable boundary.</li>
+<li>After: a failed inferential CLI run ends with BLOCKED diagnostics naming severity, file, Why, Fix, runtime errors, and the artifact path.</li>
+<li>Unchanged: provider validation, full inferential review, harness audit, Graphify freshness, proof recording, and scorecard still run on a valid tree.</li>
+</ul>
+</section>
+<section class="panel"><h2>Failure Boundaries and Observability</h2>
+<p>The preflight classifies findings as validation-map, harness-audit, contract-fixtures, or sibling-test-policy. It fails closed when a detector cannot produce evidence. The optional base reference defaults to origin/main, so a shallow or misconfigured checkout must fetch the baseline rather than silently skipping change detection.</p>
+<p>The delivery ledger records preflight as its own span. Tests prove that a nonzero preflight result preserves the exit code, leaves proof_not_recorded, records no provider-skip evidence, and never invokes validate or record-proof. The machine-readable preflight artifact is local and ignored by git.</p>
+</section>
+<section class="panel"><h2>Validation, Review, and CI Recovery</h2>
+
+<ul>
+<li>Characterization-first and test-first coverage exercised real git sibling drift, real audit-fixture subprocess failures, three simultaneous contract failures, and the fully repaired pass state.</li>
+<li>The merge-ready local gate passed: 499 root harness tests, 5,875 Athena coverage tests, Graphify freshness, compound solution validation, architecture checks, and proof recording.</li>
+<li>Correctness, testing, and standards reviewers approved unanimously with zero critical or important findings after the real-detector fixtures were strengthened.</li>
+<li>The first remote Harness Implementation run exposed a shallow-checkout test assumption. The baseline became injectable while production behavior retained origin/main as its default; the CI-safe current-tree test uses HEAD.</li>
+<li>A later webapp coverage attempt reported a Vitest worker RPC timeout after all 5,875 tests passed. A clean failed-job rerun passed, followed by the storefront context check and automatic squash merge.</li>
+</ul>
+</section>
+<section class="panel"><h2>Finish Line and Intentionally Unchanged Surfaces</h2>
+<p>PR #655 merged as d3e9ca1956a538ef2152ecde0f02f80961699e14. Linear V26-1040 moved to Done through merge automation. The root checkout fast-forwarded to that exact origin/main commit and was clean before this report branch was created.</p>
+<p>No Athena, storefront, Convex, schema, API, permissions, data, or deployment configuration changed. Production deployment was intentionally not run because the merged diff contains repository-local harness tooling, tests, documentation, and generated Graphify artifacts only.</p>
+</section>
+<section class="panel"><h2>Next-Time Guidance</h2>
+
+<ul>
+<li>Put cheap deterministic contract checks after preparation but before expensive behavioral or provider sensors.</li>
+<li>Use the real fixture tests when drift lives in test setup; a live-repository audit cannot prove fixture completeness by itself.</li>
+<li>Export the narrowest reusable detector so a preflight does not misclassify unrelated findings owned by a later review phase.</li>
+<li>When extending the registry, update the registry source, regenerate harness docs, update the registry sibling test, refresh audit fixture paths, and run the focused preflight tests.</li>
+<li>If origin/main is unreachable, fetch it. Do not replace fail-closed change detection with an empty baseline in the production command.</li>
+</ul>
+</section>
+      
+<section class="panel">
+  <h2>Key Files</h2>
+  <table>
+    <thead><tr><th>File</th><th>Why It Matters</th></tr></thead>
+    <tbody><tr><td><code>scripts/harness-contract-preflight.ts</code></td><td>Owns the four-way all-settled preflight, finding classification, repair contract, machine artifact, and fail-closed result.</td></tr>
+<tr><td><code>scripts/harness-contract-preflight.test.ts</code></td><td>Proves real mapping, fixture, sibling-policy, aggregation, repaired-pass, CI-baseline, and fail-closed behavior.</td></tr>
+<tr><td><code>scripts/pr-athena-delivery-run.ts</code></td><td>Places preflight between preparation and validation so an early block prevents provider work and proof recording.</td></tr>
+<tr><td><code>scripts/harness-inferential-review.ts</code></td><td>Exports the narrow sibling-test detector and prints terminal-first Why/Fix diagnostics for blocking inferential results.</td></tr>
+<tr><td><code>docs/solutions/workflow-issues/static-harness-contract-preflight-before-provider-validation-2026-07-13.md</code></td><td>Captures the reusable static-preflight-before-expensive-sensors pattern for future delivery work.</td></tr>
+<tr><td><code>package.json</code></td><td>Exposes pr:athena:preflight as the stable repository command used by the delivery wrapper.</td></tr></tbody>
+  </table>
+</section>
+
+      
+<section class="panel">
+  <h2>Subagent Evidence</h2>
+  <ul><li><strong>Peirce · session context:</strong> Reconstructed ticket decisions, scope expansion, review iterations, CI finish-line changes, Linear closure, and durable learning from PR, Linear, and delivery evidence.</li>
+<li><strong>Herschel · delivered diff:</strong> Mapped all 15 merged files, the before/after orchestration, failure and observability boundaries, validation evidence, generated Graphify churn, residual risks, and intentionally unchanged product behavior.</li>
+<li><strong>Kuhn · report reviewer:</strong> Approved the rendered report after per-question textual status, correct-answer disclosure, aria-describedby linkage, reset behavior, and first-incorrect focus were verified.</li></ul>
+</section>
+
+      
+<section id="quiz" class="panel">
+  <h2>Quiz: Pass Required</h2>
+  <p>You must score at least 8 out of 10 to pass.</p>
+  <form id="changeQuiz" data-threshold="8">
+    
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>1. Where does the new static contract preflight run?</legend>
+    <label><input type="radio" name="q1" value="0" /> Before generated-artifact preparation</label>
+<label><input type="radio" name="q1" value="1" /> After preparation and before provider validation</label>
+<label><input type="radio" name="q1" value="2" /> After proof recording</label>
+<label><input type="radio" name="q1" value="3" /> Only in remote CI</label>
+  </fieldset>
+  <div class="answer-detail">Preparation runs first so generated inputs are current; preflight then blocks deterministic drift before expensive validation begins.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>2. Why does the preflight use all-settled semantics?</legend>
+    <label><input type="radio" name="q2" value="0" /> To ignore detector errors</label>
+<label><input type="radio" name="q2" value="1" /> To run provider tests in the background</label>
+<label><input type="radio" name="q2" value="2" /> To report independent deterministic failures together</label>
+<label><input type="radio" name="q2" value="3" /> To automatically repair every fixture</label>
+  </fieldset>
+  <div class="answer-detail">Mapping, audit, fixture, and sibling-policy failures should be visible in one repair cycle rather than sequential full-gate runs.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>3. What happens when preflight fails?</legend>
+    <label><input type="radio" name="q3" value="0" /> Validation continues but proof is marked partial</label>
+<label><input type="radio" name="q3" value="1" /> The failure is downgraded to a warning</label>
+<label><input type="radio" name="q3" value="2" /> Validate and record-proof are not invoked</label>
+<label><input type="radio" name="q3" value="3" /> The harness edits the registry test automatically</label>
+  </fieldset>
+  <div class="answer-detail">The delivery wrapper stops at the failed preflight, preserves its exit code, and records neither provider evidence nor proof.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>4. Which source owns the registry repair contract?</legend>
+    <label><input type="radio" name="q4" value="0" /> graphify-out/graph.json</label>
+<label><input type="radio" name="q4" value="1" /> scripts/harness-app-registry.ts</label>
+<label><input type="radio" name="q4" value="2" /> The provider evidence artifact</label>
+<label><input type="radio" name="q4" value="3" /> The GitHub workflow log</label>
+  </fieldset>
+  <div class="answer-detail">The registry is the source of truth; generated docs, its sibling test, and audit fixtures must remain consistent with it.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>5. Why did preflight reuse only a narrow inferential collector?</legend>
+    <label><input type="radio" name="q5" value="0" /> The full inferential review was deleted</label>
+<label><input type="radio" name="q5" value="1" /> To keep unrelated findings owned and labeled by the later full review</label>
+<label><input type="radio" name="q5" value="2" /> To avoid testing registry changes</label>
+<label><input type="radio" name="q5" value="3" /> Because imports cannot run in Bun</label>
+  </fieldset>
+  <div class="answer-detail">The preflight owns deterministic sibling-test policy only; unrelated inferential findings remain in the existing merge-grade phase.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>6. What was the CI correction after the first Harness Implementation failure?</legend>
+    <label><input type="radio" name="q6" value="0" /> Production preflight stopped checking origin/main</label>
+<label><input type="radio" name="q6" value="1" /> The CI job was made optional</label>
+<label><input type="radio" name="q6" value="2" /> The baseline became injectable and the current-tree test uses HEAD</label>
+<label><input type="radio" name="q6" value="3" /> The test was removed</label>
+  </fieldset>
+  <div class="answer-detail">Production still defaults to origin/main and fails closed; only the environment-independent characterization supplies HEAD.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>7. What did the late webapp validation failure mean?</legend>
+    <label><input type="radio" name="q7" value="0" /> One Athena behavior test failed</label>
+<label><input type="radio" name="q7" value="1" /> Coverage fell below policy</label>
+<label><input type="radio" name="q7" value="2" /> All 5,875 tests passed but Vitest timed out sending a worker update</label>
+<label><input type="radio" name="q7" value="3" /> The storefront build failed</label>
+  </fieldset>
+  <div class="answer-detail">The log showed every Athena test passing and one unhandled worker RPC timeout; a clean failed-job rerun passed.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>8. Which behavior was intentionally unchanged?</legend>
+    <label><input type="radio" name="q8" value="0" /> Provider validation and proof still run on a valid tree</label>
+<label><input type="radio" name="q8" value="1" /> Preflight automatically rewrites fixture tests</label>
+<label><input type="radio" name="q8" value="2" /> Production deploy now runs for harness scripts</label>
+<label><input type="radio" name="q8" value="3" /> Inferential review no longer writes machine output</label>
+  </fieldset>
+  <div class="answer-detail">The new phase adds defense in depth; it does not remove or weaken the existing heavy validation and proof ladder.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>9. What should an agent do when origin/main is unreachable?</legend>
+    <label><input type="radio" name="q9" value="0" /> Treat the changed-file set as empty</label>
+<label><input type="radio" name="q9" value="1" /> Skip sibling-test policy</label>
+<label><input type="radio" name="q9" value="2" /> Fetch the baseline and rerun</label>
+<label><input type="radio" name="q9" value="3" /> Record proof anyway</label>
+  </fieldset>
+  <div class="answer-detail">Missing baseline evidence is blocking by design; fetching origin/main restores trustworthy change detection.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>10. What was the final production and repository state?</legend>
+    <label><input type="radio" name="q10" value="0" /> PR open, production deployed, Linear In Review</label>
+<label><input type="radio" name="q10" value="1" /> PR merged, no deployable runtime surface, Linear Done, local main aligned</label>
+<label><input type="radio" name="q10" value="2" /> PR merged, full production deploy required, local main stale</label>
+<label><input type="radio" name="q10" value="3" /> Auto-merge armed but no merge SHA</label>
+  </fieldset>
+  <div class="answer-detail">The harness-only change merged as d3e9ca19, required no runtime deployment, closed V26-1040, and root main was fast-forwarded.</div>
+</div>
+
+    <div class="quiz-actions">
+      <button type="button" id="gradeQuiz">Grade quiz</button>
+      <button type="button" class="secondary" id="resetQuiz">Reset</button>
+      <span id="quizResult" aria-live="polite"></span>
+    </div>
+  </form>
+</section>
+
+    </main>
+    <script>
+      const questions = Array.from(document.querySelectorAll(".quiz-question"));
+      const result = document.getElementById("quizResult");
+      const form = document.getElementById("changeQuiz");
+      const threshold = Number(form.dataset.threshold || 0);
+      questions.forEach((question, index) => {
+        const status = document.createElement("p");
+        status.id = `questionStatus${index + 1}`;
+        status.className = "question-status";
+        status.setAttribute("aria-live", "polite");
+        question.querySelector("fieldset").setAttribute("aria-describedby", status.id);
+        question.querySelector(".answer-detail").before(status);
+        question.tabIndex = -1;
+      });
+      function clearGrades() {
+        questions.forEach((question) => {
+          question.classList.remove("correct", "incorrect");
+          question.querySelector(".question-status").textContent = "";
+          question.querySelector(".answer-detail").classList.remove("visible");
+        });
+        result.textContent = "";
+        result.style.color = "";
+      }
+      document.getElementById("gradeQuiz").addEventListener("click", () => {
+        clearGrades();
+        let score = 0;
+        let firstIncorrect = null;
+        questions.forEach((question, index) => {
+          const selected = document.querySelector(`input[name="q${index + 1}"]:checked`);
+          const isCorrect = selected && Number(selected.value) === Number(question.dataset.answer);
+          if (isCorrect) score += 1;
+          if (!isCorrect && !firstIncorrect) firstIncorrect = question;
+          question.classList.add(isCorrect ? "correct" : "incorrect");
+          const correctInput = question.querySelector(`input[value="${question.dataset.answer}"]`);
+          const correctAnswer = correctInput.closest("label").textContent.trim();
+          question.querySelector(".question-status").textContent = isCorrect
+            ? "Correct."
+            : `Incorrect. Correct answer: ${correctAnswer}`;
+          question.querySelector(".answer-detail").classList.add("visible");
+        });
+        const passed = score >= threshold;
+        result.textContent = passed
+          ? `Passed: ${score}/${questions.length}.`
+          : `Not passed: ${score}/${questions.length}. Review the report and try again.`;
+        result.style.color = passed ? "var(--good)" : "var(--bad)";
+        firstIncorrect?.focus();
+      });
+      document.getElementById("resetQuiz").addEventListener("click", () => {
+        form.reset();
+        clearGrades();
+      });
+    </script>
+  </body>
+</html>

--- a/docs/solutions/workflow-issues/static-harness-contract-preflight-before-provider-validation-2026-07-13.md
+++ b/docs/solutions/workflow-issues/static-harness-contract-preflight-before-provider-validation-2026-07-13.md
@@ -11,13 +11,15 @@ applies_when:
   - "A validation registry generates maps or documentation consumed by later gates"
   - "A heavy provider suite runs before deterministic repository-contract checks"
   - "One registry edit can drift generated docs, audit fixtures, and sibling tests together"
+  - "A delivery workflow requires a landed-change report or durable learning artifact"
 tags:
   - harness
   - fail-fast
   - preflight
   - pr-validation
   - diagnostics
-delivery_diff_fingerprint: 23f2cf9c5523be0e32b5b6e1ce626dbfecdd67886d6d2d0197af1d67bc8059fd
+  - delivery-report
+delivery_diff_fingerprint: f25282af8f200818fd13b3f20587d06c9702b3d58e0eda4aa99aaab5d548e0c2
 ---
 
 # Static Harness Contracts Must Fail Before Provider Validation
@@ -60,6 +62,16 @@ For inferential review itself, print a concise blocking summary at the end of
 terminal output. Include the file, finding title, reason, concrete repair, and
 machine-artifact path so an agent does not need to open JSON before it can act.
 
+Delivery artifacts follow the same fail-early principle. Applicable
+landed-change reports, compounding notes, report review, and merge-ready Linear
+evidence belong on the delivery branch before merge. Deferring them until a
+merge SHA exists creates a second PR and means the required explanation was not
+actually included with delivery. Use the PR URL and candidate head as the
+pre-merge source, keep status wording accurate, and refresh fingerprints during
+the review loop. After merge, restrict agent work to local root alignment and
+the selected production deploys, except for either action the user or repo
+workflow explicitly deferred.
+
 ## Why This Matters
 
 Static contract checks are cheap, deterministic, and usually point directly to
@@ -85,6 +97,11 @@ the preflight actually owns; leave the full suite in its existing review phase.
   for automation and deeper inspection.
 - Do not remove the later merge-grade sensors merely because the preflight
   repeats a cheap contract check.
+- Keep reports, solution notes, skill updates, and Linear closeout evidence in
+  the delivery PR; guard this sequencing in the execute-workflow regression.
+- Do not open a post-merge documentation PR by default. Once the delivery PR
+  merges, align and clean local root, then run or explicitly defer production
+  deploys.
 
 ## Examples
 

--- a/scripts/github-pr-merge.test.ts
+++ b/scripts/github-pr-merge.test.ts
@@ -409,8 +409,12 @@ describe("github-pr-merge", () => {
 
   it("keeps the execute workflow pointed at the worktree-safe merge helper", async () => {
     const rootDir = path.resolve(import.meta.dirname, "..");
-    const [executeSkill, packageJson] = await Promise.all([
+    const [executeSkill, reportSkill, packageJson] = await Promise.all([
       readFile(path.join(rootDir, ".agents/skills/execute/SKILL.md"), "utf8"),
+      readFile(
+        path.join(rootDir, ".agents/skills/ce-landed-change-report/SKILL.md"),
+        "utf8"
+      ),
       readFile(path.join(rootDir, "package.json"), "utf8"),
     ]);
 
@@ -422,6 +426,61 @@ describe("github-pr-merge", () => {
     expect(executeSkill).toContain("Delivery always includes remote merge and local fast-forward");
     expect(executeSkill).toContain("fast-forward the local root checkout to `origin/main`");
     expect(executeSkill).toContain("Treat the merge as incomplete until the remote merge is confirmed");
+    expect(executeSkill).toContain(
+      "do not defer the report to a post-merge follow-up PR"
+    );
+    const artifactsSection = executeSkill.indexOf(
+      "### 8. Complete Delivery Artifacts + Compound The Learning"
+    );
+    const reviewSection = executeSkill.indexOf(
+      "### 9. Run The Review + Merge Loop"
+    );
+    const finalLinearComment = executeSkill.indexOf(
+      "After the review loop is unanimously green"
+    );
+    const mergeInstruction = executeSkill.indexOf(
+      "arm auto-merge with `bun run github:pr-merge",
+      finalLinearComment
+    );
+    const postMergeSection = executeSkill.indexOf(
+      "### 10. Post-Merge: Align Root + Run Non-Deferred Production Deploys"
+    );
+
+    expect(artifactsSection).toBeGreaterThan(-1);
+    expect(reviewSection).toBeGreaterThan(artifactsSection);
+    expect(finalLinearComment).toBeGreaterThan(reviewSection);
+    expect(mergeInstruction).toBeGreaterThan(finalLinearComment);
+    expect(postMergeSection).toBeGreaterThan(mergeInstruction);
+    expect(executeSkill.slice(artifactsSection, reviewSection)).toContain(
+      "Use the repo-local `$ce-compound` skill"
+    );
+    expect(executeSkill.slice(artifactsSection, reviewSection)).toContain(
+      "commit the approved report to the delivery branch"
+    );
+    expect(executeSkill.slice(reviewSection, postMergeSection)).toContain(
+      "post or refresh the merge-ready Linear comment"
+    );
+    expect(executeSkill.slice(postMergeSection)).toContain(
+      "Do not generate or refresh landed-change reports, solution notes, skills, PR descriptions, or Linear closeout comments after merge"
+    );
+    expect(executeSkill).not.toContain(
+      "Post-merge report work is limited to an explicitly requested metadata refresh"
+    );
+    expect(executeSkill).not.toContain(
+      "After merge, run repo-local `$ce-landed-change-report`"
+    );
+    expect(reportSkill).toContain(
+      "The normal execute-workflow mode is a delivery candidate"
+    );
+    expect(reportSkill).toContain(
+      "prefer the open delivery PR and its candidate head"
+    );
+    expect(reportSkill).toContain(
+      "do not claim merged, deployed, Linear `Done`, or root-aligned"
+    );
+    expect(reportSkill).toContain(
+      "do not generate or refresh it after merge"
+    );
   });
 
   it("runs local commands with optional stdin", async () => {


### PR DESCRIPTION
## Summary

- include the reviewed V26-1040 landed-change report in the delivery PR
- update the repo-local execute workflow so reports, compounding artifacts, review evidence, and the final Linear record are complete before merge
- limit post-merge delivery work to local root alignment/cleanup and non-deferred production deploys
- strengthen the workflow regression sensor with relative-order and full-prohibition diagnostics

## Why

The required report was generated after PR #655 merged, which forced a follow-up PR instead of including the delivery explanation with the change. This corrects the workflow contract and preserves it with a focused test.

## Validation

- `bun test scripts/github-pr-merge.test.ts` (13 passed, 43 assertions)
- `bun run landed-report:check`
- `bun run compound:check`
- `bun run graphify:check`
- `git diff --check`
- internal correctness, standards, and report reviews

Source change: #655
Linear: V26-1040