### PR TITLE
test(athena): stabilize POS recovery E2E setup

### DIFF
--- a/docs/reports/2026-07-16-operations-auth-pos-resilience-report.html
+++ b/docs/reports/2026-07-16-operations-auth-pos-resilience-report.html
@@ -2,7 +2,7 @@
 <html
   lang="en"
   data-athena-landed-change-report="v1"
-  data-athena-report-diff-fingerprint="16d01584c30ea7f20df7ef735722f972ccf594efbc30d22a722bba91a7240532"
+  data-athena-report-diff-fingerprint="ffb12e1d12285dae5654d92f8999a0c202f2cd0344eb74f96f29a4d8177bb9a0"
   data-athena-report-base="origin/main"
   data-athena-report-head="working-tree"
 >

--- a/docs/reports/2026-07-16-operations-auth-pos-resilience-report.html
+++ b/docs/reports/2026-07-16-operations-auth-pos-resilience-report.html
@@ -2,7 +2,7 @@
 <html
   lang="en"
   data-athena-landed-change-report="v1"
-  data-athena-report-diff-fingerprint="e72ee0ef3ebbb3d517f0826cb45e249828eaef7bae4497ecc5b3b7ced726709f"
+  data-athena-report-diff-fingerprint="16d01584c30ea7f20df7ef735722f972ccf594efbc30d22a722bba91a7240532"
   data-athena-report-base="origin/main"
   data-athena-report-head="working-tree"
 >

--- a/docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md
+++ b/docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md
@@ -12,7 +12,7 @@ symptoms:
 root_cause: logic_error
 resolution_type: code_fix
 severity: high
-delivery_diff_fingerprint: 16d01584c30ea7f20df7ef735722f972ccf594efbc30d22a722bba91a7240532
+delivery_diff_fingerprint: ffb12e1d12285dae5654d92f8999a0c202f2cd0344eb74f96f29a4d8177bb9a0
 tags:
   - convex
   - performance

--- a/docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md
+++ b/docs/solutions/performance/athena-convex-read-amplification-2026-06-29.md
@@ -12,7 +12,7 @@ symptoms:
 root_cause: logic_error
 resolution_type: code_fix
 severity: high
-delivery_diff_fingerprint: e72ee0ef3ebbb3d517f0826cb45e249828eaef7bae4497ecc5b3b7ced726709f
+delivery_diff_fingerprint: 16d01584c30ea7f20df7ef735722f972ccf594efbc30d22a722bba91a7240532
 tags:
   - convex
   - performance

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageBoundary.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageBoundary.test.ts
@@ -43,8 +43,7 @@ function collectProductionSources(directory: string): string[] {
     if (stats.isDirectory()) return collectProductionSources(nextPath);
     const extension = extname(nextPath);
     const isSource = extension === ".ts" || extension === ".tsx";
-    const isTest =
-      nextPath.endsWith(".test.ts") || nextPath.endsWith(".test.tsx");
+    const isTest = /\.(?:test|spec)\.tsx?$/.test(nextPath);
     return isSource && !isTest ? [nextPath] : [];
   });
 }

--- a/packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts
+++ b/packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts
@@ -102,9 +102,9 @@ async function openPosRecoveryForm(page: Page) {
   });
 
   await expect(page.getByRole("heading", { name: /log in/i })).toBeVisible();
-  await page.getByRole("button", { name: /pos sign in/i }).click();
+  await page.getByTestId("athena-login-pos-sign-in").click();
   await expect(page.getByRole("heading", { name: /pos recovery/i })).toBeVisible();
-  await expect(page.getByLabel(/pos account/i)).toBeVisible();
+  await expect(page.getByText(/with the recovery code/i)).toBeVisible();
   await expect(page.getByLabel(/recovery code/i)).toBeVisible();
 }
 

--- a/packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts
+++ b/packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts
@@ -17,6 +17,8 @@ const posHubPath =
 const posBasePath = posHubPath.replace(/\/$/, "");
 const posRegisterPath = `${posBasePath}/register`;
 const posLoginRecoveryPath = `/login?redirectTo=${encodeURIComponent(posRegisterPath)}`;
+const posLocalDatabaseName = "athena-pos-local";
+const posLocalSchemaVersion = 10;
 
 const publicPosEntryRoutes = [
   {
@@ -85,8 +87,7 @@ function collectProdRuntimeSignals(page: Page) {
         (message) =>
           /CONVEX Q|Server Error|Unhandled Runtime Error|Application error|ChunkLoadError/i.test(
             message,
-          ) &&
-          !message.includes("installHook.js"),
+          ) && !message.includes("installHook.js"),
       );
 
       expect(pageErrors, `${label} page errors`).toEqual([]);
@@ -102,10 +103,115 @@ async function openPosRecoveryForm(page: Page) {
   });
 
   await expect(page.getByRole("heading", { name: /log in/i })).toBeVisible();
-  await page.getByTestId("athena-login-pos-sign-in").click();
-  await expect(page.getByRole("heading", { name: /pos recovery/i })).toBeVisible();
+  const posSignInButton = page.getByTestId("athena-login-pos-sign-in");
+  let seededTerminal = false;
+
+  if (!(await posSignInButton.isVisible())) {
+    await page.waitForFunction(
+      async ({ databaseName, schemaVersion }) =>
+        (await indexedDB.databases()).some(
+          (database) =>
+            database.name === databaseName &&
+            database.version === schemaVersion,
+        ),
+      {
+        databaseName: posLocalDatabaseName,
+        schemaVersion: posLocalSchemaVersion,
+      },
+    );
+    await page.evaluate(
+      ({ databaseName, schemaVersion, storeId }) =>
+        new Promise<void>((resolve, reject) => {
+          const openRequest = indexedDB.open(databaseName, schemaVersion);
+
+          openRequest.onerror = () => reject(openRequest.error);
+          openRequest.onsuccess = () => {
+            const database = openRequest.result;
+            const transaction = database.transaction(
+              "terminalSeed",
+              "readwrite",
+            );
+
+            transaction.objectStore("terminalSeed").put(
+              {
+                terminalId: "prod-pos-e2e-terminal",
+                cloudTerminalId: "prod-pos-e2e-terminal",
+                syncSecretHash: "prod-pos-e2e-seed",
+                storeId,
+                displayName: "Production E2E terminal",
+                provisionedAt: Date.now(),
+                schemaVersion,
+              },
+              "current",
+            );
+            transaction.oncomplete = () => {
+              database.close();
+              resolve();
+            };
+            transaction.onerror = () => {
+              database.close();
+              reject(transaction.error);
+            };
+            transaction.onabort = () => {
+              database.close();
+              reject(transaction.error);
+            };
+          };
+        }),
+      {
+        databaseName: posLocalDatabaseName,
+        schemaVersion: posLocalSchemaVersion,
+        storeId: prodStoreId,
+      },
+    );
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { name: /log in/i })).toBeVisible();
+    seededTerminal = true;
+  }
+
+  await expect(posSignInButton).toBeVisible();
+  await posSignInButton.click();
+  await expect(
+    page.getByRole("heading", { name: /pos recovery/i }),
+  ).toBeVisible();
   await expect(page.getByText(/with the recovery code/i)).toBeVisible();
   await expect(page.getByLabel(/recovery code/i)).toBeVisible();
+
+  if (seededTerminal) {
+    await page.evaluate(
+      ({ databaseName, schemaVersion }) =>
+        new Promise<void>((resolve, reject) => {
+          const openRequest = indexedDB.open(databaseName, schemaVersion);
+
+          openRequest.onerror = () => reject(openRequest.error);
+          openRequest.onsuccess = () => {
+            const database = openRequest.result;
+            const transaction = database.transaction(
+              "terminalSeed",
+              "readwrite",
+            );
+
+            transaction.objectStore("terminalSeed").delete("current");
+            transaction.oncomplete = () => {
+              database.close();
+              resolve();
+            };
+            transaction.onerror = () => {
+              database.close();
+              reject(transaction.error);
+            };
+            transaction.onabort = () => {
+              database.close();
+              reject(transaction.error);
+            };
+          };
+        }),
+      {
+        databaseName: posLocalDatabaseName,
+        schemaVersion: posLocalSchemaVersion,
+      },
+    );
+  }
 }
 
 test.describe("production POS flow", () => {
@@ -117,7 +223,10 @@ test.describe("production POS flow", () => {
         const response = await gotoProdRoute(page, route.path);
 
         expect(response?.ok(), `${route.label} navigation`).toBe(true);
-        await expect(page.locator("#app"), `${route.label} app root`).not.toBeEmpty({
+        await expect(
+          page.locator("#app"),
+          `${route.label} app root`,
+        ).not.toBeEmpty({
           timeout: 30_000,
         });
         await expect(page.locator("body"), route.label).toContainText(
@@ -138,7 +247,9 @@ test.describe("production POS flow", () => {
   }) => {
     const runtimeSignals = collectProdRuntimeSignals(page);
     await openPosRecoveryForm(page);
-    await expect(page.getByRole("button", { name: /^continue$/i })).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: /^continue$/i }),
+    ).toBeDisabled();
     await expect(page.locator("body")).not.toContainText(
       /Server Error|CONVEX Q|Unhandled Runtime Error|Application error/i,
     );


### PR DESCRIPTION
## Summary

- select the POS recovery entry through its stable headless test id instead of terminal-dependent accessible copy
- provision the browser-local terminal seed required by the candidate login policy before exercising recovery
- keep the smoke compatible with the currently deployed UI while validating the merged candidate behavior
- exclude Playwright specs from the production-source storage boundary scan and refresh delivery fingerprints

## Why

PR #669 made POS recovery correctly available only on provisioned terminals. The production-backed candidate E2E starts with a fresh browser profile, so it never established that prerequisite and timed out waiting for the recovery action on desktop and mobile. This follow-up establishes the real terminal precondition in the test harness without weakening the application policy or recovery-form assertions.

## Validation

- candidate-build POS recovery smoke — 4 passed across desktop and mobile
- Athena unit suite — 6,456 passed
- focused POS suites — 636 passed and 1,436 passed
- offline POS Playwright — 2 passed
- deployed-production POS smoke — 4 passed, 4 credential-gated tests skipped locally
- typecheck, build, architecture, Graphify, documentation, and harness checks — passed

## Delivery

- Production deploy: intentionally skipped
- Local root: align to `main` after this PR merges
