### PR TITLE
fix(operations): alert admins when EOD requires manual close

### DIFF
--- a/docs/reports/2026-07-16-eod-automation-admin-alerts-report.html
+++ b/docs/reports/2026-07-16-eod-automation-admin-alerts-report.html
@@ -1,0 +1,316 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="0f3e6994d617f1b1a3a772ecfb438053d25592b79bb8dd8e68c23c750d702f7c" data-athena-report-base="origin/main@44f5a194" data-athena-report-head="codex/fix-eod-admin-alerts (uncommitted candidate)">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EOD Automation: Safe Outcomes and Manual-Close Alerts</title>
+    <style>
+      :root {
+        --ink: #1f2933;
+        --muted: #596674;
+        --line: #d9e2ec;
+        --paper: #ffffff;
+        --soft: #f6f8fb;
+        --accent: #1d4ed8;
+        --accent-soft: #dbeafe;
+        --good: #166534;
+        --bad: #b91c1c;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--soft);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      main { max-width: 1120px; margin: 0 auto; padding: 48px 24px 72px; }
+      header { border-bottom: 1px solid var(--line); margin-bottom: 28px; padding-bottom: 28px; }
+      h1, h2, h3 { line-height: 1.18; letter-spacing: 0; }
+      h1 { font-size: 42px; max-width: 880px; margin: 0 0 16px; }
+      h2 { font-size: 28px; margin: 0 0 16px; }
+      p { margin: 0 0 14px; }
+      .lede { color: var(--muted); font-size: 18px; max-width: 880px; }
+      .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 20px; }
+      .pill { border: 1px solid var(--line); border-radius: 999px; background: var(--paper); color: var(--muted); font-size: 13px; padding: 6px 10px; }
+      .panel { background: var(--paper); border: 1px solid var(--line); border-radius: 8px; margin: 18px 0; padding: 22px; }
+      code { background: #eef2f7; border: 1px solid #d8dee8; border-radius: 5px; padding: 1px 5px; }
+      pre { overflow: auto; background: #111827; color: #e5e7eb; border-radius: 8px; padding: 16px; }
+      pre code { background: transparent; border: 0; color: inherit; padding: 0; }
+      table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+      th, td { border-bottom: 1px solid var(--line); padding: 11px 12px; text-align: left; vertical-align: top; }
+      th { background: #eef2f7; color: var(--muted); font-size: 13px; text-transform: uppercase; }
+      tr:last-child td { border-bottom: 0; }
+      .quiz-question { border-top: 1px solid var(--line); padding: 18px 0; }
+      .quiz-question:first-child { border-top: 0; }
+      fieldset { border: 0; margin: 0; padding: 0; }
+      legend { font-weight: 700; margin-bottom: 10px; }
+      label { display: block; border: 1px solid var(--line); border-radius: 8px; background: #fbfdff; margin: 8px 0; padding: 10px 12px; cursor: pointer; }
+      @media (hover: hover) and (pointer: fine) {
+        label:hover { border-color: #b6c5d8; }
+      }
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 8px;
+        background: var(--accent);
+        color: #ffffff;
+        cursor: pointer;
+        font-weight: 700;
+        padding: 11px 16px;
+        transition: transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+      }
+      button:active { transform: scale(0.97); }
+      button.secondary { background: #475569; }
+      .quiz-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
+      #quizResult { font-weight: 700; }
+      .answer-detail { display: none; border-top: 1px dashed var(--line); color: var(--muted); margin-top: 10px; padding-top: 10px; }
+      .answer-detail.visible { display: block; }
+      .correct { border-color: #86efac !important; background: #f0fdf4 !important; }
+      .incorrect { border-color: #fecaca !important; background: #fef2f2 !important; }
+      @media (prefers-reduced-motion: reduce) { button { transition-duration: 0ms; } }
+      @media (max-width: 820px) { h1 { font-size: 32px; } main { padding: 32px 16px 56px; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>EOD Automation: Safe Outcomes and Manual-Close Alerts</h1>
+        <p class="lede">How Athena preserves automation evidence, tells admins when a day remains open, and avoids repeated cron email delivery.</p>
+        <div class="meta"><span class="pill">Delivery candidate</span><span class="pill">Branch codex/fix-eod-admin-alerts</span><span class="pill">Merge pending</span><span class="pill">Production deploy deferred</span><span class="pill">Local root alignment deferred</span></div>
+      </header>
+      <section class="panel"><h2>Executive Summary</h2>
+<p>This candidate fixes the EOD outcome ledger boundary and applies an explicit notification policy: every failed run and every skipped run except classification <code>completed</code> sends an action-required admin email. Applied and prepared reports keep their existing paths.</p>
+<p>Action-required delivery is reserved per recipient and store-day before the email provider is called. Successful sends are terminal, while failed or expired reservations can retry without every cron cycle resending the same alert.</p>
+</section>
+<section class="panel"><h2>Why It Mattered</h2>
+<p>The production incident began as a safe refusal to close: source evidence was incomplete, so Athena correctly did not complete the day. A second ledger patch then supplied eventIds as undefined; Convex removed the required field during validation and the visible outcome became a failure instead of a trustworthy skip.</p>
+<p>The operational consequence is the same whenever automation does not close the day: an operator must open EOD Review and finish manually. Silent skips leave admins without the instruction needed to close the operating day.</p>
+</section>
+<section class="panel"><h2>Mental Model</h2>
+<p>Treat EOD automation as a close attempt followed by an outcome router. The router trusts the recorded outcome and decision classification: failed and non-<code>completed</code> skipped outcomes require manual-close guidance. It does not independently query close state. A delivery ledger sits in front of the provider so retries are safe.</p>
+<ul>
+<li>Applied: the day closed; send the completed daily report.</li>
+<li>Prepared: manager review is expected; send the prepared report.</li>
+<li>Skipped and not classified completed: policy requires action-required guidance.</li>
+<li>Failed: policy requires action-required guidance and support context.</li>
+<li>Completed classification: no email because the day is already closed.</li>
+</ul>
+</section>
+<section class="panel"><h2>Before and After</h2>
+<p>Before, only fresh applied and prepared results entered the manager-report path. Skips and failures could leave an open day without admin notification, and the safe-skip outcome patch could erase the required eventIds evidence.</p>
+<p>After, optional patch fields are omitted unless a concrete value exists. The result router maps applied, prepared, skipped, and failed outcomes; every failure and every skip not classified <code>completed</code> carries the automation run ID into the action-required email path.</p>
+<pre><code>eventIds: undefined        -&gt; omit the patch field
+skipped + completed       -&gt; silent
+skipped + day still open -&gt; action-required email
+failed                    -&gt; action-required email</code></pre>
+</section>
+<section class="panel"><h2>Delivery and Retry Boundary</h2>
+<p>For each normalized admin email, Athena reserves an eod_action_required delivery keyed by domain, action, store, operating date, kind, and recipient. A pending reservation holds a five-minute lease. Sent is terminal; failed or expired reservations can be reclaimed and increment attemptCount.</p>
+<ul>
+<li>Provider failure marks the reservation failed and throws so a later scheduler run can retry.</li>
+<li>Recipients are processed sequentially; recipients already marked sent are suppressed on retry.</li>
+<li>The design is intentionally at-least-once at the provider boundary: acceptance followed by a failed sent-marker mutation can permit a later duplicate after lease expiry.</li>
+<li>Dedupe is once per recipient and store-day, so a later reason change that day does not send a second action-required email after success.</li>
+</ul>
+</section>
+<section class="panel"><h2>Operator Message</h2>
+<p>Skipped automation says Athena did not close the operating day and directs admins to open EOD Review, resolve remaining items, and complete the close.</p>
+<p>Failed automation says Athena could not complete the automated check, directs admins to close manually, and advises contacting support if the workflow is unavailable. Raw backend error text is not exposed as the primary instruction.</p>
+</section>
+<section class="panel"><h2>What Did Not Change</h2>
+
+<ul>
+<li>EOD eligibility, review thresholds, and close-command mechanics are unchanged.</li>
+<li>Applied and prepared daily-report behavior remains intact.</li>
+<li>ADMIN_EMAILS remains the recipient source; store-scoped recipient management is not added.</li>
+<li>Scheduled dispatch remains production-stage only.</li>
+<li>This delivery does not rerun the affected production day, align local root main, or deploy production services.</li>
+</ul>
+</section>
+<section class="panel"><h2>Validation and Current Status</h2>
+<p>Focused regression coverage proves safe skips retain eventIds, routing covers generic skips and completed suppression, email delivery retries after failure, and render copy gives manual-close guidance. The focused routing file passed 56 tests; the broader focused set previously passed 88 tests. Changed-Convex lint and diff checks passed, and Graphify was rebuilt to 10,565 nodes, 12,878 edges, and 2,529 communities.</p>
+<p>The merge-grade gate is being rerun after this required solution note and report are added. Merge is pending. Production deploy and local-root alignment are explicitly deferred by user request. A prior Convex code-generation command synchronized the configured development deployment; it did not deploy production.</p>
+</section>
+<section class="panel"><h2>Next-Time Guidance</h2>
+
+<ul>
+<li>Diagnose automation outcomes from the durable run and source-read evidence before treating a safe skip as a business-policy failure.</li>
+<li>Never patch a required Convex field with undefined; conditionally omit optional patch inputs.</li>
+<li>Route notifications by the operator action still required, not by a narrow list of backend classifications.</li>
+<li>Reserve external notifications before provider I/O and make retry semantics explicit in tests.</li>
+<li>When extending action-required mail, preserve the completed-classification silence and the per-recipient store-day dedupe boundary.</li>
+</ul>
+</section>
+      
+<section class="panel">
+  <h2>Key Files</h2>
+  <table>
+    <thead><tr><th>File</th><th>Why It Matters</th></tr></thead>
+    <tbody><tr><td><code>packages/athena-webapp/convex/automation/runLedger.ts</code></td><td>Preserves required eventIds evidence when a final outcome has no replacement IDs.</td></tr>
+<tr><td><code>packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts</code></td><td>Owns the outcome-to-notification policy and production-only dispatch.</td></tr>
+<tr><td><code>packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts</code></td><td>Validates actionable runs, builds live report data, reserves delivery, sends, and records success or failure.</td></tr>
+<tr><td><code>packages/athena-webapp/convex/emails/DailyManagerReport.tsx</code></td><td>Presents calm manual-close instructions and the EOD Review CTA.</td></tr>
+<tr><td><code>packages/athena-webapp/convex/schemas/automation.ts</code></td><td>Defines durable per-recipient delivery status, lease, attempts, and dedupe identity.</td></tr>
+<tr><td><code>packages/athena-webapp/convex/schema.ts</code></td><td>Registers the notification delivery table and indexes.</td></tr></tbody>
+  </table>
+</section>
+
+      
+<section class="panel">
+  <h2>Subagent Evidence</h2>
+  <ul><li><strong>session context:</strong> Reconstructed the production incident, policy discussion, finish-line changes, validation history, and development-deployment caveat from session evidence.</li>
+<li><strong>delivered diff:</strong> Mapped persistence, routing, email, schema, copy, tests, generated artifacts, unchanged behavior, and residual retry risks from the branch diff.</li></ul>
+</section>
+
+      
+<section id="quiz" class="panel">
+  <h2>Quiz: Pass Required</h2>
+  <p>You must score at least 8 out of 10 to pass.</p>
+  <form id="changeQuiz" data-threshold="8">
+    
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>1. Which recorded evidence suppresses an action-required email for a skipped EOD run?</legend>
+    <label><input type="radio" name="q1" value="0" /> The blocked classification</label>
+<label><input type="radio" name="q1" value="1" /> The completed classification</label>
+<label><input type="radio" name="q1" value="2" /> A variance below GH₵10</label>
+  </fieldset>
+  <div class="answer-detail">The router does not query close state; it suppresses a skipped run only when decision evidence is classified completed.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>2. Why is eventIds omitted from the outcome patch when no new IDs exist?</legend>
+    <label><input type="radio" name="q2" value="0" /> To preserve the required initialized value</label>
+<label><input type="radio" name="q2" value="1" /> To reduce email size</label>
+<label><input type="radio" name="q2" value="2" /> To disable audit history</label>
+  </fieldset>
+  <div class="answer-detail">Passing undefined can remove the required Convex field during validation; omission preserves the existing array.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>3. Which skipped outcome remains silent?</legend>
+    <label><input type="radio" name="q3" value="0" /> Outside completion window</label>
+<label><input type="radio" name="q3" value="1" /> Incomplete source reads</label>
+<label><input type="radio" name="q3" value="2" /> Already completed</label>
+  </fieldset>
+  <div class="answer-detail">A completed classification means no operator close action remains.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>4. What is the purpose of automationNotificationDelivery?</legend>
+    <label><input type="radio" name="q4" value="0" /> Replace automationRun</label>
+<label><input type="radio" name="q4" value="1" /> Prevent repeated successful alerts while supporting retries</label>
+<label><input type="radio" name="q4" value="2" /> Store email HTML forever</label>
+  </fieldset>
+  <div class="answer-detail">It reserves and records per-recipient action-required delivery state.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>5. What happens after a provider send fails?</legend>
+    <label><input type="radio" name="q5" value="0" /> The day is automatically closed</label>
+<label><input type="radio" name="q5" value="1" /> The reservation is marked failed and a later run may retry</label>
+<label><input type="radio" name="q5" value="2" /> The recipient is permanently suppressed</label>
+  </fieldset>
+  <div class="answer-detail">Failed reservations are retryable; successful sent reservations are terminal.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>6. What does a skipped-action email ask the admin to do?</legend>
+    <label><input type="radio" name="q6" value="0" /> Wait for tomorrow&#x27;s cron</label>
+<label><input type="radio" name="q6" value="1" /> Open EOD Review and complete the close manually</label>
+<label><input type="radio" name="q6" value="2" /> Delete the automation run</label>
+  </fieldset>
+  <div class="answer-detail">The message is operational: resolve remaining items and complete EOD Review.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>7. Which behavior intentionally remains unchanged?</legend>
+    <label><input type="radio" name="q7" value="0" /> Applied and prepared report paths</label>
+<label><input type="radio" name="q7" value="1" /> All skip outcomes are silent</label>
+<label><input type="radio" name="q7" value="2" /> Recipients become store-configurable</label>
+  </fieldset>
+  <div class="answer-detail">Existing applied and prepared reports remain; skip/failure action messaging is additive.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>8. What residual duplicate edge remains?</legend>
+    <label><input type="radio" name="q8" value="0" /> Provider accepts the email but marking sent fails</label>
+<label><input type="radio" name="q8" value="1" /> A sent reservation exists</label>
+<label><input type="radio" name="q8" value="2" /> The day is classified completed</label>
+  </fieldset>
+  <div class="answer-detail">After lease expiry, the system may retry because it cannot know the provider accepted the prior email.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>9. Where should future notification routing logic focus?</legend>
+    <label><input type="radio" name="q9" value="0" /> Raw backend wording</label>
+<label><input type="radio" name="q9" value="1" /> The operator action still required</label>
+<label><input type="radio" name="q9" value="2" /> The number of cron attempts</label>
+  </fieldset>
+  <div class="answer-detail">The durable product boundary is whether someone must still close the day.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>10. What tradeoff follows from deduping action-required mail once per recipient and store-day?</legend>
+    <label><input type="radio" name="q10" value="0" /> A later reason change that day does not send another alert after success</label>
+<label><input type="radio" name="q10" value="1" /> Every cron run sends a fresh alert</label>
+<label><input type="radio" name="q10" value="2" /> Failed deliveries can never retry</label>
+  </fieldset>
+  <div class="answer-detail">The dedupe key does not include the run or reason, so a successful alert suppresses later same-day action-required outcomes for that recipient.</div>
+</div>
+
+    <div class="quiz-actions">
+      <button type="button" id="gradeQuiz">Grade quiz</button>
+      <button type="button" class="secondary" id="resetQuiz">Reset</button>
+      <span id="quizResult" aria-live="polite"></span>
+    </div>
+  </form>
+</section>
+
+    </main>
+    <script>
+      const questions = Array.from(document.querySelectorAll(".quiz-question"));
+      const result = document.getElementById("quizResult");
+      const form = document.getElementById("changeQuiz");
+      const threshold = Number(form.dataset.threshold || 0);
+      function clearGrades() {
+        questions.forEach((question) => {
+          question.classList.remove("correct", "incorrect");
+          question.querySelector(".answer-detail").classList.remove("visible");
+        });
+        result.textContent = "";
+        result.style.color = "";
+      }
+      document.getElementById("gradeQuiz").addEventListener("click", () => {
+        clearGrades();
+        let score = 0;
+        questions.forEach((question, index) => {
+          const selected = document.querySelector(`input[name="q${index + 1}"]:checked`);
+          const isCorrect = selected && Number(selected.value) === Number(question.dataset.answer);
+          if (isCorrect) score += 1;
+          question.classList.add(isCorrect ? "correct" : "incorrect");
+          question.querySelector(".answer-detail").classList.add("visible");
+        });
+        const passed = score >= threshold;
+        result.textContent = passed
+          ? `Passed: ${score}/${questions.length}.`
+          : `Not passed: ${score}/${questions.length}. Review the report and try again.`;
+        result.style.color = passed ? "var(--good)" : "var(--bad)";
+      });
+      document.getElementById("resetQuiz").addEventListener("click", () => {
+        form.reset();
+        clearGrades();
+      });
+    </script>
+  </body>
+</html>

--- a/docs/solutions/architecture-patterns/athena-eod-automation-manager-report-emails-2026-07-04.md
+++ b/docs/solutions/architecture-patterns/athena-eod-automation-manager-report-emails-2026-07-04.md
@@ -1,6 +1,7 @@
 ---
 title: Athena EOD Automation Manager Report Emails
 date: 2026-07-04
+last_updated: 2026-07-16
 category: architecture-patterns
 module: athena-webapp
 problem_type: architecture_pattern
@@ -16,18 +17,19 @@ tags:
   - mailersend
   - convex-actions
   - daily-close
+delivery_diff_fingerprint: 0f3e6994d617f1b1a3a772ecfb438053d25592b79bb8dd8e68c23c750d702f7c
 ---
 
 # Athena EOD Automation Manager Report Emails
 
 ## Problem
 
-Athena needed to send a manager-facing daily report after the EOD automation
-successfully completed a store day or prepared the EOD Review for manager
-review. Completed reports depend on the completed `dailyClose.reportSnapshot`,
-while prepared reports are assembled from the live EOD Review snapshot. Both
-paths use live register-session cash-position corrections, store currency
-formatting, and the admin-recipient list in `ADMIN_EMAILS`.
+Athena needs to tell managers both when EOD automation completes a store day
+and when it leaves the day open for manual close. Completed reports depend on
+the completed `dailyClose.reportSnapshot`, while prepared, skipped, and failed
+reports are assembled from the live EOD Review snapshot. These paths use live
+register-session cash-position corrections, store currency formatting, and the
+admin-recipient list in `ADMIN_EMAILS`.
 
 The tempting implementation is to send directly from the daily close mutation,
 but email delivery is network I/O. In Convex, that belongs in an action, while
@@ -46,24 +48,29 @@ scheduled automation entrypoint:
 - `sendDailyManagerReportToAdminsForDate` is an internal action that assembles
   the report payload for one completed operating date and sends it to every
   recipient in `ADMIN_EMAILS`.
+- `automationNotificationDelivery` reserves one action-required delivery per
+  store, operating date, notification kind, and normalized recipient email.
+  Sent reservations are terminal; failed or expired reservations can retry.
 - Manual and support sends stay separate through the existing explicit
   recipient actions.
 
-The important guard is filtering only fresh action results:
+The important guard follows an explicit outcome policy: notify for every failed
+run and every skipped run unless decision evidence classifies it as already
+completed. The router does not independently query close state.
 
 ```ts
-function isReportableEodAutoCompleteResult(result) {
-  return (
-    (result?.action === "applied" && result.run.outcome === "applied") ||
-    (result?.action === "recorded" && result.run.outcome === "prepared")
-  );
+if (result.run.outcome === "skipped") {
+  return result.run.decisionEvidence?.classification === "completed"
+    ? null
+    : "skipped";
 }
 ```
 
-That includes fresh completed reports and fresh prepared-for-review reports,
-while excluding dry runs, disabled policies, skipped outcomes, and
-`already_recorded` idempotency returns so scheduled retries do not resend old
-reports.
+This includes fresh completed and prepared reports plus every skipped or failed
+run covered by the manual-close policy. Dry runs, disabled policies, and
+already-completed outcomes remain silent. Per-recipient delivery
+reservations prevent scheduled retries from resending a successful alert while
+still allowing provider failures to retry.
 
 ## Why This Matters
 
@@ -79,13 +86,24 @@ live EOD Review snapshot and link managers back to EOD Review as the CTA. Live
 register-session reads can correct cash position for historical days with
 multiple sessions in both paths.
 
+Outcome patches must also omit optional fields rather than explicitly passing
+`undefined`. Convex strips `undefined` values before validation, so patching a
+required field such as `eventIds` with `undefined` can remove the required
+field. Preserve the existing ledger value unless a concrete replacement exists.
+
 ## Prevention
 
 - Keep network delivery out of Convex mutations. Use an internal action wrapper
   when an automation mutation needs to trigger email, webhooks, or other
   external side effects.
-- Filter notification sends by fresh reportable automation results, not by the
-  presence of any applied automation run.
+- Route notification sends from the recorded outcome and classification. A
+  failed run and any skipped run not classified `completed` require
+  manual-close guidance.
+- Reserve action-required delivery per recipient before calling the provider,
+  mark successful sends terminal, and make failed or expired reservations
+  retryable.
+- When patching Convex documents, spread optional fields only when they are
+  defined so required ledger evidence cannot be stripped accidentally.
 - Preserve explicit manual-send actions for development or support workflows so
   scheduled manager notifications do not reuse ad hoc recipient arguments.
 - Add tests at both seams: one for the automation action filter and one for the
@@ -110,8 +128,17 @@ const result = await ctx.runMutation(
   {},
 );
 
-await sendDailyManagerReportsForAppliedEodAutomationWithCtx(ctx, {
+await sendDailyManagerReportsForEodAutomationWithCtx(ctx, {
   results: result.eodAutoCompleteResults,
+});
+```
+
+An optional outcome field should only be included when present:
+
+```ts
+await ctx.db.patch("automationRun", runId, {
+  ...(args.eventIds === undefined ? {} : { eventIds: args.eventIds }),
+  outcome: args.outcome,
 });
 ```
 
@@ -131,4 +158,6 @@ for (const recipient of ADMIN_EMAILS) {
 
 - `packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts`
 - `packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts`
+- `packages/athena-webapp/convex/automation/runLedger.ts`
+- `packages/athena-webapp/convex/schemas/automation.ts`
 - `packages/athena-webapp/convex/constants/email.ts`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10563 nodes · 12875 edges · 2529 communities detected
+- 10565 nodes · 12878 edges · 2529 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2724,39 +2724,39 @@ Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChanged
 
 ### Community 39 - "Community 39"
 Cohesion: 0.14
-Nodes (25): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+17 more)
+Nodes (21): buildBlockers(), buildCarryForwardItems(), buildCashMetrics(), buildDailyManagerReportPayload(), buildOpenDailyManagerReportPayload(), buildPaymentTotals(), buildPreparedBlockers(), buildPreparedCarryForwardItems() (+13 more)
 
 ### Community 40 - "Community 40"
+Cohesion: 0.14
+Nodes (25): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+17 more)
+
+### Community 41 - "Community 41"
 Cohesion: 0.21
 Nodes (27): addSafeIntegers(), allocateCostParts(), applyInboundPart(), applyInboundValuation(), applyOutboundValuation(), applyReturnValuation(), applyValuationCorrection(), assertNonemptyString() (+19 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.18
 Nodes (28): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isExpenseLocalSyncEvent(), isSyncablePosLocalEvent() (+20 more)
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.13
 Nodes (24): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClearedRegisterSessionCloseoutDatePatch(), buildClosedRegisterSessionPatch(), buildOperatingDateEvidence(), buildRegisterSession(), buildRegisterSessionCloseoutPatch() (+16 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.15
 Nodes (28): applyDeferredDeficitTransition(), applyInventoryEffectWithCtx(), applyLateValuationTransition(), applySkuValuationCorrectionWithCtx(), applyValuationTransition(), assertDeficitTransitionReconciles(), assertInteger(), assertNonempty() (+20 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.14
 Nodes (23): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+15 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.15
-Nodes (20): buildBlockers(), buildCarryForwardItems(), buildCashMetrics(), buildDailyManagerReportPayload(), buildPaymentTotals(), buildPreparedBlockers(), buildPreparedCarryForwardItems(), buildPreparedDailyManagerReportPayload() (+12 more)
 
 ### Community 48 - "Community 48"
 Cohesion: 0.07
@@ -3307,28 +3307,28 @@ Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 185 - "Community 185"
-Cohesion: 0.29
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 186 - "Community 186"
 Cohesion: 0.31
 Nodes (9): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), ensurePaymentAllocationReportingWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), matchesExistingAllocation(), matchesKeyedAllocation(), paymentAllocationReportingIdentity() (+1 more)
 
-### Community 187 - "Community 187"
+### Community 186 - "Community 186"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 188 - "Community 188"
+### Community 187 - "Community 187"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 189 - "Community 189"
+### Community 188 - "Community 188"
 Cohesion: 0.29
 Nodes (7): assertAuthorizedPosBackfillLineage(), assertField(), authorizationEnvelope(), authorizeStoreTimezoneWithCtx(), fnv1a(), requireAuthorizedLineageWithCtx(), storeTimezoneAuthorizationContentHash()
 
-### Community 190 - "Community 190"
+### Community 189 - "Community 189"
 Cohesion: 0.22
 Nodes (4): buildStoreIntradayProjection(), checkpointAtOrBefore(), persistedCheckpointAt(), safeAdd()
+
+### Community 190 - "Community 190"
+Cohesion: 0.29
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.47
@@ -3599,24 +3599,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 258 - "Community 258"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 259 - "Community 259"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 261 - "Community 261"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
 ### Community 262 - "Community 262"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 263 - "Community 263"
 Cohesion: 0.39

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2603
-- Graph nodes: 10563
-- Graph edges: 12875
+- Graph nodes: 10565
+- Graph edges: 12878
 - Communities: 2529
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/automation/automationFoundation.test.ts
+++ b/packages/athena-webapp/convex/automation/automationFoundation.test.ts
@@ -429,6 +429,51 @@ describe("automation foundation", () => {
     );
   });
 
+  it("preserves required event ids when an eligible action safely skips", async () => {
+    const { db, patches } = createDb({
+      automationPolicy: [
+        {
+          _id: "policy-1",
+          action: "opening.auto_start",
+          createdAt: 1,
+          domain: "test_domain",
+          mode: "enabled",
+          policyVersion: "policy.v2",
+          storeId: "store-1",
+          updatedAt: 1,
+        },
+      ],
+    });
+
+    const result = await evaluateAutomationActionWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        action,
+        adapterDecision: eligibleDecision,
+        apply: vi.fn().mockResolvedValue({
+          error: {
+            code: "precondition_failed",
+            message: "The action needs manager review.",
+          },
+          outcome: "skipped" as const,
+        }),
+        idempotencyKey:
+          "test_domain:opening.auto_start:store-1:2026-06-08",
+        operatingDate: "2026-06-08",
+        storeId: "store-1" as Id<"store">,
+      },
+    );
+
+    expect(result.run).toMatchObject({
+      error: {
+        code: "precondition_failed",
+      },
+      eventIds: [],
+      outcome: "skipped",
+    });
+    expect(patches.at(-1)?.value).not.toHaveProperty("eventIds");
+  });
+
   it("records invalid adapter input as a failed run without mutation", async () => {
     const { db } = createDb({
       automationPolicy: [

--- a/packages/athena-webapp/convex/automation/runLedger.ts
+++ b/packages/athena-webapp/convex/automation/runLedger.ts
@@ -532,7 +532,7 @@ export async function patchAutomationRunOutcomeWithCtx(
     appliedAt: args.appliedAt,
     decisionEvidence: args.decisionEvidence,
     error: args.error,
-    eventIds: args.eventIds,
+    ...(args.eventIds === undefined ? {} : { eventIds: args.eventIds }),
     outcome: args.outcome,
     updatedAt: Date.now(),
   });

--- a/packages/athena-webapp/convex/emails/DailyManagerReport.test.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReport.test.tsx
@@ -81,7 +81,10 @@ describe("DailyManagerReport", () => {
 
     expect(html).toContain("Ready for manager review");
     expect(html).not.toContain("Review the close when you are ready.");
-    expect(html).toContain("Next opening");
+    expect(html).toContain("Manager review");
+    expect(html).toContain(
+      "Review EOD Review before completing the store day.",
+    );
     expect(html).not.toContain("Register session is still open");
     expect(html).not.toContain("Front Counter is still open.");
     expect(html).not.toContain(
@@ -238,11 +241,12 @@ describe("DailyManagerReport", () => {
       />,
     );
 
-    expect(html).toContain("Automation failed");
+    expect(html).toContain("Automation needs attention");
     expect(html).toContain(
-      "Athena could not finish the EOD Review automation check.",
+      "Athena could not complete the automated EOD check.",
     );
-    expect(html).toContain("Before close");
+    expect(html).toContain("Required action");
+    expect(html).toContain("Open EOD Review");
     expect(html).toContain("Register session open");
     expect(html).toContain("Front Counter is still open.");
     expect(html).toContain(

--- a/packages/athena-webapp/convex/emails/DailyManagerReport.tsx
+++ b/packages/athena-webapp/convex/emails/DailyManagerReport.tsx
@@ -113,16 +113,17 @@ const statusCopy: Record<DailyReportStatus, DailyReportStatusCopy> = {
     tone: "warning",
   },
   skipped: {
-    label: "Skipped",
-    preview: "EOD automation did not change the workflow.",
-    summary: "EOD automation did not change the workflow. Review EOD manually.",
+    label: "Manager action required",
+    preview: "EOD Review needs manager action.",
+    summary:
+      "Athena did not close this operating day. Open EOD Review, resolve the remaining items, and complete the close.",
     tone: "warning",
   },
   failed: {
-    label: "Automation failed",
-    preview: "EOD automation could not finish.",
+    label: "Automation needs attention",
+    preview: "EOD automation needs attention.",
     summary:
-      "Athena could not finish the EOD Review automation check. Open the workflow to review.",
+      "Athena could not complete the automated EOD check. Open EOD Review and complete the close manually. Contact support if the workflow is unavailable.",
     tone: "danger",
   },
   dry_run: {
@@ -187,19 +188,30 @@ export default function DailyManagerReport({
     blockers,
     carryForwardItems,
   });
+  const actionRequired = status === "skipped" || status === "failed";
   const hasRegisterSessionBlocker = blockers.some(isRegisterSessionBlocker);
   const expectedCashMetrics = cashMetrics.filter((metric) =>
     /expected cash/i.test(metric.label),
   );
-  const handoffSectionTitle =
-    blockers.length > 0 ? "Before close" : "Next opening";
+  const handoffSectionTitle = actionRequired
+    ? "Required action"
+    : status === "prepared"
+      ? "Manager review"
+      : blockers.length > 0
+        ? "Before close"
+        : "Next opening";
+  const emptyAttentionCopy = actionRequired
+    ? "Open EOD Review and complete the close manually."
+    : status === "prepared"
+      ? "Review EOD Review before completing the store day."
+      : "No follow-up needed for this operating day.";
   const attentionSummary = buildAttentionSummary({
     blockers: blockers.length,
     carryForward: carryForwardItems.length,
     reviewed: reviewedItems.length,
     status,
   });
-  const showStatusBadge = blockers.length > 0;
+  const showStatusBadge = actionRequired || blockers.length > 0;
 
   return (
     <Html>
@@ -214,7 +226,9 @@ export default function DailyManagerReport({
           }
         >
           <Section style={styles.header}>
-            <Text style={styles.eyebrow}>Athena daily report</Text>
+            <Text style={styles.eyebrow}>
+              {actionRequired ? "Athena EOD alert" : "Athena daily report"}
+            </Text>
             <Text style={styles.title}>{storeName}</Text>
             <Text style={styles.subtitle}>
               {operatingDate} | {timestampLabel} at {completedAt} by{" "}
@@ -244,9 +258,7 @@ export default function DailyManagerReport({
           <Section style={styles.section}>
             <SectionHeading title={handoffSectionTitle} quietTitle />
             {attentionItems.length === 0 ? (
-              <EmptyState>
-                No follow-up needed for this operating day.
-              </EmptyState>
+              <EmptyState>{emptyAttentionCopy}</EmptyState>
             ) : (
               <Section style={styles.attentionList}>
                 {attentionItems.slice(0, 4).map((item) => (
@@ -304,7 +316,9 @@ export default function DailyManagerReport({
 
           <Section style={styles.actionSection}>
             <Button href={reportUrl} style={styles.button}>
-              <span style={styles.buttonLabel}>View EOD Review</span>
+              <span style={styles.buttonLabel}>
+                {actionRequired ? "Open EOD Review" : "View EOD Review"}
+              </span>
               <ArrowUpRight
                 aria-hidden="true"
                 color={colors.foreground}
@@ -335,6 +349,9 @@ function buildAttentionSummary(args: {
   }
   if (args.reviewed > 0) {
     return `${args.reviewed} reviewed`;
+  }
+  if (args.status === "skipped" || args.status === "failed") {
+    return "Action required";
   }
   return "Status update";
 }

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.test.ts
@@ -1,12 +1,26 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { internal } from "../_generated/api";
 import { ADMIN_EMAILS } from "../constants/email";
+import schema from "../schema";
 import {
   buildCashMetrics,
   buildSummaryMetrics,
   resolveAppUrl,
   sendDailyManagerReportToAdminsForDateWithCtx,
 } from "./dailyManagerReportEmail";
+
+const modules = Object.fromEntries(
+  Object.entries(import.meta.glob("../**/*.ts")).map(([path, loader]) => [
+    path.startsWith("../")
+      ? path.replace(/^\.\.\//, "./")
+      : path.replace(/^\.\//, "./operations/"),
+    loader,
+  ]),
+);
 
 const originalEnv = {
   ATHENA_APP_URL: process.env.ATHENA_APP_URL,
@@ -213,5 +227,199 @@ describe("daily manager report email URLs", () => {
       status: 202,
       storeName: "Accra",
     });
+  });
+
+  it("sends one action-required EOD report per reserved admin delivery", async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(null, { status: 202 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const report = {
+      blockers: [],
+      carryForwardItems: [],
+      cashMetrics: [],
+      completedAt: "10:00 PM",
+      completedBy: "Athena",
+      operatingDate: "Thursday, July 16",
+      operatingDateValue: "2026-07-16",
+      paymentTotals: [],
+      reportUrl:
+        "https://athena.wigclub.store/wigclub/store/wigclub/operations/daily-close?operatingDate=2026-07-16",
+      reviewedItems: [],
+      status: "skipped",
+      storeCurrency: "GHS",
+      storeName: "Wigclub",
+      summaryMetrics: [],
+    };
+    const runQuery = vi.fn(async () => report);
+    const runMutation = vi.fn(
+      async (_functionRef: unknown, args: Record<string, unknown>) =>
+        "recipientEmail" in args
+          ? `delivery-${String(args.recipientEmail)}`
+          : null,
+    );
+
+    const result = await sendDailyManagerReportToAdminsForDateWithCtx(
+      { runMutation, runQuery } as never,
+      {
+        automationRunId: "automation-run-1" as never,
+        operatingDate: "2026-07-16",
+        status: "skipped",
+        storeId: "store-1" as never,
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(ADMIN_EMAILS.length);
+    const body = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit).body),
+    );
+    expect(body.subject).toBe(
+      "Action required: Wigclub EOD Review - Thursday, July 16",
+    );
+    expect(body.html).toContain("Manager action required");
+    expect(body.html).toContain("Athena EOD alert");
+    expect(body.html).not.toContain("Athena daily report");
+    expect(body.html).toContain(
+      "Athena did not close this operating day.",
+    );
+    expect(body.html).toContain("Open EOD Review");
+    expect(body.html).not.toContain(
+      "No follow-up needed for this operating day.",
+    );
+    expect(runMutation).toHaveBeenCalledTimes(ADMIN_EMAILS.length * 2);
+    expect(result).toHaveLength(ADMIN_EMAILS.length);
+  });
+
+  it("does not resend an action-required EOD report after delivery was claimed", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const runQuery = vi.fn(async () => ({
+      completedAt: "10:00 PM",
+      completedBy: "Athena",
+      operatingDate: "Thursday, July 16",
+      operatingDateValue: "2026-07-16",
+      reportUrl:
+        "https://athena.wigclub.store/wigclub/store/wigclub/operations/daily-close?operatingDate=2026-07-16",
+      status: "failed",
+      storeName: "Wigclub",
+    }));
+    const runMutation = vi.fn(async () => null);
+
+    const result = await sendDailyManagerReportToAdminsForDateWithCtx(
+      { runMutation, runQuery } as never,
+      {
+        automationRunId: "automation-run-1" as never,
+        operatingDate: "2026-07-16",
+        status: "failed",
+        storeId: "store-1" as never,
+      },
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it("deduplicates sent alerts and retries failed delivery reservations", async () => {
+    const t = convexTest(schema, modules);
+    const { firstRunId, secondRunId } = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("athenaUser", {
+        email: "owner@example.com",
+        normalizedEmail: "owner@example.com",
+      });
+      const organizationId = await ctx.db.insert("organization", {
+        createdByUserId: userId,
+        name: "Accra",
+        slug: "accra",
+      });
+      const storeId = await ctx.db.insert("store", {
+        createdByUserId: userId,
+        currency: "GHS",
+        name: "Accra",
+        organizationId,
+        slug: "accra",
+      });
+      const baseRun = {
+        action: "eod.auto_complete",
+        createdAt: 1,
+        domain: "daily_operations",
+        eventIds: [],
+        idempotencyKey: `daily_operations:eod.auto_complete:${storeId}:2026-07-16`,
+        mutationBoundary: "daily_close",
+        operatingDate: "2026-07-16",
+        organizationId,
+        policyMode: "enabled" as const,
+        policyVersion: "daily-operations.v1",
+        snapshotCounts: {},
+        sourceSubjects: [],
+        storeId,
+        triggerType: "scheduled",
+        updatedAt: 1,
+      };
+      const firstRunId = await ctx.db.insert("automationRun", {
+        ...baseRun,
+        outcome: "skipped",
+      });
+      const secondRunId = await ctx.db.insert("automationRun", {
+        ...baseRun,
+        createdAt: 2,
+        idempotencyKey: `${baseRun.idempotencyKey}:retry`,
+        outcome: "failed",
+        updatedAt: 2,
+      });
+      return { firstRunId, secondRunId };
+    });
+
+    const deliveryId = await t.mutation(
+      internal.operations.dailyManagerReportEmail
+        .reserveActionRequiredDailyManagerReportDelivery,
+      {
+        automationRunId: firstRunId,
+        recipientEmail: "ADMIN@EXAMPLE.COM ",
+      },
+    );
+    expect(deliveryId).not.toBeNull();
+
+    await t.mutation(
+      internal.operations.dailyManagerReportEmail
+        .markActionRequiredDailyManagerReportDeliveryFailed,
+      { deliveryId: deliveryId! },
+    );
+    await expect(
+      t.mutation(
+        internal.operations.dailyManagerReportEmail
+          .reserveActionRequiredDailyManagerReportDelivery,
+        {
+          automationRunId: secondRunId,
+          recipientEmail: "admin@example.com",
+        },
+      ),
+    ).resolves.toBe(deliveryId);
+
+    const delivery = await t.run((ctx) =>
+      ctx.db.get("automationNotificationDelivery", deliveryId!),
+    );
+    expect(delivery).toMatchObject({
+      attemptCount: 2,
+      automationRunId: secondRunId,
+      recipientEmail: "admin@example.com",
+      status: "pending",
+    });
+
+    await t.mutation(
+      internal.operations.dailyManagerReportEmail
+        .markActionRequiredDailyManagerReportDeliverySent,
+      { deliveryId: deliveryId! },
+    );
+    await expect(
+      t.mutation(
+        internal.operations.dailyManagerReportEmail
+          .reserveActionRequiredDailyManagerReportDelivery,
+        {
+          automationRunId: firstRunId,
+          recipientEmail: "admin@example.com",
+        },
+      ),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
+++ b/packages/athena-webapp/convex/operations/dailyManagerReportEmail.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import {
   action,
   internalAction,
+  internalMutation,
   internalQuery,
   type ActionCtx,
   type QueryCtx,
@@ -73,12 +74,17 @@ type RegisterCashPositionSummary = {
   registerVarianceCount: number;
 };
 
-type DailyManagerReportSendStatus = "applied" | "prepared";
+type DailyManagerReportSendStatus =
+  | "applied"
+  | "prepared"
+  | "skipped"
+  | "failed";
 type PreparedDailyCloseSnapshot = Awaited<
   ReturnType<typeof buildDailyCloseSnapshotWithCtx>
 >;
 
 const REGISTER_SESSION_EMAIL_SOURCE_LIMIT = 1000;
+const ACTION_REQUIRED_DELIVERY_LEASE_MS = 5 * 60 * 1000;
 
 export const getMostRecentDailyManagerReportPayload = internalQuery({
   args: {
@@ -226,6 +232,161 @@ export const getPreparedDailyManagerReportPayloadForDate = internalQuery({
   },
 });
 
+export const getActionRequiredDailyManagerReportPayloadForRun = internalQuery({
+  args: {
+    automationRunId: v.id("automationRun"),
+  },
+  handler: async (ctx, args): Promise<DailyManagerReportPayload | null> => {
+    const run = await ctx.db.get("automationRun", args.automationRunId);
+
+    if (
+      !run ||
+      run.action !== "eod.auto_complete" ||
+      (run.outcome !== "skipped" && run.outcome !== "failed")
+    ) {
+      return null;
+    }
+
+    const store = await resolveStore(ctx, { storeId: run.storeId });
+    const snapshot = await buildDailyCloseSnapshotWithCtx(ctx, {
+      operatingDate: run.operatingDate,
+      storeId: run.storeId,
+    });
+    const cashPositionSummary = await buildRegisterCashPositionSummary(ctx, {
+      endAt: snapshot.endAt,
+      operatingDate: snapshot.operatingDate,
+      startAt: snapshot.startAt,
+      storeId: store._id,
+    });
+
+    return buildOpenDailyManagerReportPayload({
+      cashPositionSummary,
+      completedTimezone: await resolveStoreScheduleTimezoneForAt(ctx, {
+        at: run.updatedAt,
+        storeId: store._id,
+      }),
+      snapshot,
+      status: run.outcome,
+      statusAt: run.updatedAt,
+      store,
+    });
+  },
+});
+
+function actionRequiredDeliveryDedupeKey(args: {
+  operatingDate: string;
+  recipientEmail: string;
+  storeId: Id<"store">;
+}) {
+  return [
+    "daily_operations",
+    "eod.auto_complete",
+    args.storeId,
+    args.operatingDate,
+    "eod_action_required",
+    args.recipientEmail.trim().toLowerCase(),
+  ].join(":");
+}
+
+export const reserveActionRequiredDailyManagerReportDelivery = internalMutation({
+  args: {
+    automationRunId: v.id("automationRun"),
+    recipientEmail: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get("automationRun", args.automationRunId);
+
+    if (
+      !run ||
+      run.action !== "eod.auto_complete" ||
+      (run.outcome !== "skipped" && run.outcome !== "failed")
+    ) {
+      return null;
+    }
+
+    const now = Date.now();
+    const recipientEmail = args.recipientEmail.trim().toLowerCase();
+    const dedupeKey = actionRequiredDeliveryDedupeKey({
+      operatingDate: run.operatingDate,
+      recipientEmail,
+      storeId: run.storeId,
+    });
+    const existing = await ctx.db
+      .query("automationNotificationDelivery")
+      .withIndex("by_dedupeKey", (q) => q.eq("dedupeKey", dedupeKey))
+      .unique();
+
+    if (
+      existing?.status === "sent" ||
+      (existing?.status === "pending" &&
+        typeof existing.leaseExpiresAt === "number" &&
+        existing.leaseExpiresAt > now)
+    ) {
+      return null;
+    }
+
+    if (existing) {
+      await ctx.db.patch("automationNotificationDelivery", existing._id, {
+        attemptCount: existing.attemptCount + 1,
+        automationRunId: run._id,
+        failedAt: undefined,
+        leaseExpiresAt: now + ACTION_REQUIRED_DELIVERY_LEASE_MS,
+        status: "pending",
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+
+    return ctx.db.insert("automationNotificationDelivery", {
+      action: run.action,
+      attemptCount: 1,
+      automationRunId: run._id,
+      createdAt: now,
+      dedupeKey,
+      domain: run.domain,
+      leaseExpiresAt: now + ACTION_REQUIRED_DELIVERY_LEASE_MS,
+      notificationKind: "eod_action_required",
+      operatingDate: run.operatingDate,
+      organizationId: run.organizationId,
+      recipientEmail,
+      status: "pending",
+      storeId: run.storeId,
+      updatedAt: now,
+    });
+  },
+});
+
+export const markActionRequiredDailyManagerReportDeliverySent = internalMutation({
+  args: {
+    deliveryId: v.id("automationNotificationDelivery"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await ctx.db.patch("automationNotificationDelivery", args.deliveryId, {
+      leaseExpiresAt: undefined,
+      sentAt: now,
+      status: "sent",
+      updatedAt: now,
+    });
+  },
+});
+
+export const markActionRequiredDailyManagerReportDeliveryFailed =
+  internalMutation({
+    args: {
+      deliveryId: v.id("automationNotificationDelivery"),
+    },
+    handler: async (ctx, args) => {
+      const now = Date.now();
+      await ctx.db.patch("automationNotificationDelivery", args.deliveryId, {
+        failedAt: now,
+        leaseExpiresAt: undefined,
+        status: "failed",
+        updatedAt: now,
+      });
+    },
+  });
+
 export const sendMostRecentDailyManagerReport = action({
   args: {
     recipientEmail: v.string(),
@@ -311,8 +472,9 @@ export const sendDailyManagerReportsForDateRange = action({
 });
 
 export async function sendDailyManagerReportToAdminsForDateWithCtx(
-  ctx: Pick<ActionCtx, "runQuery">,
+  ctx: Pick<ActionCtx, "runMutation" | "runQuery">,
   args: {
+    automationRunId?: Id<"automationRun">;
     operatingDate: string;
     preparedAt?: number;
     status?: DailyManagerReportSendStatus;
@@ -320,43 +482,88 @@ export async function sendDailyManagerReportToAdminsForDateWithCtx(
   },
 ): Promise<SentDailyManagerReport[]> {
   const status = args.status ?? "applied";
-  const report =
-    status === "prepared"
-      ? await ctx.runQuery(
-          internal.operations.dailyManagerReportEmail
-            .getPreparedDailyManagerReportPayloadForDate,
-          {
-            operatingDate: args.operatingDate,
-            preparedAt: args.preparedAt,
-            storeId: args.storeId,
-          },
-        )
-      : (
-          await ctx.runQuery(
-            internal.operations.dailyManagerReportEmail
-              .getDailyManagerReportPayloadsForDateRange,
-            {
-              endOperatingDate: args.operatingDate,
-              startOperatingDate: args.operatingDate,
-              storeId: args.storeId,
-            },
-          )
-        )[0];
+  const actionRequired = status === "skipped" || status === "failed";
+  let report: DailyManagerReportPayload | null | undefined;
+
+  if (actionRequired && !args.automationRunId) {
+    throw new Error("Action-required EOD email requires an automation run.");
+  }
+
+  if (status === "prepared") {
+    report = await ctx.runQuery(
+      internal.operations.dailyManagerReportEmail
+        .getPreparedDailyManagerReportPayloadForDate,
+      {
+        operatingDate: args.operatingDate,
+        preparedAt: args.preparedAt,
+        storeId: args.storeId,
+      },
+    );
+  } else if (actionRequired && args.automationRunId) {
+    report = await ctx.runQuery(
+      internal.operations.dailyManagerReportEmail
+        .getActionRequiredDailyManagerReportPayloadForRun,
+      { automationRunId: args.automationRunId },
+    );
+  } else if (!actionRequired) {
+    report = (
+      await ctx.runQuery(
+        internal.operations.dailyManagerReportEmail
+          .getDailyManagerReportPayloadsForDateRange,
+        {
+          endOperatingDate: args.operatingDate,
+          startOperatingDate: args.operatingDate,
+          storeId: args.storeId,
+        },
+      )
+    )[0];
+  }
 
   if (!report) return [];
 
   const sentReports: SentDailyManagerReport[] = [];
 
   for (const recipient of ADMIN_EMAILS) {
+    const deliveryId =
+      actionRequired && args.automationRunId
+        ? await ctx.runMutation(
+            internal.operations.dailyManagerReportEmail
+              .reserveActionRequiredDailyManagerReportDelivery,
+            {
+              automationRunId: args.automationRunId,
+              recipientEmail: recipient.email,
+            },
+          )
+        : null;
+
+    if (actionRequired && !deliveryId) continue;
+
     const response = await sendDailyManagerReportEmail({
       ...report,
       recipientEmail: recipient.email,
       recipientName: recipient.name,
-      subject: `${report.storeName} daily report - ${report.operatingDate}`,
+      subject: actionRequired
+        ? `Action required: ${report.storeName} EOD Review - ${report.operatingDate}`
+        : `${report.storeName} daily report - ${report.operatingDate}`,
     });
 
     if (!response.ok) {
+      if (deliveryId) {
+        await ctx.runMutation(
+          internal.operations.dailyManagerReportEmail
+            .markActionRequiredDailyManagerReportDeliveryFailed,
+          { deliveryId },
+        );
+      }
       throw new Error(await response.text());
+    }
+
+    if (deliveryId) {
+      await ctx.runMutation(
+        internal.operations.dailyManagerReportEmail
+          .markActionRequiredDailyManagerReportDeliverySent,
+        { deliveryId },
+      );
     }
 
     sentReports.push({
@@ -373,9 +580,17 @@ export async function sendDailyManagerReportToAdminsForDateWithCtx(
 
 export const sendDailyManagerReportToAdminsForDate = internalAction({
   args: {
+    automationRunId: v.optional(v.id("automationRun")),
     operatingDate: v.string(),
     preparedAt: v.optional(v.number()),
-    status: v.optional(v.union(v.literal("applied"), v.literal("prepared"))),
+    status: v.optional(
+      v.union(
+        v.literal("applied"),
+        v.literal("prepared"),
+        v.literal("skipped"),
+        v.literal("failed"),
+      ),
+    ),
     storeId: v.id("store"),
   },
   handler: (ctx, args) =>
@@ -465,6 +680,24 @@ function buildPreparedDailyManagerReportPayload(args: {
   snapshot: PreparedDailyCloseSnapshot;
   store: Doc<"store">;
 }): DailyManagerReportPayload {
+  return buildOpenDailyManagerReportPayload({
+    cashPositionSummary: args.cashPositionSummary,
+    completedTimezone: args.completedTimezone,
+    snapshot: args.snapshot,
+    status: "prepared",
+    statusAt: args.preparedAt ?? Date.now(),
+    store: args.store,
+  });
+}
+
+function buildOpenDailyManagerReportPayload(args: {
+  cashPositionSummary?: RegisterCashPositionSummary;
+  completedTimezone: string;
+  snapshot: PreparedDailyCloseSnapshot;
+  status: "prepared" | "skipped" | "failed";
+  statusAt: number;
+  store: Doc<"store">;
+}): DailyManagerReportPayload {
   const storeCurrency = normalizeCurrency(args.store.currency);
   const money = moneyFormatter(storeCurrency);
   const summary = {
@@ -478,12 +711,12 @@ function buildPreparedDailyManagerReportPayload(args: {
     storeName: args.store.name,
     operatingDate: formatOperatingDate(args.snapshot.operatingDate),
     completedAt: formatCompletedAt(
-      args.preparedAt ?? Date.now(),
+      args.statusAt,
       args.completedTimezone,
     ),
     completedBy: "Athena",
     storeCurrency,
-    status: "prepared",
+    status: args.status,
     reportUrl,
     reviewedItems: buildPreparedReviewItems(args.snapshot),
     carryForwardItems: buildPreparedCarryForwardItems(args.snapshot),
@@ -491,7 +724,10 @@ function buildPreparedDailyManagerReportPayload(args: {
     summaryMetrics: buildSummaryMetrics(summary, money),
     cashMetrics: buildCashMetrics(summary, money),
     paymentTotals: buildPaymentTotals(summary, money),
-    notes: "EOD Review is waiting for manager review.",
+    notes:
+      args.status === "prepared"
+        ? "EOD Review is waiting for manager review."
+        : undefined,
   };
 }
 

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -15,7 +15,7 @@ import {
   runConfiguredDailyOperationsAutomationWithCtx,
   runDailyOpeningAutomationWithCtx,
   runScheduledDailyOperationsAutomationWithCtx,
-  sendDailyManagerReportsForAppliedEodAutomationWithCtx,
+  sendDailyManagerReportsForEodAutomationWithCtx,
   updateEodAutoCompletePolicy,
   updateOpeningAutoStartPolicy,
   updateRegisterCloseoutApprovalPolicy,
@@ -1039,7 +1039,7 @@ describe("daily operations automation adapter", () => {
     });
   });
 
-  it("sends manager reports for freshly applied or prepared EOD automation outcomes", async () => {
+  it("sends manager reports for completed, prepared, and actionable EOD automation outcomes", async () => {
     const originalStage = process.env.STAGE;
     process.env.STAGE = "prod";
     const runAction = vi.fn(async (_functionRef: unknown, args: unknown) => {
@@ -1059,7 +1059,7 @@ describe("daily operations automation adapter", () => {
     });
 
     try {
-      const result = await sendDailyManagerReportsForAppliedEodAutomationWithCtx(
+      const result = await sendDailyManagerReportsForEodAutomationWithCtx(
         { runAction } as never,
         {
           results: [
@@ -1091,11 +1091,40 @@ describe("daily operations automation adapter", () => {
               },
             },
             {
+              action: "already_completed",
+              run: {
+                _id: "automation-run-already-completed",
+                decisionEvidence: { classification: "completed" },
+                operatingDate: "2026-06-05",
+                outcome: "skipped",
+                storeId: "store-1",
+              },
+            },
+            {
               action: "recorded",
               run: {
                 _id: "automation-run-prepared",
-                operatingDate: "2026-06-05",
+                operatingDate: "2026-06-04",
                 outcome: "prepared",
+                storeId: "store-1",
+              },
+            },
+            {
+              action: "recorded",
+              run: {
+                _id: "automation-run-blocked",
+                decisionEvidence: { classification: "blocked" },
+                operatingDate: "2026-06-03",
+                outcome: "skipped",
+                storeId: "store-1",
+              },
+            },
+            {
+              action: "failed",
+              run: {
+                _id: "automation-run-failed",
+                operatingDate: "2026-06-02",
+                outcome: "failed",
                 storeId: "store-1",
               },
             },
@@ -1103,15 +1132,33 @@ describe("daily operations automation adapter", () => {
         },
       );
 
-      expect(runAction).toHaveBeenCalledTimes(2);
+      expect(runAction).toHaveBeenCalledTimes(5);
       expect(runAction.mock.calls[0]?.[1]).toEqual({
         operatingDate: "2026-06-08",
         status: "applied",
         storeId: "store-1",
       });
       expect(runAction.mock.calls[1]?.[1]).toEqual({
-        operatingDate: "2026-06-05",
+        automationRunId: "automation-run-skipped",
+        operatingDate: "2026-06-06",
+        status: "skipped",
+        storeId: "store-1",
+      });
+      expect(runAction.mock.calls[2]?.[1]).toEqual({
+        operatingDate: "2026-06-04",
         status: "prepared",
+        storeId: "store-1",
+      });
+      expect(runAction.mock.calls[3]?.[1]).toEqual({
+        automationRunId: "automation-run-blocked",
+        operatingDate: "2026-06-03",
+        status: "skipped",
+        storeId: "store-1",
+      });
+      expect(runAction.mock.calls[4]?.[1]).toEqual({
+        automationRunId: "automation-run-failed",
+        operatingDate: "2026-06-02",
+        status: "failed",
         storeId: "store-1",
       });
       expect(result).toEqual([
@@ -1130,16 +1177,55 @@ describe("daily operations automation adapter", () => {
           storeId: "store-1",
         },
         {
-          operatingDate: "2026-06-05",
+          operatingDate: "2026-06-06",
           reports: [
             {
-              operatingDate: "2026-06-05",
+              operatingDate: "2026-06-06",
+              recipientEmail: "manager@example.com",
+              status: 202,
+              storeName: "Accra",
+            },
+          ],
+          runId: "automation-run-skipped",
+          storeId: "store-1",
+        },
+        {
+          operatingDate: "2026-06-04",
+          reports: [
+            {
+              operatingDate: "2026-06-04",
               recipientEmail: "manager@example.com",
               status: 202,
               storeName: "Accra",
             },
           ],
           runId: "automation-run-prepared",
+          storeId: "store-1",
+        },
+        {
+          operatingDate: "2026-06-03",
+          reports: [
+            {
+              operatingDate: "2026-06-03",
+              recipientEmail: "manager@example.com",
+              status: 202,
+              storeName: "Accra",
+            },
+          ],
+          runId: "automation-run-blocked",
+          storeId: "store-1",
+        },
+        {
+          operatingDate: "2026-06-02",
+          reports: [
+            {
+              operatingDate: "2026-06-02",
+              recipientEmail: "manager@example.com",
+              status: 202,
+              storeName: "Accra",
+            },
+          ],
+          runId: "automation-run-failed",
           storeId: "store-1",
         },
       ]);
@@ -1154,7 +1240,7 @@ describe("daily operations automation adapter", () => {
     const runAction = vi.fn();
 
     try {
-      const result = await sendDailyManagerReportsForAppliedEodAutomationWithCtx(
+      const result = await sendDailyManagerReportsForEodAutomationWithCtx(
         { runAction } as never,
         {
           results: [

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -2100,20 +2100,32 @@ type DailyManagerReportAutomationSendResult = {
   storeId: Id<"store">;
 };
 
-function isReportableEodAutoCompleteResult(
+function dailyManagerReportStatusForEodAutoCompleteResult(
   result: DailyOperationsAutomationResult["eodAutoCompleteResults"][number],
-) {
-  return (
-    (result?.action === "applied" && result.run.outcome === "applied") ||
-    (result?.action === "recorded" && result.run.outcome === "prepared")
-  );
+): "applied" | "prepared" | "skipped" | "failed" | null {
+  if (!result) return null;
+
+  if (result.action === "applied" && result.run.outcome === "applied") {
+    return "applied";
+  }
+
+  if (result.action === "recorded" && result.run.outcome === "prepared") {
+    return "prepared";
+  }
+
+  if (result.run.outcome === "failed") return "failed";
+
+  if (result.run.outcome !== "skipped") return null;
+
+  const classification = result.run.decisionEvidence?.classification;
+  return classification === "completed" ? null : "skipped";
 }
 
 function shouldSendScheduledDailyManagerReports() {
   return process.env.STAGE === "prod";
 }
 
-export async function sendDailyManagerReportsForAppliedEodAutomationWithCtx(
+export async function sendDailyManagerReportsForEodAutomationWithCtx(
   ctx: Pick<ActionCtx, "runAction">,
   args: {
     results: DailyOperationsAutomationResult["eodAutoCompleteResults"];
@@ -2123,18 +2135,22 @@ export async function sendDailyManagerReportsForAppliedEodAutomationWithCtx(
     return [];
   }
 
-  const reportableResults = args.results.filter(
-    isReportableEodAutoCompleteResult,
-  );
+  const reportableResults = args.results.flatMap((result) => {
+    const status = dailyManagerReportStatusForEodAutoCompleteResult(result);
+    return result && status ? [{ result, status }] : [];
+  });
   const sentReports: DailyManagerReportAutomationSendResult[] = [];
 
-  for (const result of reportableResults) {
+  for (const { result, status } of reportableResults) {
     const reports = await ctx.runAction(
       internal.operations.dailyManagerReportEmail
         .sendDailyManagerReportToAdminsForDate,
       {
+        ...(status === "skipped" || status === "failed"
+          ? { automationRunId: result.run._id }
+          : {}),
         operatingDate: result.run.operatingDate,
-        status: result.run.outcome === "prepared" ? "prepared" : "applied",
+        status,
         storeId: result.run.storeId,
       },
     );
@@ -2172,7 +2188,7 @@ export const runConfiguredDailyOperationsAutomation = internalAction({
       {},
     );
     const dailyManagerReportResults =
-      await sendDailyManagerReportsForAppliedEodAutomationWithCtx(ctx, {
+      await sendDailyManagerReportsForEodAutomationWithCtx(ctx, {
         results: result.eodAutoCompleteResults,
       });
 

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -132,6 +132,7 @@ import {
   vendorSchema,
 } from "./schemas/stockOps";
 import {
+  automationNotificationDeliverySchema,
   automationPolicySchema,
   automationRunSchema,
   scheduledRunLedgerSchema,
@@ -383,6 +384,15 @@ const schema = defineSchema({
     ])
     .index("by_storeId_outcome", ["storeId", "outcome"])
     .index("by_storeId_idempotencyKey", ["storeId", "idempotencyKey"]),
+  automationNotificationDelivery: defineTable(
+    automationNotificationDeliverySchema,
+  )
+    .index("by_dedupeKey", ["dedupeKey"])
+    .index("by_storeId_operatingDate_action", [
+      "storeId",
+      "operatingDate",
+      "action",
+    ]),
   scheduledRunLedger: defineTable(scheduledRunLedgerSchema)
     .index("by_runKey", ["runKey"])
     .index("by_storeId_cronFamily_window", [

--- a/packages/athena-webapp/convex/schemas/automation.ts
+++ b/packages/athena-webapp/convex/schemas/automation.ts
@@ -106,6 +106,29 @@ export const automationRunSchema = v.object({
   appliedAt: v.optional(v.number()),
 });
 
+export const automationNotificationDeliverySchema = v.object({
+  storeId: v.id("store"),
+  organizationId: v.optional(v.id("organization")),
+  operatingDate: v.string(),
+  domain: v.string(),
+  action: v.string(),
+  notificationKind: v.literal("eod_action_required"),
+  dedupeKey: v.string(),
+  automationRunId: v.id("automationRun"),
+  recipientEmail: v.string(),
+  status: v.union(
+    v.literal("pending"),
+    v.literal("sent"),
+    v.literal("failed"),
+  ),
+  attemptCount: v.number(),
+  leaseExpiresAt: v.optional(v.number()),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  sentAt: v.optional(v.number()),
+  failedAt: v.optional(v.number()),
+});
+
 export const scheduledRunLedgerOutcomeValidator = v.union(
   v.literal("applied"),
   v.literal("no_candidates"),


### PR DESCRIPTION
## Summary

Admins now receive clear manual-close guidance whenever EOD automation records a failed outcome or a skipped outcome that is not classified `completed`. The automation ledger also preserves required event evidence during safe skips, and durable per-recipient delivery state prevents each cron cycle from resending a successful alert.

Applied and prepared daily reports retain their existing behavior. The ledger correction, notification policy, delivery retry boundary, operator copy, schema, tests, solution note, and landed-change report form one end-to-end operational path.

```mermaid
flowchart TB
  A[EOD automation result] --> B{Outcome router}
  B -->|applied| C[Completed daily report]
  B -->|prepared| D[Prepared review report]
  B -->|failed or skipped except completed| E[Reserve recipient delivery]
  E --> F[Send action-required email]
  F -->|success| G[Mark sent and suppress retries]
  F -->|failure| H[Mark failed and allow retry]
```

## Design decisions

- Optional outcome fields are omitted from Convex patches when absent, preserving the initialized `automationRun.eventIds` array.
- Notification routing follows recorded outcome and classification. Every failure and every skipped run except classification `completed` receives manual-close guidance.
- Action-required sends reserve a durable key per domain, action, store, operating date, notification kind, and normalized recipient.
- Sent deliveries are terminal. Failed or expired 5-minute leases can retry.
- Email copy directs admins to EOD Review without presenting raw backend errors as the primary instruction.

## Validation

- `bun run pr:athena`
- 56 focused daily-operations automation tests
- 88 tests across the focused ledger, routing, delivery, and email-render suites
- Compound solution and landed-change report checks
- Graphify rebuild and check

The delivery includes [the reader-facing landed-change report](docs/reports/2026-07-16-eod-automation-admin-alerts-report.html) and refreshes the existing EOD manager-email solution note.

Production deployment and local-root alignment are intentionally deferred.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
