### PR TITLE
fix(operations): restore comparisons and scope terminal review

### DIFF
--- a/docs/reports/2026-07-14-terminal-inventory-and-daily-comparisons-report.html
+++ b/docs/reports/2026-07-14-terminal-inventory-and-daily-comparisons-report.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="8529f1725053294a0a71de6e9335cc76b08e162c3f5401e174084e6ea6d981a8">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Terminal inventory boundary and Daily Operations comparisons</title>
+    <style>
+      :root { color-scheme: light; --ink:#172033; --muted:#5f6b7c; --line:#dfe5ec; --wash:#f6f8fb; --accent:#2958a6; --ok:#146c43; --warn:#9a5a00; }
+      * { box-sizing: border-box; }
+      body { margin:0; background:#fff; color:var(--ink); font:15px/1.55 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+      main { max-width:960px; margin:0 auto; padding:56px 28px 72px; }
+      h1 { margin:0 0 8px; font-size:32px; letter-spacing:-.04em; line-height:1.1; }
+      h2 { margin:40px 0 12px; font-size:19px; letter-spacing:-.02em; }
+      p { margin:0 0 12px; } .lede { max-width:760px; color:var(--muted); font-size:17px; }
+      .meta, .grid { display:grid; gap:12px; } .meta { grid-template-columns:repeat(auto-fit,minmax(170px,1fr)); margin-top:28px; }
+      .grid { grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+      .card { border:1px solid var(--line); border-radius:12px; padding:16px; background:#fff; }
+      .card strong, .label { display:block; font-size:11px; color:var(--muted); letter-spacing:.08em; text-transform:uppercase; }
+      .card span { display:block; margin-top:4px; font-weight:650; }
+      .status { color:var(--ok); } .warning { color:var(--warn); }
+      table { width:100%; border-collapse:collapse; border:1px solid var(--line); border-radius:12px; overflow:hidden; }
+      th,td { padding:12px 14px; text-align:left; vertical-align:top; border-bottom:1px solid var(--line); }
+      tr:last-child td { border-bottom:0; } th { background:var(--wash); font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); }
+      code { font:12px ui-monospace,SFMono-Regular,Menlo,monospace; color:#29436d; }
+      ul { margin:8px 0 0; padding-left:20px; } li { margin:5px 0; }
+      .callout { border-left:3px solid var(--accent); padding:13px 16px; background:#f4f7ff; border-radius:0 8px 8px 0; }
+      .blocker { border-left-color:var(--warn); background:#fff8ef; }
+      fieldset { border:1px solid var(--line); border-radius:10px; margin:12px 0; padding:14px; }
+      legend { font-weight:650; padding:0 5px; } label { display:block; margin:7px 0; cursor:pointer; }
+      button { border:0; border-radius:8px; padding:10px 14px; background:var(--accent); color:#fff; font:inherit; font-weight:650; cursor:pointer; }
+      button.secondary { margin-left:8px; background:#e9edf3; color:var(--ink); }
+      #quizResult { min-height:24px; margin-top:12px; font-weight:650; }
+      .footnote { color:var(--muted); font-size:13px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="label">Landed change report · 14 July 2026</p>
+        <h1>Terminal inventory boundary and Daily Operations comparisons</h1>
+        <p class="lede">A delivery candidate that restores useful day-over-day context without restoring broad database reads, and keeps inventory review work in its own workspace instead of presenting it as terminal trouble.</p>
+        <div class="meta">
+          <div class="card"><strong>Branch</strong><span><code>codex/terminal-inventory-boundary</code></span></div>
+          <div class="card"><strong>Target</strong><span><code>main</code> via PR</span></div>
+          <div class="card"><strong>Candidate status</strong><span class="status">Rebased; ready to open</span></div>
+          <div class="card"><strong>Deployment</strong><span>Not requested</span></div>
+        </div>
+      </header>
+
+      <section>
+        <h2>Outcome</h2>
+        <div class="grid">
+          <div class="card"><strong>Daily Operations</strong><span>Metric cards again show prior-period comparisons from the existing bounded weekly read model plus one bounded predecessor lookup, used only at the selected-week boundary.</span></div>
+          <div class="card"><strong>POS terminal</strong><span>Inventory-only synced review items no longer produce terminal manager-review posture, a register “Needs review” badge, or terminal repair evidence.</span></div>
+          <div class="card"><strong>Noise reduction</strong><span>The Cloud sync evidence panel is removed as noisy historical detail; current recovery and terminal-required evidence remain visible.</span></div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Before and after</h2>
+        <table>
+          <thead><tr><th>Area</th><th>Before</th><th>After</th></tr></thead>
+          <tbody>
+            <tr><td>Metric cards</td><td>Current-day values had no comparison after the heavy-read reduction.</td><td>Comparisons are restored using the cached weekly range plus one bounded predecessor metric, used only at the selected-week boundary.</td></tr>
+            <tr><td>Inventory conflicts</td><td>Inventory review events could be classified as unsafe cloud conflicts and fall into generic manager review.</td><td><code>conflictType === "inventory"</code> is excluded before terminal cloud-repair classification and presentation fallbacks.</td></tr>
+            <tr><td>Terminal status</td><td>Inventory-only evidence could mark Register 1 as “Needs review.”</td><td>Register and terminal review status derives from terminal-owned review evidence only.</td></tr>
+            <tr><td>Detail diagnostics</td><td>A cloud-sync panel made historical evidence look operationally relevant.</td><td>The panel is removed as noisy historical detail; current repair and terminal-required evidence keep their existing paths.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Read and ownership boundary</h2>
+        <p class="callout">The comparison restoration does not reinstate the removed heavy reads. The server reuses the bounded week aggregation and asks for at most one adjacent-day boundary metric. Terminal recovery similarly stays scoped to terminal-owned sync and runtime facts; inventory remains a review-workspace concern.</p>
+        <ul>
+          <li>Non-inventory cloud conflicts, held/rejected evidence, and terminal-local recovery remain eligible for the existing terminal paths.</li>
+          <li>UI filtering is deliberately defensive for older persisted payloads, while the query boundary prevents new inventory conflicts from being misclassified upstream.</li>
+          <li>Aggregate-only fallback data remains conservative when it cannot reliably identify the evidence owner.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Changed surfaces</h2>
+        <table>
+          <thead><tr><th>Surface</th><th>Key files</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td>Daily Operations</td><td><code>convex/operations/dailyOperations.ts</code>, <code>DailyOperationsView.tsx</code></td><td>Bounded prior-period comparison data and card copy.</td></tr>
+            <tr><td>Terminal policy/query</td><td><code>terminalOperationalState/policy.ts</code>, <code>queries/terminals.ts</code></td><td>Exclude inventory review items before recovery classification.</td></tr>
+            <tr><td>Terminal presentation</td><td><code>terminalHealthPresentation.ts</code>, <code>POSTerminalDetailView.tsx</code></td><td>Suppress inventory-only review posture and stale cloud-sync evidence.</td></tr>
+            <tr><td>Regression coverage</td><td>Daily Operations, query, policy, terminal, and detail tests</td><td>Protect bounded reads and the inventory ownership boundary.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Validation</h2>
+        <ul>
+          <li><span class="status">Passed</span> focused Daily Operations and terminal suite: 324 tests.</li>
+          <li><span class="status">Passed</span> terminal query/policy/detail regression suite: 283 tests.</li>
+          <li><span class="status">Passed</span> changed Convex lint, changed frontend lint, TypeScript check, diff whitespace check, and graph rebuild.</li>
+          <li><span class="warning">Environment blocker</span> <code>bun run pr:athena</code> reaches the generated-artifacts pre-commit step and stops on an existing shared development deployment record whose <code>posLocalSyncEvent.eventType</code> is <code>store_day_started</code>, outside the declared validator. This change does not modify that schema or record.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Subagent Evidence</h2>
+        <div class="grid">
+          <div class="card"><strong>session_context</strong><span>Confirmed the product intent: restore Daily Operations comparisons without reversing the read-efficiency work, and isolate inventory review from terminal support.</span></div>
+          <div class="card"><strong>diff_analysis</strong><span>Verified the change retains non-inventory recovery flows and applies defensive filtering at both query and presentation boundaries.</span></div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Handoff state</h2>
+        <div class="callout blocker"><strong>Pending merge and root alignment.</strong> The PR has not yet been opened at this report stage. After merge, the root checkout will be fast-forwarded to <code>main</code> and the delivery worktree removed. Deployment is intentionally out of scope for this request.</div>
+      </section>
+
+      <section id="changeQuiz">
+        <h2>Quiz: Pass Required</h2>
+        <p class="footnote">Select one answer per question. A delivery handoff passes at 8/10 or above.</p>
+        <form id="quiz">
+          <fieldset><legend>1. What data source supports comparisons for most days?</legend><label><input type="radio" name="q1" value="a"> A new full-history query</label><label><input type="radio" name="q1" value="b"> The existing bounded weekly aggregation</label><label><input type="radio" name="q1" value="c"> Browser-local estimates</label></fieldset>
+          <fieldset><legend>2. When is an extra metric lookup needed?</legend><label><input type="radio" name="q2" value="a"> At the selected week boundary</label><label><input type="radio" name="q2" value="b"> For every metric card</label><label><input type="radio" name="q2" value="c"> Never</label></fieldset>
+          <fieldset><legend>3. Which conflict type is excluded from terminal cloud-repair classification?</legend><label><input type="radio" name="q3" value="a"> Inventory</label><label><input type="radio" name="q3" value="b"> Rejected register-close</label><label><input type="radio" name="q3" value="c"> Held terminal sync</label></fieldset>
+          <fieldset><legend>4. Where should inventory review work be resolved?</legend><label><input type="radio" name="q4" value="a"> The terminal support detail</label><label><input type="radio" name="q4" value="b"> Its dedicated inventory review workspace</label><label><input type="radio" name="q4" value="c"> Remote Assist</label></fieldset>
+          <fieldset><legend>5. What must inventory-only evidence not create?</legend><label><input type="radio" name="q5" value="a"> A terminal manager-review posture</label><label><input type="radio" name="q5" value="b"> An inventory review record</label><label><input type="radio" name="q5" value="c"> A product-level audit entry</label></fieldset>
+          <fieldset><legend>6. What happens to stale Cloud sync evidence in the detail view?</legend><label><input type="radio" name="q6" value="a"> It becomes a terminal action</label><label><input type="radio" name="q6" value="b"> It is hidden as noise</label><label><input type="radio" name="q6" value="c"> It is converted to an inventory item</label></fieldset>
+          <fieldset><legend>7. Are non-inventory terminal recovery paths removed?</legend><label><input type="radio" name="q7" value="a"> Yes, all recovery is removed</label><label><input type="radio" name="q7" value="b"> No, terminal-owned evidence keeps its existing path</label><label><input type="radio" name="q7" value="c"> Only cloud repair remains</label></fieldset>
+          <fieldset><legend>8. Why does the UI keep a defensive filter?</legend><label><input type="radio" name="q8" value="a"> To tolerate older persisted payloads</label><label><input type="radio" name="q8" value="b"> To increase database reads</label><label><input type="radio" name="q8" value="c"> To hide all failures</label></fieldset>
+          <fieldset><legend>9. Did this delivery alter the production deployment?</legend><label><input type="radio" name="q9" value="a"> Yes</label><label><input type="radio" name="q9" value="b"> No, deployment was not requested</label><label><input type="radio" name="q9" value="c"> It only changed production data</label></fieldset>
+          <fieldset><legend>10. What shared environment issue blocked the full local PR gate?</legend><label><input type="radio" name="q10" value="a"> An unsupported development sync event value</label><label><input type="radio" name="q10" value="b"> A missing report file</label><label><input type="radio" name="q10" value="c"> A merge conflict</label></fieldset>
+          <button type="submit">Grade quiz</button><button class="secondary" type="reset">Reset</button>
+          <p id="quizResult" aria-live="polite"></p>
+        </form>
+      </section>
+    </main>
+    <script>
+      const answers = { q1: "b", q2: "a", q3: "a", q4: "b", q5: "a", q6: "b", q7: "b", q8: "a", q9: "b", q10: "a" };
+      const quiz = document.querySelector("#quiz");
+      const result = document.querySelector("#quizResult");
+      quiz.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const values = new FormData(quiz);
+        const score = Object.entries(answers).reduce((total, [key, answer]) => total + (values.get(key) === answer ? 1 : 0), 0);
+        result.textContent = score >= 8 ? `Pass: ${score}/10.` : `Not yet: ${score}/10. Review the report and try again.`;
+        result.className = score >= 8 ? "status" : "warning";
+      });
+      quiz.addEventListener("reset", () => { result.textContent = ""; result.className = ""; });
+    </script>
+  </body>
+</html>

--- a/docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md
+++ b/docs/solutions/architecture/athena-terminal-operational-state-aggregate-2026-06-27.md
@@ -1,6 +1,8 @@
 ---
 title: Athena Terminal Operational State Aggregate
 date: 2026-06-27
+last_updated: 2026-07-14
+delivery_diff_fingerprint: 8529f1725053294a0a71de6e9335cc76b08e162c3f5401e174084e6ea6d981a8
 category: architecture
 module: pos-terminal-health
 problem_type: architecture_pattern
@@ -59,6 +61,10 @@ Fresh runtime evidence can prove active local drawer evidence and sale authority
 Terminal Health should explain the relationship between current facts instead of exposing raw ledger joins to each UI surface. `operationalExplanation` is the extension point for that explanation. It can say "Review needed. Sales can continue." when sale readiness is intact but unresolved review evidence remains, or "Waiting for check-in." when runtime evidence is stale. It should also name the primary owner and the bounded evidence that led to the lane.
 
 Safe cloud repair is never the explanation for business facts. The only repairable cloud lane is stale duplicate register/drawer-open lifecycle evidence that passes the existing source-event, store/terminal, stale-age, projection-safety, and precondition checks. Sale, payment, inventory, closeout, variance, customer, staff proof, unknown payload, and unresolved manual-review facts remain review-owned or diagnostic-owned evidence.
+
+### Inventory Review Ownership
+
+Inventory review is independent business work and must not become terminal attention. Filter `conflictType === "inventory"` before terminal cloud-repair classification; otherwise a skipped unsafe conflict can fall through to the generic manual-review posture and incorrectly mark a terminal or register as needing review. In UI fallbacks, prefer `reviewSummary` group counts and detailed conflicts while excluding inventory, and keep aggregate-only fallbacks conservative when evidence ownership is unknown. Regression coverage belongs in terminal query, policy, presentation, and detail tests: inventory-only evidence must not produce terminal manager review, a terminal `Needs review` badge, or a stale cloud-sync panel.
 
 ## Prevention
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10452 nodes · 12701 edges · 2513 communities detected
+- 10449 nodes · 12697 edges · 2513 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2827,72 +2827,72 @@ Cohesion: 0.13
 Nodes (12): applyCheckoutAvailabilityEffects(), checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder() (+4 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.1
-Nodes (6): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onIssueTerminalRecoveryCommand(), onStartRemoteAssist(), submitUpdateApp()
-
-### Community 70 - "Community 70"
 Cohesion: 0.17
 Nodes (19): assertValidEodLocalCompletionWindowMinutes(), assertValidEodThreshold(), assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getEodAutoCompletePolicyConfigWithCtx() (+11 more)
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.16
 Nodes (17): asRecord(), buildSnapshotHash(), buildStoreInsightsPromptFromContextBundle(), buildStoreInsightsPromptFromContextEvents(), buildUserInsightsPromptFromContextBundle(), buildUserInsightsPromptFromContextEvents(), compactContextEventsForPrompt(), compactEnvironmentForPrompt() (+9 more)
 
-### Community 72 - "Community 72"
+### Community 71 - "Community 71"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 73 - "Community 73"
+### Community 72 - "Community 72"
 Cohesion: 0.16
 Nodes (16): actionableWorkItemTimestamp(), buildOperationalWorkItem(), compareOperationalWorkItems(), compareStrings(), createOperationalWorkItemWithCtx(), filterArchivedPendingCheckoutWorkItems(), joinSourceIdentity(), metadataArrayCount() (+8 more)
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.1
 Nodes (6): authoritativePosSemanticsMatch(), classifyPaymentCorrectionAuditSource(), normalizedCurrency(), paymentCorrectionSourceIsTransactionBound(), posTransactionHeaderMatchesSourceLines(), roundSourceAmount()
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.13
 Nodes (11): dateInputToCalendarDate(), formatDateLabel(), formatNextCloseSummaryLabel(), formatNextOpenSummaryLabel(), formatScheduleSummaryLabel(), formatTimeLabel(), getCurrentOpenWindow(), getDayLabel() (+3 more)
 
-### Community 76 - "Community 76"
+### Community 75 - "Community 75"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 77 - "Community 77"
+### Community 76 - "Community 76"
 Cohesion: 0.09
 Nodes (0):
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.25
 Nodes (21): asRecord(), errorFor(), getLocalExpenseSessionId(), getOrCreateSession(), isExpenseEvent(), itemSource(), itemSourceKey(), numberField() (+13 more)
 
-### Community 79 - "Community 79"
+### Community 78 - "Community 78"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 80 - "Community 80"
+### Community 79 - "Community 79"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 81 - "Community 81"
+### Community 80 - "Community 80"
 Cohesion: 0.13
 Nodes (11): catalogRefreshEntryKey(), coordinateCatalogRefresh(), mapProductByIdResult(), useBrowserOnlineStatus(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState() (+3 more)
 
-### Community 82 - "Community 82"
+### Community 81 - "Community 81"
 Cohesion: 0.19
 Nodes (17): applyLinkedPendingAliasDisplay(), compactSearchText(), dedupeRegisterCatalogRows(), extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier() (+9 more)
 
-### Community 83 - "Community 83"
+### Community 82 - "Community 82"
 Cohesion: 0.17
 Nodes (15): createConvexRegisterSessionActivityRepository(), createRegisterSessionActivityIngestionService(), findMappedCloudId(), groupMappingsByLocalEvent(), hasDisallowedMetadataKey(), hasUnsafeMetadataString(), ingestRegisterSessionActivityWithCtx(), isRegisterNumberBound() (+7 more)
 
-### Community 84 - "Community 84"
+### Community 83 - "Community 83"
 Cohesion: 0.14
 Nodes (10): addOperatingDateDay(), buildCustomRangeRequestKey(), completeCustomRangeRequest(), customRangeSkuSourceTerminalIsCurrent(), customRangeSourcesAreAuthoritative(), decideCustomRangeRequest(), nextCustomRangeEventSequence(), nextCustomRangeWork() (+2 more)
 
-### Community 85 - "Community 85"
+### Community 84 - "Community 84"
 Cohesion: 0.11
 Nodes (3): formatMinuteOfDayLabel(), formatStoreHoursTimeLabel(), parseStoreHoursTimeLabel()
+
+### Community 85 - "Community 85"
+Cohesion: 0.11
+Nodes (2): onIssueTerminalRecoveryCommand(), submitUpdateApp()
 
 ### Community 86 - "Community 86"
 Cohesion: 0.13
@@ -3588,15 +3588,15 @@ Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 260 - "Community 260"
-Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 261 - "Community 261"
+### Community 260 - "Community 260"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 261 - "Community 261"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.22
@@ -4187,104 +4187,104 @@ Cohesion: 0.4
 Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
 
 ### Community 409 - "Community 409"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 410 - "Community 410"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 411 - "Community 411"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 412 - "Community 412"
 Cohesion: 0.73
 Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 412 - "Community 412"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 413 - "Community 413"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 414 - "Community 414"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 415 - "Community 415"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 416 - "Community 416"
+### Community 415 - "Community 415"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 417 - "Community 417"
+### Community 416 - "Community 416"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 417 - "Community 417"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 418 - "Community 418"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 420 - "Community 420"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 421 - "Community 421"
+### Community 420 - "Community 420"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 422 - "Community 422"
+### Community 421 - "Community 421"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 423 - "Community 423"
+### Community 422 - "Community 422"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 424 - "Community 424"
+### Community 423 - "Community 423"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+
+### Community 424 - "Community 424"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 425 - "Community 425"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 426 - "Community 426"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 427 - "Community 427"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 428 - "Community 428"
+### Community 427 - "Community 427"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 429 - "Community 429"
+### Community 428 - "Community 428"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 429 - "Community 429"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 431 - "Community 431"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 432 - "Community 432"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 433 - "Community 433"
+### Community 432 - "Community 432"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 433 - "Community 433"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2586
-- Graph nodes: 10452
-- Graph edges: 12701
+- Graph nodes: 10449
+- Graph edges: 12697
 - Communities: 2513
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 14) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 14) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 79) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 78) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `storefrontContextEvents.ts` (17 edges, Community 102) - [`packages/storefront-webapp/src/lib/storefrontContextEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontContextEvents.ts)
 - `checkoutSession.ts` (14 edges, Community 122) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -2355,6 +2355,9 @@ describe("daily operations overview read model", () => {
 
     expect(snapshot).toEqual({
       operatingDate: "2026-05-08",
+      priorWeekBoundaryMetric: expect.objectContaining({
+        operatingDate: "2026-05-02",
+      }),
       weekEndOperatingDate: "2026-05-09",
       weekMetrics: expect.arrayContaining([
         expect.objectContaining({

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -2698,19 +2698,34 @@ export const getDailyOperationsWeekAnalyticsSnapshot = query({
     const weekEndOperatingDate = saturdayWeekEndOperatingDate(
       args.weekEndOperatingDate ?? args.operatingDate,
     );
-
-    return {
-      operatingDate: args.operatingDate,
+    const priorWeekBoundaryOperatingDate = shiftOperatingDate(
       weekEndOperatingDate,
-      weekMetrics: includeManagerReviewEvidence
-        ? await buildWeekMetrics(ctx, {
+      -7,
+    );
+    const [weekMetrics, priorWeekBoundaryMetric] = includeManagerReviewEvidence
+      ? await Promise.all([
+          buildWeekMetrics(ctx, {
             operatingDate: args.operatingDate,
             operatingTimezoneOffsetMinutes:
               args.operatingTimezoneOffsetMinutes,
             storeId: args.storeId,
             weekEndOperatingDate,
-          })
-        : [],
+          }),
+          buildWeekMetricForDate(ctx, {
+            isSelected: false,
+            operatingDate: priorWeekBoundaryOperatingDate,
+            operatingTimezoneOffsetMinutes:
+              args.operatingTimezoneOffsetMinutes,
+            storeId: args.storeId,
+          }),
+        ])
+      : [[], null];
+
+    return {
+      operatingDate: args.operatingDate,
+      priorWeekBoundaryMetric,
+      weekEndOperatingDate,
+      weekMetrics,
     };
   },
 });

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -830,6 +830,39 @@ describe("terminal health queries", () => {
     ]);
   });
 
+  it("keeps inventory review conflicts out of terminal recovery posture", async () => {
+    const inventoryConflict = buildConflict({
+      _id: "inventory-review-conflict" as Id<"posLocalSyncConflict">,
+      conflictType: "inventory",
+      details: { workItemType: "synced_sale_inventory_review" },
+      localEventId: "inventory-review-event",
+      sequence: 26,
+      summary: "Inventory needs manager review for a synced offline sale.",
+    });
+    const ctx = buildQueryCtx({
+      posLocalSyncConflict: [inventoryConflict],
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      staffProfile: [buildStaffProfile()],
+      staffRoleAssignment: [buildStaffRoleAssignment()],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.cloudRepair.safeConflictIds).toEqual([]);
+    expect(summary?.recoveryPreview?.cloudRepair.skippedConflictIds).toEqual(
+      [],
+    );
+    expect(summary?.recoveryPreview?.manualReview).toEqual([]);
+    expect(summary?.operationalExplanation.blockingDomain).not.toBe(
+      "manual_review",
+    );
+  });
+
   it("keeps terminal health roster and detail posture aligned while detail owns recovery payloads", async () => {
     const ctx = buildQueryCtx({
       posTerminal: [buildTerminal()],

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -733,10 +733,12 @@ async function buildTerminalRecoveryCloudRepairPreview(
     terminalId: Id<"posTerminal">;
   },
 ) {
-  const conflicts = await listTerminalRecoveryConflictsForRepair(ctx, {
-    storeId: args.storeId,
-    terminalId: args.terminalId,
-  });
+  const conflicts = (
+    await listTerminalRecoveryConflictsForRepair(ctx, {
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    })
+  ).filter((conflict) => conflict.conflictType !== "inventory");
   const repository = createTerminalCloudRepairQueryRepository(ctx);
   const classified = await Promise.all(
     conflicts.map(async (conflict): Promise<TerminalCloudRepairConflictClassification> => {

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts
@@ -137,7 +137,7 @@ describe("terminal operational state policy", () => {
     );
   });
 
-  it("explains sale-ready review backlog without implying cashier blocking", () => {
+  it("keeps open-work inventory review independent from terminal readiness", () => {
     const state = buildTerminalOperationalState(
       baseInput({
         runtimeStatus: buildRuntimeStatus({
@@ -201,17 +201,15 @@ describe("terminal operational state policy", () => {
     );
 
     expect(state.salesReadiness).toBe("able_to_transact_now");
-    expect(state.operationalExplanation).toMatchObject({
-      headline: "Review needed. Sales can continue.",
-      lane: "sale_ready_with_review_backlog",
-      primaryOwner: "operations",
-      saleImpact: "can_transact_now",
-      supportAction: "manual_review",
-    });
+    expect(state.attentionReasons).toEqual([]);
+    expect(state.diagnosticEvidence).not.toContainEqual(
+      expect.objectContaining({ source: "sync_evidence" }),
+    );
+    expect(state.recoveryEvidence.manualReview).toEqual([]);
     expect(state.recoveryPreview.readiness).toBe("able_to_transact_now");
   });
 
-  it("keeps unresolved synced inventory conflicts in the inventory review lane", () => {
+  it("keeps inventory review work out of terminal attention and recovery", () => {
     const state = buildTerminalOperationalState(
       baseInput({
         syncEvidence: {
@@ -240,26 +238,8 @@ describe("terminal operational state policy", () => {
       }),
     );
 
-    expect(state.attentionReasons).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          count: 2,
-          summary: "2 inventory review items need attention.",
-          type: "synced_sale_inventory_review",
-        }),
-      ]),
-    );
-    expect(state.attentionReasons[0]?.actionTarget).toBeUndefined();
-    expect(state.attentionReasons.map((reason) => reason.type)).not.toContain(
-      "cloud_conflict",
-    );
-    expect(state.recoveryEvidence.manualReview).toEqual([
-      {
-        reason: "2 inventory review items need attention.",
-        source: "cloud_sync",
-        type: "synced_sale_inventory_review",
-      },
-    ]);
+    expect(state.attentionReasons).toEqual([]);
+    expect(state.recoveryEvidence.manualReview).toEqual([]);
   });
 
   it("treats local runtime review as terminal-local evidence collection instead of manual business review", () => {

--- a/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.ts
@@ -279,34 +279,6 @@ export function deriveTerminalHealthAttentionReasons(
   }
 
   const currentReviewGroups = getCurrentReviewGroups(input.syncEvidence);
-  const inventoryReviewGroups = currentReviewGroups.filter(
-    (group) => isInventoryReviewGroup(group, !!input.syncEvidence.reviewSummary),
-  );
-  const inventoryReviewCount = sumReviewGroupCounts(inventoryReviewGroups);
-
-  if (inventoryReviewCount > 0) {
-    const inventoryReviewTarget = inventoryReviewGroups.find(
-      (group) => group.reviewTarget,
-    )?.reviewTarget;
-    const latestInventoryReviewSequence =
-      latestReviewGroupSequence(inventoryReviewGroups) ?? latestEvent?.sequence;
-    const reason: TerminalHealthAttentionReason = {
-      count: inventoryReviewCount,
-      latestEventSequence: latestInventoryReviewSequence,
-      latestEventStatus: latestEvent?.status,
-      source: "cloud_sync",
-      summary: `${inventoryReviewCount} inventory review item${inventoryReviewCount === 1 ? " needs" : "s need"} attention.`,
-      type: "synced_sale_inventory_review",
-    };
-    if (inventoryReviewTarget) {
-      reason.actionTarget = {
-        label: "Review inventory work",
-        type: "open_work",
-      };
-    }
-    reasons.push(reason);
-  }
-
   const cloudReviewGroups = currentReviewGroups.filter(
     (group) => !isInventoryReviewGroup(group, !!input.syncEvidence.reviewSummary),
   );
@@ -433,6 +405,9 @@ function reconcileTerminalHealthAttentionReasons(
   runtimeStatus: TerminalOperationalPolicyInput["runtimeStatus"],
 ): TerminalHealthAttentionReason[] {
   return reasons.filter((reason) => {
+    if (reason.type === "synced_sale_inventory_review") {
+      return false;
+    }
     if (reason.type === "local_review") {
       const sync = runtimeStatus?.sync;
       return Boolean(
@@ -630,7 +605,19 @@ function buildDiagnosticEvidence(input: TerminalOperationalPolicyInput) {
     });
   }
 
-  if ((input.syncEvidence.unresolvedConflictCount ?? 0) > 0) {
+  const reviewGroups = getCurrentReviewGroups(input.syncEvidence);
+  const hasDetailedReviewEvidence = Boolean(
+    input.syncEvidence.reviewSummary || input.syncEvidence.unresolvedConflicts,
+  );
+  const hasTerminalReviewEvidence =
+    reviewGroups.some(
+      (group) =>
+        !isInventoryReviewGroup(group, !!input.syncEvidence.reviewSummary),
+    ) ||
+    (!hasDetailedReviewEvidence &&
+      (input.syncEvidence.unresolvedConflictCount ?? 0) > 0);
+
+  if (hasTerminalReviewEvidence) {
     diagnostics.push({
       severity: "warning" as const,
       source: "sync_evidence" as const,

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -2118,7 +2118,7 @@ describe("terminal health summaries", () => {
     });
   });
 
-  it("does not synthesize inventory open-work links without a resolved target", async () => {
+  it("keeps unresolved inventory review work out of terminal attention", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(null);
     vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
@@ -2165,14 +2165,7 @@ describe("terminal health summaries", () => {
       },
     );
 
-    expect(result?.attentionReasons).toEqual([
-      expect.objectContaining({
-        count: 2,
-        summary: "2 inventory review items need attention.",
-        type: "synced_sale_inventory_review",
-      }),
-    ]);
-    expect(result?.attentionReasons[0]?.actionTarget).toBeUndefined();
+    expect(result?.attentionReasons).toEqual([]);
   });
 
   it("resolves cloud review reasons to a cash-control register session when sync mapping exists", async () => {
@@ -2234,7 +2227,7 @@ describe("terminal health summaries", () => {
     ]);
   });
 
-  it("routes projected inventory review conflicts to operations work", async () => {
+  it("keeps projected inventory review conflicts out of terminal attention", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(null);
     vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
@@ -2333,18 +2326,7 @@ describe("terminal health summaries", () => {
     );
 
     expect(resolveTerminalRegisterSessionActionTarget).not.toHaveBeenCalled();
-    expect(result?.attentionReasons).toEqual([
-      expect.objectContaining({
-        actionTarget: {
-          label: "Review inventory work",
-          type: "open_work",
-        },
-        count: 1,
-        source: "cloud_sync",
-        summary: "1 inventory review item needs attention.",
-        type: "synced_sale_inventory_review",
-      }),
-    ]);
+    expect(result?.attentionReasons).toEqual([]);
   });
 
   it("resolves each cloud review reason from its own register session evidence", async () => {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -2084,51 +2084,78 @@ describe("DailyOperationsViewContent", () => {
     const priorOperatingDate = shiftTestOperatingDate(currentOperatingDate, -1);
     const futureOperatingDate = shiftTestOperatingDate(currentOperatingDate, 1);
 
-    renderContent({
-      ...operatingSnapshot,
-      closeSummary: {
-        ...operatingSnapshot.closeSummary,
-        salesTotal: 1533100,
-        transactionCount: 3,
-      },
-      operatingDate: currentOperatingDate,
-      priorDayMetric: {
-        ...weekMetrics[0],
-        currentDayCashTotal: 200000,
-        currentDayCashTransactionCount: 1,
-        isClosed: false,
-        isSelected: false,
-        operatingDate: priorOperatingDate,
-        paymentTotals: [
-          { amount: 200000, method: "cash", transactionCount: 1 },
-          { amount: 800000, method: "mobile_money", transactionCount: 1 },
-        ],
-        salesTotal: 1000000,
-        transactionCount: 2,
-      },
-      weekMetrics: [
-        {
-          ...weekMetrics[0],
-          isClosed: false,
-          isSelected: true,
-          operatingDate: currentOperatingDate,
+    renderContent(
+      {
+        ...operatingSnapshot,
+        closeSummary: {
+          ...operatingSnapshot.closeSummary,
           salesTotal: 1533100,
           transactionCount: 3,
         },
-        {
-          ...weekMetrics[1],
+        operatingDate: currentOperatingDate,
+        priorDayMetric: undefined,
+        weekMetrics: [
+          {
+            ...weekMetrics[0],
+            isClosed: false,
+            isSelected: true,
+            operatingDate: currentOperatingDate,
+            salesTotal: 1533100,
+            transactionCount: 3,
+          },
+          {
+            ...weekMetrics[1],
+            isClosed: false,
+            isSelected: false,
+            operatingDate: futureOperatingDate,
+            salesTotal: 0,
+            transactionCount: 0,
+          },
+        ],
+      },
+      {
+        cachedPriorWeekBoundaryMetric: {
+          ...weekMetrics[0],
+          currentDayCashTotal: 200000,
+          currentDayCashTransactionCount: 1,
           isClosed: false,
           isSelected: false,
-          operatingDate: futureOperatingDate,
-          salesTotal: 0,
-          transactionCount: 0,
+          operatingDate: priorOperatingDate,
+          paymentTotals: [
+            { amount: 200000, method: "cash", transactionCount: 1 },
+            { amount: 800000, method: "mobile_money", transactionCount: 1 },
+          ],
+          salesTotal: 1000000,
+          transactionCount: 2,
         },
-      ],
-    });
+      },
+    );
 
     expect(screen.getByText("+53%")).toBeInTheDocument();
     expect(screen.getAllByText("vs yesterday").length).toBeGreaterThan(0);
     expect(screen.queryAllByText("None yesterday")).toHaveLength(0);
+  });
+
+  it("uses bounded week analytics for prior-day metric card comparisons", () => {
+    const priorMetric = weekMetrics.find(
+      (metric) => metric.operatingDate === "2026-05-07",
+    );
+
+    expect(priorMetric).toBeDefined();
+
+    renderContent(
+      {
+        ...operatingSnapshot,
+        priorDayMetric: undefined,
+        weekMetrics: [],
+      },
+      {
+        cachedWeekMetrics: weekMetrics,
+      },
+    );
+
+    expect(screen.getByText("+3307%")).toBeInTheDocument();
+    expect(screen.getAllByText("vs prior day").length).toBeGreaterThan(0);
   });
 
   it("uses payment-specific copy when a prior-day payment method has no entries", () => {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -347,6 +347,9 @@ export type DailyOperationsSnapshot = {
 };
 
 type DailyOperationsViewContentProps = {
+  cachedPriorWeekBoundaryMetric?:
+    | DailyOperationsSnapshot["weekMetrics"][number]
+    | null;
   cachedWeekAnalyticsFetchedAt?: number;
   cachedWeekMetrics?: DailyOperationsSnapshot["weekMetrics"];
   cachedWeekStorePulse?: StorePulseSummary | null;
@@ -400,6 +403,9 @@ type CachedWeekAnalytics = {
   >;
   fetchedAt: number;
   metrics: DailyOperationsSnapshot["weekMetrics"];
+  priorWeekBoundaryMetric?:
+    | DailyOperationsSnapshot["weekMetrics"][number]
+    | null;
   storePulse?: StorePulseSummary | null;
 };
 
@@ -425,6 +431,9 @@ type DailyOperationsTimelinePreviewSnapshot =
 
 type DailyOperationsWeekAnalyticsSnapshot = {
   operatingDate: string;
+  priorWeekBoundaryMetric?:
+    | DailyOperationsSnapshot["weekMetrics"][number]
+    | null;
   weekEndOperatingDate: string;
   weekMetrics: DailyOperationsSnapshot["weekMetrics"];
 };
@@ -1158,7 +1167,13 @@ function getPreviousOperatingDate(operatingDate: string) {
   return getLocalOperatingDate(date);
 }
 
-function getPriorComparisonMetric(snapshot: DailyOperationsSnapshot) {
+function getPriorComparisonMetric(
+  snapshot: DailyOperationsSnapshot,
+  cachedWeekMetrics?: DailyOperationsSnapshot["weekMetrics"],
+  cachedPriorWeekBoundaryMetric?:
+    | DailyOperationsSnapshot["weekMetrics"][number]
+    | null,
+) {
   const previousOperatingDate = getPreviousOperatingDate(
     snapshot.operatingDate,
   );
@@ -1169,7 +1184,13 @@ function getPriorComparisonMetric(snapshot: DailyOperationsSnapshot) {
     return snapshot.priorDayMetric;
   }
 
-  return snapshot.weekMetrics.find(
+  if (
+    cachedPriorWeekBoundaryMetric?.operatingDate === previousOperatingDate
+  ) {
+    return cachedPriorWeekBoundaryMetric;
+  }
+
+  return (cachedWeekMetrics ?? snapshot.weekMetrics).find(
     (metric) => metric.operatingDate === previousOperatingDate,
   );
 }
@@ -3216,6 +3237,7 @@ function WeekMetricsStrip({
 }
 
 export function DailyOperationsViewContent({
+  cachedPriorWeekBoundaryMetric,
   cachedWeekAnalyticsFetchedAt,
   cachedWeekMetrics,
   cachedWeekStorePulse,
@@ -3293,7 +3315,11 @@ export function DailyOperationsViewContent({
     ? getOtherPaymentTotals(snapshot.closeSummary)
     : [];
   const priorComparisonMetric = snapshot
-    ? getPriorComparisonMetric(snapshot)
+    ? getPriorComparisonMetric(
+        snapshot,
+        cachedWeekMetrics,
+        cachedPriorWeekBoundaryMetric,
+      )
     : undefined;
   const priorWindowLabel = snapshot
     ? getPriorWindowLabel(snapshot.operatingDate)
@@ -4290,6 +4316,8 @@ function DailyOperationsConnectedView({
           daySnapshots: existingWeekAnalytics?.daySnapshots ?? {},
           fetchedAt: Date.now(),
           metrics: queriedWeekAnalyticsSnapshot.weekMetrics,
+          priorWeekBoundaryMetric:
+            queriedWeekAnalyticsSnapshot.priorWeekBoundaryMetric,
           storePulse: existingWeekAnalytics?.storePulse,
         },
       };
@@ -4326,6 +4354,8 @@ function DailyOperationsConnectedView({
           },
           fetchedAt: existingWeekAnalytics?.fetchedAt ?? Date.now(),
           metrics: existingWeekAnalytics?.metrics ?? [],
+          priorWeekBoundaryMetric:
+            existingWeekAnalytics?.priorWeekBoundaryMetric,
           storePulse: existingWeekAnalytics?.storePulse,
         },
       };
@@ -4473,6 +4503,9 @@ function DailyOperationsConnectedView({
   return (
     <DailyOperationsViewContent
       currency={activeStore?.currency ?? "GHS"}
+      cachedPriorWeekBoundaryMetric={
+        cachedWeekAnalytics?.priorWeekBoundaryMetric
+      }
       cachedWeekAnalyticsFetchedAt={cachedWeekAnalytics?.fetchedAt}
       cachedWeekMetrics={cachedWeekMetrics}
       cachedWeekStorePulse={cachedWeekStorePulse}

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -374,9 +374,9 @@ describe("POSTerminalDetailViewContent", () => {
     expect(
       screen.getByText("Local runtime review / next upload #14"),
     ).toBeInTheDocument();
-    expect(screen.getAllByText("Cloud sync evidence").length).toBeGreaterThan(
-      0,
-    );
+    expect(
+      screen.queryByRole("heading", { name: "Cloud sync evidence" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText("Staff authority changed before sync."),
     ).toBeInTheDocument();
@@ -393,6 +393,7 @@ describe("POSTerminalDetailViewContent", () => {
       <POSTerminalDetailViewContent
         detail={{
           ...detail,
+          health: "offline",
           runtimeStatus: {
             ...detail.runtimeStatus!,
             buildSha: "old-build-sha",
@@ -2073,7 +2074,7 @@ describe("POSTerminalDetailViewContent", () => {
     expect(onResolveRegisterSessionReview).not.toHaveBeenCalled();
   });
 
-  it("routes inventory review attention to open work with inventory copy", () => {
+  it("does not render inventory review work as terminal attention", () => {
     render(
       <POSTerminalDetailViewContent
         detail={{
@@ -2092,6 +2093,70 @@ describe("POSTerminalDetailViewContent", () => {
               type: "synced_sale_inventory_review",
             },
           ],
+          operationalExplanation: {
+            blockingDomain: "manual_review",
+            detail:
+              "Manual review must finish before support repairs this terminal.",
+            evidenceReferences: [
+              {
+                count: 1,
+                source: "cloud_sync",
+                summary: "Inventory review work",
+                type: "synced_sale_inventory_review",
+              },
+            ],
+            headline: "Manager review needed",
+            lane: "needs_manual_review",
+            nextStep: "Use the linked review workspace.",
+            primaryOwner: "manager",
+            saleImpact: "can_transact_now",
+            secondaryActions: [],
+            severity: "warning",
+            summaryMeta: {
+              hasSecondarySafeRepair: false,
+              reviewBacklogCount: 1,
+              targetResolutionIncomplete: false,
+            },
+            supportAction: "manual_review",
+          },
+          recoveryPreview: {
+            manualReview: [
+              {
+                reason: "Inventory review work",
+                source: "cloud_sync",
+                type: "synced_sale_inventory_review",
+              },
+            ],
+            readiness: "needs_manual_review",
+          },
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              failedEventCount: 0,
+              localOnlyEventCount: 0,
+              pendingEventCount: 0,
+              reviewEventCount: 0,
+              reviewEvents: [],
+              status: "idle",
+              uploadableEventCount: 0,
+            },
+          },
+          syncEvidence: {
+            unresolvedConflictCount: 1,
+            unresolvedConflicts: [
+              {
+                _id: "inventory-conflict-1",
+                conflictType: "inventory",
+                createdAt: Date.now(),
+                localEventId: "inventory-event-1",
+                localRegisterSessionId: "local-register-1",
+                sequence: 26,
+                summary:
+                  "Inventory needs manager review for a synced offline sale.",
+              },
+            ],
+          },
         }}
         isLoading={false}
         orgUrlSlug="wigclub"
@@ -2100,17 +2165,25 @@ describe("POSTerminalDetailViewContent", () => {
     );
 
     expect(
-      screen.getByText("1 inventory review item needs attention."),
-    ).toBeInTheDocument();
+      screen.queryByText("1 inventory review item needs attention."),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: /review inventory work/i }),
-    ).toHaveAttribute("href", "/wigclub/store/osu/operations/open-work");
+      screen.queryByText("Why this terminal needs attention"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Manager review needed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Needs review")).not.toBeInTheDocument();
+    expect(screen.queryByText("Conflicts and review")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: /review register session/i }),
+      screen.queryByRole("heading", { name: "Cloud sync evidence" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Inventory needs manager review for a synced offline sale.",
+      ),
     ).not.toBeInTheDocument();
   });
 
-  it("renders unresolved inventory review reasons without fabricating a CTA", () => {
+  it("hides unresolved legacy inventory review reasons", () => {
     render(
       <POSTerminalDetailViewContent
         detail={{
@@ -2133,13 +2206,10 @@ describe("POSTerminalDetailViewContent", () => {
     );
 
     expect(
-      screen.getByText("2 inventory review items need attention."),
-    ).toBeInTheDocument();
+      screen.queryByText("2 inventory review items need attention."),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Inventory review required before support repair"),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: /review inventory work/i }),
+      screen.queryByText("Why this terminal needs attention"),
     ).not.toBeInTheDocument();
   });
 
@@ -2629,7 +2699,7 @@ describe("POSTerminalDetailViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders the current aggregate sync evidence query shape", () => {
+  it("keeps aggregate sync telemetry out of the terminal support page", () => {
     render(
       <POSTerminalDetailViewContent
         detail={{
@@ -2658,8 +2728,11 @@ describe("POSTerminalDetailViewContent", () => {
       />,
     );
 
-    expect(screen.getByText("5 sampled")).toBeInTheDocument();
-    expect(screen.getByText("sale.completed")).toBeInTheDocument();
+    expect(screen.queryByText("5 sampled")).not.toBeInTheDocument();
+    expect(screen.queryByText("sale.completed")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Cloud sync evidence" }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText(
         "2 sync items need review; detailed conflict records were not returned.",

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -57,7 +57,6 @@ import {
   formatRegisterNumber,
   formatStatusLabel,
   formatTerminalTimestamp,
-  getRecentSyncEvents,
   getReviewEvidenceCount,
   getStaffAuthorityLabel,
   getSupportSafeAttentionReasonSummary,
@@ -70,7 +69,6 @@ import type {
   TerminalHealthAttentionReason,
   TerminalRecoveryAction,
   TerminalRuntimeStatus,
-  TerminalSyncEvent,
   TerminalSyncEvidence,
 } from "./terminalHealthTypes";
 
@@ -239,17 +237,6 @@ function DetailPanel({
       </div>
       {children}
     </section>
-  );
-}
-
-function Field({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div>
-      <p className="text-xs font-medium uppercase text-muted-foreground">
-        {label}
-      </p>
-      <div className="mt-1 text-sm text-foreground">{value}</div>
-    </div>
   );
 }
 
@@ -970,41 +957,6 @@ function normalizeOptionalRuntimeMetadata(value: string | undefined) {
   return value && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-function SyncMetric({
-  detail,
-  label,
-  tone = "neutral",
-  value,
-}: {
-  detail: string;
-  label: string;
-  tone?: "danger" | "neutral" | "success" | "warning";
-  value: React.ReactNode;
-}) {
-  return (
-    <div
-      className={cn(
-        "rounded-md border bg-surface px-layout-md py-layout-md",
-        tone === "success"
-          ? "border-success/25 bg-success/5"
-          : tone === "warning"
-            ? "border-warning/30 bg-warning/10"
-            : tone === "danger"
-              ? "border-danger/25 bg-danger/5"
-              : "border-border/80",
-      )}
-    >
-      <p className="text-xs font-medium uppercase text-muted-foreground">
-        {label}
-      </p>
-      <p className="mt-1 font-numeric text-xl font-semibold tabular-nums text-foreground">
-        {value}
-      </p>
-      <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
-    </div>
-  );
-}
-
 function getSyncEventStatusClassName(status: string) {
   switch (status) {
     case "accepted":
@@ -1018,117 +970,6 @@ function getSyncEventStatusClassName(status: string) {
     default:
       return "border-border bg-surface text-muted-foreground";
   }
-}
-
-function RecentSyncEventRow({ event }: { event: TerminalSyncEvent }) {
-  return (
-    <div className="grid gap-layout-sm px-layout-md py-layout-sm text-sm md:grid-cols-[5rem_minmax(0,1fr)_7rem] md:items-center">
-      <span className="font-numeric text-xs font-semibold tabular-nums text-muted-foreground">
-        #{event.sequence}
-      </span>
-      <span className="min-w-0 truncate font-medium text-foreground">
-        {event.eventType}
-      </span>
-      <span
-        className={cn(
-          "inline-flex w-fit items-center rounded-md border px-layout-xs py-1 text-xs font-medium",
-          getSyncEventStatusClassName(event.status),
-        )}
-      >
-        {formatStatusLabel(event.status)}
-      </span>
-    </div>
-  );
-}
-
-function SyncEvidenceSection({
-  syncEvidence,
-}: {
-  syncEvidence: TerminalSyncEvidence;
-}) {
-  const recentEvents = getRecentSyncEvents(syncEvidence);
-  const sampledEventCount =
-    syncEvidence.sampledEventCount ?? recentEvents.length;
-
-  return (
-    <DetailPanel
-      icon={<CheckCircle2 className="h-4 w-4 text-muted-foreground" />}
-      title="Cloud sync evidence"
-    >
-      <div className="rounded-md border border-border/80 bg-surface px-layout-md py-layout-md">
-        <div className="grid gap-layout-md md:grid-cols-[minmax(0,1fr)_11rem_10rem] md:items-center">
-          <div className="min-w-0">
-            <p className="text-xs font-medium uppercase text-muted-foreground">
-              Accepted through sequence
-            </p>
-            <div className="mt-1 flex min-w-0 flex-wrap items-baseline gap-layout-xs">
-              <p className="font-numeric text-2xl font-semibold tabular-nums text-foreground">
-                {syncEvidence.acceptedThroughSequence == null
-                  ? "No sequence"
-                  : `#${syncEvidence.acceptedThroughSequence}`}
-              </p>
-              <p className="text-sm text-muted-foreground">
-                latest cloud cursor for this terminal
-              </p>
-            </div>
-          </div>
-          <Field
-            label="Cursor updated"
-            value={formatTerminalTimestamp(syncEvidence.cursorUpdatedAt)}
-          />
-          <Field label="Recent sample" value={`${sampledEventCount} sampled`} />
-        </div>
-      </div>
-
-      <div className="mt-layout-md grid gap-layout-sm sm:grid-cols-2 xl:grid-cols-4">
-        <SyncMetric
-          detail="accepted by cloud"
-          label="Accepted"
-          tone="success"
-          value={syncEvidence.acceptedCount ?? 0}
-        />
-        <SyncMetric
-          detail="applied to read models"
-          label="Projected"
-          value={syncEvidence.projectedCount ?? 0}
-        />
-        <SyncMetric
-          detail="waiting before projection"
-          label="Held"
-          tone={(syncEvidence.heldCount ?? 0) > 0 ? "warning" : "neutral"}
-          value={syncEvidence.heldCount ?? 0}
-        />
-        <SyncMetric
-          detail="rejected by server"
-          label="Rejected"
-          tone={(syncEvidence.rejectedCount ?? 0) > 0 ? "danger" : "neutral"}
-          value={syncEvidence.rejectedCount ?? 0}
-        />
-      </div>
-
-      <div className="mt-layout-md overflow-hidden rounded-md border border-border/80 bg-surface">
-        <div className="grid gap-layout-sm border-b border-border/80 bg-surface-muted/40 px-layout-md py-layout-xs text-xs font-medium uppercase text-muted-foreground md:grid-cols-[5rem_minmax(0,1fr)_7rem]">
-          <span>Sequence</span>
-          <span>Event</span>
-          <span>Status</span>
-        </div>
-        <div className="divide-y divide-border/80">
-          {recentEvents.length === 0 ? (
-            <p className="px-layout-md py-layout-sm text-sm text-muted-foreground">
-              No recent sync events reported for this terminal.
-            </p>
-          ) : (
-            recentEvents.map((event) => (
-              <RecentSyncEventRow
-                event={event}
-                key={event._id ?? event.localEventId}
-              />
-            ))
-          )}
-        </div>
-      </div>
-    </DetailPanel>
-  );
 }
 
 function ConflictSection({
@@ -1165,7 +1006,9 @@ function ConflictSection({
         : [];
   const missingRuntimeReviewDetails =
     runtimeReviewCount > 0 && localReviewEvents.length === 0;
-  const unresolvedConflicts = syncEvidence.unresolvedConflicts ?? [];
+  const unresolvedConflicts = (syncEvidence.unresolvedConflicts ?? []).filter(
+    (conflict) => conflict.conflictType !== "inventory",
+  );
   const visibleConflicts = isConflictListExpanded
     ? unresolvedConflicts
     : unresolvedConflicts.slice(0, TERMINAL_DETAIL_LIST_VISIBLE_LIMIT);
@@ -1180,7 +1023,11 @@ function ConflictSection({
     localReviewEvents.length - TERMINAL_DETAIL_LIST_VISIBLE_LIMIT,
     0,
   );
-  const reviewCount = getReviewEvidenceCount(syncEvidence);
+  const reviewCount = detail && hasOnlyInventoryReviewEvidence(detail)
+    ? 0
+    : syncEvidence.unresolvedConflicts
+      ? unresolvedConflicts.length
+      : getReviewEvidenceCount(syncEvidence);
   const localReviewActionReason = {
     actionTarget: { type: "pos_register" },
     count: runtimeReviewCount,
@@ -1193,6 +1040,15 @@ function ConflictSection({
   );
   const localReviewClearAllAction =
     getLocalReviewClearAllAction(recoveryPreview);
+
+  if (
+    !operationalExplanation &&
+    reviewCount === 0 &&
+    localReviewEvents.length === 0 &&
+    !missingRuntimeReviewDetails
+  ) {
+    return null;
+  }
 
   return (
     <DetailPanel
@@ -1577,7 +1433,9 @@ function AttentionReasonsSection({
   storeUrlSlug?: string;
 }) {
   const reasons = getTerminalAttentionReasons(detail).filter(
-    (reason) => !isVerifiedTerminalCommandAttention(reason, detail),
+    (reason) =>
+      reason.type !== "synced_sale_inventory_review" &&
+      !isVerifiedTerminalCommandAttention(reason, detail),
   );
 
   if (reasons.length === 0) {
@@ -2502,7 +2360,8 @@ function RecoveryPanel({
   const operationalExplanation =
     buildTerminalOperationalExplanationPresentation(detail);
   const hasServerOperationalExplanation = Boolean(
-    detail.operationalExplanation,
+    detail.operationalExplanation &&
+      !shouldSuppressInventoryOperationalExplanation(detail),
   );
   const hasCurrentRecoveryWork = hasCurrentSupportRecoveryWork(recovery);
   const supportReadiness = hasCurrentRecoveryWork
@@ -2640,6 +2499,49 @@ function RecoveryPanel({
         </>
       ) : null}
     </DetailPanel>
+  );
+}
+
+function hasOnlyInventoryReviewEvidence(detail: TerminalHealthDetail) {
+  const recoveryPreview = detail.recoveryPreview ?? detail.recovery;
+  const conflicts = detail.syncEvidence.unresolvedConflicts ?? [];
+  const manualReview = recoveryPreview?.manualReview ?? [];
+  const explanationReferences =
+    detail.operationalExplanation?.evidenceReferences ?? [];
+  const hasInventoryReviewEvidence =
+    conflicts.some((conflict) => conflict.conflictType === "inventory") ||
+    manualReview.some(
+      (item) => item.type === "synced_sale_inventory_review",
+    ) ||
+    explanationReferences.some(
+      (reference) => reference.type === "synced_sale_inventory_review",
+    );
+  const terminalReviewEvidenceTypes = new Set([
+    "cloud_conflict",
+    "cloud_held",
+    "cloud_rejected",
+    "local_review",
+    "unsafe_cloud_conflict",
+  ]);
+  const hasTerminalReviewEvidence =
+    conflicts.some((conflict) => conflict.conflictType !== "inventory") ||
+    manualReview.some(
+      (item) => item.type !== "synced_sale_inventory_review",
+    ) ||
+    explanationReferences.some((reference) =>
+      terminalReviewEvidenceTypes.has(reference.type),
+    );
+
+  return hasInventoryReviewEvidence && !hasTerminalReviewEvidence;
+}
+
+function shouldSuppressInventoryOperationalExplanation(
+  detail: TerminalHealthDetail,
+) {
+  const blockingDomain = detail.operationalExplanation?.blockingDomain;
+  return (
+    (blockingDomain === "manual_review" || blockingDomain === "sync_review") &&
+    hasOnlyInventoryReviewEvidence(detail)
   );
 }
 
@@ -3094,7 +2996,7 @@ export function POSTerminalDetailViewContent({
             eyebrow="POS terminal"
             showBackButton
             title={detail.terminal.displayName}
-            description="Inspect the latest terminal check-in, cloud sync evidence, and support notes."
+            description="Inspect the latest terminal check-in, support recovery evidence, and support notes."
           />
 
           <div className="grid gap-layout-xl xl:grid-cols-[20rem_minmax(0,1fr)]">
@@ -3129,12 +3031,12 @@ export function POSTerminalDetailViewContent({
                 orgUrlSlug={orgUrlSlug}
                 storeUrlSlug={storeUrlSlug}
               />
-              <SyncEvidenceSection syncEvidence={detail.syncEvidence} />
               <ConflictSection
                 detail={detail}
                 onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
                 operationalExplanation={
-                  detail.operationalExplanation
+                  detail.operationalExplanation &&
+                  !shouldSuppressInventoryOperationalExplanation(detail)
                     ? buildTerminalOperationalExplanationPresentation(detail)
                     : undefined
                 }

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -672,6 +672,27 @@ describe("terminal health presentation", () => {
     ]);
   });
 
+  it("keeps legacy inventory review work out of terminal recovery", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        manualReview: [
+          {
+            reason: "Inventory review work",
+            source: "cloud_sync",
+            type: "synced_sale_inventory_review",
+          },
+        ],
+        readiness: "needs_manual_review",
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.groups.manualReview).toEqual([]);
+    expect(presentation.safeActions).toEqual([]);
+  });
+
   it("uses the Convex recoveryPreview field for terminal command actions", () => {
     const presentation = buildTerminalRecoveryPresentation({
       recoveryPreview: {
@@ -1412,6 +1433,44 @@ describe("terminal health presentation", () => {
     ).toBe("1 local review item is still on this terminal.");
 
     vi.useRealTimers();
+  });
+
+  it("does not classify inventory-only sync evidence as terminal review", () => {
+    expect(
+      classifyTerminalHealth({
+        health: "offline",
+        runtimeStatus: {
+          receivedAt: Date.now() - 4 * 60 * 60_000,
+          sync: {
+            failedEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+        },
+        syncEvidence: {
+          conflictedCount: 1,
+          reviewSummary: {
+            groups: [{ conflictType: "inventory", count: 1 }],
+          },
+          unresolvedConflictCount: 1,
+          unresolvedConflicts: [
+            {
+              _id: "inventory-conflict-1",
+              conflictType: "inventory",
+              createdAt: Date.now(),
+              localEventId: "inventory-event-1",
+              localRegisterSessionId: "local-register-1",
+              sequence: 26,
+              summary:
+                "Inventory needs manager review for a synced offline sale.",
+            },
+          ],
+        },
+        terminal: { status: "active" },
+      }).label,
+    ).toBe("Offline");
   });
 
   it("returns backend attention reasons without synthesizing fallback reasons", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -222,6 +222,20 @@ export function getReviewEvidenceCount(
     return 0;
   }
 
+  if (syncEvidence.reviewSummary) {
+    return syncEvidence.reviewSummary.groups.reduce(
+      (count, group) =>
+        group.conflictType === "inventory" ? count : count + group.count,
+      0,
+    );
+  }
+
+  if (syncEvidence.unresolvedConflicts) {
+    return syncEvidence.unresolvedConflicts.filter(
+      (conflict) => conflict.conflictType !== "inventory",
+    ).length;
+  }
+
   const cloudReviewCount =
     (syncEvidence.conflictedCount ?? 0) +
     (syncEvidence.heldCount ?? 0) +
@@ -1589,6 +1603,10 @@ function buildRecoveryBlockersFromPreview(
   });
 
   preview.manualReview?.forEach((item, index) => {
+    if (item.type === "synced_sale_inventory_review") {
+      return;
+    }
+
     const normalizedReason = normalizeSupportCopy(item.reason);
     blockers.push({
       category: "manual_review",

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -227,6 +227,12 @@ export type TerminalSyncEvidence = {
   };
   projectedCount?: number;
   rejectedCount?: number;
+  reviewSummary?: {
+    groups: Array<{
+      conflictType: string;
+      count: number;
+    }>;
+  };
   sampledEventCount?: number;
   unresolvedConflictCount?: number;
   unresolvedConflicts?: TerminalSyncConflict[];


### PR DESCRIPTION
## Summary
- restore Daily Operations metric comparisons with the existing bounded week data plus one bounded predecessor metric
- keep inventory review work out of terminal recovery, manager-review posture, and register review badges
- remove noisy Cloud sync evidence from terminal detail while retaining terminal-owned recovery paths

## Validation
- `bun run test -- convex/operations/dailyOperations.test.ts src/components/operations/DailyOperationsView.test.tsx convex/pos/application/terminalOperationalState/policy.test.ts convex/pos/application/queries/terminals.test.ts convex/pos/application/terminals.test.ts convex/pos/public/terminals.test.ts src/components/pos/terminals/terminalHealthPresentation.test.ts src/components/pos/terminals/POSTerminalDetailView.test.tsx src/components/pos/terminals/POSTerminalHealthView.test.tsx` (428 passed)
- `bun run lint:convex:changed`
- `bun run lint:frontend:changed`
- `bun run typecheck`
- `bun run graphify:rebuild`
- `bun run compound:check`
- `bun run landed-report:check`
- `bun run pr:athena`

Delivery report: `docs/reports/2026-07-14-terminal-inventory-and-daily-comparisons-report.html`.