### PR TITLE
[V26-1055 V26-1056 V26-1057]: POS Phase 0 — close IDOR/PII surfaces and stop silent rejected-sale loss

### DIFF
--- a/docs/plans/2026-07-15-001-fix-pos-local-first-hardening-plan.md
+++ b/docs/plans/2026-07-15-001-fix-pos-local-first-hardening-plan.md
@@ -1,0 +1,566 @@
+---
+title: "fix: POS local-first hardening — data-loss, liveness, and trust-boundary gaps"
+type: fix
+status: active
+date: 2026-07-15
+deepened: 2026-07-15
+---
+
+# fix: POS local-first hardening — data-loss, liveness, and trust-boundary gaps
+
+## Summary
+
+A nine-pass audit of the local-first POS stack found the event-sourced core sound (single-mutation exactly-once ingest, durable-commit-before-ack, monotonic per-cursor ordering) but exposed clustered gaps in the seams around it. This plan closes them in three independently-shippable phases: **Phase 0** stops active silent-failure paths (unauthenticated cross-tenant reads/writes, and offline sales that vanish with no record); **Phase 1** hardens liveness and convergence (batch-poisoning, unbounded ledger growth, wedged cursors, local/server conflict divergence); **Phase 2** tightens the client→server trust boundary (server-side re-pricing, idempotency keys, clock trust, money typing). Each phase lands as one integration PR from its own worktree, and each phase's finish line is an **opened, mergeable PR** (green `bun run pr:athena`, review-clean, no conflicts with `origin/main`).
+
+This plan was strengthened by a four-lens review pass (security, money/payments, Convex backend correctness, plan quality) whose blocking findings are integrated below — most notably a re-specification of U3 (Convex has no partial-transaction rollback, so the original "catch-and-continue" approach was infeasible) and the discovery of a second unauthorized public surface (`customers.ts`).
+
+---
+
+## Problem Frame
+
+The POS runs local-first on in-store terminals with flaky connectivity: sales append to an IndexedDB event log, project into React, and drain to Convex via a backoff scheduler. For an offline cash system the failure that matters most is "money changed hands but the record is gone or wrong." The audit found several paths that produce exactly that outcome — a validation-rejected offline sale dropped with no conflict record, unbounded ledger growth that eventually blocks selling, and a server that trusts terminal-supplied prices, totals, and clocks without independent recomputation. Separately, two public surfaces (`register.getState`, and all of `customers.ts`) perform cross-tenant reads/writes with no authorization. None of these are failures of the event-sourcing core; they are gaps in the validation, purge, convergence, authorization, and trust seams around it.
+
+---
+
+## Unit ↔ Audit-Label Map
+
+The nine-pass audit used letter labels; this plan uses stable U-IDs. Mapping for cross-reference:
+
+| U-ID | Audit label | Theme |
+|------|-------------|-------|
+| U1 | E1 + E2 | Authorize `register.getState` + `openDrawer` |
+| U2 | A2 | Rejected financial events → manager-visible conflict |
+| U3 | B2 | Per-event projection isolation (validate-before-write) |
+| U4 | B1 | Bounded local ledger (evidence-gated purge) |
+| U5 | B3/B4 | Stuck/held cursor escalation + truthful sync status |
+| U6 | C1 | Local review resolution round-trips to server |
+| U7 | D2 | Server-side re-pricing + override audit |
+| U8 | D3 | Idempotency key across completion + register cash |
+| U9 | D1 | Server-derived/clamped `occurredAt`/`operatingDate` |
+| U10 | D4 | Money as integer minor units + finish pesewas migration |
+| U11 | E1-adjacent | Authorize `customers.ts` (PII + writes) |
+
+---
+
+## Requirements
+
+- R1. No completed offline sale (money collected) may leave the sync pipeline without either a canonical transaction or a manager-visible conflict record.
+- R2. No authenticated user may read or mutate POS state (including customer PII) for a store/organization they do not belong to.
+- R3. A single malformed or unprojectable event must not stall or discard an entire register session's sync stream, and must never commit a partially-projected sale.
+- R4. The local event ledger must have a bounded, safe purge path so an all-day terminal cannot grow into a quota-exceeded sell-block.
+- R5. When the server records a conflict, terminal and server must converge on resolution state; a locally-cleared review must not leave the server conflict permanently open.
+- R6. Sale line prices and totals recorded server-side must be validated against catalog authority on every completion path, and any deviation (override/discount) must be authorized and attributable in an append-only audit.
+- R7. Completing a sale must be idempotent across client retries on every completion path, including drawer cash effects.
+- R8. Business timestamps and operating-date attribution must not be silently corruptible by terminal clock skew.
+- R9. Money must be represented and validated as integer minor units end to end, including cash-drawer fields.
+
+---
+
+## Scope Boundaries
+
+- Not rewriting the event-sourcing core, the sync-contract event shapes, or the authority/revision (CAS) model — these are sound and out of scope.
+- Not changing the offline-first posture (no online-only fallback sell path is introduced).
+- Not addressing the Paystack/MTN webhook signature gaps found in the storefront/online payment path — real, but they belong to the storefront checkout surface, not the in-store POS local-first flow this plan targets. Tracked separately (see Deferred to Follow-Up Work).
+- Not implementing offline PIN lockout / cashier auto-lock or backend error-tracking (Sentry) in these three phases.
+
+### Deferred to Follow-Up Work
+
+- **A1 — authority-cutover wipe telemetry review** (explicitly dropped from active scope by request): confirm via `deletedEventCount` telemetry whether the one-time #642 cutover lost events; add a lint guard forbidding unconditional event deletion without a drain-first precondition. Separate investigation ticket.
+- **Storefront payment-webhook hardening** (Paystack HMAC verification, amount verification, MTN callback auth): separate PR against the storefront/http surface.
+- **Terminal security hardening** (offline PIN attempt-limiting, cashier inactivity auto-lock).
+- **Backend observability** (Convex-side error tracking + cron dead-letter/alerting) — the force-multiplier that makes A2/B2/B3-class failures visible fleet-wide; strong candidate to pull forward as its own initiative.
+- **C4 — finalized-lineage repair re-reconciliation** (repair applies a late sale to a closed register without recomputing its signed-off closeout): scoped follow-up in the cash-controls domain.
+- **Storefront/POS reservation unification** (online decrements shared counter; POS holds invisible to storefront): inventory-domain follow-up.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Ingest/projection engine** — `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` (batch driver, sequence gate, `rejected`/`held` handling, cursor advance at `advanceAcceptedThroughSequence`), `projectLocalEvents.ts` (per-type projectors: `projectSaleCompleted` runs `validateSaleCompletedInputs`/`resolveSaleRegisterAndSession`/`validateSaleInventory` *before* the `persist*` write steps; `createConflict`, `resolveExistingSaleProjection`), `projectionPolicies.ts`, `infrastructure/repositories/localSyncRepository.ts` (`resolveConflictsForEvent` resolves conflicts; the write primitives). Single Convex mutation = one serializable OCC transaction with **no savepoints and no partial rollback** — a caught mid-projection throw does not undo prior `ctx.db` writes.
+- **Conflict surface** — `convex/pos/application/sync/registerSessionSyncReview.ts` (`classifyRegisterSessionSyncReview` already has a dead `server_rejected` branch at ~:159), schema `convex/schemas/pos/posLocalSyncConflict.ts` (closed `conflictType` union `duplicate_local_id | inventory | payment | permission`; `status` union `needs_review | resolved`; `details: v.record(v.string(), v.any())`).
+- **Authorization pattern to mirror** — `convex/pos/public/transactions.ts` resolves `store` → `requireAuthenticatedAthenaUserWithCtx` → `requireOrganizationMemberRoleWithCtx(store.organizationId)`; helper `requirePosTransactionStoreAccess`. Central helpers in `convex/lib/athenaUserAuth.ts`. Unauthorized surfaces: `getRegisterState.ts` (behind `register.getState`), `register.openDrawer` (authentication-only, no org check), and **all of `convex/pos/public/customers.ts`** (13 endpoints, zero auth at any layer). Deliberate non-IDOR exception: `terminalAppSessions.ts` authorizes via terminal-proof secret + `validatePosAppAccount` org check — do not add a redundant guard there.
+- **Override/approval precedent** — `completeTransaction.ts` already uses the approval framework (`ApprovalRequirement`, `buildVoidApprovalRequirement` → `requiredRole: "manager"`, `inline_manager_proof`/`async_request`). This is the exact precedent for U7's price-override authority.
+- **Client local store / scheduler** — `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts` (`appendEvent`, `clearLocalReviewEvents` sets `locally_resolved` with no server call, `resetRegisterOperationalStateForAuthorityCutover`, `assertCanClearIndexedDbPosLocalStore` authority/presence checks), `syncScheduler.ts`, `usePosLocalSyncRuntime.ts`, `posLocalLedgerPolicy.ts` (`assessPosLocalLedgerRetention` — dead code, classifies `settled_unreferenced` vs `review_required`/`unsettled_sync`; no store-day input), `syncStatus.ts` (`isLocallySettledSyncStatus` counts `locally_resolved` as settled — the divergence vector), `components/pos/register/POSRegisterView.tsx` (chip styling).
+- **Completion / pricing / money** — `convex/pos/application/commands/completeTransaction.ts` (`calculateCanonicalTransactionTotals` at ~:737 sums client `item.price`, `roundStoredAmount = Number(amount.toFixed(2))` at ~:733; two `recordRegisterSessionSale` call sites at ~:1199 and ~:2622 that omit `idempotencyKey`; void path passes it at ~:1833). Two public completion paths: `completeTransaction` (`transactions.ts:417`) and `createTransactionFromSession` (`transactions.ts:868`). Offline sale projection **already re-prices**: `projectLocalEvents.ts` ~:3926 computes `expectedUnitPrice = provisional.importedPrice ?? sku.netPrice ?? sku.price` and raises a non-blocking price review conflict on mismatch. Money schemas: `convex/schemas/pos/posTransaction.ts`, `posSession.ts`, and cash-drawer `convex/schemas/operations/registerSession.ts` (`openingFloat`/`expectedCash`/`countedCash`/`variance`, plus `closeoutRecords[]`), and `posLocalSyncContractValidators.ts` cash fields — all unconstrained `v.number()`. `convex/lib/currency.ts` (`toPesewas`/`toDisplayAmount`); `convex/migrations/migrateAmountsToPesewas.ts` (covers only online-order/checkout/sku tables — **no POS tables**; `onlineOrder.amount`/`paymentDue` conversions commented out; `productSku` heuristic `if (price < 10_000) skip`).
+- **Server store-day derivation** — `convex/reporting/operatingPeriods.ts` `resolveReportingFinancialPeriod` derives `operatingDate` from versioned store timezone authority + schedule windows (returns `missing/invalid_timezone_authority`). It currently has **no callers under `pos/` or `operations/`** — U9 must thread it (or its inputs) into ingest.
+
+### Institutional Learnings
+
+- Search `docs/solutions/` for prior POS sync, closeout, and read-amplification notes before touching those surfaces (per AGENTS.md `## solutions`). Recurring fix classes (read amplification #591/#623/#657, terminal/register recovery #598/#602/#642, EOD/closeout #588–#599, duplicate POS-session sales #595, sync-replay #633/#637) indicate design-level fragility around exactly these seams.
+
+### External References
+
+- None required; this is internal hardening with strong local patterns to mirror (the offline path already implements the idempotency, re-pricing, and conflict discipline the online path lacks). External research skipped.
+
+---
+
+## Key Technical Decisions
+
+- **Reuse the existing conflict rail, don't invent a new one.** A2/B2 route failures through the existing `posLocalSyncConflict` `needs_review` surface (via `createConflict` / `resolveConflictsForEvent`) and wire up the already-present-but-dead `server_rejected` classifier branch by adding that literal to the `conflictType` union — so managers see them in one place.
+- **U3 is validate-before-write, not catch-and-continue.** Convex mutations are one OCC transaction with no partial rollback; catching a projector throw *after* a write would commit a corrupted half-sale. The fix makes projection **total** for data-shaped failures: every currently-throwing data condition is checked *before the first `ctx.db` write* for that event and returns `status: "conflicted"` instead of throwing. Genuine infra errors still abort the whole mutation for a real retry.
+- **Extend the offline idempotency/re-pricing discipline to the online path.** The offline path is the *template*, not a fix target: it already dedups via `localTransactionId` and re-prices via `importedPrice ?? netPrice ?? price`. The online path must inherit both, with the behavior difference made explicit (offline flags-and-projects because money already moved; online hard-rejects pre-commit when no authorized override).
+- **Server recomputes, client proposes.** Pricing (U7) and clock/operating-date (U9): the server derives the authoritative value from its own state (catalog price basis; store-day window from `operatingPeriods.ts`) and validates the client value as a proposal.
+- **Purge is opt-in and evidence-gated.** U4 activates `assessPosLocalLedgerRetention` and deletes only events classified `settled_unreferenced` AND past a store-day/rollover boundary (a new input the classifier lacks today), composed with the authority/cashier-presence/protected-record checks from `assertCanClearIndexedDbPosLocalStore` — but **not** its `events.length > 0` whole-DB refusal, which would always block a selective purge.
+- **Schema constraints over runtime-only rounding.** U10 moves money integrality into schema validators across POS *and* cash-drawer tables, and finishes the pesewas migration for the POS tables it never covered before any constraint is flipped.
+- **Each phase is one integration PR from its own worktree**, finish line = opened + mergeable PR. Phase 2 units that share `completeTransaction.ts` (U7/U8/U9) are implemented sequentially in the same worktree; U10 (schema/migration) is parallelizable within Phase 2.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- *U3 mechanism* — validate-before-write returning `conflicted`, NOT try/catch-and-continue. Convex has no partial rollback, so a caught post-write throw commits a corrupted partial sale (reviewer-confirmed). Only a projector proven to perform no writes before it can throw may be wrapped.
+- *U2 surface vs retry* — surface as `needs_review` conflict using the `server_rejected` literal; a validation-rejected financial event cannot be auto-corrected. Cursor still advances on rejected (liveness preserved; confirmed at `advanceAcceptedThroughSequence`).
+- *U7 reject vs flag* — online hard-rejects an unauthorized price deviation pre-commit; an authorized override (mirroring `buildVoidApprovalRequirement`) completes with an append-only audit. Offline keeps its flag-and-project review conflict (money already moved).
+- *U10 migration scope* — fresh deterministic migration for the POS tables (`posTransaction`, `posTransactionItem`, `posSession`, `registerSession`) which were never migrated, not verification-only; replace the `< 10_000` heuristic and commented-out online-order conversions with a deterministic rule before flipping any constraint.
+- *U4 guard reuse* — reuse only the authority/presence/protected checks, not the `events.length > 0` refusal.
+
+### Deferred to Implementation
+
+- Exact `occurredAt` skew-tolerance window and the ingest behavior when a store lacks timezone authority (`missing/invalid_timezone_authority`) — reject vs. fall back to terminal value with a flag (U9).
+- The precise deterministic rule for disambiguating legacy cedis vs pesewas POS rows (U10) — determined against real data shape during characterization.
+- Whether U5's stuck-`held` escalation reuses an existing conflict kind or adds a new signal — resolved against `registerSessionSyncReview` classification.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+Event lifecycle today vs. after this plan (per register-session cursor):
+
+```
+pending --drain--> [single Convex ingest mutation, no partial rollback]
+                     |-- valid ---------------> projected  (canonical write + mapping)      [OK today]
+                     |-- business/perm/dup ----> conflicted (needs_review)                  [OK today]
+                     |-- envelope/payload -----> rejected  (cursor advances, NO record)     [U2: also add conflict]
+                     |-- data throw AFTER write-> whole batch aborts, cursor stuck          [U3: validate BEFORE
+                     |                                                                        first write -> conflicted;
+                     |                                                                        never commit partial sale]
+                     |-- gap / held -----------> held (successor stalls indefinitely)       [U5: escalate + surface]
+
+local review clear: needs_review --> locally_resolved (counted as settled locally)          [U6: also resolve server
+                                                                                              conflict via resolveConflictsForEvent]
+local ledger: append-only, no purge --> [U4: purge settled_unreferenced past rollover]
+```
+
+Trust boundary (Phase 2): for each completion path (`completeTransaction` AND `createTransactionFromSession`), server derives authoritative `{unitPrice basis = importedPrice ?? netPrice ?? price; occurredAt/operatingDate from server store-day; amounts as integer pesewas}`, validates the client proposal, dedups on a client-stable idempotency token *before* minting the transaction, and records an append-only override audit when an authorized deviation is accepted.
+
+---
+
+## Implementation Units
+
+### Phase 0 — Stop the bleed (one integration PR, worktree `fix/pos-phase0-data-loss-authz`)
+
+- U1. **Authorize `register.getState` and `register.openDrawer`, sweep sibling POS queries** *(audit E1+E2)*
+
+**Goal:** Close two cross-tenant IDOR holes in `register.ts`: `getState` has no authorization at all (reads another tenant's terminal state, active cashier, open register session, held cart contents); `openDrawer` is authentication-only (any authenticated user from any org can open a drawer on a target store given valid terminal/staff IDs, corrupting cash-control attribution).
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/public/register.ts` (`getState` wrapper) and `packages/athena-webapp/convex/pos/application/commands/register.ts` (`openDrawer` command — add org-membership, ~:64)
+- Reference (no change expected): `packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts`
+- Reference pattern: `packages/athena-webapp/convex/pos/public/transactions.ts` (`requirePosTransactionStoreAccess`), `convex/lib/athenaUserAuth.ts`
+- Test: `packages/athena-webapp/convex/pos/public/register.test.ts` (create) and the `openDrawer` command test
+
+**Approach:**
+- For `getState`: resolve `store` from `storeId`, then apply `requireAuthenticatedAthenaUserWithCtx` → `requireOrganizationMemberRoleWithCtx(store.organizationId)` before delegating.
+- For `openDrawer`: add the same `requireOrganizationMemberRoleWithCtx(store.organizationId)` check (it currently calls only `requireAuthenticatedAthenaUserWithCtx`), keeping the existing resource-consistency checks.
+- Sweep `terminals.ts`, `catalog.ts`, `sync.ts`, `posRecoveryCodes.ts` per-endpoint (auth-ref count < endpoint count in several, so presence-grep is insufficient) for the same omission. If the sweep finds more than a couple of same-shape omissions, split them into their own unit rather than growing U1. Do **not** touch `terminalAppSessions.ts` (deliberate terminal-proof + `validatePosAppAccount` exception — adding a guard there would be wrong). `customers.ts` is handled by U11.
+
+**Execution note:** Test-first — write failing cross-org access tests for both `getState` and `openDrawer` before adding guards.
+
+**Test scenarios:**
+- Authorization: a user from a different org passing a valid foreign `storeId` is denied `getState` (IDOR regression).
+- Authorization: a foreign-org user cannot `openDrawer` on a target store's terminal (attribution-integrity regression).
+- Happy path: an org member reads state / opens a drawer successfully.
+- Authorization: unauthenticated caller denied on both.
+- Edge case: non-existent `storeId` yields clean not-found/denied, not a leak.
+
+**Verification:** Both `getState` and `openDrawer` reject cross-org callers; same-org still works; sweep documented (fixed or ticketed).
+
+---
+
+- U11. **Authorize the `customers.ts` public surface (PII + writes)** *(audit E1-adjacent)*
+
+**Goal:** Close a fully-unauthorized public surface: all 13 endpoints in `convex/pos/public/customers.ts` (search, get-by-id, create, update, stats, transactions, links) have zero authorization at any layer. `getCustomerById` returns full PII (name, email, phone, address, `totalSpent`, transaction history) keyed only by `customerId`; the create/update mutations are unauthenticated cross-tenant writes.
+
+**Requirements:** R2
+
+**Dependencies:** None (co-shipped in Phase 0)
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/public/customers.ts` (all endpoints)
+- Modify: `packages/athena-webapp/convex/pos/application/queries/searchCustomers.ts` and `application/commands/assignCustomer.ts` (and sibling customer query/command modules) — add store/org scoping
+- Test: `packages/athena-webapp/convex/pos/public/customers.test.ts` (create)
+
+**Approach:**
+- Apply the standard `requireAuthenticatedAthenaUserWithCtx` → `requireOrganizationMemberRoleWithCtx(store.organizationId)` guard to every endpoint, resolving the store from `storeId`. For `getCustomerById`/`getCustomerTransactions` (keyed by `customerId`, no store arg today), scope the read to the caller's store/org — resolve the customer's store and verify membership, or require a `storeId` arg and verify the customer belongs to it. Ensure no endpoint returns or mutates a customer outside the caller's org.
+
+**Execution note:** Test-first — cross-org denial tests for a read (PII leak) and a write (create/update) before adding guards.
+
+**Test scenarios:**
+- Authorization: foreign-org user cannot `searchCustomers`/`getCustomerById` for a store they don't belong to (PII-leak regression).
+- Authorization: foreign-org user cannot `createCustomer`/`updateCustomer` against another store (cross-tenant write regression).
+- Happy path: an org member performs each operation for their own store.
+- Edge case: `getCustomerById` for a customer in another org is denied even with a valid `customerId`.
+- Authorization: unauthenticated caller denied on all.
+
+**Verification:** No `customers.ts` endpoint reads or writes across org boundaries; PII is store/org-scoped.
+
+---
+
+- U2. **Rejected financial sync events become manager-visible conflicts** *(audit A2)*
+
+**Goal:** Stop silent loss of completed offline sales. Today an envelope/payload/reference validation failure marks the event `rejected`, advances the cursor, and writes no `posLocalSyncConflict` — a cash sale can vanish with the drawer left short and nobody notified.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` (the `rejected` branch)
+- Modify: `packages/athena-webapp/convex/schemas/pos/posLocalSyncConflict.ts` (add a `server_rejected` literal to the `conflictType` union — this wires up the already-present-but-dead classifier branch)
+- Modify/reference: `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts` (`classifyRegisterSessionSyncReview` already handles `server_rejected` ~:159) and the conflict query feeding the review UI
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+
+**Approach:**
+- When a `rejected` event is money-bearing (`sale_completed` with payments), also create a `posLocalSyncConflict` with `conflictType: "server_rejected"` (`needs_review`), carrying `localEventId`, register session, amount, and rejection reason in `details` (the `v.record` field supports this). Keep cursor-advance behavior (liveness). Non-financial rejects (malformed telemetry) may keep today's silent-reject to avoid conflict-spam — scope the new conflict to money-bearing events.
+- Add/confirm a query + review-surface entry listing rejected financial events for reconciliation.
+
+**Execution note:** Test-first — assert a `sale_completed` with non-reconciling totals produces a `server_rejected` `needs_review` conflict, not a silent drop.
+
+**Patterns to follow:** existing `createConflict` call sites in `projectLocalEvents.ts` and the conflict dedup in `localSyncRepository.ts`.
+
+**Test scenarios:**
+- Error path: `sale_completed` whose totals don't reconcile → event `rejected` AND a `server_rejected` conflict exists with the reason.
+- Error path: `sale_completed` with a payment missing its timestamp → conflict created.
+- Replay/idempotency: re-sending the same rejected event does not create duplicate conflicts (reuse conflict dedup).
+- Edge case: a non-financial malformed event does not spawn a conflict (no spam).
+- Audit: the conflict carries localEventId / register session / amount / reason for reconciliation.
+
+**Verification:** No money-bearing event exits ingest as a bare `rejected` with no conflict; rejected financial events appear in the review surface.
+
+---
+
+### Phase 1 — Liveness & convergence (one integration PR, worktree `fix/pos-phase1-liveness-convergence`)
+
+- U3. **Make projection total for data-shaped failures (validate before first write → conflict)** *(audit B2)*
+
+**Goal:** A single event whose projector currently *throws* after it has already written (e.g. sale session + sale record inserted, then a mapping-collision / normalized-id-null / authority-revision throw) must not (a) abort the whole batch and wedge the register's sync stream, nor (b) — the trap in the naive fix — commit a corrupted half-projected sale. Convex has no partial-transaction rollback, so catching a post-write throw and continuing would commit the partial writes.
+
+**Requirements:** R3
+
+**Dependencies:** None (independent of Phase 0)
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` (move every currently-throwing data condition ahead of the first `ctx.db` write in each projector; return `conflicted` instead)
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` (batch driver: a `conflicted` event does not abort; cursor advances; only genuine infra errors abort)
+- Reference: throw sites in `registerMappingAuthorityRevision.ts`, `localSyncRepository.ts`, and `projectLocalEvents.ts` (`requireNormalizedCloudId`, store-day-not-configured, unsupported-type, `assertNever`)
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`, `projectLocalEvents.test.ts`
+
+**Approach:**
+- Audit each projector's write span. `projectSaleCompleted` already front-loads `validateSaleCompletedInputs`/`resolveSaleRegisterAndSession`/`validateSaleInventory` before the `persist*` steps; the work is to move the *post-first-write* throw conditions (normalized-id nulls, mapping-authority collisions, store-day-missing, unsupported-type) into pre-write validation that returns a `needs_review`/`conflicted` result. A bad event then produces **zero** canonical writes plus a conflict; good events in the batch commit; the cursor advances.
+- A `try/catch` around a projector is acceptable ONLY where that projector is proven to perform no `ctx.db` writes before any point it can throw. Otherwise the condition must become pre-write validation.
+- Classify genuine infra errors (DB failure) distinctly — those still throw and abort the mutation for a real client retry (no false conflict).
+
+**Execution note:** Characterization-first — capture current batch-abort-on-throw behavior, then change it. Include a test asserting that a data-shaped failure leaves **zero committed rows** for that event (not merely that the batch survives).
+
+**Test scenarios:**
+- Error path: a batch where event k hits a mapping-collision condition → events 1..k-1 and k+1..N commit, event k is `conflicted` with zero canonical rows written for it, cursor advances.
+- Error path (the critical one): a condition that today throws *after* the sale session/record insert produces **no** committed transaction/session/inventory rows for event k.
+- Edge case: a simulated infra/DB error still aborts the whole mutation (no false conflict; client retries).
+- Idempotency: reprocessing after the conflict does not double-apply surrounding events.
+- Happy path: an all-valid batch is unaffected.
+
+**Verification:** One poison event neither wedges the stream nor commits a partial sale; it becomes a zero-write conflict.
+
+---
+
+- U4. **Bounded local ledger — evidence-gated purge at a safe boundary** *(audit B1)*
+
+**Goal:** The IndexedDB event ledger grows unbounded all day (no purge/rollover exists); a high-volume terminal eventually hits `quota_exceeded` on `appendEvent`, which blocks selling. The retention classifier that would fix this is dead code.
+
+**Requirements:** R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalLedgerPolicy.ts` (activate `assessPosLocalLedgerRetention`; add a store-day/rollover-boundary input, which it lacks today)
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts` (add an evidence-gated selective purge op composing the classifier with the authority/cashier-presence/protected-record checks from `assertCanClearIndexedDbPosLocalStore` — but NOT its `events.length > 0` whole-DB refusal, which would always block a selective purge)
+- Modify: the caller that triggers purge at a safe idle/rollover boundary (`posLocalStoreMaintenance.ts` / `usePosLocalSyncRuntime.ts` / `posLocalStorageHealth.ts`)
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalLedgerPolicy.test.ts`, and the store's bounded-operations test
+
+**Approach:**
+- Purge an event only when `assessPosLocalLedgerRetention` classifies it `settled_unreferenced` (server-acked / `synced` or `locally_resolved`, not `review_required`/`unsettled_sync`/`upload_deferred`, no activity/workflow/receipt dependency) AND it is older than the current active register-session / store-day boundary (new input).
+- Never run while unsynced/protected/active-cashier-presence records exist (reuse the authority/presence/protected portion of `assertCanClearIndexedDbPosLocalStore`).
+- Trigger at a safe idle/rollover boundary, not mid-sale; emit a health/log signal with the purge count (no silent bulk delete).
+
+**Execution note:** Test-first for the classifier extension (pure function); characterization for the store op guard.
+
+**Test scenarios:**
+- Happy path: `settled_unreferenced` past-boundary events are purged; ledger shrinks.
+- Safety: an unsynced event is never purged.
+- Safety: a `synced` event still referenced (open conflict / drawer-authority block / activity dependency) is never purged.
+- Safety: purge refuses when active cashier presence / protected records exist.
+- Edge case: nothing purgeable → no-op.
+- Observability: purge count surfaced (not silent).
+
+**Verification:** An all-day terminal's ledger is bounded across a rollover; no unsynced or referenced event is ever deleted.
+
+---
+
+- U5. **Escalate stuck/held cursors and stop treating `locally_resolved` as silently settled** *(audit B3/B4)*
+
+**Goal:** A `held` successor of a `needs_review` precursor wedges foreground auto-drain indefinitely, and the sync status treats `locally_resolved` (and an operable register) as settled so a cashier gets no signal that prior sales still need reconciliation.
+
+**Requirements:** R3, R5 (partial)
+
+**Dependencies:** None (complements U3 on the server; shares status surface with U6)
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.ts` (`isLocallySettledSyncStatus` treats `locally_resolved` as settled ~:122 — the divergence vector; and the review-count derivation ~:135) and `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx` (confirm and fix the "ready"-styling mask)
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts` / `usePosLocalSyncRuntime.ts` (held-successor path)
+- Possibly modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` or `registerSessionSyncReview.ts` (server-side stuck-gap escalation)
+- Test: `syncStatus.test.ts`, `syncScheduler.test.ts`
+
+**Approach:**
+- Make an outstanding review truthful in the chip: an unresolved/`needs_review` (and a `locally_resolved` not yet server-confirmed — see U6) renders as an attention state, not success "ready", while the register stays operable. Verify the exact "ready" styling location in `POSRegisterView.tsx` during implementation.
+- Give a `held` successor of a stuck review precursor a path forward: include the precursor in an escalation drain, or escalate a long-`held` gap to a visible conflict/manager action so the cursor is not silently stuck forever. Prefer reusing the review classification over a new UI.
+
+**Execution note:** Characterization-first on scheduler wedge behavior and the status derivation.
+
+**Test scenarios:**
+- Error path: a `held` event whose precursor is `needs_review` surfaces an actionable state instead of looping silently.
+- UI: an outstanding review renders as review-needed, not success "ready", with the register operable.
+- Convergence: a `locally_resolved` event not yet server-confirmed does not read as fully settled (ties to U6).
+- Happy path: a fully-synced register shows "ready".
+- Edge case: a transient `held` that resolves next drain does not false-alarm.
+
+**Verification:** No silent indefinite wedge; cashiers see when prior sales need review.
+
+---
+
+- U6. **Round-trip local review resolution to the server** *(audit C1)*
+
+**Goal:** `clearLocalReviewEvents` moves ANY `needs_review` event to `locally_resolved` (treated as settled locally) but never tells the server, which still holds the `posLocalSyncConflict` as `needs_review`. Terminal shows "clear" while the server shows an open conflict — the two never converge.
+
+**Requirements:** R5
+
+**Dependencies:** U5 (shares the status surface; integrate after)
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts` / `terminalRecoveryCommands.ts` (local clear path emits a server resolution call; only mark `locally_resolved` after server ack, else reconcile next sync)
+- Add: an authorization-checked resolve mutation in `packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts` (or a public wrapper) built on the existing `resolveConflictsForEvent` primitive in `localSyncRepository.ts`
+- Test: `convex/pos/application/sync/registerSessionSyncReview.test.ts` (create) and the client store/recovery test
+
+**Approach:**
+- On local resolve, round-trip a server resolution that transitions the `posLocalSyncConflict` to `resolved` via `resolveConflictsForEvent`, authorization-checked with an explicit role: the POS org role (`requireOrganizationMemberRoleWithCtx(["full_admin","pos_only"])`) at minimum, or `manager` if the conflict class warrants it (pick one explicitly — do not invent a third notion). Mark the event `locally_resolved` only after server ack; otherwise leave it `needs_review` to reconcile on next sync.
+- Note the current local clear is broader than "uploaded `register.opened`" — it clears any `needs_review` — so scope the server round-trip to match the events that are actually clearable.
+
+**Execution note:** Test-first for the server resolve mutation including the authz path.
+
+**Test scenarios:**
+- Happy path: local resolve → server conflict transitions to `resolved`; both converge.
+- Authorization: a caller without the chosen review role cannot resolve the server conflict.
+- Failure path: server resolution fails/offline → event stays `needs_review` (not falsely settled); reconciles next sync.
+- Idempotency: resolving an already-`resolved` conflict is a safe no-op.
+- Audit: server-side resolution is attributable (who/when).
+
+**Verification:** No terminal can show a conflict cleared while the server still lists it open.
+
+---
+
+### Phase 2 — Trust boundary (one integration PR, worktree `fix/pos-phase2-trust-boundary`)
+
+- U7. **Server-side re-pricing (both paths) + append-only override audit** *(audit D2)*
+
+**Goal:** Both online completion paths recompute totals from client-supplied `item.price` and only check internal arithmetic; the authoritative catalog price is never compared. A stale-catalog or tampered terminal sells at an arbitrary price with no attribution. The offline path already re-prices — it is the template, not a fix target.
+
+**Requirements:** R6
+
+**Dependencies:** None (shares `completeTransaction.ts` with U8/U9 — sequence within the Phase 2 worktree)
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` — `calculateCanonicalTransactionTotals` (~:737) and BOTH the direct (`completeTransaction`, ~:997) and session (`createTransactionFromSession`, ~:2400) paths
+- Modify: the reporting-ingress write sites so the server-derived price flows into `posTransactionItem.unitPrice/totalPrice` (~:1276, ~:2730) AND the reporting line `unitPriceMinor/totalAmountMinor/grossAmountMinor` (~:1336, ~:2818) AND transaction `subtotal/total`
+- Add: an append-only price-override audit (reuse `operationalEvent` or the lifecycle-journal rail; do not invent a new table). Mirror the `buildVoidApprovalRequirement` approval pattern for override authority (`requiredRole: "manager"`).
+- Reference: offline basis `projectLocalEvents.ts` ~:3926 (`importedPrice ?? netPrice ?? price`)
+- Test: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.test.ts`
+
+**Approach:**
+- Compute the canonical line from the catalog price **basis `provisional.importedPrice ?? sku.netPrice ?? sku.price`** (matching the offline path exactly — comparing bare `sku.price` would spuriously reject legitimate net-priced/provisional-import lines that project fine offline). Confirm the unit of the catalog field and avoid comparing cedis against pesewas (this overlaps U10; U7 lands first, so handle the unit explicitly here).
+- If the client line matches the derived basis → proceed. If it differs and the actor carries override authority (mirror `buildVoidApprovalRequirement`) → accept and write an append-only override audit (actor, sku, catalog basis, charged price, delta, reason). If it differs with no override authority → **hard-reject** (this is the online behavior; offline keeps its flag-and-project review conflict because money already moved).
+- Cover provisional-import lines explicitly. Apply to both completion paths so terminals cannot bypass via the session path.
+
+**Execution note:** Test-first — write the tamper-rejection and override-audit tests first.
+
+**Test scenarios:**
+- Happy path: client price equals derived basis → completes, no override audit.
+- Tamper/error: client price below basis, no override authority → rejected (both direct and session paths).
+- Override: authorized manager discount → completes AND an append-only audit records the delta/actor.
+- Basis correctness: a net-priced / provisional-import line prices against `importedPrice ?? netPrice ?? price`, not bare `sku.price`, and is not spuriously rejected.
+- Parity: reporting `*Minor` fields and transaction totals reflect the server-derived price, not the client value.
+- Edge case: missing SKU price / deactivated product → explicit handling, not silent client-trust.
+
+**Verification:** No sale on either path records a line price the server did not derive or an authorized actor did not explicitly override with an audit trail; reporting reflects the derived price.
+
+---
+
+- U8. **Idempotency token across both completion paths + register cash effect** *(audit D3)*
+
+**Goal:** The online completion mutations accept no idempotency token and always mint a new transaction number; a non-deduped resubmit creates a second sale, second stock decrement, and — because `recordRegisterSessionSale` omits the `idempotencyKey` the void path uses — double drawer cash. The offline path already solves this via `localTransactionId`.
+
+**Requirements:** R7
+
+**Dependencies:** None (shares `completeTransaction.ts`/`registerSessions.ts` — sequence within Phase 2 worktree)
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/public/transactions.ts` — accept a client-stable idempotency token on BOTH `completeTransaction` (:417) and `createTransactionFromSession` (:868)
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` — dedup on the token **before** `createPosTransaction`/`generateTransactionNumber` (~:1156); pass the same token as `idempotencyKey` to both `recordRegisterSessionSale` call sites (~:1199, ~:2622)
+- Modify (confirm): `packages/athena-webapp/convex/operations/registerSessions.ts` — `recordRegisterSessionSale` threads the key through `recordedTransactionKeys` exactly like the void path
+- Modify: client completion gateway in `packages/athena-webapp/src/lib/pos/...` to generate/send the token where the online paths are used
+- Test: `completeTransaction.test.ts`, `registerSessions.test.ts`
+
+**Approach:**
+- Accept a client-generated stable idempotency token. Dedup the transaction **mint** on it (return the existing transaction on replay, mirroring `resolveExistingSaleProjection`) — keying off the freshly-minted `transactionId` would produce a new key per retry and dedup nothing, since a sale has no stable server id before mint (unlike the void path which keys off an existing `transaction._id`). Thread the same token into `recordRegisterSessionSale` so the drawer cash increment is guarded by `recordedTransactionKeys`.
+- Ensure the online token namespace cannot double-record a sale that also arrives via the offline `localTransactionId` path (prefer a shared/derivable token).
+
+**Execution note:** Test-first — assert double-submit yields one transaction, one stock decrement, one cash delta, on both completion paths.
+
+**Test scenarios:**
+- Idempotency: two `completeTransaction` calls with the same token → one `posTransaction`, one inventory decrement, one register cash delta.
+- Idempotency: same for `createTransactionFromSession`.
+- Integration: register `expectedCash` incremented exactly once under retry.
+- Edge case: missing token → defined behavior (reject or server-derive), not silent double-charge risk.
+- Cross-path: a sale recorded online then arriving offline (or vice versa) is not double-recorded.
+
+**Verification:** No completion path can double-charge cash or double-decrement stock under client retry.
+
+---
+
+- U9. **Server-derived/clamped `occurredAt` and `operatingDate`** *(audit D1)*
+
+**Goal:** Every event's `occurredAt` and the `operatingDate`/day-window are taken from the terminal clock and trusted (server checks only finite/positive and a date regex). A skewed/backdated terminal books sales into the wrong operating day and computes closeout variance against terminal-provided dates.
+
+**Requirements:** R8
+
+**Dependencies:** None (shares completion/ingest surface)
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` (`occurredAt` validation ~:603, `operatingDate` validation ~:802, and the window taken from the `register.opened` payload ~:656) and the sale/open/close projectors that persist them
+- Thread in: `packages/athena-webapp/convex/reporting/operatingPeriods.ts` `resolveReportingFinancialPeriod` (server store-day derivation from versioned timezone authority + schedule) — currently has no `pos/` callers, so U9 wires its inputs (timezone authority + schedule) into the ingest mutation
+- Test: `ingestLocalEvents.test.ts` and any operating-date attribution test
+
+**Approach:**
+- Derive `operatingDate` server-side from the store-day window (`resolveReportingFinancialPeriod`) or validate the terminal-supplied date against that window, correcting/rejecting out-of-window values. Clamp/annotate `occurredAt` against server time with a bounded skew tolerance; when terminal time is implausible, record server time as authoritative and flag the divergence. Preserve legitimate offline lag — distinguish "old but plausible" from "skewed/backdated".
+- Define behavior when the store lacks timezone authority (`missing/invalid_timezone_authority` from `resolveReportingFinancialPeriod`): reject, or fall back to the terminal value with an explicit flag — decide at implementation and document. Note that clamping shifts the value feeding closeout variance and reporting fingerprints (intended, downstream effect).
+
+**Execution note:** Characterization-first — capture current attribution, then constrain, to avoid misattributing legitimate offline-lag sales.
+
+**Test scenarios:**
+- Happy path: a plausibly-timed offline sale keeps its `occurredAt` and lands in the correct operating day.
+- Error path: a wildly future/backdated `occurredAt` is clamped/flagged, not trusted verbatim.
+- Edge case: a legitimate long-offline sale (created hours ago) is still attributed correctly, not falsely clamped.
+- Edge case: `operatingDate` outside the server store-day window is corrected/rejected.
+- Edge case: store lacking timezone authority → the defined fallback/rejection behavior (not silent terminal-trust).
+- Boundary: sale near local midnight attributes to the correct store-day.
+
+**Verification:** Operating-day attribution and sale timestamps cannot be silently corrupted by terminal clock skew.
+
+---
+
+- U10. **Money as integer minor units in schema (POS + cash drawer) + finish POS pesewas migration** *(audit D4)*
+
+**Goal:** Money fields are unconstrained `v.number()` (float-capable) across POS *and* cash-drawer tables; rounding is enforced only in code. The pesewas migration never covered the POS tables at all, and its online-order coverage is half-done/heuristic. A float can still be written by any mutation, and legacy POS rows may be in cedis.
+
+**Requirements:** R9
+
+**Dependencies:** None (parallelizable within Phase 2 — does not touch `completeTransaction.ts` control flow)
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/schemas/pos/posTransaction.ts`, `posSession.ts`, payment amount schemas, AND `packages/athena-webapp/convex/schemas/operations/registerSession.ts` (`openingFloat`/`expectedCash`/`countedCash`/`variance` + `closeoutRecords[]`), and the cash fields in `posLocalSyncContractValidators.ts` — apply a shared integer-minor-unit validator
+- Modify: `packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts` — add deterministic POS-table migration (`posTransaction`, `posTransactionItem`, `posSession`, `registerSession`); replace the `< 10_000` heuristic and the commented-out `onlineOrder.amount`/`paymentDue` conversions with a deterministic rule; add an idempotent completion/verification marker
+- Align: float-producing writers to integer arithmetic — `roundStoredAmount = Number(amount.toFixed(2))` and `totalsMatch`/`roundMoney` (`completeTransaction.ts` ~:733/:755) become no-ops-at-best / wrong-at-worst once amounts are integer pesewas
+- Reference: `packages/athena-webapp/convex/lib/currency.ts`
+- Test: schema/validator tests; a migration verification test
+- Coordinate: `bun run pre-commit:generated-artifacts` (Convex `_generated` refresh)
+
+**Approach:**
+- Characterize the current money representation of existing `posTransaction`/`posTransactionItem`/`posSession`/`registerSession` rows FIRST (they were never migrated to pesewas). Add a deterministic POS-table migration where legacy cedis rows exist, with an idempotent completion marker; do not use the `< 10_000` heuristic (it mis-reads a legitimately cheap cedis item as pesewas). Only after the migration is complete and verified, flip the schema money fields to an integer-minor-unit validator across POS and cash-drawer tables. Audit and align float-producing code paths to integer arithmetic.
+
+**Execution note:** Characterization-first on current data shape; verify the migration ran to completion before flipping the schema constraint to avoid rejecting existing rows.
+
+**Test scenarios:**
+- Happy path: a valid integer-pesewas amount writes successfully (POS and drawer fields).
+- Error path: a fractional amount is rejected by the schema validator (POS and drawer fields).
+- Migration: a legacy cedis POS row is converted deterministically (no double-conversion, no skip of a cheap cedis item).
+- Migration idempotency: re-running does not double-convert; the completion marker is honored.
+- Verification: the completion marker records the migration ran to completion for POS tables.
+- Regression: drawer `variance = countedCash − expectedCash` stays correct under integer arithmetic.
+
+**Verification:** No POS or cash-drawer money field can hold a float; the POS pesewas migration has a verifiable completion state; no dual-represented rows remain.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Phase 0 concentrates in public authz wrappers; Phase 1 in the ingest mutation + client scheduler/store; Phase 2 in the completion command + money schema. The offline sale-projection path and the online completion path must stay consistent for U7/U8/U9 — a fix on one path that misses the other leaves a bypass.
+- **Error propagation:** U2/U3 convert silent drops and batch aborts into `needs_review`/`conflicted` records — the review surface must render the new (money-bearing-scoped) conflict volume without overwhelming managers.
+- **State lifecycle risks:** U3 must never commit a partial sale; U4 purge and U6 resolution must be strictly evidence-gated to avoid deleting/settling something still in flight.
+- **API surface parity:** U7/U8/U9 must apply to BOTH `completeTransaction` and `createTransactionFromSession` (and stay consistent with the offline projection), or terminals bypass the guard.
+- **Unchanged invariants:** The event-sourcing core (single-mutation exactly-once, monotonic cursor, durable-commit-before-ack), the authority/revision CAS model, and the sync-contract event shapes are explicitly unchanged; new work sits at the validation/purge/convergence/authorization/trust seams around them.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| U3 done as naive catch-and-continue commits a corrupted partial sale (Convex has no partial rollback) | Re-specified as validate-before-first-write → `conflicted`; test asserts zero committed rows for a data-failed event; only no-write projectors may be try/caught. |
+| U3's per-event isolation swallows a genuine infra error, hiding real outages | Classify infra vs data-shaped conditions; infra still aborts the mutation for a real retry; DB-failure test. |
+| U1/U11 miss another unauthorized public surface | Per-endpoint sweep (not presence-grep) across `terminals.ts`/`catalog.ts`/`sync.ts`/`posRecoveryCodes.ts`; `customers.ts` given its own unit; `terminalAppSessions.ts` documented as a deliberate exception. |
+| U4 purge deletes an acked-but-referenced event, or the reused guard always blocks | Gate on `settled_unreferenced` AND not-referenced AND past-boundary; reuse only the authority/presence/protected checks, not `events.length > 0`; per-case safety tests; surface counts. |
+| U7 rejects legitimate net-priced/provisional/discount sales | Basis `importedPrice ?? netPrice ?? price` (matches offline); override-with-audit via the void-approval framework; hard-reject only without authority; explicit basis tests. |
+| U8 keys the cash effect off the freshly-minted id and dedups nothing | Client-stable token dedups the mint pre-`createPosTransaction` and guards the cash effect with the same key; both completion paths covered. |
+| U9 clamping misattributes legitimate long-offline sales, or store lacks timezone authority | Distinguish "old but plausible" from "skewed"; characterization-first; defined behavior for `missing/invalid_timezone_authority`. |
+| U10 schema constraint rejects existing float/cedis POS rows on deploy | POS tables were never migrated — characterize + deterministic POS migration + completion marker BEFORE flipping the constraint; include cash-drawer schema. |
+| Phase 2 units all touch `completeTransaction.ts` and conflict at integration | Implement U7/U8/U9 sequentially in the single Phase 2 worktree; U10 parallelizable; one integration PR. |
+| Prod-backend POS E2E runs on PRs against a live store | Confirm the E2E fixture store is disposable and runs are cleaned; flag if these changes affect it. |
+
+---
+
+## Documentation / Operational Notes
+
+- After each phase merges, refresh graphify (`bun run graphify:rebuild`) per AGENTS.md and any POS docs whose standing behavior changed (conflict surface, purge, re-pricing, authz).
+- If a phase changes durable POS behavior materially, add a `docs/solutions/` note per the repo's `ce-compound` contract (recurring bug classes here justify durable learnings).
+- Delivery sensor for every phase: `bun run pr:athena` (PR-equivalent gate); targeted Vitest per unit via `bun run test -- <path> -t "<name>"` from `packages/athena-webapp`; `bun run pre-commit:generated-artifacts` when Convex modules/schema change (esp. U10).
+
+---
+
+## Phased Delivery
+
+Each phase's finish line is an **opened, mergeable PR**: green `bun run pr:athena`, review-loop clean (unanimous reviewer approval, no unresolved actionable threads), and no conflicts with `origin/main`. Per user scope, the phases are not auto-merged — they are delivered as mergeable PRs.
+
+### Phase 0 — Stop the bleed (worktree `fix/pos-phase0-data-loss-authz`)
+- U1 (register authz: getState + openDrawer), U11 (customers.ts authz), U2 (rejected-sale conflict). Highest severity, smallest surface. One integration PR.
+
+### Phase 1 — Liveness & convergence (worktree `fix/pos-phase1-liveness-convergence`)
+- U3 (validate-before-write projection isolation), U4 (ledger purge), U5 (stuck/held escalation + truthful status), U6 (local-resolve round-trip). One integration PR. Sequence U6 after U5 (shared status surface).
+
+### Phase 2 — Trust boundary (worktree `fix/pos-phase2-trust-boundary`)
+- U7 (re-pricing + override audit), U8 (idempotency), U9 (clock/operating-date), U10 (money schema + migration). One integration PR. Sequence U7/U8/U9 (shared `completeTransaction.ts`); U10 parallelizable.
+
+---
+
+## Sources & References
+
+- Origin: nine-pass POS stack audit (this session) — backend domain, payments, cash-controls, inventory coupling, frontend resilience, cross-cutting, and three local-first deep-dives (ingest/projection engine, authority/replication, local store & convergence) — plus a four-lens plan review (security, money/payments, Convex backend correctness, plan quality).
+- Related code: `packages/athena-webapp/convex/pos/**`, `packages/athena-webapp/src/lib/pos/**`, `packages/athena-webapp/convex/operations/**`, `packages/athena-webapp/convex/schemas/pos/**`, `packages/athena-webapp/convex/schemas/operations/registerSession.ts`, `packages/athena-webapp/convex/reporting/operatingPeriods.ts`, `packages/athena-webapp/convex/migrations/migrateAmountsToPesewas.ts`.
+- Related prior work (recurring fix classes): #591/#623/#657 read amplification, #633/#637 sync replay/contract, #642 register authority replication, #595 duplicate POS-session sales, #588–#599 EOD/closeout.

--- a/docs/reports/2026-07-15-pos-phase0-idor-pii-rejected-sale-report.html
+++ b/docs/reports/2026-07-15-pos-phase0-idor-pii-rejected-sale-report.html
@@ -1,0 +1,360 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="cd97b2c82044ebbbc1f7037f81d980aa756792a205e1187c48a0c92a2aa878ac">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>POS Phase 0 — Close IDOR/PII surfaces and stop silent rejected-sale loss</title>
+<style>
+  :root {
+    --bg: #0f1115;
+    --panel: #171a21;
+    --panel-2: #1e222b;
+    --border: #2a2f3a;
+    --text: #e6e9ef;
+    --muted: #9aa3b2;
+    --accent: #6ea8fe;
+    --ok: #4ade80;
+    --warn: #fbbf24;
+    --bad: #f87171;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f6f7f9; --panel: #ffffff; --panel-2: #f0f2f5; --border: #d9dee6;
+      --text: #1a1f29; --muted: #57607080; --muted: #5b6472; --accent: #2563eb;
+    }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text);
+    font: 15px/1.6 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+  .wrap { max-width: 940px; margin: 0 auto; padding: 32px 20px 80px; }
+  header.top { border-bottom: 1px solid var(--border); padding-bottom: 20px; margin-bottom: 28px; }
+  h1 { font-size: 26px; line-height: 1.25; margin: 0 0 10px; }
+  h2 { font-size: 19px; margin: 34px 0 12px; padding-top: 8px; }
+  h3 { font-size: 15px; margin: 20px 0 8px; color: var(--accent); }
+  p { margin: 10px 0; }
+  a { color: var(--accent); }
+  code { font-family: var(--mono); font-size: 0.86em; background: var(--panel-2);
+    padding: 1px 5px; border-radius: 4px; }
+  pre { background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px;
+    padding: 12px 14px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; }
+  .pills { display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0; }
+  .pill { font-size: 12px; padding: 3px 10px; border-radius: 999px; border: 1px solid var(--border);
+    background: var(--panel-2); color: var(--muted); }
+  .pill.ok { color: var(--ok); border-color: #2e5a3f; }
+  .pill.warn { color: var(--warn); border-color: #5a4a1f; }
+  .pill.accent { color: var(--accent); border-color: #2a4a7a; }
+  .meta { display: grid; grid-template-columns: 140px 1fr; gap: 4px 16px; font-size: 13.5px;
+    background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; }
+  .meta dt { color: var(--muted); }
+  .meta dd { margin: 0; }
+  section { background: transparent; }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
+    padding: 4px 18px 14px; margin: 14px 0; }
+  table { border-collapse: collapse; width: 100%; font-size: 13px; margin: 10px 0; }
+  th, td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; }
+  ul, ol { padding-left: 22px; }
+  li { margin: 4px 0; }
+  .twocol { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  @media (max-width: 680px) { .twocol { grid-template-columns: 1fr; } .meta { grid-template-columns: 1fr; } }
+  .flow { font-family: var(--mono); font-size: 12px; white-space: pre-wrap; }
+  .quiz { margin-top: 10px; }
+  .q { background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
+    padding: 12px 16px; margin: 12px 0; }
+  .q p.stem { font-weight: 600; margin: 4px 0 8px; }
+  .q label { display: block; padding: 6px 8px; border-radius: 6px; cursor: pointer; }
+  .q label:hover { background: var(--panel-2); }
+  .q .explain { display: none; margin-top: 8px; font-size: 13px; color: var(--muted);
+    border-left: 3px solid var(--border); padding-left: 10px; }
+  .q.correct { border-color: #2e5a3f; }
+  .q.incorrect { border-color: #5a2e2e; }
+  .q.graded .explain { display: block; }
+  .quizbar { position: sticky; bottom: 0; background: var(--panel); border: 1px solid var(--border);
+    border-radius: 10px; padding: 12px 16px; margin-top: 16px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
+  button { font: inherit; padding: 8px 16px; border-radius: 8px; border: 1px solid var(--border);
+    background: var(--accent); color: #061020; font-weight: 600; cursor: pointer; }
+  button.secondary { background: var(--panel-2); color: var(--text); }
+  button:active { transform: translateY(1px); }
+  #score { font-weight: 700; }
+  .small { font-size: 12.5px; color: var(--muted); }
+  hr { border: none; border-top: 1px solid var(--border); margin: 28px 0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="top">
+  <div class="pills">
+    <span class="pill accent">Delivery candidate</span>
+    <span class="pill">POS local-first hardening · Phase 0</span>
+    <span class="pill ok">pr:athena green (pre-report)</span>
+    <span class="pill warn">Merge: pending</span>
+  </div>
+  <h1>POS Phase 0 — close IDOR/PII surfaces and stop silent rejected-sale loss</h1>
+  <p class="small">A digestible walkthrough of the change delivered on branch
+  <code>fix/pos-phase0-data-loss-authz</code>, batching Linear V26-1055, V26-1056, and V26-1057
+  into one integration PR.</p>
+</header>
+
+<dl class="meta">
+  <dt>Branch</dt><dd><code>fix/pos-phase0-data-loss-authz</code> → <code>main</code></dd>
+  <dt>Tickets</dt><dd>V26-1055 (U1 register authz), V26-1056 (U11 customers authz), V26-1057 (U2 rejected-sale conflict)</dd>
+  <dt>Plan</dt><dd><code>docs/plans/2026-07-15-001-fix-pos-local-first-hardening-plan.md</code></dd>
+  <dt>Status</dt><dd>Delivery candidate — not merged, not deployed, Linear not <em>Done</em></dd>
+  <dt>Deploy</dt><dd>Pending (post-merge, Convex-prod surface)</dd>
+  <dt>Root alignment</dt><dd>Pending (post-merge)</dd>
+  <dt>Diff fingerprint</dt><dd><code>cd97b2c8…a878ac</code></dd>
+</dl>
+
+<h2>Executive summary</h2>
+<div class="card">
+<p>A nine-pass audit found the event-sourced POS core sound but exposed active silent-failure paths in the
+seams around it. Phase 0 closes the three highest-severity ones:</p>
+<ul>
+  <li><strong>V26-1055 (U1):</strong> <code>register.getState</code> had <em>no</em> authorization and
+  <code>openDrawer</code> was authentication-only — two cross-tenant IDOR holes. Both now require org membership
+  scoped to the store that owns the resource.</li>
+  <li><strong>V26-1056 (U11):</strong> all 13 endpoints of <code>customers.ts</code> had zero authorization
+  (full PII by <code>customerId</code>, unauthenticated cross-tenant writes). Every endpoint is now org-scoped.</li>
+  <li><strong>V26-1057 (U2):</strong> a rejected money-bearing offline sale advanced the sync cursor and left
+  no record. It now creates a manager-visible <code>server_rejected</code> conflict while preserving cursor liveness.</li>
+</ul>
+</div>
+
+<h2>Why it mattered</h2>
+<p>This is an offline cash system running on in-store terminals. The failures that matter most are
+"another tenant can read/alter my POS state" and "money changed hands but the record is gone." The three
+gaps produced exactly those outcomes: a foreign-org user could read a store's cashier/drawer/held-cart state
+or open its drawer (corrupting cash-control attribution); anyone could read full customer PII by id or write
+customer records across tenants; and a validation-rejected cash sale could vanish with the drawer left short
+and nobody notified.</p>
+
+<h2>The mental model</h2>
+<div class="card">
+<p>Think of two trust boundaries around a sound core:</p>
+<ol>
+  <li><strong>Authorization boundary (U1/U11):</strong> every public Convex POS endpoint must resolve the
+  <em>store that owns the targeted resource</em> and confirm the caller is a member of that store's organization
+  <em>before</em> reading or writing. The template already existed:
+  <code>requirePosTransactionStoreAccess</code> in <code>transactions.ts</code>.</li>
+  <li><strong>Data-durability boundary (U2):</strong> no money-bearing event may leave the sync pipeline
+  without either a canonical transaction or a <code>needs_review</code> conflict. The conflict rail already
+  existed; the rejected branch just wasn't using it.</li>
+</ol>
+</div>
+
+<h2>Before vs after</h2>
+<div class="twocol">
+  <div class="card">
+    <h3>Before</h3>
+    <ul>
+      <li><code>getState</code>: any/no caller → full register state for any store.</li>
+      <li><code>openDrawer</code>: authenticated-only → open a drawer on any org's terminal.</li>
+      <li><code>customers.ts</code>: 13 endpoints, no auth → PII by id, cross-tenant writes.</li>
+      <li>Rejected money-bearing sale → cursor advances, no conflict, silent loss.</li>
+    </ul>
+  </div>
+  <div class="card">
+    <h3>After</h3>
+    <ul>
+      <li><code>getState</code>: resolve store → require org member (<code>full_admin</code>/<code>pos_only</code>).</li>
+      <li><code>openDrawer</code>: same org check in the command before opening the session.</li>
+      <li><code>customers.ts</code>: every endpoint org-scoped; id-keyed reads scoped to the resource's store.</li>
+      <li>Rejected money-bearing sale → one <code>server_rejected</code> conflict, cursor still advances.</li>
+    </ul>
+  </div>
+</div>
+
+<h2>Rejected-sale flow (U2)</h2>
+<div class="card">
+<div class="flow">pending --drain--> [single Convex ingest mutation]
+   |-- valid ------------------> projected  (canonical write + mapping)     [unchanged]
+   |-- business/perm/dup ------> conflicted (needs_review)                  [unchanged]
+   |-- envelope/payload -------> rejected  (cursor advances)
+   |         └── money-bearing (sale_completed + payments)?
+   |                 ├── yes → ALSO create server_rejected conflict (needs_review)  [NEW]
+   |                 └── no  → stay silent (no conflict spam)                        [unchanged]
+</div>
+<p class="small">Cursor advance is preserved in every branch (liveness). <code>createConflict</code> dedups on
+(store, terminal, localEventId, needs_review, sequence, conflictType, summary, details), so replays create no
+duplicate; the replay path re-lists the existing conflict via <code>listConflictsForEvent</code>.</p>
+</div>
+
+<h2>Key files</h2>
+<table>
+<thead><tr><th>File</th><th>Why it matters</th></tr></thead>
+<tbody>
+<tr><td><code>convex/pos/public/register.ts</code></td><td>Adds the store-resolve + org-membership guard to the <code>getState</code> query wrapper; returns <code>null</code> for a missing store.</td></tr>
+<tr><td><code>convex/pos/application/commands/register.ts</code></td><td>Adds <code>requireOrganizationMemberRoleWithCtx</code> to <code>openDrawer</code> after the store/user are resolved, before the register session is opened.</td></tr>
+<tr><td><code>convex/pos/public/customers.ts</code></td><td>Adds <code>requirePosCustomerStoreAccess</code> / <code>requirePosCustomerAccessById</code> and guards all 13 endpoints; id-keyed reads scope to the resource's store org.</td></tr>
+<tr><td><code>convex/pos/application/sync/ingestLocalEvents.ts</code></td><td>Rejected branch creates a <code>server_rejected</code> conflict for money-bearing sales; adds money-bearing + amount helpers.</td></tr>
+<tr><td><code>convex/schemas/pos/posLocalSyncConflict.ts</code>, <code>.../sync/types.ts</code></td><td>Add the <code>server_rejected</code> literal to the conflictType union (schema + type), wiring up the dead classifier branch.</td></tr>
+<tr><td><code>src/lib/pos/infrastructure/convex/registerGateway.ts</code></td><td>Treats a <code>null</code> <code>getState</code> (store not found) as no-state so the client hook return type stays stable.</td></tr>
+<tr><td>4 <code>*.test.ts</code> files</td><td>Cross-org denial tests (proving the delegate is not called), PII-scope tests, and the rejected-sale conflict/dedup/no-spam tests.</td></tr>
+</tbody>
+</table>
+
+<h2>What intentionally did NOT change</h2>
+<ul>
+  <li>The event-sourcing core (single-mutation exactly-once, monotonic cursor, durable-commit-before-ack) and the sync-contract event shapes.</li>
+  <li>POS <code>catalog.ts</code> search/barcode exposure — deliberately deferred to V26-956.</li>
+  <li><code>terminalAppSessions.ts</code> — a deliberate terminal-proof + <code>validatePosAppAccount</code> exception; no redundant guard added.</li>
+  <li>Sibling POS surfaces (<code>terminals.ts</code>, <code>sync.ts</code>, <code>posRecoveryCodes.ts</code>) were swept per-endpoint and found already guarded — no change needed.</li>
+  <li>Non-financial rejected events stay silent (no new conflict) to avoid manager-facing spam.</li>
+</ul>
+
+<h2>Failure boundaries</h2>
+<ul>
+  <li><strong>Cross-org caller:</strong> <code>requireOrganizationMemberRoleWithCtx</code> throws → the endpoint rejects; the underlying query/command never runs.</li>
+  <li><strong>Missing store/customer:</strong> returns a clean <code>null</code> / empty / <code>not_found</code> without leaking existence beyond the pre-existing pattern; membership checks are skipped.</li>
+  <li><strong>Foreign valid id:</strong> id-keyed customer reads resolve the target's store first, so a valid foreign <code>customerId</code> is still denied.</li>
+  <li><strong>Malformed rejected payload:</strong> amount summarization is defensive (guards non-finite numbers), so the rejected branch cannot throw and abort the batch.</li>
+  <li><strong>Replay:</strong> conflict dedup makes re-ingesting a rejected event idempotent (exactly one conflict).</li>
+</ul>
+
+<h2>Validation &amp; review evidence</h2>
+<div class="card">
+<ul>
+  <li><strong>Targeted tests (green):</strong> <code>register.test.ts</code> (public + command), <code>customers.test.ts</code> (10 authz tests), <code>ingestLocalEvents.test.ts</code> (88 tests incl. 4 new server_rejected cases).</li>
+  <li><strong>Typecheck:</strong> <code>tsc --noEmit</code> clean (0 errors) after fixing the client <code>getState</code> null consumer.</li>
+  <li><strong>Full gate:</strong> <code>bun run pr:athena</code> — passed through dependency/generated-artifacts/harness/lint/architecture/tsc/coverage; then flagged the required solution note + this landed-change report (both added), after which the gate is re-run to green.</li>
+  <li><strong>Multi-lens internal review:</strong> three read-only reviewer subagents — Security/Authorization, Correctness (U2), and Tests — reviewed <code>git diff origin/main...HEAD</code>. Round 1: Correctness APPROVED; Security and Tests requested changes. Two blocking findings were integrated: (1) <code>linkToStoreFrontUser</code>/<code>linkToGuest</code> did not re-scope the secondary storefront-user/guest to the customer's store (cross-org PII read) — now rejected in the command; (2) 7 of 13 <code>customers.ts</code> guard sites lacked a cross-org denial test — added table-driven coverage. Round 2: both re-reviewed and APPROVED. Unanimous.</li>
+</ul>
+<p class="small">Residual risk: authorization is enforced at the public surface (and the <code>openDrawer</code> command); the
+customer application modules have no other callers, but a future internal caller would need its own guard.
+U2 changes the manager-visible conflict volume — the review surface renders the new money-bearing-scoped conflicts.</p>
+</div>
+
+<h2>Next-time guidance</h2>
+<ul>
+  <li>Adding a POS public endpoint? Resolve the store (directly or via the targeted resource) and call
+  <code>requireOrganizationMemberRoleWithCtx</code> before any read/write — copy <code>requirePosTransactionStoreAccess</code>.</li>
+  <li>Auditing auth coverage? Check <em>per endpoint</em>; an auth import in a file does not prove every export is guarded.</li>
+  <li>Touching sync ingest? Preserve cursor-advance on rejects, and never let a money-bearing event exit without a canonical row or a conflict.</li>
+</ul>
+
+<h2>Subagent Evidence</h2>
+<div class="card">
+<ul>
+  <li><strong>Security/Authorization reviewer</strong> — verified <code>getState</code>, <code>openDrawer</code>, and all 13 customer endpoints are org-scoped with no remaining IDOR/PII leak, and spot-checked the sibling-sweep claim.</li>
+  <li><strong>Correctness reviewer (U2)</strong> — traced the rejected branch, dedup, replay, cursor advance, and confirmed the classifier branch is no longer dead.</li>
+  <li><strong>Tests reviewer</strong> — verified the tests assert the regressions (cross-org denial proving delegate-not-called, PII scope, conflict creation/dedup/no-spam) rather than tautologies.</li>
+</ul>
+<p class="small">These read-only subagents analyzed the delivered diff and validation; the orchestrator synthesized this report.</p>
+</div>
+
+<h2>Comprehension quiz</h2>
+<p class="small">Quiz: Pass Required — 10 questions · pass threshold 8/10. Grading is local to your browser.</p>
+<div class="quiz" id="changeQuiz"></div>
+<div class="quizbar">
+  <button id="grade">Grade quiz</button>
+  <button id="reset" class="secondary">Reset</button>
+  <span id="score" class="small">Not graded yet.</span>
+</div>
+
+<hr />
+<p class="small">Generated as a delivery-candidate landed-change report. It does not claim merge, deploy, or Linear
+<em>Done</em> — those happen after this PR merges.</p>
+
+</div>
+
+<script>
+const QUESTIONS = [
+  { s: "Why did register.getState need a fix?", a: [
+    "It performed cross-tenant reads with no authorization, leaking another store's terminal/cashier/drawer/cart state",
+    "It was too slow and needed an index",
+    "It returned the wrong TypeScript type",
+    "It duplicated the openDrawer logic" ], c: 0,
+    e: "getState had no authorization at all — a classic IDOR read across tenants." },
+  { s: "How is the authorization scoped for these endpoints?", a: [
+    "By the caller's default organization only",
+    "By resolving the store that owns the targeted resource, then requiring org membership on that store",
+    "By a global admin allow-list",
+    "By the terminal sync-secret only" ], c: 1,
+    e: "Membership is checked against the resource's own organizationId, so a valid foreign id is still denied." },
+  { s: "What made openDrawer insufficient before?", a: [
+    "It had no authentication",
+    "It was authentication-only with no org-membership check, so any org's user could open a drawer",
+    "It opened two sessions at once",
+    "It skipped the terminal check" ], c: 1,
+    e: "It called requireAuthenticatedAthenaUserWithCtx but never verified org membership." },
+  { s: "For customerId-keyed reads (e.g. getCustomerById), how is cross-org access prevented?", a: [
+    "The endpoint trusts the customerId",
+    "It resolves the customer, then scopes membership to that customer's store org",
+    "It returns redacted PII to everyone",
+    "It requires a storeId that is never checked" ], c: 1,
+    e: "requirePosCustomerAccessById resolves the customer and checks membership on its store's org." },
+  { s: "When does a rejected sync event now create a conflict?", a: [
+    "For every rejected event",
+    "Only when it is money-bearing (sale_completed with a non-empty payments array)",
+    "Only for register_opened events",
+    "Never — it just logs" ], c: 1,
+    e: "Non-financial rejects stay silent to avoid conflict spam; only money-bearing sales create a conflict." },
+  { s: "What happens to the sync cursor when a money-bearing sale is rejected?", a: [
+    "It stalls until a manager resolves the conflict",
+    "It still advances (liveness preserved); the conflict is created in parallel",
+    "It rolls back the whole batch",
+    "It resets to zero" ], c: 1,
+    e: "Cursor advance is preserved in the rejected branch; a validation-rejected event cannot be auto-corrected." },
+  { s: "How is replay of a rejected event kept idempotent?", a: [
+    "A new conflict is created each time",
+    "createConflict dedups on the conflict key, and the replay path re-lists the existing conflict",
+    "The event is deleted on replay",
+    "Replays are blocked entirely" ], c: 1,
+    e: "createConflict returns the existing needs_review conflict; the replay path re-lists via listConflictsForEvent." },
+  { s: "What schema change wired up the manager review surface?", a: [
+    "A new posLocalSyncConflict table",
+    "Adding the server_rejected literal to the conflictType union in the schema and the type alias",
+    "Renaming needs_review to server_rejected",
+    "Removing the permission conflictType" ], c: 1,
+    e: "The classifier already had a dead server_rejected branch; adding the literal activated it." },
+  { s: "Which POS surface was intentionally left unchanged?", a: [
+    "customers.ts",
+    "terminalAppSessions.ts — a deliberate terminal-proof exception (and catalog.ts deferred to V26-956)",
+    "register.ts",
+    "ingestLocalEvents.ts" ], c: 1,
+    e: "terminalAppSessions.ts authorizes via terminal proof + validatePosAppAccount; catalog.ts is deferred." },
+  { s: "How should a future POS public endpoint be authorized?", a: [
+    "Trust the client-supplied storeId",
+    "Resolve the store (directly or via the targeted resource) and call requireOrganizationMemberRoleWithCtx before any read/write",
+    "Only check that the user is signed in",
+    "Rely on a per-file auth import being present" ], c: 1,
+    e: "Copy the requirePosTransactionStoreAccess pattern; per-file import presence is not proof of per-endpoint coverage." }
+];
+
+const quizEl = document.getElementById("changeQuiz");
+QUESTIONS.forEach((q, i) => {
+  const div = document.createElement("div");
+  div.className = "q"; div.dataset.i = i;
+  const opts = q.a.map((t, j) =>
+    `<label><input type="radio" name="q${i}" value="${j}"> ${t}</label>`).join("");
+  div.innerHTML = `<p class="stem">${i + 1}. ${q.s}</p>${opts}<div class="explain">${q.e}</div>`;
+  quizEl.appendChild(div);
+});
+
+document.getElementById("grade").addEventListener("click", () => {
+  let score = 0;
+  QUESTIONS.forEach((q, i) => {
+    const el = quizEl.querySelector(`.q[data-i="${i}"]`);
+    const sel = el.querySelector(`input[name="q${i}"]:checked`);
+    el.classList.add("graded");
+    el.classList.remove("correct", "incorrect");
+    if (sel && Number(sel.value) === q.c) { score++; el.classList.add("correct"); }
+    else { el.classList.add("incorrect"); }
+  });
+  const pass = score >= 8;
+  const s = document.getElementById("score");
+  s.textContent = `Score: ${score}/10 — ${pass ? "PASS ✓" : "below pass threshold (8/10)"}`;
+  s.style.color = pass ? "var(--ok)" : "var(--bad)";
+});
+
+document.getElementById("reset").addEventListener("click", () => {
+  quizEl.querySelectorAll(".q").forEach((el) => el.classList.remove("graded", "correct", "incorrect"));
+  quizEl.querySelectorAll("input[type=radio]").forEach((r) => (r.checked = false));
+  const s = document.getElementById("score");
+  s.textContent = "Not graded yet."; s.style.color = "";
+});
+</script>
+</body>
+</html>

--- a/docs/reports/2026-07-15-pos-phase0-idor-pii-rejected-sale-report.html
+++ b/docs/reports/2026-07-15-pos-phase0-idor-pii-rejected-sale-report.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="8b6b4a580e8c85e9379046eb27165d200676216c8479f2ae448228f7076b84fc">
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="5d34f79afaf9ce6d1197f0fcf06a3de2a59e65affe958674c92b694e4d7fa03f">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -104,7 +104,7 @@
   <dt>Status</dt><dd>Delivery candidate — not merged, not deployed, Linear not <em>Done</em></dd>
   <dt>Deploy</dt><dd>Pending (post-merge, Convex-prod surface)</dd>
   <dt>Root alignment</dt><dd>Pending (post-merge)</dd>
-  <dt>Diff fingerprint</dt><dd><code>8b6b4a58…6b84fc</code></dd>
+  <dt>Diff fingerprint</dt><dd><code>5d34f79a…7fa03f</code></dd>
 </dl>
 
 <h2>Executive summary</h2>

--- a/docs/reports/2026-07-15-pos-phase0-idor-pii-rejected-sale-report.html
+++ b/docs/reports/2026-07-15-pos-phase0-idor-pii-rejected-sale-report.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="cd97b2c82044ebbbc1f7037f81d980aa756792a205e1187c48a0c92a2aa878ac">
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="8b6b4a580e8c85e9379046eb27165d200676216c8479f2ae448228f7076b84fc">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -104,7 +104,7 @@
   <dt>Status</dt><dd>Delivery candidate — not merged, not deployed, Linear not <em>Done</em></dd>
   <dt>Deploy</dt><dd>Pending (post-merge, Convex-prod surface)</dd>
   <dt>Root alignment</dt><dd>Pending (post-merge)</dd>
-  <dt>Diff fingerprint</dt><dd><code>cd97b2c8…a878ac</code></dd>
+  <dt>Diff fingerprint</dt><dd><code>8b6b4a58…6b84fc</code></dd>
 </dl>
 
 <h2>Executive summary</h2>

--- a/docs/solutions/security-issues/pos-public-surface-authz-and-rejected-sale-loss-2026-07-15.md
+++ b/docs/solutions/security-issues/pos-public-surface-authz-and-rejected-sale-loss-2026-07-15.md
@@ -1,0 +1,65 @@
+---
+title: "POS public surfaces need per-endpoint org authorization; rejected money-bearing sync events must leave a conflict"
+date: 2026-07-15
+category: security-issues
+module: pos
+problem_type: security_issue
+component: authentication
+symptoms:
+  - "register.getState returned another tenant's terminal state, active cashier, open register session, and held cart contents with no authorization"
+  - "openDrawer was authentication-only, so any org's user could open a drawer on a target store's terminal and corrupt cash-control attribution"
+  - "All 13 convex/pos/public/customers.ts endpoints had zero authorization; getCustomerById leaked full PII by customerId and create/update were unauthenticated cross-tenant writes"
+  - "A money-bearing offline sale rejected during sync advanced the cursor and wrote no conflict, so a cash sale vanished with the drawer left short"
+root_cause: missing_permission
+resolution_type: code_fix
+severity: critical
+tags: [pos, authorization, idor, pii, convex, sync-conflict, multi-tenant]
+delivery_diff_fingerprint: cd97b2c82044ebbbc1f7037f81d980aa756792a205e1187c48a0c92a2aa878ac
+---
+
+# POS public surfaces need per-endpoint org authorization; rejected money-bearing sync events must leave a conflict
+
+## Problem
+
+A POS local-first hardening audit found two active silent-failure classes at the seams around a sound event-sourcing core. First, several public Convex POS endpoints performed cross-tenant reads/writes with no authorization: `register.getState` (no auth at all), `register.openDrawer` (authentication only, no org check), and every endpoint in `convex/pos/public/customers.ts` (13 endpoints, PII reads plus cross-tenant writes). Second, a completed offline sale whose envelope/payload validation failed was marked `rejected`, advanced the sync cursor, and wrote no `posLocalSyncConflict` — money changed hands but the record silently disappeared.
+
+## Symptoms
+
+- `register.getState` returned a foreign store's terminal state, cashier, open register session, and held cart contents.
+- `openDrawer` accepted any authenticated user from any org, corrupting cash-control attribution.
+- `getCustomerById` returned full customer PII keyed only by `customerId`; `createCustomer`/`updateCustomer` were unauthenticated cross-tenant writes.
+- A rejected money-bearing `sale_completed` event left no manager-visible record.
+
+## What Didn't Work
+
+- Presence-grep is insufficient for the sweep: a file can import `requireOrganizationMemberRoleWithCtx` yet still leave individual endpoints unguarded. The audit required a per-endpoint check, not a per-file one.
+- For U2, a naive "retry the rejected event" is wrong — a validation-rejected financial event cannot be auto-corrected. It must surface as a `needs_review` conflict while the cursor still advances (liveness).
+
+## Solution
+
+Authorization (mirror the existing `requirePosTransactionStoreAccess` pattern in `convex/pos/public/transactions.ts`):
+
+- `register.getState` (public wrapper `convex/pos/public/register.ts`): resolve the store from `storeId`, then `requireAuthenticatedAthenaUserWithCtx` → `requireOrganizationMemberRoleWithCtx(store.organizationId, ["full_admin","pos_only"])` before delegating. Return `null` for a missing store (no existence leak beyond the existing pattern).
+- `openDrawer` (command `convex/pos/application/commands/register.ts`): add the same `requireOrganizationMemberRoleWithCtx` check right after the store is resolved and the user is authenticated.
+- `customers.ts`: add two helpers — `requirePosCustomerStoreAccess({storeId})` and `requirePosCustomerAccessById({customerId})` (resolves the customer, then scopes to *its* store's org). Guard all 13 endpoints. `customerId`- and `storeFrontUserId`-keyed reads resolve the target's store first so a valid foreign id is still denied. The customer query/command application modules have no other callers, so the boundary is fully closed at the public surface.
+
+Rejected-sale conflict (`convex/pos/application/sync/ingestLocalEvents.ts`):
+
+- In the `rejected` branch, when the event is money-bearing (`sale_completed` with a non-empty `payments` array), create a `posLocalSyncConflict` with `conflictType: "server_rejected"` (`needs_review`) carrying `localEventId`, register session, `amount`, `localTransactionId`, and the rejection `reason` in `details`. The cursor still advances; non-financial rejects stay silent to avoid conflict spam.
+- Add the `server_rejected` literal to the closed `conflictType` union in both the schema (`convex/schemas/pos/posLocalSyncConflict.ts`) and the type alias (`convex/pos/application/sync/types.ts`). This wires up the already-present-but-dead `server_rejected` branch in `classifyRegisterSessionSyncReview`, so the conflict reaches the manager review surface.
+
+## Why This Works
+
+The trust boundary for these operations is the public Convex wrapper (and the `openDrawer` command, which is the only caller of its logic). Enforcing org membership there — resolved from the store that owns the targeted resource — makes cross-tenant access impossible even with a valid foreign id, because membership is checked against the resource's own `organizationId`. For the rejected sale, routing money-bearing failures through the existing `posLocalSyncConflict` `needs_review` rail (with `createConflict`'s built-in dedup) guarantees exactly one durable, manager-visible artifact per rejected sale, idempotent on replay, without stalling the cursor.
+
+## Prevention
+
+- Sweep public Convex boundaries **per endpoint**, not per file. Auth-import presence is not proof of coverage.
+- New POS public endpoints should resolve the store (directly, or via the resource they target) and call `requireOrganizationMemberRoleWithCtx` before any read/write — copy `requirePosTransactionStoreAccess`.
+- Never let a money-bearing event leave the sync pipeline without either a canonical transaction or a `needs_review` conflict. Tests must assert cross-org denial (proving the underlying query/command is not called) and, for sync, that a rejected financial event creates exactly one conflict while the cursor advances.
+
+## Related Issues
+
+- Linear V26-1055 (register authz), V26-1056 (customers authz), V26-1057 (rejected-sale conflict).
+- Plan: `docs/plans/2026-07-15-001-fix-pos-local-first-hardening-plan.md` (Phase 0, units U1/U11/U2).
+- Deferred: POS `catalog.ts` search/barcode exposure → V26-956. `terminalAppSessions.ts` is a deliberate terminal-proof exception.

--- a/docs/solutions/security-issues/pos-public-surface-authz-and-rejected-sale-loss-2026-07-15.md
+++ b/docs/solutions/security-issues/pos-public-surface-authz-and-rejected-sale-loss-2026-07-15.md
@@ -14,7 +14,7 @@ root_cause: missing_permission
 resolution_type: code_fix
 severity: critical
 tags: [pos, authorization, idor, pii, convex, sync-conflict, multi-tenant]
-delivery_diff_fingerprint: cd97b2c82044ebbbc1f7037f81d980aa756792a205e1187c48a0c92a2aa878ac
+delivery_diff_fingerprint: 8b6b4a580e8c85e9379046eb27165d200676216c8479f2ae448228f7076b84fc
 ---
 
 # POS public surfaces need per-endpoint org authorization; rejected money-bearing sync events must leave a conflict

--- a/docs/solutions/security-issues/pos-public-surface-authz-and-rejected-sale-loss-2026-07-15.md
+++ b/docs/solutions/security-issues/pos-public-surface-authz-and-rejected-sale-loss-2026-07-15.md
@@ -14,7 +14,7 @@ root_cause: missing_permission
 resolution_type: code_fix
 severity: critical
 tags: [pos, authorization, idor, pii, convex, sync-conflict, multi-tenant]
-delivery_diff_fingerprint: 8b6b4a580e8c85e9379046eb27165d200676216c8479f2ae448228f7076b84fc
+delivery_diff_fingerprint: 5d34f79afaf9ce6d1197f0fcf06a3de2a59e65affe958674c92b694e4d7fa03f
 ---
 
 # POS public surfaces need per-endpoint org authorization; rejected money-bearing sync events must leave a conflict

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10457 nodes · 12705 edges · 2514 communities detected
+- 10459 nodes · 12709 edges · 2514 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2592,8 +2592,8 @@ Cohesion: 0.08
 Nodes (58): applyImportedSkuInventoryWithCtx(), buildFinalTrustedQuantitiesByRowNumber(), buildProductPageFinalizationMetadata(), buildProductPageFinalizationPayloadHash(), buildProvisionalSkuPatch(), buildSaleEvidenceFingerprint(), buildSkuInsert(), buildSkuPatch() (+50 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.09
-Nodes (47): buildLocalSyncEventRecordInput(), canonicalize(), canonicalJson(), createLocalSyncIngestionService(), getLocalSyncCursorIdentity(), getLocalSyncScope(), ingestLocalEventsWithCtx(), isNonEmptyString() (+39 more)
+Cohesion: 0.08
+Nodes (48): buildLocalSyncEventRecordInput(), canonicalize(), canonicalJson(), createLocalSyncIngestionService(), getLocalSyncCursorIdentity(), getLocalSyncScope(), ingestLocalEventsWithCtx(), isNonEmptyString() (+40 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.07
@@ -3576,24 +3576,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 256 - "Community 256"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 257 - "Community 257"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 258 - "Community 258"
+### Community 257 - "Community 257"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 259 - "Community 259"
+### Community 258 - "Community 258"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 259 - "Community 259"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 260 - "Community 260"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 261 - "Community 261"
 Cohesion: 0.39
@@ -4188,104 +4188,104 @@ Cohesion: 0.4
 Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
 
 ### Community 409 - "Community 409"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 410 - "Community 410"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 411 - "Community 411"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 412 - "Community 412"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 412 - "Community 412"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 414 - "Community 414"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 415 - "Community 415"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 0.53
 Nodes (4): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState(), isLocallySettledSyncStatus()
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
-
-### Community 417 - "Community 417"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 418 - "Community 418"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 420 - "Community 420"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 421 - "Community 421"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 422 - "Community 422"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 420 - "Community 420"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 421 - "Community 421"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 422 - "Community 422"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 423 - "Community 423"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 424 - "Community 424"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 425 - "Community 425"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 426 - "Community 426"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 427 - "Community 427"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 428 - "Community 428"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 429 - "Community 429"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 431 - "Community 431"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 432 - "Community 432"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 432 - "Community 432"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 433 - "Community 433"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 434 - "Community 434"
 Cohesion: 0.53
@@ -4836,40 +4836,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 571 - "Community 571"
+Cohesion: 0.5
+Nodes (1): buildCtx()
+
+### Community 572 - "Community 572"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 572 - "Community 572"
+### Community 573 - "Community 573"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 573 - "Community 573"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 574 - "Community 574"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 575 - "Community 575"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 576 - "Community 576"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 576 - "Community 576"
+### Community 577 - "Community 577"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 577 - "Community 577"
+### Community 578 - "Community 578"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 578 - "Community 578"
+### Community 579 - "Community 579"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 579 - "Community 579"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 580 - "Community 580"
 Cohesion: 0.5
@@ -4881,7 +4881,7 @@ Nodes (0):
 
 ### Community 582 - "Community 582"
 Cohesion: 0.5
-Nodes (1): buildCtx()
+Nodes (0):
 
 ### Community 583 - "Community 583"
 Cohesion: 0.5

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2586 files · ~0 words
+- 2587 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10449 nodes · 12697 edges · 2513 communities detected
+- 10452 nodes · 12700 edges · 2513 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3575,28 +3575,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 256 - "Community 256"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 257 - "Community 257"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 258 - "Community 258"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 259 - "Community 259"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 260 - "Community 260"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+### Community 257 - "Community 257"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 261 - "Community 261"
+### Community 258 - "Community 258"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 259 - "Community 259"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 260 - "Community 260"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 261 - "Community 261"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.22
@@ -4880,75 +4880,75 @@ Nodes (0):
 
 ### Community 582 - "Community 582"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 583 - "Community 583"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 584 - "Community 584"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 585 - "Community 585"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 586 - "Community 586"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 587 - "Community 587"
-Cohesion: 0.83
-Nodes (3): actorRefWithCtx(), preflightReportingRunAccessWithCtx(), recordReportingDirectAccessDenialWithCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 588 - "Community 588"
 Cohesion: 0.83
-Nodes (3): assertMinor(), lineFact(), recognizeCommerceEvent()
+Nodes (3): actorRefWithCtx(), preflightReportingRunAccessWithCtx(), recordReportingDirectAccessDenialWithCtx()
 
 ### Community 589 - "Community 589"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): assertMinor(), lineFact(), recognizeCommerceEvent()
 
 ### Community 590 - "Community 590"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 591 - "Community 591"
-Cohesion: 0.67
-Nodes (2): buildReportingRun(), createReportingRunWithCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
-Nodes (2): getMetricContract(), validateMetricContractVersion()
+Nodes (2): buildReportingRun(), createReportingRunWithCtx()
 
 ### Community 593 - "Community 593"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getMetricContract(), validateMetricContractVersion()
 
 ### Community 594 - "Community 594"
-Cohesion: 0.67
-Nodes (2): completeCoverage(), emptyPresetContext()
-
-### Community 595 - "Community 595"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 595 - "Community 595"
+Cohesion: 0.67
+Nodes (2): completeCoverage(), emptyPresetContext()
 
 ### Community 596 - "Community 596"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 597 - "Community 597"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 598 - "Community 598"
 Cohesion: 0.83
 Nodes (3): createOpaqueTicket(), encodeBase64Url(), hashSharedDemoTicket()
 
-### Community 598 - "Community 598"
+### Community 599 - "Community 599"
 Cohesion: 0.67
 Nodes (2): runHourlyRestoreWithCtx(), sharedDemoRestoreEnabled()
-
-### Community 599 - "Community 599"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 600 - "Community 600"
 Cohesion: 0.5
@@ -4959,16 +4959,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 602 - "Community 602"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 603 - "Community 603"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 603 - "Community 603"
+### Community 604 - "Community 604"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 604 - "Community 604"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 605 - "Community 605"
 Cohesion: 0.5
@@ -4979,52 +4979,52 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 607 - "Community 607"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 608 - "Community 608"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 609 - "Community 609"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 610 - "Community 610"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 611 - "Community 611"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 612 - "Community 612"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 613 - "Community 613"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 613 - "Community 613"
+### Community 614 - "Community 614"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 614 - "Community 614"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 615 - "Community 615"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 616 - "Community 616"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 617 - "Community 617"
-Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
-
-### Community 618 - "Community 618"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 618 - "Community 618"
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 619 - "Community 619"
 Cohesion: 0.5
@@ -5063,12 +5063,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 628 - "Community 628"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 629 - "Community 629"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 629 - "Community 629"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 630 - "Community 630"
 Cohesion: 0.5
@@ -5079,12 +5079,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 632 - "Community 632"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 633 - "Community 633"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 633 - "Community 633"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.5
@@ -5107,12 +5107,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 639 - "Community 639"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 640 - "Community 640"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 640 - "Community 640"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 641 - "Community 641"
 Cohesion: 0.5
@@ -5127,108 +5127,108 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 644 - "Community 644"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 645 - "Community 645"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 647 - "Community 647"
 Cohesion: 0.67
-Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 648 - "Community 648"
+Cohesion: 0.67
+Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
+
+### Community 649 - "Community 649"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 649 - "Community 649"
+### Community 650 - "Community 650"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 650 - "Community 650"
+### Community 651 - "Community 651"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 651 - "Community 651"
-Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
 
 ### Community 652 - "Community 652"
 Cohesion: 0.67
-Nodes (2): coarseDevice(), emitLandingFunnelEvent()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 653 - "Community 653"
+Cohesion: 0.67
+Nodes (2): coarseDevice(), emitLandingFunnelEvent()
+
+### Community 654 - "Community 654"
 Cohesion: 0.83
 Nodes (3): getRecoveryHomePath(), isPublicRoutePath(), normalizePathname()
 
-### Community 654 - "Community 654"
+### Community 655 - "Community 655"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 655 - "Community 655"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 657 - "Community 657"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 658 - "Community 658"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 659 - "Community 659"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 660 - "Community 660"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 660 - "Community 660"
+### Community 661 - "Community 661"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 661 - "Community 661"
+### Community 662 - "Community 662"
 Cohesion: 0.67
 Nodes (2): buildPosLocalStoreFixtureSnapshot(), fixtureIntegrity()
 
-### Community 662 - "Community 662"
+### Community 663 - "Community 663"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 663 - "Community 663"
+### Community 664 - "Community 664"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 664 - "Community 664"
+### Community 665 - "Community 665"
 Cohesion: 0.67
 Nodes (2): assessPosLocalStoreClear(), hasValidClearInspectionCounts()
 
-### Community 665 - "Community 665"
+### Community 666 - "Community 666"
 Cohesion: 0.83
 Nodes (3): isVersioned(), reconcileRegisterLifecycleServerAuthority(), sameAuthorityPayload()
 
-### Community 666 - "Community 666"
+### Community 667 - "Community 667"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 667 - "Community 667"
+### Community 668 - "Community 668"
 Cohesion: 0.67
 Nodes (2): applySnapshot(), toObservation()
 
-### Community 668 - "Community 668"
+### Community 669 - "Community 669"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 669 - "Community 669"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 670 - "Community 670"
 Cohesion: 0.5
@@ -5239,28 +5239,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 672 - "Community 672"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 673 - "Community 673"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 673 - "Community 673"
+### Community 674 - "Community 674"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 674 - "Community 674"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 675 - "Community 675"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 676 - "Community 676"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 677 - "Community 677"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 678 - "Community 678"
 Cohesion: 0.5
@@ -5291,63 +5291,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 685 - "Community 685"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 686 - "Community 686"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 687 - "Community 687"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 688 - "Community 688"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 688 - "Community 688"
+### Community 689 - "Community 689"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 689 - "Community 689"
+### Community 690 - "Community 690"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 690 - "Community 690"
+### Community 691 - "Community 691"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 691 - "Community 691"
+### Community 692 - "Community 692"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 692 - "Community 692"
+### Community 693 - "Community 693"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 693 - "Community 693"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 694 - "Community 694"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 695 - "Community 695"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 696 - "Community 696"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 696 - "Community 696"
+### Community 697 - "Community 697"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 697 - "Community 697"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 698 - "Community 698"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 699 - "Community 699"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 700 - "Community 700"
@@ -5359,12 +5359,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 702 - "Community 702"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 703 - "Community 703"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 703 - "Community 703"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 704 - "Community 704"
 Cohesion: 0.67
@@ -5407,12 +5407,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 714 - "Community 714"
-Cohesion: 1.0
-Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
-
-### Community 715 - "Community 715"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 715 - "Community 715"
+Cohesion: 1.0
+Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
 
 ### Community 716 - "Community 716"
 Cohesion: 0.67
@@ -5443,36 +5443,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 723 - "Community 723"
-Cohesion: 1.0
-Nodes (2): closedRegisterReplayConflict(), repairConflict()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 724 - "Community 724"
 Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 725 - "Community 725"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 726 - "Community 726"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 727 - "Community 727"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 728 - "Community 728"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 729 - "Community 729"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 730 - "Community 730"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 731 - "Community 731"
 Cohesion: 0.67
@@ -5487,16 +5487,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 734 - "Community 734"
-Cohesion: 1.0
-Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 735 - "Community 735"
 Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
 
 ### Community 736 - "Community 736"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 737 - "Community 737"
 Cohesion: 0.67
@@ -5519,12 +5519,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 742 - "Community 742"
-Cohesion: 1.0
-Nodes (2): evaluateAttention(), reason()
-
-### Community 743 - "Community 743"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 743 - "Community 743"
+Cohesion: 1.0
+Nodes (2): evaluateAttention(), reason()
 
 ### Community 744 - "Community 744"
 Cohesion: 0.67
@@ -5543,28 +5543,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 748 - "Community 748"
-Cohesion: 1.0
-Nodes (2): buildDailyProjection(), integer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 749 - "Community 749"
 Cohesion: 1.0
-Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
+Nodes (2): buildDailyProjection(), integer()
 
 ### Community 750 - "Community 750"
 Cohesion: 1.0
-Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
+Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
 
 ### Community 751 - "Community 751"
 Cohesion: 1.0
-Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
+Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
-Nodes (2): reconcileProjection(), unitFor()
+Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
 
 ### Community 753 - "Community 753"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reconcileProjection(), unitFor()
 
 ### Community 754 - "Community 754"
 Cohesion: 0.67
@@ -5587,12 +5587,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 759 - "Community 759"
-Cohesion: 1.0
-Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
-
-### Community 760 - "Community 760"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 760 - "Community 760"
+Cohesion: 1.0
+Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
 
 ### Community 761 - "Community 761"
 Cohesion: 0.67
@@ -5607,16 +5607,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 764 - "Community 764"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 765 - "Community 765"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 766 - "Community 766"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 767 - "Community 767"
 Cohesion: 0.67
@@ -5627,28 +5627,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 769 - "Community 769"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 770 - "Community 770"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 771 - "Community 771"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 772 - "Community 772"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 773 - "Community 773"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 774 - "Community 774"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 774 - "Community 774"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 775 - "Community 775"
 Cohesion: 0.67
@@ -5656,11 +5656,11 @@ Nodes (0):
 
 ### Community 776 - "Community 776"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 777 - "Community 777"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 778 - "Community 778"
 Cohesion: 0.67
@@ -5675,12 +5675,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 781 - "Community 781"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 782 - "Community 782"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 782 - "Community 782"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 783 - "Community 783"
 Cohesion: 0.67
@@ -5704,23 +5704,23 @@ Nodes (0):
 
 ### Community 788 - "Community 788"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 789 - "Community 789"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 790 - "Community 790"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 791 - "Community 791"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 792 - "Community 792"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 792 - "Community 792"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 793 - "Community 793"
 Cohesion: 0.67
@@ -5728,23 +5728,23 @@ Nodes (0):
 
 ### Community 794 - "Community 794"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 795 - "Community 795"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 796 - "Community 796"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 797 - "Community 797"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 798 - "Community 798"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 798 - "Community 798"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 799 - "Community 799"
 Cohesion: 0.67
@@ -5755,16 +5755,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 801 - "Community 801"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 802 - "Community 802"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 803 - "Community 803"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 804 - "Community 804"
 Cohesion: 0.67
@@ -5832,79 +5832,79 @@ Nodes (0):
 
 ### Community 820 - "Community 820"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 821 - "Community 821"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 822 - "Community 822"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 823 - "Community 823"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 824 - "Community 824"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 825 - "Community 825"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 826 - "Community 826"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 827 - "Community 827"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 828 - "Community 828"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 828 - "Community 828"
+### Community 829 - "Community 829"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 829 - "Community 829"
+### Community 830 - "Community 830"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 830 - "Community 830"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 831 - "Community 831"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 832 - "Community 832"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 833 - "Community 833"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 834 - "Community 834"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 835 - "Community 835"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 836 - "Community 836"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 837 - "Community 837"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 838 - "Community 838"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 839 - "Community 839"
 Cohesion: 0.67
@@ -5936,11 +5936,11 @@ Nodes (0):
 
 ### Community 846 - "Community 846"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 847 - "Community 847"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 848 - "Community 848"
 Cohesion: 0.67
@@ -5971,28 +5971,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 855 - "Community 855"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 856 - "Community 856"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 856 - "Community 856"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 857 - "Community 857"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 858 - "Community 858"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 859 - "Community 859"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
-
-### Community 860 - "Community 860"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 860 - "Community 860"
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 861 - "Community 861"
 Cohesion: 0.67
@@ -6011,28 +6011,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 865 - "Community 865"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 866 - "Community 866"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 867 - "Community 867"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 868 - "Community 868"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 869 - "Community 869"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 870 - "Community 870"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 870 - "Community 870"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 871 - "Community 871"
 Cohesion: 0.67
@@ -6063,16 +6063,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 878 - "Community 878"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 879 - "Community 879"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 880 - "Community 880"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 881 - "Community 881"
 Cohesion: 0.67
@@ -6083,60 +6083,60 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 883 - "Community 883"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 884 - "Community 884"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 885 - "Community 885"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 886 - "Community 886"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 887 - "Community 887"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 888 - "Community 888"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 889 - "Community 889"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 890 - "Community 890"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 891 - "Community 891"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 892 - "Community 892"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 893 - "Community 893"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 894 - "Community 894"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 895 - "Community 895"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 896 - "Community 896"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 897 - "Community 897"
 Cohesion: 0.67
@@ -6151,12 +6151,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 900 - "Community 900"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 901 - "Community 901"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 901 - "Community 901"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 902 - "Community 902"
 Cohesion: 0.67
@@ -6167,12 +6167,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 904 - "Community 904"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 905 - "Community 905"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 905 - "Community 905"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 906 - "Community 906"
 Cohesion: 0.67
@@ -6239,16 +6239,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 922 - "Community 922"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 923 - "Community 923"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 924 - "Community 924"
+### Community 923 - "Community 923"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 924 - "Community 924"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 925 - "Community 925"
 Cohesion: 1.0
@@ -6263,24 +6263,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 928 - "Community 928"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 929 - "Community 929"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 929 - "Community 929"
+### Community 930 - "Community 930"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 930 - "Community 930"
+### Community 931 - "Community 931"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 931 - "Community 931"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 932 - "Community 932"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 933 - "Community 933"
 Cohesion: 1.0
@@ -7656,11 +7656,11 @@ Nodes (0):
 
 ### Community 1276 - "Community 1276"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1277 - "Community 1277"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1278 - "Community 1278"
 Cohesion: 1.0
@@ -12605,461 +12605,461 @@ Nodes (0):
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 932`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
+- **Thin community `Community 933`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 934`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 935`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 936`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 937`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 938`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 939`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 940`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 941`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 942`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 943`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 944`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 945`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 946`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 947`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
+- **Thin community `Community 948`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 949`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
+- **Thin community `Community 950`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 951`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 952`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 953`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 954`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 955`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 956`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
+- **Thin community `Community 957`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
+- **Thin community `Community 958`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 959`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 960`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 961`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 962`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 963`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 964`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 965`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
+- **Thin community `Community 966`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 967`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 968`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 969`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
+- **Thin community `Community 970`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 971`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
+- **Thin community `Community 972`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 973`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 974`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 975`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
+- **Thin community `Community 976`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
+- **Thin community `Community 977`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
+- **Thin community `Community 978`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 979`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 980`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 981`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 982`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 983`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 984`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 985`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 986`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 987`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
+- **Thin community `Community 988`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
+- **Thin community `Community 989`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
+- **Thin community `Community 990`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 991`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 992`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 993`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 994`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 995`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 996`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 997`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
+- **Thin community `Community 998`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
+- **Thin community `Community 999`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 1000`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 1001`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
+- **Thin community `Community 1002`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
+- **Thin community `Community 1003`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 1004`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 1005`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 1006`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
+- **Thin community `Community 1007`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 1008`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 1009`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 1010`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 1011`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1012`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 1013`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 1014`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 1015`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `context()`, `access.test.ts`
+- **Thin community `Community 1016`** (2 nodes): `context()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `current()`, `coverage.test.ts`
+- **Thin community `Community 1017`** (2 nodes): `current()`, `coverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `context()`, `directAccess.test.ts`
+- **Thin community `Community 1018`** (2 nodes): `context()`, `directAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `rows()`, `evidence.test.ts`
+- **Thin community `Community 1019`** (2 nodes): `rows()`, `evidence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `context()`, `evidenceAccess.test.ts`
+- **Thin community `Community 1020`** (2 nodes): `context()`, `evidenceAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
+- **Thin community `Community 1021`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `context()`, `commerceEffects.test.ts`
+- **Thin community `Community 1022`** (2 nodes): `context()`, `commerceEffects.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
+- **Thin community `Community 1023`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
+- **Thin community `Community 1024`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `processing.ts`, `processBoundedBatch()`
+- **Thin community `Community 1025`** (2 nodes): `processing.ts`, `processBoundedBatch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
+- **Thin community `Community 1026`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
+- **Thin community `Community 1027`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
+- **Thin community `Community 1028`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `reportingDestination()`, `destinations.ts`
+- **Thin community `Community 1029`** (2 nodes): `reportingDestination()`, `destinations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
+- **Thin community `Community 1030`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
+- **Thin community `Community 1031`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
+- **Thin community `Community 1032`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
+- **Thin community `Community 1033`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
+- **Thin community `Community 1034`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `settlement.ts`, `adaptSettlement()`
+- **Thin community `Community 1035`** (2 nodes): `settlement.ts`, `adaptSettlement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
+- **Thin community `Community 1036`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
+- **Thin community `Community 1037`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 1038`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 1039`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `contextFor()`, `actor.test.ts`
+- **Thin community `Community 1040`** (2 nodes): `contextFor()`, `actor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `contextWith()`, `admission.test.ts`
+- **Thin community `Community 1041`** (2 nodes): `contextWith()`, `admission.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `invoke()`, `enforcement.test.ts`
+- **Thin community `Community 1042`** (2 nodes): `invoke()`, `enforcement.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
+- **Thin community `Community 1043`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `public.ts`, `selectSharedDemoRegisterBootstrapRecords()`
+- **Thin community `Community 1044`** (2 nodes): `public.ts`, `selectSharedDemoRegisterBootstrapRecords()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `readBoundary.test.ts`, `invoke()`
+- **Thin community `Community 1045`** (2 nodes): `readBoundary.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
+- **Thin community `Community 1046`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 1047`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 1048`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 1049`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 1050`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 1051`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 1052`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 1053`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 1054`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 1055`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 1056`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 1057`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 1058`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 1059`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 1060`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 1061`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 1062`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 1063`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 1064`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 1065`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 1066`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 1067`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 1068`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 1069`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 1070`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 1071`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 1072`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 1073`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
+- **Thin community `Community 1074`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 1075`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 1076`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 1077`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 1078`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 1079`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 1080`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 1081`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 1082`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 1083`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 1084`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 1085`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 1086`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 1087`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 1088`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 1089`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 1090`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 1091`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
+- **Thin community `Community 1092`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 1093`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
+- **Thin community `Community 1094`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 1095`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 1096`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 1097`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 1098`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 1099`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 1100`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1101`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 1102`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 1103`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 1104`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 1105`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 1106`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 1107`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 1108`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 1109`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 1110`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 1111`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 1112`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 1113`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 1114`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 1115`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 1116`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 1117`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 1118`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 1119`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 1120`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 1121`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 1122`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 1123`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 1124`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 1125`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 1126`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 1127`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 1128`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 1129`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 1130`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 1131`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 1132`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 1133`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 1134`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 1135`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 1136`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 1137`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 1138`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 1139`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 1140`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 1141`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 1142`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 1143`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 1144`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 1145`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 1146`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 1147`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 1148`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 1149`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 1150`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 1151`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 1152`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 1153`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 1154`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 1155`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 1156`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 1157`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 1158`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 1159`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 1160`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -13095,967 +13095,965 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 1161`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 1162`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 1163`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 1164`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 1165`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 1166`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 1167`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 1168`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 1169`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 1170`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 1171`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 1172`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 1173`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 1174`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
+- **Thin community `Community 1175`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 1176`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 1177`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 1178`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 1179`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 1180`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 1181`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 1182`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 1183`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 1184`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 1185`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 1186`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 1187`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 1188`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
+- **Thin community `Community 1189`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
+- **Thin community `Community 1190`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
+- **Thin community `Community 1191`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
+- **Thin community `Community 1192`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
+- **Thin community `Community 1193`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
+- **Thin community `Community 1194`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 1195`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1196`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1197`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1198`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1199`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
+- **Thin community `Community 1200`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
+- **Thin community `Community 1201`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `SharedDemoStatusBar.tsx`, `SharedDemoStatusBar()`
+- **Thin community `Community 1202`** (2 nodes): `SharedDemoStatusBar.tsx`, `SharedDemoStatusBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
+- **Thin community `Community 1203`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
+- **Thin community `Community 1204`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
+- **Thin community `Community 1205`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
+- **Thin community `Community 1206`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 1207`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 1208`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 1209`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 1210`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 1211`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 1212`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 1213`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 1214`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 1215`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 1216`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 1217`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 1218`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 1219`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 1220`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 1221`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 1222`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 1223`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 1224`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 1225`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 1226`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1227`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1228`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1229`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
+- **Thin community `Community 1230`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1231`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1232`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1233`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1234`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1235`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1236`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1237`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1238`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1239`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1240`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1241`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1242`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1243`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1244`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1245`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1246`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
+- **Thin community `Community 1247`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1248`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1249`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1250`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1251`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1252`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1253`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1254`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1255`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1256`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1257`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1258`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1259`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1260`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1261`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1262`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1263`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1264`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1265`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1266`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1267`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1268`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1269`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1270`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1271`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1272`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1273`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1274`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1275`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1276`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1277`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1278`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1279`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1280`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1281`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1282`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1283`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1284`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
+- **Thin community `Community 1285`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1286`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1287`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1288`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1289`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1290`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1291`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1292`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
+- **Thin community `Community 1293`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
+- **Thin community `Community 1294`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
+- **Thin community `Community 1295`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `posLocalStoreBoundedOperations.test.ts`, `poisonWholeStoreReads()`
+- **Thin community `Community 1296`** (2 nodes): `posLocalStoreBoundedOperations.test.ts`, `poisonWholeStoreReads()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
+- **Thin community `Community 1297`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
+- **Thin community `Community 1298`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
+- **Thin community `Community 1299`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
+- **Thin community `Community 1300`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
+- **Thin community `Community 1301`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
+- **Thin community `Community 1302`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1303`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1304`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
+- **Thin community `Community 1305`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1306`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1307`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
+- **Thin community `Community 1308`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1309`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1310`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1311`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1312`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1313`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1314`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1315`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1316`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1317`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1318`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1319`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1320`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1321`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1322`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1323`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1324`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `-public-layout.tsx`, `PublicLayout()`
+- **Thin community `Community 1325`** (2 nodes): `-public-layout.tsx`, `PublicLayout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1326`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1327`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1328`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1329`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1330`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1331`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1332`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1333`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1334`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1335`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1336`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1337`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1338`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1339`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1340`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1341`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
+- **Thin community `Community 1342`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
+- **Thin community `Community 1343`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
+- **Thin community `Community 1344`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1345`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
+- **Thin community `Community 1346`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1347`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
+- **Thin community `Community 1348`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `AuthenticatedLayout()`, `_authed.tsx`
+- **Thin community `Community 1349`** (2 nodes): `AuthenticatedLayout()`, `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `SharedDemoEntry()`, `demo.tsx`
+- **Thin community `Community 1350`** (2 nodes): `SharedDemoEntry()`, `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `getSharedDemoEntryPresentation()`, `demoPresentation.ts`
+- **Thin community `Community 1351`** (2 nodes): `getSharedDemoEntryPresentation()`, `demoPresentation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1352`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1353`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `walkthrough.tsx`, `WalkthroughPage()`
+- **Thin community `Community 1354`** (2 nodes): `walkthrough.tsx`, `WalkthroughPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1355`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1356`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1357`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1358`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1359`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1360`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1361`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1362`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1363`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1364`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1365`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1366`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1367`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1368`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1369`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1370`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1371`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1372`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1373`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1374`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1375`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1376`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1377`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1378`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1379`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1380`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1381`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1382`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1383`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1384`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1385`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1386`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1387`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1388`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1389`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1390`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1391`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1392`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1393`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1394`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1395`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1396`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1397`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1398`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1399`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1400`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1401`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1402`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1403`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1404`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1405`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1406`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1407`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1408`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1409`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1410`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1411`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1412`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1413`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1414`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1415`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1416`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1417`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1418`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1419`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1420`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1421`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1422`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1423`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1424`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1425`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1426`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1427`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1428`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1429`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1430`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1431`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1432`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1433`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1434`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1435`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1436`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1437`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1438`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1439`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1440`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1441`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1442`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1443`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1444`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1445`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1446`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1447`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1448`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1449`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1450`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1451`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1452`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1453`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1454`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1455`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1456`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1457`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1458`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1459`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1460`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1461`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1462`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1463`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1464`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1465`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1466`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1467`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1468`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1469`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1470`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1471`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1472`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1473`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1474`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1475`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1476`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1477`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1478`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1479`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1480`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1481`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1482`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1483`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1484`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1485`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1486`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1487`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1488`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1489`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1490`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1491`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1492`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1493`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1494`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `api.js`
+- **Thin community `Community 1495`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1496`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1497`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `server.js`
+- **Thin community `Community 1498`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `app.ts`
+- **Thin community `Community 1499`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1501`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `SharedDemoTicket.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `SharedDemoTicket.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1503`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `auth.ts`
+- **Thin community `Community 1505`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1507`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `countries.ts`
+- **Thin community `Community 1509`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `email.ts`
+- **Thin community `Community 1510`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1511`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `payment.ts`
+- **Thin community `Community 1512`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1513`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `types.ts`
+- **Thin community `Community 1514`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1515`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1516`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `crons.ts`
+- **Thin community `Community 1517`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1518`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `internal.ts`
+- **Thin community `Community 1519`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1520`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1524`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1525`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `DailyManagerReport.tsx`
+- **Thin community `Community 1526`** (1 nodes): `DailyManagerReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1527`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1528`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1529`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1530`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1531`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1532`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1533`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
+- **Thin community `Community 1534`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1535`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `env.ts`
+- **Thin community `Community 1536`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1537`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `auth.ts`
+- **Thin community `Community 1538`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1539`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `colors.ts`
+- **Thin community `Community 1540`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `index.ts`
+- **Thin community `Community 1541`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1543`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1544`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `products.ts`
+- **Thin community `Community 1545`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1546`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `stores.ts`
+- **Thin community `Community 1547`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1548`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `bag.ts`
+- **Thin community `Community 1550`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `guest.ts`
+- **Thin community `Community 1551`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1552`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `index.ts`
+- **Thin community `Community 1553`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `me.ts`
+- **Thin community `Community 1554`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `offers.ts`
+- **Thin community `Community 1555`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1556`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1557`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1558`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1559`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1560`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1561`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1562`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1563`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1564`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `user.ts`
+- **Thin community `Community 1565`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1566`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `index.ts`
+- **Thin community `Community 1567`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1568`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `http.ts`
+- **Thin community `Community 1569`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `access.ts`
+- **Thin community `Community 1570`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1573`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `index.ts`
+- **Thin community `Community 1574`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1575`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `types.ts`
+- **Thin community `Community 1576`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `athenaUser.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `athenaUser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `categories.ts`
+- **Thin community `Community 1579`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `colors.ts`
+- **Thin community `Community 1580`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1581`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1582`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1583`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1584`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1585`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `pos.ts`
+- **Thin community `Community 1586`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1587`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1588`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1589`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1592`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `stores.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `stores.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1595`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1597`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `storeMemberAccess.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `storeMemberAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1599`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1600`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1606`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `types.ts`
+- **Thin community `Community 1610`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1614`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1615`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
+- **Thin community `Community 1617`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1618`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1620`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `dto.ts`
+- **Thin community `Community 1625`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1627`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1628`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1629`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1630`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `types.ts`
+- **Thin community `Community 1631`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `facts.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `types.ts`
+- **Thin community `Community 1632`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1633`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1634`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `types.ts`
+- **Thin community `Community 1635`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1637`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1638`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `customers.ts`
+- **Thin community `Community 1639`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `register.test.ts`
+- **Thin community `Community 1640`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1641`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2587 files · ~0 words
+- 2588 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10452 nodes · 12700 edges · 2513 communities detected
+- 10457 nodes · 12705 edges · 2514 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2523,6 +2523,7 @@
 - [[_COMMUNITY_Community 2510|Community 2510]]
 - [[_COMMUNITY_Community 2511|Community 2511]]
 - [[_COMMUNITY_Community 2512|Community 2512]]
+- [[_COMMUNITY_Community 2513|Community 2513]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -5507,8 +5508,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 739 - "Community 739"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): requirePosCustomerAccessById(), requirePosCustomerStoreAccess()
 
 ### Community 740 - "Community 740"
 Cohesion: 0.67
@@ -5523,16 +5524,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 743 - "Community 743"
-Cohesion: 1.0
-Nodes (2): evaluateAttention(), reason()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 744 - "Community 744"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 745 - "Community 745"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): evaluateAttention(), reason()
 
 ### Community 746 - "Community 746"
 Cohesion: 0.67
@@ -5547,32 +5548,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 749 - "Community 749"
-Cohesion: 1.0
-Nodes (2): buildDailyProjection(), integer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 750 - "Community 750"
-Cohesion: 1.0
-Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 751 - "Community 751"
 Cohesion: 1.0
-Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
+Nodes (2): buildDailyProjection(), integer()
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
-Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
+Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
 
 ### Community 753 - "Community 753"
 Cohesion: 1.0
-Nodes (2): reconcileProjection(), unitFor()
+Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
 
 ### Community 754 - "Community 754"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
 
 ### Community 755 - "Community 755"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reconcileProjection(), unitFor()
 
 ### Community 756 - "Community 756"
 Cohesion: 0.67
@@ -5591,16 +5592,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 760 - "Community 760"
-Cohesion: 1.0
-Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 761 - "Community 761"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 762 - "Community 762"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
 
 ### Community 763 - "Community 763"
 Cohesion: 0.67
@@ -5611,56 +5612,56 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 765 - "Community 765"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 766 - "Community 766"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 767 - "Community 767"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 766 - "Community 766"
+### Community 768 - "Community 768"
 Cohesion: 1.0
 Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
-
-### Community 767 - "Community 767"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 768 - "Community 768"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 769 - "Community 769"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 770 - "Community 770"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
-
-### Community 771 - "Community 771"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
-
-### Community 772 - "Community 772"
-Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
-
-### Community 773 - "Community 773"
 Cohesion: 0.67
 Nodes (0):
 
+### Community 771 - "Community 771"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 772 - "Community 772"
+Cohesion: 1.0
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+
+### Community 773 - "Community 773"
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+
 ### Community 774 - "Community 774"
 Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 775 - "Community 775"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 776 - "Community 776"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 777 - "Community 777"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 778 - "Community 778"
 Cohesion: 0.67
@@ -5668,7 +5669,7 @@ Nodes (0):
 
 ### Community 779 - "Community 779"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 780 - "Community 780"
 Cohesion: 0.67
@@ -5679,16 +5680,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 782 - "Community 782"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 783 - "Community 783"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 784 - "Community 784"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 785 - "Community 785"
 Cohesion: 0.67
@@ -5708,7 +5709,7 @@ Nodes (0):
 
 ### Community 789 - "Community 789"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 790 - "Community 790"
 Cohesion: 0.67
@@ -5716,23 +5717,23 @@ Nodes (0):
 
 ### Community 791 - "Community 791"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 792 - "Community 792"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 793 - "Community 793"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 794 - "Community 794"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 795 - "Community 795"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 796 - "Community 796"
 Cohesion: 0.67
@@ -5740,39 +5741,39 @@ Nodes (0):
 
 ### Community 797 - "Community 797"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 798 - "Community 798"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 799 - "Community 799"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 800 - "Community 800"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 801 - "Community 801"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 802 - "Community 802"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 803 - "Community 803"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 804 - "Community 804"
 Cohesion: 1.0
 Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
-### Community 803 - "Community 803"
+### Community 805 - "Community 805"
 Cohesion: 1.0
 Nodes (2): buildTodaySummary(), renderStorePulse()
-
-### Community 804 - "Community 804"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 805 - "Community 805"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 806 - "Community 806"
 Cohesion: 0.67
@@ -5836,83 +5837,83 @@ Nodes (0):
 
 ### Community 821 - "Community 821"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 822 - "Community 822"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 823 - "Community 823"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 824 - "Community 824"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 825 - "Community 825"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 826 - "Community 826"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 827 - "Community 827"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 828 - "Community 828"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): TransactionsSkeleton()
 
 ### Community 829 - "Community 829"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 830 - "Community 830"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 831 - "Community 831"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 832 - "Community 832"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 833 - "Community 833"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (0):
 
 ### Community 834 - "Community 834"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 835 - "Community 835"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 836 - "Community 836"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 837 - "Community 837"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 838 - "Community 838"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 839 - "Community 839"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 840 - "Community 840"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 841 - "Community 841"
 Cohesion: 0.67
@@ -5940,7 +5941,7 @@ Nodes (0):
 
 ### Community 847 - "Community 847"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 848 - "Community 848"
 Cohesion: 0.67
@@ -5948,7 +5949,7 @@ Nodes (0):
 
 ### Community 849 - "Community 849"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 850 - "Community 850"
 Cohesion: 0.67
@@ -5975,32 +5976,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 856 - "Community 856"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 857 - "Community 857"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 858 - "Community 858"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getApprovalGuidance(), presentCommandToast()
 
 ### Community 859 - "Community 859"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 860 - "Community 860"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 861 - "Community 861"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 862 - "Community 862"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 863 - "Community 863"
 Cohesion: 0.67
@@ -6015,32 +6016,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 866 - "Community 866"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 867 - "Community 867"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 868 - "Community 868"
 Cohesion: 1.0
 Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
-### Community 867 - "Community 867"
+### Community 869 - "Community 869"
 Cohesion: 1.0
 Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
-### Community 868 - "Community 868"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 869 - "Community 869"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 870 - "Community 870"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 871 - "Community 871"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 872 - "Community 872"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 873 - "Community 873"
 Cohesion: 0.67
@@ -6067,44 +6068,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 879 - "Community 879"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 880 - "Community 880"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 881 - "Community 881"
 Cohesion: 1.0
 Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
-### Community 880 - "Community 880"
+### Community 882 - "Community 882"
 Cohesion: 1.0
 Nodes (2): collectSourceFiles(), findIllegalConvexImports()
-
-### Community 881 - "Community 881"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 882 - "Community 882"
-Cohesion: 0.67
-Nodes (0):
 
 ### Community 883 - "Community 883"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 884 - "Community 884"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
-
-### Community 885 - "Community 885"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
-
-### Community 886 - "Community 886"
-Cohesion: 0.67
-Nodes (1): hashPassword()
-
-### Community 887 - "Community 887"
 Cohesion: 0.67
 Nodes (0):
 
+### Community 885 - "Community 885"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 886 - "Community 886"
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+
+### Community 887 - "Community 887"
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
+
 ### Community 888 - "Community 888"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): hashPassword()
 
 ### Community 889 - "Community 889"
 Cohesion: 0.67
@@ -6112,39 +6113,39 @@ Nodes (0):
 
 ### Community 890 - "Community 890"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 891 - "Community 891"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 892 - "Community 892"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 893 - "Community 893"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 892 - "Community 892"
+### Community 894 - "Community 894"
 Cohesion: 1.0
 Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
-### Community 893 - "Community 893"
+### Community 895 - "Community 895"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 894 - "Community 894"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
-
-### Community 895 - "Community 895"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 896 - "Community 896"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 897 - "Community 897"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 898 - "Community 898"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 899 - "Community 899"
 Cohesion: 0.67
@@ -6155,32 +6156,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 901 - "Community 901"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 902 - "Community 902"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 903 - "Community 903"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 904 - "Community 904"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 905 - "Community 905"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 906 - "Community 906"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 907 - "Community 907"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 908 - "Community 908"
 Cohesion: 0.67
@@ -6243,8 +6244,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 923 - "Community 923"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 924 - "Community 924"
 Cohesion: 0.67
@@ -6252,11 +6253,11 @@ Nodes (0):
 
 ### Community 925 - "Community 925"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 926 - "Community 926"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 927 - "Community 927"
 Cohesion: 1.0
@@ -6267,12 +6268,12 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 929 - "Community 929"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 930 - "Community 930"
 Cohesion: 1.0
-Nodes (2): gitFixtureEnv(), runGit()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 931 - "Community 931"
 Cohesion: 0.67
@@ -6280,15 +6281,15 @@ Nodes (0):
 
 ### Community 932 - "Community 932"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): gitFixtureEnv(), runGit()
 
 ### Community 933 - "Community 933"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 934 - "Community 934"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 935 - "Community 935"
 Cohesion: 1.0
@@ -7660,7 +7661,7 @@ Nodes (0):
 
 ### Community 1277 - "Community 1277"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1278 - "Community 1278"
 Cohesion: 1.0
@@ -7668,7 +7669,7 @@ Nodes (0):
 
 ### Community 1279 - "Community 1279"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1280 - "Community 1280"
 Cohesion: 1.0
@@ -12602,464 +12603,468 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2513 - "Community 2513"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 933`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
+- **Thin community `Community 935`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 936`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 937`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 938`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 939`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 940`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 941`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 942`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 943`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 944`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 945`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 946`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 947`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 948`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 949`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
+- **Thin community `Community 950`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 951`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
+- **Thin community `Community 952`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 953`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 954`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 955`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 956`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 957`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 958`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
+- **Thin community `Community 959`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
+- **Thin community `Community 960`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 961`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 962`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 963`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 964`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 965`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 966`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 967`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
+- **Thin community `Community 968`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 969`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 970`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 971`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
+- **Thin community `Community 972`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 973`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
+- **Thin community `Community 974`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 975`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 976`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 977`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
+- **Thin community `Community 978`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
+- **Thin community `Community 979`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
+- **Thin community `Community 980`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 981`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 982`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 983`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 984`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 985`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 986`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 987`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 988`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 989`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
+- **Thin community `Community 990`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
+- **Thin community `Community 991`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
+- **Thin community `Community 992`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 993`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 994`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 995`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 996`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 997`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 998`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 999`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
+- **Thin community `Community 1000`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
+- **Thin community `Community 1001`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 1002`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 1003`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
+- **Thin community `Community 1004`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
+- **Thin community `Community 1005`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 1006`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 1007`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 1008`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
+- **Thin community `Community 1009`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 1010`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 1011`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 1012`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 1013`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1014`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 1015`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 1016`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 1017`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `context()`, `access.test.ts`
+- **Thin community `Community 1018`** (2 nodes): `context()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `current()`, `coverage.test.ts`
+- **Thin community `Community 1019`** (2 nodes): `current()`, `coverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `context()`, `directAccess.test.ts`
+- **Thin community `Community 1020`** (2 nodes): `context()`, `directAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `rows()`, `evidence.test.ts`
+- **Thin community `Community 1021`** (2 nodes): `rows()`, `evidence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `context()`, `evidenceAccess.test.ts`
+- **Thin community `Community 1022`** (2 nodes): `context()`, `evidenceAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
+- **Thin community `Community 1023`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `context()`, `commerceEffects.test.ts`
+- **Thin community `Community 1024`** (2 nodes): `context()`, `commerceEffects.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
+- **Thin community `Community 1025`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
+- **Thin community `Community 1026`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `processing.ts`, `processBoundedBatch()`
+- **Thin community `Community 1027`** (2 nodes): `processing.ts`, `processBoundedBatch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
+- **Thin community `Community 1028`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
+- **Thin community `Community 1029`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
+- **Thin community `Community 1030`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `reportingDestination()`, `destinations.ts`
+- **Thin community `Community 1031`** (2 nodes): `reportingDestination()`, `destinations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
+- **Thin community `Community 1032`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
+- **Thin community `Community 1033`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
+- **Thin community `Community 1034`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
+- **Thin community `Community 1035`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
+- **Thin community `Community 1036`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `settlement.ts`, `adaptSettlement()`
+- **Thin community `Community 1037`** (2 nodes): `settlement.ts`, `adaptSettlement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
+- **Thin community `Community 1038`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
+- **Thin community `Community 1039`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 1040`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 1041`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `contextFor()`, `actor.test.ts`
+- **Thin community `Community 1042`** (2 nodes): `contextFor()`, `actor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `contextWith()`, `admission.test.ts`
+- **Thin community `Community 1043`** (2 nodes): `contextWith()`, `admission.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `invoke()`, `enforcement.test.ts`
+- **Thin community `Community 1044`** (2 nodes): `invoke()`, `enforcement.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
+- **Thin community `Community 1045`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `public.ts`, `selectSharedDemoRegisterBootstrapRecords()`
+- **Thin community `Community 1046`** (2 nodes): `public.ts`, `selectSharedDemoRegisterBootstrapRecords()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `readBoundary.test.ts`, `invoke()`
+- **Thin community `Community 1047`** (2 nodes): `readBoundary.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
+- **Thin community `Community 1048`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 1049`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 1050`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 1051`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 1052`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 1053`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 1054`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 1055`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 1056`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 1057`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 1058`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 1059`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 1060`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 1061`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 1062`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 1063`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 1064`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 1065`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 1066`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 1067`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 1068`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 1069`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 1070`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 1071`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 1072`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 1073`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 1074`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 1075`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
+- **Thin community `Community 1076`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 1077`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 1078`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 1079`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 1080`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 1081`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 1082`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 1083`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 1084`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 1085`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 1086`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 1087`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 1088`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 1089`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 1090`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 1091`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 1092`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 1093`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
+- **Thin community `Community 1094`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 1095`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
+- **Thin community `Community 1096`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 1097`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 1098`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 1099`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 1100`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 1101`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 1102`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1103`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 1104`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 1105`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 1106`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 1107`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 1108`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 1109`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 1110`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 1111`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 1112`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 1113`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 1114`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 1115`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 1116`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 1117`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 1118`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 1119`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 1120`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 1121`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 1122`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 1123`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 1124`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 1125`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 1126`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 1127`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 1128`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 1129`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 1130`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 1131`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 1132`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 1133`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 1134`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 1135`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 1136`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 1137`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 1138`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 1139`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 1140`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 1141`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 1142`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 1143`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 1144`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 1145`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 1146`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 1147`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 1148`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 1149`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 1150`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 1151`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 1152`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 1153`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 1154`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 1155`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 1156`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 1157`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 1158`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 1159`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 1160`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 1161`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 1162`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -13095,2709 +13100,2707 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 1163`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 1164`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 1165`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 1166`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 1167`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 1168`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 1169`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 1170`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 1171`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 1172`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 1173`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 1174`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 1175`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 1176`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
+- **Thin community `Community 1177`** (2 nodes): `handlePaginationChange()`, `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 1178`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 1179`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 1180`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 1181`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 1182`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 1183`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 1184`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 1185`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 1186`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 1187`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 1188`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 1189`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 1190`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
+- **Thin community `Community 1191`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
+- **Thin community `Community 1192`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
+- **Thin community `Community 1193`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
+- **Thin community `Community 1194`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
+- **Thin community `Community 1195`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
+- **Thin community `Community 1196`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 1197`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1198`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1199`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1200`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1201`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
+- **Thin community `Community 1202`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
+- **Thin community `Community 1203`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `SharedDemoStatusBar.tsx`, `SharedDemoStatusBar()`
+- **Thin community `Community 1204`** (2 nodes): `SharedDemoStatusBar.tsx`, `SharedDemoStatusBar()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
+- **Thin community `Community 1205`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
+- **Thin community `Community 1206`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
+- **Thin community `Community 1207`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
+- **Thin community `Community 1208`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 1209`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 1210`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 1211`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 1212`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 1213`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 1214`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 1215`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 1216`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 1217`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 1218`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 1219`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 1220`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 1221`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 1222`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 1223`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 1224`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 1225`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 1226`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 1227`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 1228`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1229`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1230`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1231`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
+- **Thin community `Community 1232`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1233`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1234`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1235`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1236`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1237`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1238`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1239`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1240`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1241`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1242`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1243`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1244`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1245`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1246`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1247`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1248`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
+- **Thin community `Community 1249`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1250`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1251`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1252`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1253`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1254`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1255`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1256`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1257`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1258`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1259`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1260`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1261`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1262`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1263`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1264`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1265`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1266`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1267`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1268`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1269`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1270`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1271`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1272`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1273`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1274`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1275`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1276`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1277`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1278`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1279`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1280`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1281`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1282`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1283`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1284`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1285`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1286`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
+- **Thin community `Community 1287`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1288`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1289`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1290`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1291`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1292`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1293`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1294`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
+- **Thin community `Community 1295`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
+- **Thin community `Community 1296`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
+- **Thin community `Community 1297`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `posLocalStoreBoundedOperations.test.ts`, `poisonWholeStoreReads()`
+- **Thin community `Community 1298`** (2 nodes): `posLocalStoreBoundedOperations.test.ts`, `poisonWholeStoreReads()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
+- **Thin community `Community 1299`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
+- **Thin community `Community 1300`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
+- **Thin community `Community 1301`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
+- **Thin community `Community 1302`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
+- **Thin community `Community 1303`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
+- **Thin community `Community 1304`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1305`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1306`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
+- **Thin community `Community 1307`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1308`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1309`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
+- **Thin community `Community 1310`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1311`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1312`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1313`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1314`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1315`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1316`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1317`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1318`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1319`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1320`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1321`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1322`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1323`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1324`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1325`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1326`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `-public-layout.tsx`, `PublicLayout()`
+- **Thin community `Community 1327`** (2 nodes): `-public-layout.tsx`, `PublicLayout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1328`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1329`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1330`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1331`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1332`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1333`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1334`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1335`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1336`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1337`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1338`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1339`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1340`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1341`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1342`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1343`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
+- **Thin community `Community 1344`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
+- **Thin community `Community 1345`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
+- **Thin community `Community 1346`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1347`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
+- **Thin community `Community 1348`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1349`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
+- **Thin community `Community 1350`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `AuthenticatedLayout()`, `_authed.tsx`
+- **Thin community `Community 1351`** (2 nodes): `AuthenticatedLayout()`, `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `SharedDemoEntry()`, `demo.tsx`
+- **Thin community `Community 1352`** (2 nodes): `SharedDemoEntry()`, `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `getSharedDemoEntryPresentation()`, `demoPresentation.ts`
+- **Thin community `Community 1353`** (2 nodes): `getSharedDemoEntryPresentation()`, `demoPresentation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1354`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1355`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `walkthrough.tsx`, `WalkthroughPage()`
+- **Thin community `Community 1356`** (2 nodes): `walkthrough.tsx`, `WalkthroughPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1357`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1358`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1359`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1360`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1361`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1362`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1363`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1364`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1365`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1366`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1367`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1368`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1369`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1370`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1371`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1372`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1373`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1374`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1375`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1376`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1377`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1378`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1379`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1380`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1381`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1382`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1383`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1384`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1385`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1386`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1387`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1388`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1389`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1390`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1391`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1392`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1393`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1394`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1395`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1396`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1397`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1398`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1399`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1400`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1401`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1402`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1403`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1404`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1405`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1406`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1407`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1408`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1409`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1410`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1411`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1412`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1413`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1414`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1415`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1416`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1417`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1418`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1419`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1420`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1421`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1422`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1423`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1424`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1425`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1426`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1427`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1428`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1429`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1430`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1431`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1432`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1433`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1434`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1435`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1436`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1437`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1438`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1439`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1440`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1441`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1442`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1443`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1444`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1445`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1446`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1447`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1448`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1449`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1450`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1451`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1452`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1453`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1454`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1455`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1456`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1457`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1458`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1459`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1460`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1461`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1462`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1463`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1464`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1465`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1466`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1467`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1468`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1469`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1470`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1471`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1472`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1473`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1474`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1475`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1476`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1477`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1478`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1479`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1480`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1481`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1482`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1483`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1484`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1485`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1486`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1487`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1488`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1489`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1490`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1491`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1492`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1493`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1494`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1495`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1496`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `api.js`
+- **Thin community `Community 1497`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1498`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1499`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `server.js`
+- **Thin community `Community 1500`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `app.ts`
+- **Thin community `Community 1501`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1503`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `SharedDemoTicket.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `SharedDemoTicket.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1505`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `auth.ts`
+- **Thin community `Community 1507`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1509`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `countries.ts`
+- **Thin community `Community 1511`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `email.ts`
+- **Thin community `Community 1512`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1513`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `payment.ts`
+- **Thin community `Community 1514`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1515`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `types.ts`
+- **Thin community `Community 1516`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1517`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1518`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `crons.ts`
+- **Thin community `Community 1519`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1520`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `internal.ts`
+- **Thin community `Community 1521`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1526`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1527`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `DailyManagerReport.tsx`
+- **Thin community `Community 1528`** (1 nodes): `DailyManagerReport.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1529`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1530`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1531`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1532`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1533`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1534`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1535`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
+- **Thin community `Community 1536`** (1 nodes): `RegisterCloseoutVarianceAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1537`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `env.ts`
+- **Thin community `Community 1538`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1539`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `auth.ts`
+- **Thin community `Community 1540`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1541`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `colors.ts`
+- **Thin community `Community 1542`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `index.ts`
+- **Thin community `Community 1543`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1544`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1545`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1546`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `products.ts`
+- **Thin community `Community 1547`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1548`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `stores.ts`
+- **Thin community `Community 1549`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1550`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1551`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `bag.ts`
+- **Thin community `Community 1552`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `guest.ts`
+- **Thin community `Community 1553`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1554`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `index.ts`
+- **Thin community `Community 1555`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `me.ts`
+- **Thin community `Community 1556`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `offers.ts`
+- **Thin community `Community 1557`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1558`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1559`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1560`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1561`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1562`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1563`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1564`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1565`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1566`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `user.ts`
+- **Thin community `Community 1567`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1568`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `index.ts`
+- **Thin community `Community 1569`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1570`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `http.ts`
+- **Thin community `Community 1571`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `access.ts`
+- **Thin community `Community 1572`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1573`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1574`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1575`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `index.ts`
+- **Thin community `Community 1576`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `types.ts`
+- **Thin community `Community 1578`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `athenaUser.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `athenaUser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `categories.ts`
+- **Thin community `Community 1581`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `colors.ts`
+- **Thin community `Community 1582`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1583`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1584`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1585`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1586`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1587`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `pos.ts`
+- **Thin community `Community 1588`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1589`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1590`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1592`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1594`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `stores.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `stores.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1597`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `storeMemberAccess.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `storeMemberAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1601`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1602`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1608`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `types.ts`
+- **Thin community `Community 1612`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1614`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1615`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1617`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1618`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `registerCloseoutVarianceEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1620`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1625`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `dto.ts`
+- **Thin community `Community 1627`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1628`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1629`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1630`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1631`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `facts.ts`
+- **Thin community `Community 1632`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1633`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `types.ts`
+- **Thin community `Community 1634`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1635`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1636`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1637`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1638`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1639`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `customers.ts`
+- **Thin community `Community 1640`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `register.ts`
+- **Thin community `Community 1641`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1642`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1643`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1644`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `activation.test.ts`
+- **Thin community `Community 1645`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `attentionRules.test.ts`
+- **Thin community `Community 1646`** (1 nodes): `activation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `commerceRecognition.test.ts`
+- **Thin community `Community 1647`** (1 nodes): `attentionRules.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `customRangeRequests.test.ts`
+- **Thin community `Community 1648`** (1 nodes): `commerceRecognition.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `export.test.ts`
+- **Thin community `Community 1649`** (1 nodes): `customRangeRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `factFingerprint.test.ts`
+- **Thin community `Community 1650`** (1 nodes): `export.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `factIdentity.test.ts`
+- **Thin community `Community 1651`** (1 nodes): `factFingerprint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1652`** (1 nodes): `factIdentity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `integrity.test.ts`
+- **Thin community `Community 1653`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `corrections.test.ts`
+- **Thin community `Community 1654`** (1 nodes): `integrity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `corrections.ts`
+- **Thin community `Community 1655`** (1 nodes): `corrections.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `deficitResolutionWork.test.ts`
+- **Thin community `Community 1656`** (1 nodes): `corrections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `types.ts`
+- **Thin community `Community 1657`** (1 nodes): `deficitResolutionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `authorizedPosBackfill.test.ts`
+- **Thin community `Community 1658`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `backfillAuthorization.test.ts`
+- **Thin community `Community 1659`** (1 nodes): `authorizedPosBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `cutover.test.ts`
+- **Thin community `Community 1660`** (1 nodes): `backfillAuthorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `inventoryRebuild.test.ts`
+- **Thin community `Community 1661`** (1 nodes): `cutover.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `legacyCompatibility.test.ts`
+- **Thin community `Community 1662`** (1 nodes): `inventoryRebuild.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `posCensusBackfill.test.ts`
+- **Thin community `Community 1663`** (1 nodes): `legacyCompatibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `posSourceReconciliationGate.test.ts`
+- **Thin community `Community 1664`** (1 nodes): `posCensusBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `processing.test.ts`
+- **Thin community `Community 1665`** (1 nodes): `posSourceReconciliationGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `runLedger.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `processing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `metricContracts.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `runLedger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `periods.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `metricContracts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `projectionWork.test.ts`
+- **Thin community `Community 1669`** (1 nodes): `periods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `attention.test.ts`
+- **Thin community `Community 1670`** (1 nodes): `projectionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `currentInventory.test.ts`
+- **Thin community `Community 1671`** (1 nodes): `attention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `customRange.test.ts`
+- **Thin community `Community 1672`** (1 nodes): `currentInventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `daily.test.ts`
+- **Thin community `Community 1673`** (1 nodes): `customRange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `dailyCloseTrust.test.ts`
+- **Thin community `Community 1674`** (1 nodes): `daily.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `factContributions.test.ts`
+- **Thin community `Community 1675`** (1 nodes): `dailyCloseTrust.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `inventory.test.ts`
+- **Thin community `Community 1676`** (1 nodes): `factContributions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `processor.test.ts`
+- **Thin community `Community 1677`** (1 nodes): `inventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `reconciliation.test.ts`
+- **Thin community `Community 1678`** (1 nodes): `processor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `skuDay.test.ts`
+- **Thin community `Community 1679`** (1 nodes): `reconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `skuInsights.test.ts`
+- **Thin community `Community 1680`** (1 nodes): `skuDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `storeIntraday.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `skuInsights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1682`** (1 nodes): `storeIntraday.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `destinations.test.ts`
+- **Thin community `Community 1683`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `items.ts`
+- **Thin community `Community 1684`** (1 nodes): `destinations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `reportingReadModels.test.ts`
+- **Thin community `Community 1685`** (1 nodes): `items.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `skuAttributionSequence.test.ts`
+- **Thin community `Community 1686`** (1 nodes): `reportingReadModels.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `types.ts`
+- **Thin community `Community 1687`** (1 nodes): `skuAttributionSequence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `sourceAdapters.test.ts`
+- **Thin community `Community 1688`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `storeTimeAuthority.test.ts`
+- **Thin community `Community 1689`** (1 nodes): `sourceAdapters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `schema.ts`
+- **Thin community `Community 1690`** (1 nodes): `storeTimeAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `automation.ts`
+- **Thin community `Community 1691`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1692`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1693`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `index.ts`
+- **Thin community `Community 1694`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1695`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1696`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1697`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1698`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1699`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1700`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1701`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `category.ts`
+- **Thin community `Community 1702`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `color.ts`
+- **Thin community `Community 1703`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1704`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1705`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `index.ts`
+- **Thin community `Community 1706`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1707`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1708`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1709`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1710`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `organization.ts`
+- **Thin community `Community 1711`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1712`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `posRegisterCatalogRevision.ts`
+- **Thin community `Community 1713`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `product.ts`
+- **Thin community `Community 1714`** (1 nodes): `posRegisterCatalogRevision.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1715`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1716`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1717`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `store.ts`
+- **Thin community `Community 1718`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1719`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `storeTimezone.ts`
+- **Thin community `Community 1720`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1721`** (1 nodes): `storeTimezone.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `landingFunnelEvent.ts`
+- **Thin community `Community 1722`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `walkthroughRequest.ts`
+- **Thin community `Community 1723`** (1 nodes): `landingFunnelEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `index.ts`
+- **Thin community `Community 1724`** (1 nodes): `walkthroughRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1725`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1726`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1727`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1728`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1729`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1730`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1731`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `index.ts`
+- **Thin community `Community 1732`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1733`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1734`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1735`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1736`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1737`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1738`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1739`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1740`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1741`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1742`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1743`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `customer.ts`
+- **Thin community `Community 1744`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1745`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1746`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1747`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1748`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `index.ts`
+- **Thin community `Community 1749`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `posLifecycleJournal.ts`
+- **Thin community `Community 1750`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1751`** (1 nodes): `posLifecycleJournal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1752`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1753`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1754`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1755`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1756`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1757`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1758`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
+- **Thin community `Community 1759`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `posRegisterMappingAuthority.ts`
+- **Thin community `Community 1760`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 1761`** (1 nodes): `posRegisterMappingAuthority.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 1762`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1763`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1764`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1765`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1766`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1767`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1768`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1769`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1770`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1771`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1772`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1774`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `index.ts`
+- **Thin community `Community 1775`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1776`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1777`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `facts.ts`
+- **Thin community `Community 1778`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `index.ts`
+- **Thin community `Community 1779`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `inventoryValuation.ts`
+- **Thin community `Community 1780`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `maintenance.ts`
+- **Thin community `Community 1781`** (1 nodes): `inventoryValuation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `projections.ts`
+- **Thin community `Community 1782`** (1 nodes): `maintenance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `index.ts`
+- **Thin community `Community 1783`** (1 nodes): `projections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1784`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1785`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1786`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1787`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1788`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `sharedDemo.ts`
+- **Thin community `Community 1789`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `staffMessages.ts`
+- **Thin community `Community 1790`** (1 nodes): `sharedDemo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1791`** (1 nodes): `staffMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `index.ts`
+- **Thin community `Community 1792`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1793`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1794`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1795`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1796`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1797`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1798`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `bag.ts`
+- **Thin community `Community 1799`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1800`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1801`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1802`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `guest.ts`
+- **Thin community `Community 1803`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `index.ts`
+- **Thin community `Community 1804`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `offer.ts`
+- **Thin community `Community 1805`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1806`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1807`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `review.ts`
+- **Thin community `Community 1808`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1809`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1810`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1811`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1812`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1813`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1814`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1815`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1816`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `authBoundary.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `authBoundary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `domainRestore.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `foundation.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `domainRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `openingBaseline.test.ts`
+- **Thin community `Community 1821`** (1 nodes): `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `policy.test.ts`
+- **Thin community `Community 1822`** (1 nodes): `openingBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `provision.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `policy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `provision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `registerBaseline.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `reporting.test.ts`
+- **Thin community `Community 1826`** (1 nodes): `registerBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `scheduledRestore.test.ts`
+- **Thin community `Community 1827`** (1 nodes): `reporting.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `bag.ts`
+- **Thin community `Community 1828`** (1 nodes): `scheduledRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1829`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `customer.ts`
+- **Thin community `Community 1830`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `guest.ts`
+- **Thin community `Community 1831`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1833`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1835`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1836`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1837`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1838`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `users.ts`
+- **Thin community `Community 1839`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `payment.ts`
+- **Thin community `Community 1840`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1841`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1842`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1843`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1844`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1845`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1846`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1847`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `index.ts`
+- **Thin community `Community 1848`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1849`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1850`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1851`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1852`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `auth.ts`
+- **Thin community `Community 1853`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1854`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1855`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1857`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1858`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1859`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1860`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `index.ts`
+- **Thin community `Community 1861`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1862`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `terminalRuntimeMaterial.test.ts`
+- **Thin community `Community 1863`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 1864`** (1 nodes): `terminalRuntimeMaterial.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1865`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1866`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `reportingContract.ts`
+- **Thin community `Community 1867`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1868`** (1 nodes): `reportingContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1869`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1870`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1871`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1872`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1873`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 1874`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1875`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 1876`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1877`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1878`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1879`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1880`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1881`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1882`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1883`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1884`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1885`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 1886`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1887`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1888`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `CopyImagesView.test.tsx`
+- **Thin community `Community 1889`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `constants.ts`
+- **Thin community `Community 1890`** (1 nodes): `CopyImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1891`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1892`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1893`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `types.ts`
+- **Thin community `Community 1894`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `AnalyticsView.test.tsx`
+- **Thin community `Community 1895`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1896`** (1 nodes): `AnalyticsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1897`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1898`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1899`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1900`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1901`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1902`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1903`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1904`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1905`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1906`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1907`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1908`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1909`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1910`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1911`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1912`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1913`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1914`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1915`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `constants.ts`
+- **Thin community `Community 1916`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1917`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1918`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1919`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `data.ts`
+- **Thin community `Community 1920`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1921`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1922`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1923`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1924`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1925`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1926`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1927`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1928`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1929`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1930`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1931`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `constants.ts`
+- **Thin community `Community 1932`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1933`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1934`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1935`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `data.ts`
+- **Thin community `Community 1936`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1937`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1938`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1939`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1940`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1941`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1942`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1943`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1944`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1945`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1946`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1947`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `constants.ts`
+- **Thin community `Community 1948`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1949`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1950`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 1951`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1952`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1953`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1954`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1955`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1956`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1957`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1958`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1959`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1960`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1961`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1962`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1963`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1964`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1965`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1966`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1967`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1968`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1969`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `Home.test.tsx`
+- **Thin community `Community 1970`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 1971`** (1 nodes): `Home.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `ShopLookImageUploader.test.tsx`
+- **Thin community `Community 1972`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1973`** (1 nodes): `ShopLookImageUploader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1974`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `OperationReviewItemCard.tsx`
+- **Thin community `Community 1975`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1976`** (1 nodes): `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1977`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 1978`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1979`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1980`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 1981`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1982`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `OrderDetailsView.test.tsx`
+- **Thin community `Community 1983`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1984`** (1 nodes): `OrderDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1985`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1986`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `OrdersView.test.tsx`
+- **Thin community `Community 1987`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1988`** (1 nodes): `OrdersView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1989`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `constants.ts`
+- **Thin community `Community 1990`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1991`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1992`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1993`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `data.ts`
+- **Thin community `Community 1994`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1995`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1996`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `constants.ts`
+- **Thin community `Community 1997`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1998`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1999`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2000`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2001`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `data.ts`
+- **Thin community `Community 2002`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 2003`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `constants.ts`
+- **Thin community `Community 2004`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2005`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2006`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2007`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2008`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `data.ts`
+- **Thin community `Community 2009`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 2010`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 2011`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 2012`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 2013`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 2014`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 2015`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 2016`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 2017`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 2018`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 2019`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 2020`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 2021`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 2022`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 2023`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 2024`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 2025`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 2026`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 2027`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 2028`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 2029`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 2030`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 2031`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 2032`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 2033`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 2034`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 2035`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 2036`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 2037`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `types.ts`
+- **Thin community `Community 2038`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 2039`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 2040`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 2041`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 2042`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 2043`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 2044`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 2045`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 2046`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 2047`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 2048`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 2049`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 2050`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 2051`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 2052`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 2053`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2054`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2055`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2056`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `data.ts`
+- **Thin community `Community 2057`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 2058`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 2059`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 2060`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 2061`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 2062`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 2063`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2064`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2065`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2066`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2067`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2068`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2069`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `constants.ts`
+- **Thin community `Community 2070`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2071`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2072`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2073`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `data.ts`
+- **Thin community `Community 2074`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `types.ts`
+- **Thin community `Community 2075`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 2076`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 2077`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 2078`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 2079`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 2080`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `index.ts`
+- **Thin community `Community 2081`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `CustomRangeStatus.test.tsx`
+- **Thin community `Community 2082`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `InventoryMovementSummary.tsx`
+- **Thin community `Community 2083`** (1 nodes): `CustomRangeStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `ReportAttentionList.tsx`
+- **Thin community `Community 2084`** (1 nodes): `InventoryMovementSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `ReportPeriodControl.test.tsx`
+- **Thin community `Community 2085`** (1 nodes): `ReportAttentionList.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `ReportsInventoryView.test.tsx`
+- **Thin community `Community 2086`** (1 nodes): `ReportPeriodControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `ReportsInventoryView.tsx`
+- **Thin community `Community 2087`** (1 nodes): `ReportsInventoryView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `ReportsItemsView.test.tsx`
+- **Thin community `Community 2088`** (1 nodes): `ReportsInventoryView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `ReportsItemsView.tsx`
+- **Thin community `Community 2089`** (1 nodes): `ReportsItemsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `ReportsLayout.test.tsx`
+- **Thin community `Community 2090`** (1 nodes): `ReportsItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `ReportsOverviewView.test.tsx`
+- **Thin community `Community 2091`** (1 nodes): `ReportsLayout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `ReportsSkuDetailView.test.tsx`
+- **Thin community `Community 2092`** (1 nodes): `ReportsOverviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
+- **Thin community `Community 2093`** (1 nodes): `ReportsSkuDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
+- **Thin community `Community 2094`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
+- **Thin community `Community 2095`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `ReportsWorkspaceControls.tsx`
+- **Thin community `Community 2096`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `RevenueContribution.tsx`
+- **Thin community `Community 2097`** (1 nodes): `ReportsWorkspaceControls.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `reportPresentation.test.ts`
+- **Thin community `Community 2098`** (1 nodes): `RevenueContribution.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2099`** (1 nodes): `reportPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2100`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2101`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2102`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `SharedDemoExperience.test.tsx`
+- **Thin community `Community 2103`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `SharedDemoOwnerHome.tsx`
+- **Thin community `Community 2104`** (1 nodes): `SharedDemoExperience.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `SharedDemoRuntime.test.tsx`
+- **Thin community `Community 2105`** (1 nodes): `SharedDemoOwnerHome.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
+- **Thin community `Community 2106`** (1 nodes): `SharedDemoRuntime.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `index.tsx`
+- **Thin community `Community 2107`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2108`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2108`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2109`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2110`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2111`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2112`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2113`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2114`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2115`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 2116`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2117`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2118`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `index.tsx`
+- **Thin community `Community 2119`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2120`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2121`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2122`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `button.tsx`
+- **Thin community `Community 2123`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2124`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2125`** (1 nodes): `card.tsx`
+- **Thin community `Community 2125`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2126`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2126`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2127`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2127`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2128`** (1 nodes): `command.tsx`
+- **Thin community `Community 2128`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2129`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2129`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2130`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2130`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2131`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2131`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2132`** (1 nodes): `form.tsx`
+- **Thin community `Community 2132`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2133`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2133`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2134`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2134`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2135`** (1 nodes): `input.tsx`
+- **Thin community `Community 2135`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2136`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2136`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2137`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2137`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2138`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2138`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2139`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2139`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2140`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2140`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2141`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2141`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2142`** (1 nodes): `select.tsx`
+- **Thin community `Community 2142`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2143`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2143`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2144`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2144`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2145`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2145`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2146`** (1 nodes): `table.tsx`
+- **Thin community `Community 2146`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2147`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2147`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2148`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2148`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2149`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2149`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2150`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2150`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2151`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2151`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2152`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2152`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2153`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2153`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2154`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2154`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2155`** (1 nodes): `constants.ts`
+- **Thin community `Community 2155`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2156`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2156`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2157`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2157`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2158`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2158`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2159`** (1 nodes): `data.ts`
+- **Thin community `Community 2159`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2160`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2160`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2161`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2161`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2162`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2162`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2163`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2163`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2164`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2164`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2165`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2165`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2166`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2166`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2167`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2167`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2168`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2168`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2169`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2169`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2170`** (1 nodes): `index.ts`
+- **Thin community `Community 2170`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2171`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2171`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2172`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2172`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2173`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2173`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2174`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2174`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2175`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2175`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2176`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2176`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2177`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2177`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2178`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2178`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2179`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2179`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2180`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2180`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2181`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2181`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2182`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2182`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2183`** (1 nodes): `useSharedDemoContext.test.ts`
+- **Thin community `Community 2183`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2184`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2184`** (1 nodes): `useSharedDemoContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2185`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2185`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2186`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2186`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2187`** (1 nodes): `index.ts`
+- **Thin community `Community 2187`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2188`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2188`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2189`** (1 nodes): `index.ts`
+- **Thin community `Community 2189`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2190`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2190`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2191`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2191`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2192`** (1 nodes): `aws.ts`
+- **Thin community `Community 2192`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2193`** (1 nodes): `constants.ts`
+- **Thin community `Community 2193`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2194`** (1 nodes): `countries.ts`
+- **Thin community `Community 2194`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2195`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2195`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2196`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2196`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2197`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2197`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2198`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2198`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2199`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2199`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2200`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2200`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2201`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2201`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2202`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2202`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2203`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2203`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2204`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2204`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2205`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2205`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2206`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2206`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2207`** (1 nodes): `dto.ts`
+- **Thin community `Community 2207`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2208`** (1 nodes): `ports.ts`
+- **Thin community `Community 2208`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2209`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2209`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2210`** (1 nodes): `constants.ts`
+- **Thin community `Community 2210`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2211`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2211`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2212`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2212`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2213`** (1 nodes): `index.ts`
+- **Thin community `Community 2213`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2214`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2214`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2215`** (1 nodes): `types.ts`
+- **Thin community `Community 2215`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2216`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2216`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2217`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2217`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2218`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2218`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2219`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2219`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2220`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2220`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2221`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2221`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2222`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2222`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2223`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2223`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2224`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2224`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2225`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2225`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2226`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2226`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2227`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2227`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2228`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2228`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2229`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2229`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2230`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2230`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2231`** (1 nodes): `registerCatalogPinRuntime.test.ts`
+- **Thin community `Community 2231`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2232`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2232`** (1 nodes): `registerCatalogPinRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2233`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
+- **Thin community `Community 2233`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2234`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2234`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2235`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 2235`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2236`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2236`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2237`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2237`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2238`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2238`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2239`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2239`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2240`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2240`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2241`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2241`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2242`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2242`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2243`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2243`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2244`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2244`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2245`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2245`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2246`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2246`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2247`** (1 nodes): `index.ts`
+- **Thin community `Community 2247`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2248`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2248`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2249`** (1 nodes): `category.ts`
+- **Thin community `Community 2249`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2250`** (1 nodes): `product.ts`
+- **Thin community `Community 2250`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2251`** (1 nodes): `store.ts`
+- **Thin community `Community 2251`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2252`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2252`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2253`** (1 nodes): `user.ts`
+- **Thin community `Community 2253`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2254`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2254`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2255`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2255`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2256`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2256`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2257`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2257`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2258`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2258`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2259`** (1 nodes): `main.tsx`
+- **Thin community `Community 2259`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2260`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2260`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2261`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2261`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2262`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2262`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2263`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2263`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2264`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2264`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2265`** (1 nodes): `-index-route-view.tsx`
+- **Thin community `Community 2265`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2266`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2266`** (1 nodes): `-index-route-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2267`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2267`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2268`** (1 nodes): `index.tsx`
+- **Thin community `Community 2268`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2269`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2270`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2271`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2271`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2272`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2272`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2273`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2273`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2274`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2274`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2275`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2275`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2276`** (1 nodes): `index.tsx`
+- **Thin community `Community 2276`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2277`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2277`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2278`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2278`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2279`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2279`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2280`** (1 nodes): `home.tsx`
+- **Thin community `Community 2280`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2281`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2281`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2282`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2282`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2283`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2283`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2284`** (1 nodes): `index.tsx`
+- **Thin community `Community 2284`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2285`** (1 nodes): `review.tsx`
+- **Thin community `Community 2285`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2286`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2286`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2287`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2287`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2288`** (1 nodes): `index.tsx`
+- **Thin community `Community 2288`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2289`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2289`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2290`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2290`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2291`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2291`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2292`** (1 nodes): `index.tsx`
+- **Thin community `Community 2292`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2293`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2293`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2294`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2294`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2295`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2295`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2296`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2296`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2297`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2297`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2298`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2298`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2299`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2299`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2300`** (1 nodes): `index.tsx`
+- **Thin community `Community 2300`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2301`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2301`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2302`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2302`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2303`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2303`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2304`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2304`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2305`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2305`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2306`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2306`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2307`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2307`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2308`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2308`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2309`** (1 nodes): `index.tsx`
+- **Thin community `Community 2309`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2310`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2310`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2311`** (1 nodes): `new.tsx`
+- **Thin community `Community 2311`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2312`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2313`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2313`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2314`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2314`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2315`** (1 nodes): `index.tsx`
+- **Thin community `Community 2315`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2316`** (1 nodes): `new.tsx`
+- **Thin community `Community 2316`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2317`** (1 nodes): `items.tsx`
+- **Thin community `Community 2317`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2318`** (1 nodes): `search.test.ts`
+- **Thin community `Community 2318`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2319`** (1 nodes): `storefront.tsx`
+- **Thin community `Community 2319`** (1 nodes): `search.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2320`** (1 nodes): `index.tsx`
+- **Thin community `Community 2320`** (1 nodes): `storefront.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2321`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2321`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2322`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2322`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2323`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2323`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2324`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2324`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2325`** (1 nodes): `index.tsx`
+- **Thin community `Community 2325`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2326`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2326`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2327`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2327`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2328`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2328`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2329`** (1 nodes): `index.tsx`
+- **Thin community `Community 2329`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2330`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2330`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2331`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2331`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2332`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2332`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2333`** (1 nodes): `app.tsx`
+- **Thin community `Community 2333`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2334`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2334`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2335`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2335`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2336`** (1 nodes): `index.tsx`
+- **Thin community `Community 2336`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2337`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2337`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `landing.test.tsx`
+- **Thin community `Community 2338`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2339`** (1 nodes): `landing.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2340`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2341`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2342`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2343`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2344`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2345`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2346`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2347`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2348`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2349`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2350`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2351`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2351`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2352`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2353`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2354`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2355`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2356`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2357`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2358`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2359`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2360`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2361`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2362`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2362`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2363`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `setup.ts`
+- **Thin community `Community 2364`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2365`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `types.ts`
+- **Thin community `Community 2366`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2367`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2368`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2369`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2370`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2371`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2372`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2373`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `types.ts`
+- **Thin community `Community 2374`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2375`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2376`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2377`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2378`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2379`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2380`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2381`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2382`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `schema.ts`
+- **Thin community `Community 2383`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2384`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2385`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2386`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2387`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2388`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2389`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2390`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2391`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2392`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `types.ts`
+- **Thin community `Community 2393`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2394`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2395`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2396`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2397`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2398`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2399`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2400`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `constants.ts`
+- **Thin community `Community 2401`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2402`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `About.tsx`
+- **Thin community `Community 2403`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2404`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2405`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2406`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2407`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2408`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2409`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2410`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2411`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2412`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2413`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `types.ts`
+- **Thin community `Community 2414`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2415`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2416`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2417`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2418`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2419`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2420`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2421`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2422`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2423`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2424`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2425`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `button.tsx`
+- **Thin community `Community 2426`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `card.tsx`
+- **Thin community `Community 2427`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2428`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `command.tsx`
+- **Thin community `Community 2429`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2430`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2431`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2431`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2432`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `form.tsx`
+- **Thin community `Community 2433`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2434`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2435`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2436`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2437`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `input.tsx`
+- **Thin community `Community 2438`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `label.tsx`
+- **Thin community `Community 2439`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2440`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2441`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2442`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `index.ts`
+- **Thin community `Community 2443`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `types.ts`
+- **Thin community `Community 2444`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2445`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2446`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2447`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2448`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `select.tsx`
+- **Thin community `Community 2449`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2450`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2451`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `table.tsx`
+- **Thin community `Community 2452`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2453`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2454`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2455`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2456`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2457`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `config.ts`
+- **Thin community `Community 2458`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2459`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2460`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2461`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2462`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2463`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `constants.ts`
+- **Thin community `Community 2464`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `countries.ts`
+- **Thin community `Community 2465`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2466`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2467`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2468`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2469`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `index.ts`
+- **Thin community `Community 2470`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2471`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `store.ts`
+- **Thin community `Community 2472`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `bag.ts`
+- **Thin community `Community 2473`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2474`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `category.ts`
+- **Thin community `Community 2475`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `organization.ts`
+- **Thin community `Community 2476`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `product.ts`
+- **Thin community `Community 2477`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `store.ts`
+- **Thin community `Community 2478`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2479`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `user.ts`
+- **Thin community `Community 2480`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `states.ts`
+- **Thin community `Community 2481`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2482`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2483`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2484`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2485`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2486`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2487`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2488`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2489`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `index.tsx`
+- **Thin community `Community 2490`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2491`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `index.tsx`
+- **Thin community `Community 2492`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2493`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2494`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2495`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2496`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2497`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `index.tsx`
+- **Thin community `Community 2498`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2499`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2500`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2501`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2502`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2503`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `index.js`
+- **Thin community `Community 2504`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2505`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2506`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2507`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2508`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2509`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2510`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2511`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2512`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2513`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2587
-- Graph nodes: 10452
-- Graph edges: 12700
-- Communities: 2513
+- Code files discovered: 2588
+- Graph nodes: 10457
+- Graph edges: 12705
+- Communities: 2514
 
 ## Graph Hotspots
 - `dailyClose.ts` (88 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2588
-- Graph nodes: 10457
-- Graph edges: 12705
+- Graph nodes: 10459
+- Graph edges: 12709
 - Communities: 2514
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,9 +7,9 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2586
-- Graph nodes: 10449
-- Graph edges: 12697
+- Code files discovered: 2587
+- Graph nodes: 10452
+- Graph edges: 12700
 - Communities: 2513
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../../_generated/dataModel";
 import {
   createCustomer,
+  linkToGuest,
+  linkToStoreFrontUser,
   resolveGuestMatch,
   resolvePosCustomerSelection,
   resolveStoreFrontUserMatch,
@@ -233,6 +235,68 @@ describe("POS customer attribution commands", () => {
       }),
     );
     expect(createPosCustomer).not.toHaveBeenCalled();
+  });
+
+  it("links a same-store storefront user to a POS customer", async () => {
+    vi.mocked(getPosCustomerById).mockResolvedValue(posCustomer() as never);
+    vi.mocked(getStoreFrontUserById).mockResolvedValue(
+      storeFrontUser() as never,
+    );
+    vi.mocked(findPosCustomerByStoreFrontUser).mockResolvedValue(null as never);
+    vi.mocked(ensureCustomerProfileFromSources).mockResolvedValue(
+      customerProfile() as never,
+    );
+
+    const result = await linkToStoreFrontUser({} as never, {
+      posCustomerId: "pos-customer-1" as Id<"posCustomer">,
+      storeFrontUserId: "storefront-user-1" as Id<"storeFrontUser">,
+    });
+
+    expect(result).toMatchObject({ kind: "ok" });
+    expect(patchPosCustomer).toHaveBeenCalled();
+  });
+
+  it("refuses to link a storefront user from another store and never writes PII", async () => {
+    vi.mocked(getPosCustomerById).mockResolvedValue(posCustomer() as never);
+    vi.mocked(getStoreFrontUserById).mockResolvedValue({
+      ...storeFrontUser(),
+      _id: "storefront-user-2" as Id<"storeFrontUser">,
+      storeId: "store-2" as Id<"store">,
+      email: "victim@other-org.example.com",
+    } as never);
+
+    const result = await linkToStoreFrontUser({} as never, {
+      posCustomerId: "pos-customer-1" as Id<"posCustomer">,
+      storeFrontUserId: "storefront-user-2" as Id<"storeFrontUser">,
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({ code: "not_found" }),
+    });
+    // No foreign PII is written onto the caller's customer.
+    expect(patchPosCustomer).not.toHaveBeenCalled();
+  });
+
+  it("refuses to link a guest from another store and never writes PII", async () => {
+    vi.mocked(getPosCustomerById).mockResolvedValue(posCustomer() as never);
+    vi.mocked(getGuestById).mockResolvedValue({
+      ...guest(),
+      _id: "guest-2" as Id<"guest">,
+      storeId: "store-2" as Id<"store">,
+      email: "victim@other-org.example.com",
+    } as never);
+
+    const result = await linkToGuest({} as never, {
+      posCustomerId: "pos-customer-1" as Id<"posCustomer">,
+      guestId: "guest-2" as Id<"guest">,
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({ code: "not_found" }),
+    });
+    expect(patchPosCustomer).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts
@@ -300,7 +300,14 @@ export async function linkToStoreFrontUser(
     args.storeFrontUserId,
   );
 
-  if (!posCustomer || !storeFrontUser) {
+  // Scope the storefront user to the POS customer's store. Without this a
+  // caller authorized for the POS customer's org could link (and read the
+  // PII of) a storefront user belonging to another store/org.
+  if (
+    !posCustomer ||
+    !storeFrontUser ||
+    storeFrontUser.storeId !== posCustomer.storeId
+  ) {
     return userError({
       code: "not_found",
       message: "Customer or storefront user not found.",
@@ -348,7 +355,9 @@ export async function linkToGuest(
   const posCustomer = await getPosCustomerById(ctx, args.posCustomerId);
   const guest = await getGuestById(ctx, args.guestId);
 
-  if (!posCustomer || !guest) {
+  // Scope the guest to the POS customer's store, mirroring linkToStoreFrontUser,
+  // so a caller cannot link (and read the PII of) another store/org's guest.
+  if (!posCustomer || !guest || guest.storeId !== posCustomer.storeId) {
     return userError({
       code: "not_found",
       message: "Customer or guest not found.",

--- a/packages/athena-webapp/convex/pos/application/commands/register.test.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/register.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAuthenticatedAthenaUserWithCtx: vi.fn(),
+  requireOrganizationMemberRoleWithCtx: vi.fn(),
+}));
+
+vi.mock("../../../lib/athenaUserAuth", () => ({
+  requireAuthenticatedAthenaUserWithCtx:
+    mocks.requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx:
+    mocks.requireOrganizationMemberRoleWithCtx,
+}));
+
+import { openDrawer } from "./register";
+
+const OPEN_REGISTER_SESSION = {
+  _id: "register-session-1",
+  status: "active" as const,
+  terminalId: "terminal-1",
+  registerNumber: "1",
+  openingFloat: 100,
+  expectedCash: 100,
+  openedAt: 1_000,
+};
+
+function buildCtx(
+  overrides: {
+    store?: Record<string, unknown> | null;
+    terminal?: Record<string, unknown> | null;
+    staffProfile?: Record<string, unknown> | null;
+    roleAssignments?: Array<Record<string, unknown>>;
+  } = {},
+) {
+  const runMutation = vi.fn(async () => OPEN_REGISTER_SESSION);
+  const runQuery = vi.fn(async () =>
+    Object.prototype.hasOwnProperty.call(overrides, "store")
+      ? overrides.store
+      : { _id: "store-1", organizationId: "org-1" },
+  );
+  return {
+    runMutation,
+    runQuery,
+    db: {
+      get: vi.fn(async (tableName: string, id: string) => {
+        if (tableName === "posTerminal" && id === "terminal-1") {
+          return Object.prototype.hasOwnProperty.call(overrides, "terminal")
+            ? overrides.terminal
+            : {
+                _id: "terminal-1",
+                storeId: "store-1",
+                registerNumber: "1",
+                status: "active",
+              };
+        }
+        if (tableName === "staffProfile" && id === "staff-1") {
+          return Object.prototype.hasOwnProperty.call(overrides, "staffProfile")
+            ? overrides.staffProfile
+            : { _id: "staff-1", storeId: "store-1", status: "active" };
+        }
+        return null;
+      }),
+      query: vi.fn(() => ({
+        withIndex: () => ({
+          take: async () =>
+            overrides.roleAssignments ?? [
+              {
+                staffProfileId: "staff-1",
+                storeId: "store-1",
+                status: "active",
+                role: "cashier",
+              },
+            ],
+        }),
+      })),
+    },
+  };
+}
+
+const baseArgs = {
+  storeId: "store-1" as never,
+  terminalId: "terminal-1" as never,
+  staffProfileId: "staff-1" as never,
+  registerNumber: "1",
+  openingFloat: 100,
+};
+
+describe("openDrawer command authorization", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockResolvedValue({
+      _id: "athena-user-1",
+    });
+    mocks.requireOrganizationMemberRoleWithCtx.mockResolvedValue({
+      role: "pos_only",
+    });
+  });
+
+  it("opens the drawer for a same-org member", async () => {
+    const ctx = buildCtx();
+
+    const result = await openDrawer(ctx as never, baseArgs);
+
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        allowedRoles: ["full_admin", "pos_only"],
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      }),
+    );
+    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expect.objectContaining({ kind: "ok" }));
+  });
+
+  it("denies a foreign-org user opening a drawer and never opens a register session", async () => {
+    mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
+      new Error("You cannot open a register drawer for this store."),
+    );
+    const ctx = buildCtx();
+
+    await expect(openDrawer(ctx as never, baseArgs)).rejects.toThrow(
+      "You cannot open a register drawer for this store.",
+    );
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("denies an unauthenticated caller opening a drawer", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("Sign in again to continue."),
+    );
+    const ctx = buildCtx();
+
+    await expect(openDrawer(ctx as never, baseArgs)).rejects.toThrow(
+      "Sign in again to continue.",
+    );
+    expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("returns a clean not-found for a non-existent store without membership checks", async () => {
+    const ctx = buildCtx({ store: null });
+
+    const result = await openDrawer(ctx as never, baseArgs);
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({ code: "not_found" }),
+    });
+    expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/athena-webapp/convex/pos/application/commands/register.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/register.ts
@@ -1,7 +1,10 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import { internal } from "../../../_generated/api";
-import { requireAuthenticatedAthenaUserWithCtx } from "../../../lib/athenaUserAuth";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../../../lib/athenaUserAuth";
 import type { PosCashDrawerSummary } from "../../domain/types";
 import { mapRegisterSessionToCashDrawerSummary } from "../../infrastructure/repositories/registerSessionRepository";
 import {
@@ -75,6 +78,13 @@ export async function openDrawer(
       message: "Store not found.",
     });
   }
+
+  await requireOrganizationMemberRoleWithCtx(ctx, {
+    allowedRoles: ["full_admin", "pos_only"],
+    failureMessage: "You cannot open a register drawer for this store.",
+    organizationId: store.organizationId,
+    userId: athenaUser._id,
+  });
 
   const terminal = await ctx.db.get("posTerminal", args.terminalId);
   if (!terminal || terminal.storeId !== args.storeId) {

--- a/packages/athena-webapp/convex/pos/application/openDrawer.test.ts
+++ b/packages/athena-webapp/convex/pos/application/openDrawer.test.ts
@@ -7,11 +7,14 @@ import { openDrawer } from "./commands/register";
 
 const authMocks = vi.hoisted(() => ({
   requireAuthenticatedAthenaUserWithCtx: vi.fn(),
+  requireOrganizationMemberRoleWithCtx: vi.fn(),
 }));
 
 vi.mock("../../lib/athenaUserAuth", () => ({
   requireAuthenticatedAthenaUserWithCtx:
     authMocks.requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx:
+    authMocks.requireOrganizationMemberRoleWithCtx,
 }));
 
 const terminal = {
@@ -109,6 +112,13 @@ function createDbMock(
 describe("openDrawer", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // Default to an authenticated org member; individual tests override as needed.
+    authMocks.requireAuthenticatedAthenaUserWithCtx.mockResolvedValue({
+      _id: "user-1" as Id<"athenaUser">,
+    });
+    authMocks.requireOrganizationMemberRoleWithCtx.mockResolvedValue({
+      role: "pos_only",
+    });
   });
 
   it("opens a register session with the authenticated Athena user and signed-in staff member", async () => {

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -194,6 +194,155 @@ describe("createLocalSyncIngestionService", () => {
     expect(repository.createdPendingCheckoutItems).toEqual([]);
   });
 
+  it("creates a server_rejected conflict when a money-bearing sale is rejected for non-reconciling totals", async () => {
+    const repository = createFakeSyncRepository();
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+
+    const event = buildSaleCompletedEvent({ sequence: 1 });
+    (event.payload as Record<string, unknown>).totals = {
+      subtotal: 25,
+      tax: 0,
+      total: 9_999,
+    };
+
+    const result = await service.ingestBatch(buildBatch({ events: [event] }));
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("Expected ok result");
+    expect(result.data.accepted).toEqual([
+      expect.objectContaining({
+        localEventId: "event-sale-completed-1",
+        sequence: 1,
+        status: "rejected",
+      }),
+    ]);
+    // Liveness preserved: the cursor still advances past a rejected event.
+    expect(result.data.syncCursor.acceptedThroughSequence).toBe(1);
+    // No canonical transaction is persisted for a rejected sale.
+    expect(repository.createdTransactions).toHaveLength(0);
+
+    const conflict = repository.conflicts.find(
+      (candidate) => candidate.conflictType === "server_rejected",
+    );
+    expect(conflict).toEqual(
+      expect.objectContaining({
+        localEventId: "event-sale-completed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 1,
+        conflictType: "server_rejected",
+        status: "needs_review",
+      }),
+    );
+    expect(conflict?.details).toEqual(
+      expect.objectContaining({
+        code: "server_rejected",
+        localEventId: "event-sale-completed-1",
+        localRegisterSessionId: "local-register-1",
+        reason: expect.stringContaining("totals"),
+      }),
+    );
+    expect(result.data.conflicts).toContainEqual(
+      expect.objectContaining({ conflictType: "server_rejected" }),
+    );
+  });
+
+  it("records the sale amount when a money-bearing sale is rejected for an invalid payment", async () => {
+    const repository = createFakeSyncRepository();
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+
+    const event = buildSaleCompletedEvent({ sequence: 1 });
+    const payments = (event.payload as Record<string, unknown>)
+      .payments as Array<Record<string, unknown>>;
+    delete payments[0].timestamp;
+
+    const result = await service.ingestBatch(buildBatch({ events: [event] }));
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("Expected ok result");
+    expect(result.data.accepted).toEqual([
+      expect.objectContaining({
+        localEventId: "event-sale-completed-1",
+        status: "rejected",
+      }),
+    ]);
+
+    const conflict = repository.conflicts.find(
+      (candidate) => candidate.conflictType === "server_rejected",
+    );
+    expect(conflict?.details).toEqual(
+      expect.objectContaining({
+        amount: 25,
+        localTransactionId: "local-txn-1",
+        reason: expect.stringContaining("payment"),
+      }),
+    );
+  });
+
+  it("does not duplicate the server_rejected conflict when a rejected sale is retried", async () => {
+    const repository = createFakeSyncRepository();
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+
+    const event = buildSaleCompletedEvent({ sequence: 1 });
+    (event.payload as Record<string, unknown>).totals = {
+      subtotal: 25,
+      tax: 0,
+      total: 9_999,
+    };
+
+    await service.ingestBatch(buildBatch({ events: [event] }));
+    const retry = await service.ingestBatch(buildBatch({ events: [event] }));
+
+    expect(retry.kind).toBe("ok");
+    if (retry.kind !== "ok") throw new Error("Expected ok result");
+    const serverRejectedConflicts = repository.conflicts.filter(
+      (candidate) => candidate.conflictType === "server_rejected",
+    );
+    expect(serverRejectedConflicts).toHaveLength(1);
+    // The conflict still surfaces to the caller on replay.
+    expect(retry.data.conflicts).toContainEqual(
+      expect.objectContaining({ conflictType: "server_rejected" }),
+    );
+  });
+
+  it("does not create a conflict when a non-financial event is rejected", async () => {
+    const repository = createFakeSyncRepository();
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+
+    const result = await service.ingestBatch(
+      buildBatch({
+        events: [
+          buildSaleClearedEvent({
+            sequence: 1,
+            payload: { localPosSessionId: "", reason: "Sale cleared" },
+          }),
+        ],
+      }),
+    );
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("Expected ok result");
+    expect(result.data.accepted).toEqual([
+      expect.objectContaining({ status: "rejected" }),
+    ]);
+    expect(repository.conflicts).toHaveLength(0);
+  });
+
   it("rejects malformed sale clear payloads", async () => {
     const repository = createFakeSyncRepository();
     const service = createLocalSyncIngestionService({

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
@@ -382,6 +382,44 @@ export function createLocalSyncIngestionService(
               rejectionMessage: preparedEvent.message,
             });
           }
+          // A money-bearing sale that the server rejects would otherwise
+          // vanish with the drawer left short and nobody notified. Surface it
+          // as a manager-visible conflict while keeping the cursor advancing.
+          // Non-financial rejects stay silent to avoid conflict spam.
+          if (isMoneyBearingRejectedSaleEvent(event)) {
+            const rejectedCursorIdentity = getLocalSyncCursorIdentity(event);
+            const rejectedAmount = summarizeRejectedSaleAmount(event);
+            const rejectedLocalTransactionId = optionalString(
+              (event.payload as Record<string, unknown>).localTransactionId,
+            );
+            const serverRejectedConflict =
+              await dependencies.repository.createConflict({
+                storeId: batch.storeId,
+                terminalId: batch.terminalId,
+                localRegisterSessionId:
+                  rejectedCursorIdentity.localSyncCursorId,
+                localEventId: event.localEventId,
+                sequence: event.sequence,
+                conflictType: "server_rejected",
+                status: "needs_review",
+                summary: SERVER_REJECTED_SALE_CONFLICT_SUMMARY,
+                details: {
+                  code: "server_rejected",
+                  reason: preparedEvent.message,
+                  localEventId: event.localEventId,
+                  localRegisterSessionId:
+                    rejectedCursorIdentity.localSyncCursorId,
+                  ...(rejectedAmount === undefined
+                    ? {}
+                    : { amount: rejectedAmount }),
+                  ...(rejectedLocalTransactionId
+                    ? { localTransactionId: rejectedLocalTransactionId }
+                    : {}),
+                },
+                createdAt: dependencies.now(),
+              });
+            conflicts.push(serverRejectedConflict);
+          }
           accepted.push({
             localEventId: rejectedEvent.localEventId,
             sequence: rejectedEvent.sequence,
@@ -527,6 +565,44 @@ function getLocalSyncCursorIdentity(
     localSyncCursorId: localRegisterSessionId,
     localRegisterSessionId,
   };
+}
+
+const SERVER_REJECTED_SALE_CONFLICT_SUMMARY =
+  "Server rejected a completed sale during sync. Reconcile the drawer before closing.";
+
+function isMoneyBearingRejectedSaleEvent(
+  event: PosLocalSyncEventInput,
+): boolean {
+  if (event.eventType !== "sale_completed") {
+    return false;
+  }
+  const payments = (event.payload as { payments?: unknown } | undefined)
+    ?.payments;
+  return Array.isArray(payments) && payments.length > 0;
+}
+
+function summarizeRejectedSaleAmount(
+  event: PosLocalSyncEventInput,
+): number | undefined {
+  const payload = event.payload as
+    | { payments?: unknown; totals?: { total?: unknown } }
+    | undefined;
+  const payments = payload?.payments;
+  if (Array.isArray(payments)) {
+    let sum = 0;
+    let sawAmount = false;
+    for (const payment of payments) {
+      if (isRecord(payment) && isNonNegativeFiniteNumber(payment.amount)) {
+        sum += payment.amount;
+        sawAmount = true;
+      }
+    }
+    if (sawAmount) {
+      return sum;
+    }
+  }
+  const total = payload?.totals?.total;
+  return isNonNegativeFiniteNumber(total) ? total : undefined;
 }
 
 function prepareLocalSyncEventForProjection(input: {

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -24,7 +24,11 @@ import type { CommandResult } from "../../../../shared/commandResult";
 export type { PosLocalSyncEventStatus, PosLocalSyncEventType };
 
 export type PosLocalSyncConflictType =
-  "duplicate_local_id" | "inventory" | "payment" | "permission";
+  | "duplicate_local_id"
+  | "inventory"
+  | "payment"
+  | "permission"
+  | "server_rejected";
 
 export type PosLocalSyncMappingKind =
   | "registerSession"

--- a/packages/athena-webapp/convex/pos/public/customers.test.ts
+++ b/packages/athena-webapp/convex/pos/public/customers.test.ts
@@ -49,8 +49,15 @@ import {
   getCustomerById,
   getCustomerTransactions,
   findByStoreFrontUser,
+  findPotentialMatches,
+  linkToGuest,
+  linkToStoreFrontUser,
+  resolveGuestMatch,
+  resolvePosCustomerSelection,
+  resolveStoreFrontUserMatch,
   searchCustomers,
   updateCustomer,
+  updateCustomerStats,
 } from "./customers";
 
 function getHandler(definition: unknown) {
@@ -252,4 +259,71 @@ describe("pos public customers authorization", () => {
     ).rejects.toThrow("You cannot view this customer.");
     expect(mocks.getCustomerTransactions).not.toHaveBeenCalled();
   });
+
+  // Every endpoint wires its own guard one-liner, so each guard site needs its
+  // own cross-org denial regression — shared-helper coverage is not enough.
+  const denialCases: Array<{
+    name: string;
+    handler: unknown;
+    args: Record<string, unknown>;
+    delegate: () => ReturnType<typeof vi.fn>;
+  }> = [
+    {
+      name: "updateCustomerStats",
+      handler: updateCustomerStats,
+      args: { customerId: "customer-1", transactionAmount: 100 },
+      delegate: () => mocks.updateCustomerStats,
+    },
+    {
+      name: "resolvePosCustomerSelection",
+      handler: resolvePosCustomerSelection,
+      args: { customerId: "customer-1" },
+      delegate: () => mocks.resolvePosCustomerSelection,
+    },
+    {
+      name: "linkToStoreFrontUser",
+      handler: linkToStoreFrontUser,
+      args: { posCustomerId: "customer-1", storeFrontUserId: "sf-user-1" },
+      delegate: () => mocks.linkToStoreFrontUser,
+    },
+    {
+      name: "linkToGuest",
+      handler: linkToGuest,
+      args: { posCustomerId: "customer-1", guestId: "guest-1" },
+      delegate: () => mocks.linkToGuest,
+    },
+    {
+      name: "resolveStoreFrontUserMatch",
+      handler: resolveStoreFrontUserMatch,
+      args: { storeId: "store-1", storeFrontUserId: "sf-user-1" },
+      delegate: () => mocks.resolveStoreFrontUserMatch,
+    },
+    {
+      name: "resolveGuestMatch",
+      handler: resolveGuestMatch,
+      args: { storeId: "store-1", guestId: "guest-1" },
+      delegate: () => mocks.resolveGuestMatch,
+    },
+    {
+      name: "findPotentialMatches",
+      handler: findPotentialMatches,
+      args: { storeId: "store-1", email: "a@b.com" },
+      delegate: () => mocks.findPotentialMatches,
+    },
+  ];
+
+  it.each(denialCases)(
+    "denies $name across org boundaries and never runs the delegate",
+    async ({ handler, args, delegate }) => {
+      mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
+        new Error("cross-org denied"),
+      );
+      const ctx = buildCtx();
+
+      await expect(getHandler(handler)(ctx as never, args)).rejects.toThrow(
+        "cross-org denied",
+      );
+      expect(delegate()).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/packages/athena-webapp/convex/pos/public/customers.test.ts
+++ b/packages/athena-webapp/convex/pos/public/customers.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAuthenticatedAthenaUserWithCtx: vi.fn(),
+  requireOrganizationMemberRoleWithCtx: vi.fn(),
+  searchCustomers: vi.fn(),
+  getCustomerById: vi.fn(),
+  getCustomerTransactions: vi.fn(),
+  findByStoreFrontUser: vi.fn(),
+  findPotentialMatches: vi.fn(),
+  createCustomer: vi.fn(),
+  updateCustomer: vi.fn(),
+  updateCustomerStats: vi.fn(),
+  resolvePosCustomerSelection: vi.fn(),
+  linkToStoreFrontUser: vi.fn(),
+  linkToGuest: vi.fn(),
+  resolveStoreFrontUserMatch: vi.fn(),
+  resolveGuestMatch: vi.fn(),
+}));
+
+vi.mock("../../lib/athenaUserAuth", () => ({
+  requireAuthenticatedAthenaUserWithCtx:
+    mocks.requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx:
+    mocks.requireOrganizationMemberRoleWithCtx,
+}));
+
+vi.mock("../application/queries/searchCustomers", () => ({
+  searchCustomers: mocks.searchCustomers,
+  getCustomerById: mocks.getCustomerById,
+  getCustomerTransactions: mocks.getCustomerTransactions,
+  findByStoreFrontUser: mocks.findByStoreFrontUser,
+  findPotentialMatches: mocks.findPotentialMatches,
+}));
+
+vi.mock("../application/commands/assignCustomer", () => ({
+  createCustomer: mocks.createCustomer,
+  updateCustomer: mocks.updateCustomer,
+  updateCustomerStats: mocks.updateCustomerStats,
+  resolvePosCustomerSelection: mocks.resolvePosCustomerSelection,
+  linkToStoreFrontUser: mocks.linkToStoreFrontUser,
+  linkToGuest: mocks.linkToGuest,
+  resolveStoreFrontUserMatch: mocks.resolveStoreFrontUserMatch,
+  resolveGuestMatch: mocks.resolveGuestMatch,
+}));
+
+import {
+  createCustomer,
+  getCustomerById,
+  getCustomerTransactions,
+  findByStoreFrontUser,
+  searchCustomers,
+  updateCustomer,
+} from "./customers";
+
+function getHandler(definition: unknown) {
+  return (definition as { _handler: Function })._handler;
+}
+
+function buildCtx(
+  overrides: {
+    store?: Record<string, unknown> | null;
+    posCustomer?: Record<string, unknown> | null;
+    storeFrontUser?: Record<string, unknown> | null;
+  } = {},
+) {
+  return {
+    db: {
+      get: vi.fn(async (tableName: string, id: string) => {
+        if (tableName === "store" && id === "store-1") {
+          return Object.prototype.hasOwnProperty.call(overrides, "store")
+            ? overrides.store
+            : { _id: "store-1", organizationId: "org-1" };
+        }
+        if (tableName === "posCustomer" && id === "customer-1") {
+          return Object.prototype.hasOwnProperty.call(overrides, "posCustomer")
+            ? overrides.posCustomer
+            : { _id: "customer-1", storeId: "store-1", name: "Ada" };
+        }
+        if (tableName === "storeFrontUser" && id === "sf-user-1") {
+          return Object.prototype.hasOwnProperty.call(
+            overrides,
+            "storeFrontUser",
+          )
+            ? overrides.storeFrontUser
+            : { _id: "sf-user-1", storeId: "store-1" };
+        }
+        return null;
+      }),
+    },
+  };
+}
+
+describe("pos public customers authorization", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockResolvedValue({
+      _id: "athena-user-1",
+    });
+    mocks.requireOrganizationMemberRoleWithCtx.mockResolvedValue({
+      role: "pos_only",
+    });
+    mocks.searchCustomers.mockResolvedValue([{ _id: "customer-1" }]);
+    mocks.getCustomerById.mockResolvedValue({ _id: "customer-1", name: "Ada" });
+    mocks.createCustomer.mockResolvedValue({ kind: "ok", data: {} });
+    mocks.updateCustomer.mockResolvedValue({ kind: "ok", data: null });
+    mocks.findByStoreFrontUser.mockResolvedValue({ _id: "customer-1" });
+  });
+
+  it("searches customers for a same-org member", async () => {
+    const ctx = buildCtx();
+
+    const result = await getHandler(searchCustomers)(ctx as never, {
+      storeId: "store-1",
+      searchQuery: "ada",
+    });
+
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        allowedRoles: ["full_admin", "pos_only"],
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      }),
+    );
+    expect(mocks.searchCustomers).toHaveBeenCalled();
+    expect(result).toEqual([{ _id: "customer-1" }]);
+  });
+
+  it("denies a foreign-org user searching another store's customers (PII leak)", async () => {
+    mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
+      new Error("You cannot search customers for this store."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(searchCustomers)(ctx as never, {
+        storeId: "store-1",
+        searchQuery: "ada",
+      }),
+    ).rejects.toThrow("You cannot search customers for this store.");
+    expect(mocks.searchCustomers).not.toHaveBeenCalled();
+  });
+
+  it("denies a foreign-org user reading a customer by id even with a valid id", async () => {
+    mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
+      new Error("You cannot view this customer."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(getCustomerById)(ctx as never, { customerId: "customer-1" }),
+    ).rejects.toThrow("You cannot view this customer.");
+    expect(mocks.getCustomerById).not.toHaveBeenCalled();
+  });
+
+  it("scopes getCustomerById to the customer's store organization", async () => {
+    const ctx = buildCtx();
+
+    await getHandler(getCustomerById)(ctx as never, {
+      customerId: "customer-1",
+    });
+
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ organizationId: "org-1" }),
+    );
+    expect(mocks.getCustomerById).toHaveBeenCalled();
+  });
+
+  it("returns null without leaking PII for a non-existent customer", async () => {
+    const ctx = buildCtx({ posCustomer: null });
+
+    const result = await getHandler(getCustomerById)(ctx as never, {
+      customerId: "customer-1",
+    });
+
+    expect(result).toBeNull();
+    expect(mocks.requireAuthenticatedAthenaUserWithCtx).not.toHaveBeenCalled();
+    expect(mocks.getCustomerById).not.toHaveBeenCalled();
+  });
+
+  it("denies a foreign-org user creating a customer for another store", async () => {
+    mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
+      new Error("You cannot create customers for this store."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(createCustomer)(ctx as never, {
+        storeId: "store-1",
+        name: "Mallory",
+      }),
+    ).rejects.toThrow("You cannot create customers for this store.");
+    expect(mocks.createCustomer).not.toHaveBeenCalled();
+  });
+
+  it("denies a foreign-org user updating another store's customer", async () => {
+    mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
+      new Error("You cannot update this customer."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(updateCustomer)(ctx as never, {
+        customerId: "customer-1",
+        name: "Mallory",
+      }),
+    ).rejects.toThrow("You cannot update this customer.");
+    expect(mocks.updateCustomer).not.toHaveBeenCalled();
+  });
+
+  it("denies an unauthenticated caller creating a customer", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("Sign in again to continue."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(createCustomer)(ctx as never, {
+        storeId: "store-1",
+        name: "Mallory",
+      }),
+    ).rejects.toThrow("Sign in again to continue.");
+    expect(mocks.createCustomer).not.toHaveBeenCalled();
+  });
+
+  it("scopes findByStoreFrontUser to the storefront user's store org", async () => {
+    const ctx = buildCtx();
+
+    await getHandler(findByStoreFrontUser)(ctx as never, {
+      storeFrontUserId: "sf-user-1",
+    });
+
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ organizationId: "org-1" }),
+    );
+    expect(mocks.findByStoreFrontUser).toHaveBeenCalled();
+  });
+
+  it("denies getCustomerTransactions across org boundaries", async () => {
+    mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
+      new Error("You cannot view this customer."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(getCustomerTransactions)(ctx as never, {
+        customerId: "customer-1",
+      }),
+    ).rejects.toThrow("You cannot view this customer.");
+    expect(mocks.getCustomerTransactions).not.toHaveBeenCalled();
+  });
+});

--- a/packages/athena-webapp/convex/pos/public/customers.test.ts
+++ b/packages/athena-webapp/convex/pos/public/customers.test.ts
@@ -59,6 +59,7 @@ import {
   updateCustomer,
   updateCustomerStats,
 } from "./customers";
+import { assertConformsToExportedReturns } from "../../lib/returnValidatorContract";
 
 function getHandler(definition: unknown) {
   return (definition as { _handler: Function })._handler;
@@ -326,4 +327,64 @@ describe("pos public customers authorization", () => {
       expect(delegate()).not.toHaveBeenCalled();
     },
   );
+});
+
+describe("pos public customers return contracts", () => {
+  const userErr = {
+    kind: "user_error" as const,
+    error: { code: "not_found" as const, message: "Not found." },
+  };
+  const attribution = {
+    kind: "ok" as const,
+    data: {
+      name: "Ada",
+      attribution: { kind: "sale_only" as const, reusable: false as const },
+    },
+  };
+
+  it("conforms searchCustomers returns to its exported validator", () => {
+    assertConformsToExportedReturns(searchCustomers as never, []);
+  });
+  it("conforms getCustomerById returns to its exported validator", () => {
+    assertConformsToExportedReturns(getCustomerById as never, null);
+  });
+  it("conforms createCustomer returns to its exported validator", () => {
+    assertConformsToExportedReturns(createCustomer as never, attribution);
+  });
+  it("conforms updateCustomer returns to its exported validator", () => {
+    assertConformsToExportedReturns(updateCustomer as never, userErr);
+  });
+  it("conforms updateCustomerStats returns to its exported validator", () => {
+    assertConformsToExportedReturns(updateCustomerStats as never, null);
+  });
+  it("conforms resolvePosCustomerSelection returns to its exported validator", () => {
+    assertConformsToExportedReturns(
+      resolvePosCustomerSelection as never,
+      attribution,
+    );
+  });
+  it("conforms getCustomerTransactions returns to its exported validator", () => {
+    assertConformsToExportedReturns(getCustomerTransactions as never, []);
+  });
+  it("conforms linkToStoreFrontUser returns to its exported validator", () => {
+    assertConformsToExportedReturns(linkToStoreFrontUser as never, userErr);
+  });
+  it("conforms linkToGuest returns to its exported validator", () => {
+    assertConformsToExportedReturns(linkToGuest as never, userErr);
+  });
+  it("conforms resolveStoreFrontUserMatch returns to its exported validator", () => {
+    assertConformsToExportedReturns(resolveStoreFrontUserMatch as never, userErr);
+  });
+  it("conforms resolveGuestMatch returns to its exported validator", () => {
+    assertConformsToExportedReturns(resolveGuestMatch as never, userErr);
+  });
+  it("conforms findByStoreFrontUser returns to its exported validator", () => {
+    assertConformsToExportedReturns(findByStoreFrontUser as never, null);
+  });
+  it("conforms findPotentialMatches returns to its exported validator", () => {
+    assertConformsToExportedReturns(findPotentialMatches as never, {
+      storeFrontUsers: [],
+      guests: [],
+    });
+  });
 });

--- a/packages/athena-webapp/convex/pos/public/customers.ts
+++ b/packages/athena-webapp/convex/pos/public/customers.ts
@@ -1,7 +1,18 @@
 import { v } from "convex/values";
 
-import { mutation, query } from "../../_generated/server";
+import {
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "../../_generated/server";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { commandResultValidator } from "../../lib/commandResultValidators";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../../lib/athenaUserAuth";
+import { userError } from "../../../shared/commandResult";
 import {
   createCustomer as createCustomerCommand,
   linkToGuest as linkToGuestCommand,
@@ -19,6 +30,61 @@ import {
   getCustomerTransactions as getCustomerTransactionsQuery,
   searchCustomers as searchCustomersQuery,
 } from "../application/queries/searchCustomers";
+
+type PosCustomerStoreAccess =
+  | {
+      ok: true;
+      store: Doc<"store">;
+      athenaUser: Doc<"athenaUser">;
+      membership: Doc<"organizationMember">;
+    }
+  | { ok: false };
+
+async function requirePosCustomerStoreAccess(
+  ctx: MutationCtx | QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    failureMessage: string;
+  },
+): Promise<PosCustomerStoreAccess> {
+  const store = await ctx.db.get("store", args.storeId);
+  if (!store) {
+    return { ok: false };
+  }
+
+  const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+  const membership = await requireOrganizationMemberRoleWithCtx(ctx, {
+    allowedRoles: ["full_admin", "pos_only"],
+    failureMessage: args.failureMessage,
+    organizationId: store.organizationId,
+    userId: athenaUser._id,
+  });
+
+  return { ok: true, store, athenaUser, membership };
+}
+
+async function requirePosCustomerAccessById(
+  ctx: MutationCtx | QueryCtx,
+  args: {
+    customerId: Id<"posCustomer">;
+    failureMessage: string;
+  },
+): Promise<PosCustomerStoreAccess & { customer?: Doc<"posCustomer"> }> {
+  const customer = await ctx.db.get("posCustomer", args.customerId);
+  if (!customer) {
+    return { ok: false };
+  }
+
+  const access = await requirePosCustomerStoreAccess(ctx, {
+    storeId: customer.storeId,
+    failureMessage: args.failureMessage,
+  });
+  if (!access.ok) {
+    return { ok: false };
+  }
+
+  return { ...access, customer };
+}
 
 const customerAddressValidator = v.object({
   street: v.optional(v.string()),
@@ -82,7 +148,17 @@ export const searchCustomers = query({
     searchQuery: v.string(),
   },
   returns: v.array(customerSummaryValidator),
-  handler: async (ctx, args) => searchCustomersQuery(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerStoreAccess(ctx, {
+      storeId: args.storeId,
+      failureMessage: "You cannot search customers for this store.",
+    });
+    if (!access.ok) {
+      return [];
+    }
+
+    return searchCustomersQuery(ctx, args);
+  },
 });
 
 export const getCustomerById = query({
@@ -109,7 +185,17 @@ export const getCustomerById = query({
     }),
     v.null(),
   ),
-  handler: async (ctx, args) => getCustomerByIdQuery(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerAccessById(ctx, {
+      customerId: args.customerId,
+      failureMessage: "You cannot view this customer.",
+    });
+    if (!access.ok) {
+      return null;
+    }
+
+    return getCustomerByIdQuery(ctx, args);
+  },
 });
 
 export const createCustomer = mutation({
@@ -122,7 +208,17 @@ export const createCustomer = mutation({
     notes: v.optional(v.string()),
   },
   returns: commandResultValidator(customerAttributionResultValidator),
-  handler: async (ctx, args) => createCustomerCommand(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerStoreAccess(ctx, {
+      storeId: args.storeId,
+      failureMessage: "You cannot create customers for this store.",
+    });
+    if (!access.ok) {
+      return userError({ code: "not_found", message: "Store not found." });
+    }
+
+    return createCustomerCommand(ctx, args);
+  },
 });
 
 export const updateCustomer = mutation({
@@ -135,7 +231,17 @@ export const updateCustomer = mutation({
     notes: v.optional(v.string()),
   },
   returns: commandResultValidator(v.null()),
-  handler: async (ctx, args) => updateCustomerCommand(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerAccessById(ctx, {
+      customerId: args.customerId,
+      failureMessage: "You cannot update this customer.",
+    });
+    if (!access.ok) {
+      return userError({ code: "not_found", message: "Customer not found." });
+    }
+
+    return updateCustomerCommand(ctx, args);
+  },
 });
 
 export const updateCustomerStats = mutation({
@@ -144,7 +250,17 @@ export const updateCustomerStats = mutation({
     transactionAmount: v.number(),
   },
   returns: v.null(),
-  handler: async (ctx, args) => updateCustomerStatsCommand(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerAccessById(ctx, {
+      customerId: args.customerId,
+      failureMessage: "You cannot update this customer.",
+    });
+    if (!access.ok) {
+      return null;
+    }
+
+    return updateCustomerStatsCommand(ctx, args);
+  },
 });
 
 export const resolvePosCustomerSelection = mutation({
@@ -152,7 +268,17 @@ export const resolvePosCustomerSelection = mutation({
     customerId: v.id("posCustomer"),
   },
   returns: commandResultValidator(customerAttributionResultValidator),
-  handler: async (ctx, args) => resolvePosCustomerSelectionCommand(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerAccessById(ctx, {
+      customerId: args.customerId,
+      failureMessage: "You cannot resolve this customer.",
+    });
+    if (!access.ok) {
+      return userError({ code: "not_found", message: "Customer not found." });
+    }
+
+    return resolvePosCustomerSelectionCommand(ctx, args);
+  },
 });
 
 export const getCustomerTransactions = query({
@@ -171,7 +297,17 @@ export const getCustomerTransactions = query({
       completedAt: v.number(),
     }),
   ),
-  handler: async (ctx, args) => getCustomerTransactionsQuery(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerAccessById(ctx, {
+      customerId: args.customerId,
+      failureMessage: "You cannot view this customer.",
+    });
+    if (!access.ok) {
+      return [];
+    }
+
+    return getCustomerTransactionsQuery(ctx, args);
+  },
 });
 
 export const linkToStoreFrontUser = mutation({
@@ -180,7 +316,17 @@ export const linkToStoreFrontUser = mutation({
     storeFrontUserId: v.id("storeFrontUser"),
   },
   returns: commandResultValidator(customerAttributionResultValidator),
-  handler: async (ctx, args) => linkToStoreFrontUserCommand(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerAccessById(ctx, {
+      customerId: args.posCustomerId,
+      failureMessage: "You cannot update this customer.",
+    });
+    if (!access.ok) {
+      return userError({ code: "not_found", message: "Customer not found." });
+    }
+
+    return linkToStoreFrontUserCommand(ctx, args);
+  },
 });
 
 export const linkToGuest = mutation({
@@ -189,7 +335,17 @@ export const linkToGuest = mutation({
     guestId: v.id("guest"),
   },
   returns: commandResultValidator(customerAttributionResultValidator),
-  handler: async (ctx, args) => linkToGuestCommand(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerAccessById(ctx, {
+      customerId: args.posCustomerId,
+      failureMessage: "You cannot update this customer.",
+    });
+    if (!access.ok) {
+      return userError({ code: "not_found", message: "Customer not found." });
+    }
+
+    return linkToGuestCommand(ctx, args);
+  },
 });
 
 export const resolveStoreFrontUserMatch = mutation({
@@ -198,7 +354,17 @@ export const resolveStoreFrontUserMatch = mutation({
     storeFrontUserId: v.id("storeFrontUser"),
   },
   returns: commandResultValidator(customerAttributionResultValidator),
-  handler: async (ctx, args) => resolveStoreFrontUserMatchCommand(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerStoreAccess(ctx, {
+      storeId: args.storeId,
+      failureMessage: "You cannot resolve customers for this store.",
+    });
+    if (!access.ok) {
+      return userError({ code: "not_found", message: "Store not found." });
+    }
+
+    return resolveStoreFrontUserMatchCommand(ctx, args);
+  },
 });
 
 export const resolveGuestMatch = mutation({
@@ -207,7 +373,17 @@ export const resolveGuestMatch = mutation({
     guestId: v.id("guest"),
   },
   returns: commandResultValidator(customerAttributionResultValidator),
-  handler: async (ctx, args) => resolveGuestMatchCommand(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerStoreAccess(ctx, {
+      storeId: args.storeId,
+      failureMessage: "You cannot resolve customers for this store.",
+    });
+    if (!access.ok) {
+      return userError({ code: "not_found", message: "Store not found." });
+    }
+
+    return resolveGuestMatchCommand(ctx, args);
+  },
 });
 
 export const findByStoreFrontUser = query({
@@ -227,7 +403,25 @@ export const findByStoreFrontUser = query({
     }),
     v.null(),
   ),
-  handler: async (ctx, args) => findByStoreFrontUserQuery(ctx, args),
+  handler: async (ctx, args) => {
+    const storeFrontUser = await ctx.db.get(
+      "storeFrontUser",
+      args.storeFrontUserId,
+    );
+    if (!storeFrontUser) {
+      return null;
+    }
+
+    const access = await requirePosCustomerStoreAccess(ctx, {
+      storeId: storeFrontUser.storeId,
+      failureMessage: "You cannot view this customer.",
+    });
+    if (!access.ok) {
+      return null;
+    }
+
+    return findByStoreFrontUserQuery(ctx, args);
+  },
 });
 
 export const findPotentialMatches = query({
@@ -256,5 +450,15 @@ export const findPotentialMatches = query({
       }),
     ),
   }),
-  handler: async (ctx, args) => findPotentialMatchesQuery(ctx, args),
+  handler: async (ctx, args) => {
+    const access = await requirePosCustomerStoreAccess(ctx, {
+      storeId: args.storeId,
+      failureMessage: "You cannot view potential matches for this store.",
+    });
+    if (!access.ok) {
+      return { storeFrontUsers: [], guests: [] };
+    }
+
+    return findPotentialMatchesQuery(ctx, args);
+  },
 });

--- a/packages/athena-webapp/convex/pos/public/register.test.ts
+++ b/packages/athena-webapp/convex/pos/public/register.test.ts
@@ -1,7 +1,52 @@
-import { describe, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAuthenticatedAthenaUserWithCtx: vi.fn(),
+  requireOrganizationMemberRoleWithCtx: vi.fn(),
+  getRegisterState: vi.fn(),
+  openDrawerCommand: vi.fn(),
+}));
+
+vi.mock("../../lib/athenaUserAuth", () => ({
+  requireAuthenticatedAthenaUserWithCtx:
+    mocks.requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx:
+    mocks.requireOrganizationMemberRoleWithCtx,
+}));
+
+vi.mock("../application/queries/getRegisterState", () => ({
+  getRegisterState: mocks.getRegisterState,
+}));
+
+vi.mock("../application/commands/register", () => ({
+  openDrawer: mocks.openDrawerCommand,
+}));
 
 import { assertConformsToExportedReturns } from "../../lib/returnValidatorContract";
-import { openDrawer } from "./register";
+import { getState, openDrawer } from "./register";
+
+function getHandler(definition: unknown) {
+  return (definition as { _handler: Function })._handler;
+}
+
+function buildCtx(
+  overrides: {
+    store?: Record<string, unknown> | null;
+  } = {},
+) {
+  return {
+    db: {
+      get: vi.fn(async (tableName: string, id: string) => {
+        if (tableName === "store" && id === "store-1") {
+          return Object.prototype.hasOwnProperty.call(overrides, "store")
+            ? overrides.store
+            : { _id: "store-1", organizationId: "org-1" };
+        }
+        return null;
+      }),
+    },
+  };
+}
 
 describe("pos public register contracts", () => {
   it("accepts review-only closeout register-session statuses in command results", () => {
@@ -19,5 +64,76 @@ describe("pos public register contracts", () => {
         workflowTraceId: "trace-register-session-1",
       },
     });
+  });
+});
+
+describe("pos public register.getState authorization", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockResolvedValue({
+      _id: "athena-user-1",
+    });
+    mocks.requireOrganizationMemberRoleWithCtx.mockResolvedValue({
+      role: "pos_only",
+    });
+    mocks.getRegisterState.mockResolvedValue({ phase: "ready" });
+  });
+
+  it("reads register state for a same-org member", async () => {
+    const ctx = buildCtx();
+
+    const result = await getHandler(getState)(ctx as never, {
+      storeId: "store-1",
+    });
+
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        allowedRoles: ["full_admin", "pos_only"],
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      }),
+    );
+    expect(mocks.getRegisterState).toHaveBeenCalledWith(ctx, {
+      storeId: "store-1",
+    });
+    expect(result).toEqual({ phase: "ready" });
+  });
+
+  it("denies a foreign-org user reading another store's register state", async () => {
+    mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
+      new Error("You cannot view register state for this store."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(getState)(ctx as never, { storeId: "store-1" }),
+    ).rejects.toThrow("You cannot view register state for this store.");
+    expect(mocks.getRegisterState).not.toHaveBeenCalled();
+  });
+
+  it("denies an unauthenticated caller reading register state", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("Sign in again to continue."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(getState)(ctx as never, { storeId: "store-1" }),
+    ).rejects.toThrow("Sign in again to continue.");
+    expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
+    expect(mocks.getRegisterState).not.toHaveBeenCalled();
+  });
+
+  it("returns null without leaking state for a non-existent store", async () => {
+    const ctx = buildCtx({ store: null });
+
+    const result = await getHandler(getState)(ctx as never, {
+      storeId: "store-1",
+    });
+
+    expect(result).toBeNull();
+    expect(mocks.requireAuthenticatedAthenaUserWithCtx).not.toHaveBeenCalled();
+    expect(mocks.getRegisterState).not.toHaveBeenCalled();
   });
 });

--- a/packages/athena-webapp/convex/pos/public/register.ts
+++ b/packages/athena-webapp/convex/pos/public/register.ts
@@ -1,6 +1,10 @@
 import { v } from "convex/values";
 
 import { mutation, query } from "../../_generated/server";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../../lib/athenaUserAuth";
 import { getRegisterState } from "../application/queries/getRegisterState";
 import { openDrawer as openDrawerCommand } from "../application/commands/register";
 
@@ -59,7 +63,22 @@ export const getState = query({
     staffProfileId: v.optional(v.id("staffProfile")),
     registerNumber: v.optional(v.string()),
   },
-  handler: async (ctx, args) => getRegisterState(ctx, args),
+  handler: async (ctx, args) => {
+    const store = await ctx.db.get("store", args.storeId);
+    if (!store) {
+      return null;
+    }
+
+    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    await requireOrganizationMemberRoleWithCtx(ctx, {
+      allowedRoles: ["full_admin", "pos_only"],
+      failureMessage: "You cannot view register state for this store.",
+      organizationId: store.organizationId,
+      userId: athenaUser._id,
+    });
+
+    return getRegisterState(ctx, args);
+  },
 });
 
 export const openDrawer = mutation({

--- a/packages/athena-webapp/convex/schemas/pos/posLocalSyncConflict.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posLocalSyncConflict.ts
@@ -5,6 +5,7 @@ export const posLocalSyncConflictTypeValidator = v.union(
   v.literal("inventory"),
   v.literal("payment"),
   v.literal("permission"),
+  v.literal("server_rejected"),
 );
 
 export const posLocalSyncConflictStatusValidator = v.union(

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -23,7 +23,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/reporting`](../../convex/reporting) — Versioned facts, inventory valuation, replayable projections, activation, evidence, and store-scoped reporting reads. Currently 131 file(s); key children: access.test.ts, access.ts, activation.test.ts, activation.ts, attentionRules.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 885 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 886 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -23,7 +23,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/reporting`](../../convex/reporting) — Versioned facts, inventory valuation, replayable projections, activation, evidence, and store-scoped reporting reads. Currently 131 file(s); key children: access.test.ts, access.ts, activation.test.ts, activation.ts, attentionRules.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 8 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCaseTracing.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 19 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 886 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 887 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -190,6 +190,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/infrastructure/repositories/terminalRepository.test.ts`](../../convex/pos/infrastructure/repositories/terminalRepository.test.ts)
 - [`convex/pos/infrastructure/repositories/transactionRepository.test.ts`](../../convex/pos/infrastructure/repositories/transactionRepository.test.ts)
 - [`convex/pos/public/catalog.test.ts`](../../convex/pos/public/catalog.test.ts)
+- [`convex/pos/public/customers.test.ts`](../../convex/pos/public/customers.test.ts)
 - [`convex/pos/public/posRecoveryCodes.test.ts`](../../convex/pos/public/posRecoveryCodes.test.ts)
 - [`convex/pos/public/register.test.ts`](../../convex/pos/public/register.test.ts)
 - [`convex/pos/public/sync.sharedDemo.test.ts`](../../convex/pos/public/sync.sharedDemo.test.ts)

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -144,6 +144,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/application/commands/assignCustomer.test.ts`](../../convex/pos/application/commands/assignCustomer.test.ts)
 - [`convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts`](../../convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts)
 - [`convex/pos/application/commands/quickAddCatalogItem.test.ts`](../../convex/pos/application/commands/quickAddCatalogItem.test.ts)
+- [`convex/pos/application/commands/register.test.ts`](../../convex/pos/application/commands/register.test.ts)
 - [`convex/pos/application/commands/registerLifecycleAuthority.test.ts`](../../convex/pos/application/commands/registerLifecycleAuthority.test.ts)
 - [`convex/pos/application/completeTransaction.test.ts`](../../convex/pos/application/completeTransaction.test.ts)
 - [`convex/pos/application/correctTransactionCustomer.test.ts`](../../convex/pos/application/correctTransactionCustomer.test.ts)

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/registerGateway.ts
@@ -48,7 +48,7 @@ export function useConvexRegisterState(
       : "skip",
   );
 
-  if (result === undefined) {
+  if (result === undefined || result === null) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Phase 0 of the POS local-first hardening initiative, batching three tickets into one integration PR. It closes the highest-severity active silent-failure paths in the seams around a sound event-sourcing core:

- **V26-1055 (U1) — register authorization.** `register.getState` had no authorization at all (leaked another tenant's terminal state, active cashier, open register session, and held cart contents); `openDrawer` was authentication-only (any org's user could open a drawer on a target store's terminal and corrupt cash-control attribution). Both now resolve the store and require org membership (`full_admin`/`pos_only`) before any read/write. A per-endpoint sweep of `terminals.ts`, `sync.ts`, and `posRecoveryCodes.ts` found every endpoint already guarded (org membership or terminal sync-secret proof); `catalog.ts` is deferred to V26-956 and `terminalAppSessions.ts` is the deliberate terminal-proof exception.
- **V26-1056 (U11) — customers authorization.** All 13 endpoints in `convex/pos/public/customers.ts` had zero authorization (`getCustomerById` returned full PII by `customerId`; create/update were unauthenticated cross-tenant writes). Every endpoint is now org-scoped; `customerId`- and `storeFrontUserId`-keyed reads resolve the target's store first so a valid foreign id is still denied. The `linkToStoreFrontUser`/`linkToGuest` commands additionally reject a storefront-user/guest from another store (found in review).
- **V26-1057 (U2) — rejected-sale conflict.** A money-bearing offline sale rejected during sync advanced the cursor and wrote no record — a cash sale could vanish with the drawer left short. Rejected `sale_completed` events with payments now create a `posLocalSyncConflict` (`conflictType: "server_rejected"`, `needs_review`) carrying `localEventId`, register session, amount, and reason; the cursor still advances and non-financial rejects stay silent. Adds the `server_rejected` literal to the conflictType union (schema + type), wiring up the previously-dead classifier branch so these reach the manager review surface.

## Why

The POS runs local-first on in-store terminals handling cash. The failures that matter most are "another tenant can read/alter my POS state (including customer PII)" and "money changed hands but the record is gone or wrong." These three gaps produced exactly those outcomes. None are failures of the event-sourcing core; they are gaps in the authorization and data-durability seams around it.

## Validation

- **Test-first per unit.** New/updated tests: `register.test.ts` (public getState + openDrawer command authz), `customers.test.ts` (per-endpoint cross-org denial for all 13 guard sites + 13 return-validator contract proofs), `assignCustomer.test.ts` (cross-store link rejection), `ingestLocalEvents.test.ts` (server_rejected conflict created, cursor advances, no spam on non-financial rejects, dedup on replay, audit fields).
- **Gate:** `bun run pr:athena` green (dependency/generated-artifacts/harness/audit/lint/architecture/tsc/coverage), plus `bun run landed-report:check`.
- **Multi-lens review loop (unanimous APPROVE).** Three read-only reviewer subagents on `git diff origin/main...HEAD`:
  - Correctness (U2): APPROVE round 1.
  - Security/Authorization: CHANGES_REQUESTED then fixed (linkToStoreFrontUser/linkToGuest did not re-scope the secondary storefront-user/guest to the customer's store, a cross-org PII read) then APPROVE.
  - Tests: CHANGES_REQUESTED then fixed (7 of 13 customers guard sites lacked a cross-org denial test) then APPROVE.
- **Landed-change report:** `docs/reports/2026-07-15-pos-phase0-idor-pii-rejected-sale-report.html`. **Solution note:** `docs/solutions/security-issues/pos-public-surface-authz-and-rejected-sale-loss-2026-07-15.md`. **Plan:** `docs/plans/2026-07-15-001-fix-pos-local-first-hardening-plan.md`.

## Linear

- https://linear.app/v26-labs/issue/V26-1055
- https://linear.app/v26-labs/issue/V26-1056
- https://linear.app/v26-labs/issue/V26-1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)
