### PR TITLE
docs(repo): restructure README into focused docs and retarget docs contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,334 +1,150 @@
 # Athena
 
-Athena is an operating system for a solo business owner. The product goal is to
-put the daily control loop of a business in one place: sell in person,
-sell online, track stock, fulfill orders, manage cash, handle services, assign
-staff work, understand customer behavior, and keep enough operational evidence
-that the owner can trust what happened without becoming a full-time systems
-operator.
+Athena is an operating system for a solo business owner. The goal is to put the
+daily control loop of a business in one place: sell in person, sell online,
+track stock, fulfill orders, manage cash, handle services, assign staff work,
+understand customer behavior, and keep enough operational evidence that the
+owner can trust what happened without becoming a full-time systems operator.
 
-## Business OS Audit
+Today it is closest to a **retail and service business OS**. It is not a
+complete business OS yet; the honest gaps are listed below.
 
-Current coverage is closest to a retail and service business OS:
+## Status
 
-- **Sales and checkout:** POS register, online checkout, orders, refunds,
-  returns/exchanges, reviews, offers, rewards, saved bags, and customer-facing
-  storefront flows are already present.
-- **Inventory and procurement:** Product catalog, SKUs, stock movements,
-  adjustments, purchase orders, receiving, replenishment, vendors, unresolved
-  product cleanup, and bulk operations are represented.
-- **Operations and accountability:** Staff profiles, credentials, register
-  sessions, cash controls, Daily Close, payment allocation, approvals,
-  operational work items, workflow traces, and app logs give the owner a
-  control plane instead of isolated screens.
-- **Service businesses:** Service intake, appointments, active service cases,
-  service catalog management, and service inventory usage are first-class
-  backend and UI surfaces.
-- **Owner visibility:** Analytics, customer behavior timelines, storefront
-  observability, production health checks, generated route/test indexes, and
-  graphify give both product and engineering visibility.
+Built and in use:
 
-The main gaps before it feels like a complete solo-business OS are:
+| Domain | Coverage |
+| --- | --- |
+| Sales and checkout | POS register, online checkout, orders, refunds, returns and exchanges, reviews, offers, rewards, saved bags |
+| Inventory and procurement | Catalog, SKUs, stock movements, adjustments, purchase orders, receiving, replenishment, vendors |
+| Operations and accountability | Staff profiles and credentials, register sessions, cash controls, Daily Close, payment allocation, manager approvals, work items, workflow traces |
+| Services | Service intake, appointments, active cases, service catalog, service inventory usage |
+| Reporting and visibility | Reports workspace (overview, inventory exposure, item performance, revenue contribution, SKU evidence), storefront analytics, customer behavior timelines, health checks |
 
-- **Financial operating picture:** Cash controls and payment allocations exist,
-  but owner-level profit, expense, payout, tax, and reconciliation views are not
-  yet the central cockpit.
-- **Cross-domain command center:** Work items, approvals, traces, services,
-  stock, orders, and POS flows exist, but the owner still needs stronger
-  unified queues and exception views across domains.
-- **Automation and guidance:** The LLM/provider foundation exists, but the OS
-  does not yet consistently turn data into proactive recommendations, next
-  actions, or owner-facing decision support.
-- **External system coverage:** Payments, email, storage, and monitoring are
-  wired, but accounting, banking, payroll, supplier, and broader CRM
-  integrations are still outside the core loop.
+Not there yet:
 
-## Repo Setup
+- **A complete financial picture.** The Reports workspace covers revenue
+  contribution, inventory exposure, and item performance, and expenses are
+  tracked through the POS expense flows. Profit and margin, payouts, tax, and
+  bank reconciliation are still missing, so the owner cannot yet answer "did I
+  make money this month" inside Athena.
+- **A cross-domain command center.** Work items, approvals, traces, services,
+  stock, orders, and POS flows each have good individual surfaces. The owner
+  still has to move between them instead of working one unified queue of
+  exceptions.
+- **Automation and guidance.** The intelligence and automation layers exist
+  (`convex/intelligence`, `convex/automation`), but the OS does not yet
+  consistently turn its data into proactive recommendations or next actions.
+- **External system coverage.** Payments, email, storage, and monitoring are
+  wired. Accounting, banking, payroll, supplier, and broader CRM integrations
+  are outside the core loop.
 
-This is a Bun workspace with three primary packages:
+## Getting Started
 
-- `packages/athena-webapp`: the authenticated owner/operator app plus the
-  Convex backend.
-- `packages/storefront-webapp`: the customer-facing storefront.
-- `packages/valkey-proxy-server`: local request/response proxy support for
-  Valkey-backed flows.
+A Bun workspace with three packages:
 
-Install dependencies from the repo root:
+| Package | Role |
+| --- | --- |
+| `packages/athena-webapp` (`@athena/webapp`) | The authenticated owner/operator app plus the Convex backend. |
+| `packages/storefront-webapp` (`@athena/storefront-webapp`) | The customer-facing storefront. |
+| `packages/valkey-proxy-server` | Local request/response proxy support for Valkey-backed flows. |
 
 ```bash
-bun install
+bun install                                        # also points Git at .husky hooks
+bun run --filter '@athena/webapp' dev              # operator app
+bun run --filter '@athena/storefront-webapp' dev   # storefront
 ```
 
-Run the main authenticated app:
+Run `bun install` (or `bun run prepare`) after cloning so Git picks up the
+tracked hooks in `.husky/`. Those hooks run the delivery gates described under
+[Working In This Repo](#working-in-this-repo).
 
-```bash
-bun run --filter '@athena/webapp' dev
-```
+## Documentation
 
-Run the storefront app:
+| Doc | Covers |
+| --- | --- |
+| [Athena webapp architecture](./packages/athena-webapp/docs/agent/architecture.md) | The real architecture reference: routing, the Convex HTTP boundary, command-result and approval contracts, money handling, reporting, POS local-first boundaries |
+| [Packages agent router](./packages/AGENTS.md) | Per-package `AGENTS.md` and `docs/agent/*` — the operational source of truth for edits and validation |
+| [Repo harness and sensors](./docs/harness.md) | The delivery safety system, plus the full command, artifact, and CI reference |
+| [Graphify](./docs/graphify.md) | The repo knowledge graph, its freshness gate, artifacts, and Python runtime |
+| [VPS production runtime](./docs/deployment/vps-production.md) | Deployment topology, access prerequisites, nginx and Cloudflare setup, QA deploys, rollback |
+| [Graphify wiki index](./graphify-out/wiki/index.md) | Generated repo-wide navigation and package landing pages |
 
-```bash
-bun run --filter '@athena/storefront-webapp' dev
-```
-
-## VPS Agent Readiness
-
-For a remote deployment, point the agent at
-[docs/deployment/vps-production.md](./docs/deployment/vps-production.md) as the
-authoritative runbook. Before the agent starts, the VPS and external accounts
-need the small amount of access that cannot be created from inside the repo:
-
-- **Root SSH access:** the agent must be able to reach the VPS as `root`, either
-  through an SSH alias such as `ssh-do` or a direct `ssh root@<vps-ip>` target.
-- **Ubuntu with `apt`:** the bootstrap script assumes a fresh Ubuntu-style VPS.
-  It installs nginx, git, Node.js 22, PM2, Valkey, rsync, and related packages.
-- **Cloudflare Tunnel credential or token:** provide either the tunnel
-  credential JSON for `/etc/cloudflared/` or the Cloudflare dashboard's tunnel
-  install token. These secrets must stay out of the repo.
-- **Cloudflare DNS and tunnel permissions:** the agent needs account access if
-  it should create or update hostname routes such as `athena-qa.wigclub.store`.
-  Otherwise, create those routes before handing over.
-- **GitHub deploy key registration:** the agent can generate the VPS SSH key,
-  but a human or GitHub-authorized agent must add the public key to the
-  `kwam1na/athena` repo as a deploy key before `scripts/deploy-vps.sh check-git`
-  can pass.
-- **Convex deploy auth, if needed:** only required when the agent should run
-  `scripts/deploy-vps.sh convex-prod`. Static app deploys and QA can point at
-  existing Convex deployments.
-
-Once those prerequisites are in place, the agent should follow the deployment
-runbook, starting with:
-
-```bash
-scripts/setup-production-vps.sh
-scripts/deploy-vps.sh check-git
-scripts/deploy-vps.sh all
-```
-
-The setup script owns the nginx bootstrap. It writes the Athena config to
-`/etc/nginx/conf.d/wigclub.conf`, disables Ubuntu's default enabled site, and
-the runbook includes the nginx verification commands the agent should run before
-checking Cloudflare.
-
-QA deploys are automatic after merges to `main` through the
-`Athena QA Deploy` GitHub Actions workflow. The workflow uses the same
-`scripts/deploy-vps.sh qa` path and requires the QA VPS SSH secrets documented
-in the deployment runbook.
-
-Production static app rollback is also script-backed. Use
-`scripts/deploy-vps.sh rollback athena previous` or
-`scripts/deploy-vps.sh rollback storefront <version>` locally, or run the
-manual `Athena Production Rollback` GitHub Actions workflow. New static
-deployments keep timestamped version directories and write `deploy.json`
-metadata with the Git SHA and deployment time for rollback auditability.
+Deeper material lives under `docs/`: `docs/solutions/` holds durable solution
+notes for architecture foundations and recurring bug classes, `docs/plans/`
+holds delivery plans, and `docs/operations/` holds production runbooks.
 
 ## Backend Shape
 
-The primary backend lives in `packages/athena-webapp/convex`.
+The primary backend lives in `packages/athena-webapp/convex`, with
+`convex/http.ts` composing the public Hono boundary over four HTTP domains:
 
-- `convex/http.ts` composes the public Hono HTTP boundary.
-- `convex/http/domains/core` contains owner/admin core routes such as
-  organizations, stores, catalog, analytics, and auth.
-- `convex/http/domains/customerChannel` contains customer-facing commerce
-  routes such as bags, checkout, orders, reviews, rewards, offers, and
-  storefront session flows.
-- `convex/http/domains/moneyMovement` contains payment collection and webhook
-  routes.
-- `convex/operations`, `convex/pos`, `convex/cashControls`,
-  `convex/stockOps`, `convex/serviceOps`, `convex/storeFront`, and
-  `convex/workflowTraces` hold the business workflows behind those public
-  boundaries.
+- `core` — owner/admin routes such as organizations, stores, catalog,
+  analytics, and auth.
+- `customerChannel` — customer commerce routes such as bags, checkout, orders,
+  reviews, rewards, offers, and storefront sessions.
+- `customerMessaging` — customer messaging surfaces.
+- `moneyMovement` — payment collection and webhook routes.
 
-Daily Close belongs to the Daily Operations Lifecycle. It is scoped to a store
-day and composes operational state into close readiness, a daily summary, and
-carry-forward work for a future opening workflow. It is separate from Cash
-Controls, which is drawer/session scoped; from a POS session, which is the
-sale/cart lifecycle; and from `registerSession`, which is the drawer/shift
-ledger that backs cash-control closeout.
+Business workflows sit behind those boundaries in domain folders including
+`convex/operations`, `convex/pos`, `convex/cashControls`, `convex/stockOps`,
+`convex/serviceOps`, `convex/storeFront`, `convex/reporting`,
+`convex/inventory`, `convex/intelligence`, `convex/automation`, and
+`convex/workflowTraces`.
 
-## Harness
+See the [architecture doc](./packages/athena-webapp/docs/agent/architecture.md)
+for how to choose a boundary before editing.
 
-The harness is the repo's agent-readiness and delivery safety system. It keeps
-the codebase navigable for agents, turns local changes into reviewable evidence,
-and prevents stale generated docs or graph artifacts from drifting away from
-the code.
+### Daily Operations Vocabulary
 
-For a balanced overview of how the harness is set up and what each sensor does,
-read [Repo Harness And Sensors](./docs/harness.md).
+Four similar-sounding concepts are deliberately distinct, and conflating them
+causes real bugs:
 
-At a high level, it does five jobs:
+| Concept | Scope |
+| --- | --- |
+| **Daily Close** | The store day. Composes operational state into close readiness, a daily summary, and carry-forward work for the next opening. |
+| **Cash Controls** | The drawer/session. Cash counting, variance, and closeout review. |
+| **POS session** | The sale/cart lifecycle at a terminal. |
+| **`registerSession`** | The drawer/shift ledger that backs cash-control closeout. |
 
-- **Documents the repo shape:** generated route, test, folder, validation, and
-  graph indexes give agents a fast map of what exists before they edit.
-- **Checks implementation health:** package tests, architecture checks, Convex
-  audits, graphify freshness, and harness script tests catch broken contracts
-  before a PR reaches CI.
-- **Reviews changes:** deterministic self-review and inferential review compare
-  a branch against `origin/main` and look for missing tests, stale docs, risky
-  edits, and harness regressions.
-- **Exercises runtime behavior:** behavior scenarios boot representative flows
-  and record structured runtime signals, latency thresholds, and optional
-  videos for browser-based evidence.
-- **Repairs generated artifacts:** pre-commit and pre-push paths regenerate
-  harness docs and graphify artifacts when safe, then stop so the repaired
-  files can be reviewed and committed intentionally.
+The durable note is
+[Athena Daily Close Is A Store-Day Boundary](./docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md).
 
-Key repo-level commands:
+## Working In This Repo
 
-- `bun run harness:test`
-- `bun run harness:check`
-- `bun run harness:audit`
-- `bun run harness:review`
-- `bun run harness:inferential-review`
-- `HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow bun run harness:inferential-review`
-- `HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow bun run harness:inferential-review --persist-history`
-- `bun run harness:scorecard`
-- `bun run harness:janitor`
-- `bun run harness:self-review --base origin/main`
-- `bun run harness:behavior --scenario <name>`
-- `bun run harness:behavior --scenario <name> --record-video`
-- `cat <behavior-log-file> | bun run harness:runtime-trends`
-- `cat <behavior-log-file> | bun run harness:runtime-trends --persist-history`
-- `bun run architecture:check`
-- `bun run pre-push:review`
-- `bun run pr:athena`
-- `bun run graphify:check`
+Changes are gated by the harness rather than by convention. The commands you
+will actually reach for:
 
-Run `bun install` (or `bun run prepare`) after cloning to point Git at the tracked hooks in `.husky/`. Worktrees inherit the repo config, so using the tracked `.husky` directory avoids the missing generated shim problem we saw with `.husky/_`.
+| Command | When |
+| --- | --- |
+| `bun run harness:check` | Quick repo health check. |
+| `bun run harness:test` | After changing anything under `scripts/`. |
+| `bun run pr:athena` | The full delivery ladder; records reusable pre-push proof. |
+| `bun run graphify:check` | Freshness gate for tracked graph artifacts. |
 
-For repo-harness edits such as `scripts/harness-app-registry.ts`, keep
-`bun run harness:review --base origin/main` and
-`bun run harness:inferential-review` in the local ladder so a missing sibling
-test update like `scripts/harness-app-registry.test.ts` fails before push.
-`bun run pr:athena` passes an explicit provider flag to `harness:review` because
-the PR ladder already ran the repo-owned validation commands directly. Standalone
-`harness:review` and `pre-push:review` stay fail-closed for repo-harness edits.
+Two behaviors are worth knowing up front:
 
-`bun run harness:test` is the canonical harness implementation gate for harness scripts, graphify tooling, and pre-push review wiring.
-It targets repo-root `scripts/*.test.ts` files only (excluding cloned worktree trees).
-Use `bun run harness:test -- --dry-run` to print the selected files without executing tests.
-The repo pins Bun via `package.json` (`bun@1.1.29` today), and GitHub Actions reads that same repo-declared version so CI and local harness runs stay aligned.
+- **Repair is fail-closed.** Hooks will regenerate stale docs and graph
+  artifacts for you, then **stop**, so you review and commit the repair instead
+  of pushing a stale ref.
+- **Substantial changes need a solution note.** `compound:check` blocks
+  behavior-bearing work that does not also add a note under `docs/solutions/`.
+  Small edits, test-only changes, and docs-only changes pass without one.
 
-`pre-commit:generated-artifacts` automatically runs `bun run harness:generate` and `bun run graphify:rebuild`, then stages the tracked generated harness docs and graphify outputs before the commit is finalized, so the pushed ref includes refreshed generated artifacts.
-`bun run pr:athena:prepare` starts with that same generated-artifact repair step, then blocks before the heavy validation ladder if unstaged or untracked files would prevent a reusable proof. Stage intended new files explicitly, or remove unrelated local files, before running the full gate.
-`bun run pr:athena:preflight` then aggregates validation-map coverage, live harness audit, audit-fixture consistency, and harness-script sibling-test policy before provider validation starts. Its failure report names the registry source, generated-doc repair, fixture and sibling-test files, and focused verification command.
-`bun run pr:athena:validate` runs the heavy validation ladder without recording proof, and `bun run pr:athena:record-proof` records the reusable pre-push proof for the current clean or staged-only tree.
-The default `bun run pr:athena` command runs the delivery-run wrapper, which composes those steps in order, writes same-tree provider evidence after the provider commands pass, writes the current local run ledger, and runs the scorecard against that ledger.
-`pre-push:review` starts with `bun run graphify:check`, then runs `bun run delivery:documentation-check`, before the rest of the local validation suite. The combined documentation check reports solution-note and landed-change-report policy failures together, so agents can create or refresh both required artifacts in one pass. If tracked graphify artifacts are stale, the hook runs `bun run graphify:rebuild` once, reruns `bun run graphify:check`, and then stops so you can review and commit the repaired graphify artifacts before pushing again.
-If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs, the hook runs `bun run harness:generate` once, retries the blocked step on the repaired tree, and:
+[The harness doc](./docs/harness.md) explains each sensor and how to read a
+failure.
 
-- Blocks so you can review, commit, and push the repaired generated docs instead of sending a stale ref to CI.
+## Deployment
 
-After a clean or staged-only `bun run pr:athena`, the repo records a git-private
-proof for the validated tree and `origin/main`. `pre-push:review` reuses that
-proof only when the pushed tree, base, clean working tree, Bun version, command
-wiring, and validation fingerprint still match; otherwise it reruns and prints
-the reason. If `origin/main` or the base diff cannot be read, the hook blocks
-instead of treating the changed-file set as empty.
+Production and QA run on an Ubuntu VPS behind Cloudflare Tunnel, with Convex
+hosting the backend. [The VPS runbook](./docs/deployment/vps-production.md) is
+authoritative, including the access prerequisites needed before a deploy can
+start.
 
-Proof status is local-only telemetry for the worktree that produced it. The
-pre-push handoff summary reports `validation=<passed|skipped>` separately from
-`proof=<status>` so a successful validation rerun is not mistaken for proof
-reuse. Local run ledgers/providers may record statuses such as `reusable`,
-`missing`, `dirty`, `stale`, `base_changed`,
-`validation_wiring_changed`, `generated_repaired`, `source_registry_drift`, and
-`proof_not_recorded`, but those records do not make the proof portable across
-machines, worktrees, or a changed `origin/main`.
-
-List runtime behavior scenarios with `bun run harness:behavior --list`.
-Bundled scenarios include:
-
-- `sample-runtime-smoke`
-- `athena-admin-shell-boot`
-- `athena-convex-storefront-composition`
-- `athena-convex-storefront-failure-visibility`
-- `athena-qa-live-smoke`
-- `valkey-proxy-local-request-response`
-- `storefront-backend-first-load`
-- `storefront-checkout-bootstrap`
-- `storefront-checkout-validation-blocker`
-- `storefront-checkout-verification-recovery`
-
-Add `--record-video` to persist browser-flow evidence under
-`artifacts/harness-behavior/videos/<scenario>/<run-stamp>/`.
-
-`harness:behavior` now emits a machine-parseable per-scenario report line:
-
-- `[harness:behavior:report] { ...json... }`
-
-Each report includes phase durations, runtime-signal summaries, and threshold diagnostics.
-Scenario thresholds are configured in `scripts/harness-behavior-scenarios.ts` via:
-
-- `runtimeSignals[].minMatches` / `runtimeSignals[].maxMatches`
-- `thresholds.latency.maxPhaseDurationMs`
-- `thresholds.latency.maxTotalDurationMs`
-
-`harness:scorecard` emits a deterministic quality artifact at:
-
-- `artifacts/harness-scorecard/latest.json`
-
-`harness:inferential-review` has two lanes:
-
-- deterministic findings remain the blocking source of truth
-- `HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow` adds a semantic shadow lane for telemetry without changing the exit code
-
-When `ANTHROPIC_API_KEY` is not configured, the shadow lane records a skipped status instead of failing the deterministic lane.
-
-Use `--persist-history` when you want append-only timestamped inferential snapshots alongside the latest artifact:
-
-- `artifacts/harness-inferential-review/latest.json`
-- `artifacts/harness-inferential-review/history/<run-stamp>.json`
-
-`harness:runtime-trends` consumes `[harness:behavior:report]` lines from stdin and
-prints aggregated scenario trend telemetry (pass/fail rates, latency stats, and
-runtime-signal health diagnostics).
-
-Use `--persist-history` to keep timestamped runtime trend snapshots alongside the latest trend artifact:
-
-- `artifacts/harness-behavior/trends/latest.json`
-- `artifacts/harness-behavior/trends/history/<run-stamp>.json`
-
-GitHub Actions wiring:
-
-- PR CI runs `bun run harness:inferential-review` with `HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow`
-- scheduled and manual harness runs persist inferential history by default
-- manual runs can paste `[harness:behavior:report]` lines through the workflow dispatch input to persist runtime trend history
-- PR and scheduled/manual harness jobs upload inferential, runtime-trend, and scorecard artifacts for inspection
-
-`harness:janitor` runs drift sensors in report mode by default. Add `--repair` to
-apply safe automated repair steps (`harness:generate` and `graphify:rebuild`) before
-re-running checks.
-
-## Graphify
-
-The repo keeps a graphify knowledge graph at `graphify-out/`.
-
-Start with [the Graphify wiki index](./graphify-out/wiki/index.md) for repo-wide navigation, package landing pages, and graph hotspots.
-
-Use [the packages agent router](./packages/AGENTS.md) plus each package's `AGENTS.md` and `docs/agent/*` docs as the operational source of truth for edits and validation.
-
-Use `bun run graphify:check` as the freshness gate for tracked graphify artifacts.
-
-Use `bun run graphify:rebuild` as the repair path when the check reports stale artifacts. The rebuild command uses the interpreter recorded in `.graphify_python` (default `python3` in this repo). Local `pre-commit:generated-artifacts` runs this repair step with `bun run harness:generate` and stages the tracked graphify outputs plus generated harness docs before the commit is finalized. `pre-push:review` can also run this repair once for stale tracked graphify artifacts, reruns `bun run graphify:check`, and then blocks until you commit the repaired tracked artifacts.
-
-If you need to repair the local graphify setup, install the repo-pinned runtime with `python3 -m pip install -r .graphify-requirements.txt`.
-
-Tracked graphify artifacts:
-
-- `graphify-out/GRAPH_REPORT.md`
-- `graphify-out/graph.json`
-- `graphify-out/wiki/index.md`
-- `graphify-out/wiki/packages/*.md`
-
-Local-only graphify artifacts:
-
-- `graphify-out/cache/`
-- `artifacts/harness-inferential-review/`
-- `artifacts/harness-contract-preflight/`
-- `artifacts/harness-scorecard/`
-- `artifacts/harness-behavior/trends/`
-- `artifacts/harness-behavior/videos/`
-
-`graphify-out/cache/` is intentionally ignored because it is a large local acceleration cache, not a reviewable source artifact.
-
-The `artifacts/harness-*/` paths above are also intentionally ignored because they are machine-generated local or CI evidence outputs, not reviewable source artifacts.
+- QA deploys automatically after merges to `main` through the **Athena QA
+  Deploy** workflow.
+- Production static rollback is script-backed via
+  `scripts/deploy-vps.sh rollback athena previous`, or the manual **Athena
+  Production Rollback** workflow. Static deploys keep timestamped version
+  directories and write `deploy.json` metadata with the Git SHA for
+  auditability.

--- a/docs/deployment/vps-production.md
+++ b/docs/deployment/vps-production.md
@@ -26,6 +26,42 @@ This runbook captures the production VPS shape for `wigclub.store` and the steps
 
 Do not expose the cache proxy through the VPS public interface. The service has cache read, write, and invalidation endpoints, so the expected runtime boundary is loopback plus Cloudflare Tunnel.
 
+## Prerequisites
+
+This runbook is the authoritative deployment reference, including for an agent
+driving the deploy. Before starting, the VPS and external accounts need the
+access that cannot be created from inside the repo:
+
+- **Root SSH access:** reachable as `root`, either through an SSH alias such as
+  `ssh-do` or a direct `ssh root@<vps-ip>` target.
+- **Ubuntu with `apt`:** the bootstrap script assumes a fresh Ubuntu-style VPS.
+  It installs nginx, git, Node.js 22, PM2, Valkey, rsync, and related packages.
+- **Cloudflare Tunnel credential or token:** either the tunnel credential JSON
+  for `/etc/cloudflared/` or the dashboard's tunnel install token. These secrets
+  must stay out of the repo.
+- **Cloudflare DNS and tunnel permissions:** needed only to create or update
+  hostname routes such as `athena-qa.wigclub.store`. Otherwise create those
+  routes before handing over.
+- **GitHub deploy key registration:** the VPS SSH key can be generated on the
+  box, but a human or GitHub-authorized agent must add the public key to the
+  `kwam1na/athena` repo as a deploy key before
+  `scripts/deploy-vps.sh check-git` can pass.
+- **Convex deploy auth:** required only for `scripts/deploy-vps.sh convex-prod`.
+  Static app deploys and QA can point at existing Convex deployments.
+
+With those in place, the usual first run is:
+
+```bash
+scripts/setup-production-vps.sh
+scripts/deploy-vps.sh check-git
+scripts/deploy-vps.sh all
+```
+
+The setup script owns the nginx bootstrap. It writes the Athena config to
+`/etc/nginx/conf.d/wigclub.conf` and disables Ubuntu's default enabled site; the
+nginx verification commands to run before checking Cloudflare are in
+[nginx Configuration](#nginx-configuration).
+
 ## Bootstrap A New VPS
 
 Run the setup script as `root` on a fresh Ubuntu VPS:

--- a/docs/graphify.md
+++ b/docs/graphify.md
@@ -1,0 +1,109 @@
+# Graphify Knowledge Graph
+
+Graphify builds a knowledge graph of the repo under `graphify-out/`. It gives
+agents and maintainers a way to orient around packages, communities, and code
+relationships before reading raw files.
+
+The graph is treated as a reviewable source artifact, not decorative output.
+Tracked graphify files are committed, and a freshness gate blocks pushes when
+they drift from the code they describe.
+
+## Start Here
+
+- [Graphify wiki index](../graphify-out/wiki/index.md) — repo-wide navigation,
+  package landing pages, and graph hotspots.
+- [Graph report](../graphify-out/GRAPH_REPORT.md) — the generated summary of
+  communities and structure.
+- [Packages agent router](../packages/AGENTS.md) — per-package `AGENTS.md` and
+  `docs/agent/*`, which stay the operational source of truth for making edits
+  and choosing validation commands.
+
+Use graphify to find your way to the right package or module. Use the package
+agent docs to decide what to change and how to validate it.
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `bun run graphify:check` | Freshness gate for tracked graphify artifacts. |
+| `bun run graphify:rebuild` | Regenerate the graph when the check reports drift. |
+
+`graphify:check` rebuilds into a temporary workspace and compares the result
+against the tracked files, so it detects drift without mutating your tree.
+
+## Artifacts
+
+Tracked and freshness-gated, from `TRACKED_GRAPHIFY_ARTIFACTS` in
+`scripts/graphify-check.ts`:
+
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.json`
+- `graphify-out/wiki/index.md`
+- `graphify-out/wiki/packages/<app>.md` — one page per package registered in
+  `scripts/harness-app-registry.ts` (`athena-webapp`, `storefront-webapp`,
+  `valkey-proxy-server` today)
+
+`graphify-out/graph.html` is also committed, but it is deliberately outside
+`TRACKED_GRAPHIFY_ARTIFACTS`. It is a browsable convenience view, so it is not
+part of the freshness comparison and can lag the gated artifacts.
+
+`graphify-out/cache/` is git-ignored. It is a large local acceleration cache,
+not a reviewable artifact.
+
+## Python Runtime
+
+Graphify itself is a Python package. The repo pins it in
+`.graphify-requirements.txt` (`graphifyy==0.4.12` today).
+
+Install or repair the local runtime with:
+
+```bash
+python3 -m pip install -r .graphify-requirements.txt
+```
+
+`graphify:rebuild` picks its interpreter through `resolveGraphifyPython` in
+`scripts/graphify-rebuild.ts`:
+
+1. If `.graphify_python` is missing or empty, use `python3`.
+2. If its contents contain no path separator, treat the value as a command name
+   and use it as-is.
+3. If it looks like a path and that path exists, use it.
+4. If it looks like a path and the path does not exist, warn and fall back to
+   `python3`.
+
+`.graphify_python` is tracked, and its committed value is currently the
+macOS Homebrew path `/opt/homebrew/bin/python3.10`. That is a convenience for
+the primary development machine, not a portable default. On Linux, in CI, or on
+a Mac without that exact interpreter, step 4 applies: the rebuild prints a
+fallback warning and uses `python3`. If you see that warning, it is expected
+behavior rather than a broken setup — but the resulting `python3` must still
+have `graphifyy` installed, or the rebuild will fail.
+
+## How It Fits The Harness
+
+Graphify is one of the harness freshness sensors. See
+[Repo harness and sensors](./harness.md) for the full picture. The parts
+specific to graphify:
+
+- `pre-commit:generated-artifacts` runs `graphify:rebuild` alongside
+  `harness:generate` and stages the refreshed tracked outputs, so a commit
+  carries its own updated graph.
+- `pre-push:review` runs `graphify:check` first. If tracked artifacts are
+  stale, it rebuilds once, rechecks, then **blocks** so you review and commit
+  the repaired artifacts rather than pushing a stale ref.
+- `pr:athena` ends its review half with `graphify:check`.
+- `harness:janitor --repair` includes `graphify:rebuild` among its safe repairs.
+
+The consistent rule is fail-closed repair: the harness will refresh the graph
+for you, but it will not silently push the refreshed files past review.
+
+## When To Rebuild
+
+Rebuild when the code or documentation structure changes in a way the graph
+should reflect — new modules, moved boundaries, renamed packages, or
+substantially reorganized docs. In practice the pre-commit hook handles this,
+and you mostly interact with graphify when `graphify:check` blocks a push.
+
+If a check failure surprises you, run `bun run graphify:rebuild` and read the
+diff before committing. A large unexplained diff usually means the local
+interpreter or `graphifyy` version differs from the pinned one.

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -271,6 +271,7 @@ composing explicit phases:
 
 ```sh
 bun run pr:athena:prepare
+bun run pr:athena:preflight
 bun run pr:athena:validate
 bun run pr:athena:record-proof
 bun run pr:athena:scorecard
@@ -280,6 +281,13 @@ bun run pr:athena:scorecard
 stops before the heavy ladder if unstaged or untracked files remain. It does not
 stage new files automatically; stage intended new files explicitly and rerun the
 prepare step before spending the full validation cycle.
+
+`pr:athena:preflight` then aggregates validation-map coverage, live harness
+audit, audit-fixture consistency, and harness-script sibling-test policy before
+provider validation starts. Its failure report names the registry source,
+generated-doc repair, fixture and sibling-test files, and the focused
+verification command, so a preflight failure is actionable without reading the
+sensor source.
 
 `pr:athena:validate` runs the main repo ladder in two halves. The provider half
 runs Convex audits, architecture checks, and coverage; if those commands pass,
@@ -385,3 +393,190 @@ touches validation wiring. In those cases rerunning is the fail-closed policy.
 The pre-push handoff line separates `validation=<passed|skipped>` from
 `proof=<status>` so a successful validation rerun is not confused with proof
 reuse.
+
+## Command And Artifact Reference
+
+This section is the lookup table for the commands and outputs described above.
+The narrative sections explain why a sensor exists; this section records what to
+type and where the output lands.
+
+### Repo-Level Commands
+
+| Command | Purpose |
+| --- | --- |
+| `bun run harness:generate` | Regenerate the generated agent docs from the registry and live filesystem. |
+| `bun run harness:check` | Verify generated harness docs, links, and validation maps are present and fresh. |
+| `bun run harness:test` | Run the harness implementation tests. |
+| `bun run harness:audit` | Audit harness coverage across registered surfaces. |
+| `bun run harness:self-review --base origin/main` | Deterministic branch review against the base. |
+| `bun run harness:review --base origin/main` | Touched-surface validation review; fail-closed when run standalone. |
+| `bun run harness:inferential-review` | Higher-level review pass; deterministic lane is blocking. |
+| `bun run harness:behavior --list` | List available runtime behavior scenarios. |
+| `bun run harness:behavior --scenario <name>` | Run one runtime behavior scenario. |
+| `bun run harness:runtime-trends` | Aggregate `[harness:behavior:report]` lines from stdin into trend telemetry. |
+| `bun run harness:scorecard` | Emit the deterministic quality snapshot. |
+| `bun run harness:janitor` | Report drift; `--repair` applies safe repairs, then rechecks. |
+| `bun run architecture:check` | Run architecture boundary checks. |
+| `bun run compound:check` | Enforce the solution-note delivery guardrail. |
+| `bun run delivery:documentation-check` | Combined solution-note and landed-change-report policy check. |
+| `bun run graphify:check` | Freshness gate for tracked graphify artifacts. |
+| `bun run graphify:rebuild` | Repair path for stale graphify artifacts. |
+| `bun run pre-push:review` | The pre-push gate; also runnable by hand. |
+| `bun run pr:athena` | The full delivery ladder (see phases below). |
+
+`harness:test` selects `.test.ts` files from the top level of the repo-root
+`scripts/` directory only. The scan is non-recursive, so nested trees — including
+cloned worktrees under `worktrees/` — are never picked up. Use
+`bun run harness:test -- --dry-run` to print the selected files without running
+them.
+
+The repo pins Bun through `packageManager` in `package.json` (`bun@1.1.29`
+today). Every GitHub Actions job sets up Bun with `bun-version-file: package.json`,
+so CI and local harness runs read the same declared version.
+
+### Delivery Ladder Phases
+
+`pr:athena` delegates to `pr:athena:delivery-run`, which composes:
+
+| Phase | Command | Notes |
+| --- | --- | --- |
+| Prepare | `pr:athena:prepare` | Dependency check, generated-artifact repair, then blocks if unstaged or untracked files would prevent reusable proof. |
+| Preflight | `pr:athena:preflight` | Validation-map coverage, live harness audit, audit-fixture consistency, and harness-script sibling-test policy. |
+| Validate | `pr:athena:validate` | Provider half (docs check, workflow check, Convex audit and lint, frontend lint, architecture, `tsc --noEmit`, coverage), then writes provider evidence, then the review half (harness review, inferential review, audit, graphify check). |
+| Record proof | `pr:athena:record-proof` | Records the git-private proof for the validated tree. |
+| Scorecard | `pr:athena:scorecard` | Runs against the current delivery-run ledger. |
+
+Inside the ladder, `harness:review` is called with
+`--repo-validation-provided-by pr:athena` plus a `--provider-evidence` path,
+because the repo-owned validation commands already ran directly.
+
+The two provider flags are similarly named but differ in **scope**, and passing
+the wrong one silently changes how much work review skips:
+
+| Flag | Scope |
+| --- | --- |
+| `--repo-validation-provided-by pr:athena` | Narrow. Suppresses only the repo-owned validation set. Package validation still runs, because `pr:athena` leaves package selection to review. |
+| `--validation-provided-by athena-pr-tests` | Broad. Suppresses the repo-owned set *and* prunes package commands the PR workflow runs as separate jobs, leaving validation-map checks and behavior scenarios. |
+
+Neither is a legacy alias of the other. Standalone `harness:review` and
+`pre-push:review` pass neither flag and stay fail-closed.
+
+### Inferential Review Modes
+
+The deterministic lane always runs and is the blocking source of truth. The
+semantic shadow lane is opt-in:
+
+```sh
+HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow bun run harness:inferential-review
+HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow bun run harness:inferential-review --persist-history
+```
+
+The shadow lane calls the Anthropic API. When `ANTHROPIC_API_KEY` is not
+configured it records a `skipped` status rather than failing the deterministic
+lane. `HARNESS_INFERENTIAL_ANTHROPIC_MODEL` overrides the default model.
+
+## Behavior Scenario Reference
+
+`bun run harness:behavior --list` prints these from the registry, and
+`harness:check` keeps this section in sync with it. Bundled scenarios include:
+
+| Scenario | Covers |
+| --- | --- |
+| `sample-runtime-smoke` | Minimal local app boot, browser click, signal propagation, teardown. |
+| `athena-admin-shell-boot` | Admin-shell fixture with deterministic auth bootstrap. |
+| `athena-convex-storefront-composition` | Authenticated shell driving a Convex-backed storefront route composition. |
+| `athena-convex-storefront-failure-visibility` | Convex composition failures stay visible in browser state. |
+| `athena-qa-live-smoke` | Live QA surface; fails on blank app, page errors, failed same-origin requests, or 5xx resources. |
+| `valkey-proxy-local-request-response` | Local Valkey proxy round trip with an in-memory client. |
+| `storefront-backend-first-load` | First-load backend requests; fails on direct Convex browser traffic, CORS/preflight failures, or non-2xx API responses. |
+| `storefront-checkout-bootstrap` | Checkout bootstrap UI and runtime signals. |
+| `storefront-checkout-validation-blocker` | Invalid checkout-session routing surfaces the validation blocker. |
+| `storefront-checkout-verification-recovery` | Paystack-origin redirect and verification recovery to checkout complete. |
+
+Add `--record-video` to persist browser evidence under
+`artifacts/harness-behavior/videos/<scenario>/<run-stamp>/`.
+
+Scenario thresholds live in `scripts/harness-behavior-scenarios.ts`:
+
+- `runtimeSignals[].minMatches` / `runtimeSignals[].maxMatches` — expected match
+  counts for a named runtime signal.
+- `thresholds.latency.maxTotalDurationMs` — ceiling for the whole run.
+- `thresholds.latency.maxPhaseDurationMs` — a per-phase map, not a single value.
+  Phases are `boot`, `readiness`, `browser`, `runtime`, `assertion`, and
+  `cleanup`. Scenarios share preset budgets, so storefront scenarios allow a much
+  longer boot than the sample runtime does.
+
+## Artifacts And CI Reference
+
+`harness:check` reads the scenario list above by scanning from its marker to the
+next `##` heading, so this heading also bounds that scan. Keep it at `##` level:
+scenario-shaped names in backticks below it would otherwise be read as part of
+the scenario list.
+
+### Artifacts
+
+Tracked, freshness-gated graphify artifacts:
+
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graph.json`
+- `graphify-out/wiki/index.md`
+- `graphify-out/wiki/packages/*.md`
+
+`graphify-out/graph.html` is committed but sits outside the freshness gate. See
+[Graphify](./graphify.md) for the artifact and Python-runtime details.
+
+Local and CI evidence outputs, all git-ignored:
+
+| Path | Written by |
+| --- | --- |
+| `artifacts/harness-scorecard/latest.json` | `harness:scorecard` |
+| `artifacts/harness-inferential-review/latest.json` | `harness:inferential-review` |
+| `artifacts/harness-inferential-review/history/<run-stamp>.json` | `harness:inferential-review --persist-history` |
+| `artifacts/harness-behavior/trends/latest.json` | `harness:runtime-trends` |
+| `artifacts/harness-behavior/trends/history/<run-stamp>.json` | `harness:runtime-trends --persist-history` |
+| `artifacts/harness-behavior/videos/<scenario>/<run-stamp>/` | `harness:behavior --record-video` |
+| `artifacts/harness-delivery-runs/` | `pr:athena` delivery-run ledger and provider evidence |
+| `artifacts/harness-contract-preflight/latest.json` | `pr:athena:preflight` |
+| `graphify-out/cache/` | `graphify:rebuild` |
+
+These are ignored on purpose. `graphify-out/cache/` is a large local
+acceleration cache, and the `artifacts/harness-*` paths are machine-generated
+evidence, not reviewable source.
+
+### GitHub Actions Wiring
+
+`.github/workflows/athena-pr-tests.yml` runs on pull requests, on a weekly
+schedule (Mondays 14:00 UTC), and on manual dispatch.
+
+- The `harness-validation` job runs self-review, review with
+  `--validation-provided-by athena-pr-tests`, docs check, architecture check,
+  audit, inferential review in `shadow` mode, scorecard, and graphify freshness.
+- The `harness-janitor` job runs only on schedule or manual dispatch. It runs the
+  janitor in report mode, persists inferential history, persists runtime trend
+  history, and regenerates the telemetry scorecard.
+- Manual dispatch accepts literal `[harness:behavior:report]` lines as an input,
+  which the janitor job pipes into `harness:runtime-trends --persist-history`.
+- Both jobs upload their artifacts with `if: always()` so failures stay
+  inspectable.
+
+### Git Hooks
+
+Run `bun install` (or `bun run prepare`) after cloning to point Git at the
+tracked hooks in `.husky/`. Worktrees inherit the repo config, so using the
+tracked `.husky` directory avoids the missing generated shim problem that a
+`.husky/_` layout produces.
+
+- `pre-commit:generated-artifacts` runs `harness:generate` and
+  `graphify:rebuild`, then stages the tracked generated outputs so the commit
+  includes refreshed artifacts.
+- `pre-push:review` starts with `graphify:check`, then
+  `delivery:documentation-check`, then the rest of the local suite. If tracked
+  graphify artifacts are stale it rebuilds once, rechecks, and stops so the
+  repaired artifacts can be reviewed and committed. If `harness:self-review` or
+  `harness:review` is blocked by stale generated docs, it runs `harness:generate`
+  once, retries, and then blocks for the same reason.
+
+For repo-harness edits such as `scripts/harness-app-registry.ts`, keep
+`bun run harness:review --base origin/main` and
+`bun run harness:inferential-review` in the local ladder so a missing sibling
+test like `scripts/harness-app-registry.test.ts` fails before push.

--- a/docs/reports/2026-07-18-readme-focused-docs-report.html
+++ b/docs/reports/2026-07-18-readme-focused-docs-report.html
@@ -1,0 +1,370 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="fa8123077a676427973ee2f27b7527254d049c8729ddd7935943f85ecf1b3445" data-athena-report-base="origin/main" data-athena-report-head="docs/readme-focused-docs">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>README Restructure and Docs Contract Retargeting</title>
+    <style>
+      :root {
+        --ink: #1f2933;
+        --muted: #596674;
+        --line: #d9e2ec;
+        --paper: #ffffff;
+        --soft: #f6f8fb;
+        --accent: #1d4ed8;
+        --accent-soft: #dbeafe;
+        --good: #166534;
+        --bad: #b91c1c;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--soft);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      main { max-width: 1120px; margin: 0 auto; padding: 48px 24px 72px; }
+      header { border-bottom: 1px solid var(--line); margin-bottom: 28px; padding-bottom: 28px; }
+      h1, h2, h3 { line-height: 1.18; letter-spacing: 0; }
+      h1 { font-size: 42px; max-width: 880px; margin: 0 0 16px; }
+      h2 { font-size: 28px; margin: 0 0 16px; }
+      h3 { font-size: 19px; margin: 22px 0 10px; }
+      p { margin: 0 0 14px; }
+      .lede { color: var(--muted); font-size: 18px; max-width: 880px; }
+      .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 20px; }
+      .pill { border: 1px solid var(--line); border-radius: 999px; background: var(--paper); color: var(--muted); font-size: 13px; padding: 6px 10px; }
+      .panel { background: var(--paper); border: 1px solid var(--line); border-radius: 8px; margin: 18px 0; padding: 22px; }
+      code { background: #eef2f7; border: 1px solid #d8dee8; border-radius: 5px; padding: 1px 5px; }
+      pre { overflow: auto; background: #111827; color: #e5e7eb; border-radius: 8px; padding: 16px; }
+      pre code { background: transparent; border: 0; color: inherit; padding: 0; }
+      table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+      th, td { border-bottom: 1px solid var(--line); padding: 11px 12px; text-align: left; vertical-align: top; }
+      th { background: #eef2f7; color: var(--muted); font-size: 13px; text-transform: uppercase; }
+      tr:last-child td { border-bottom: 0; }
+      ul, ol { margin: 0 0 14px; padding-left: 22px; }
+      li { margin-bottom: 7px; }
+      .callout { border-left: 3px solid var(--accent); background: var(--accent-soft); border-radius: 0 8px 8px 0; padding: 14px 16px; margin: 16px 0; }
+      .quiz-question { border-top: 1px solid var(--line); padding: 18px 0; }
+      .quiz-question:first-child { border-top: 0; }
+      fieldset { border: 0; margin: 0; padding: 0; }
+      legend { font-weight: 700; margin-bottom: 10px; }
+      label { display: block; border: 1px solid var(--line); border-radius: 8px; background: #fbfdff; margin: 8px 0; padding: 10px 12px; cursor: pointer; }
+      @media (hover: hover) and (pointer: fine) {
+        label:hover { border-color: #b6c5d8; }
+      }
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 8px;
+        background: var(--accent);
+        color: #ffffff;
+        cursor: pointer;
+        font-weight: 700;
+        padding: 11px 16px;
+      }
+      button.secondary { background: #e2e8f0; color: var(--ink); }
+      .quiz-actions { display: flex; align-items: center; gap: 12px; margin-top: 18px; }
+      .answer-detail { display: none; color: var(--muted); font-size: 14px; margin-top: 8px; }
+      .answer-detail.visible { display: block; }
+      .quiz-question.correct { background: #f0fdf4; border-radius: 8px; padding-left: 12px; padding-right: 12px; }
+      .quiz-question.incorrect { background: #fef2f2; border-radius: 8px; padding-left: 12px; padding-right: 12px; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>README Restructure and Docs Contract Retargeting</h1>
+        <p class="lede">The Athena README went from 334 lines to 150 by moving reference detail into focused docs. The hard part was not editing prose — it was discovering that three harness contracts <em>required</em> that detail to live in the README, and retargeting them to follow the content.</p>
+        <div class="meta"><span class="pill">Delivery candidate</span><span class="pill">Branch: docs/readme-focused-docs</span><span class="pill">Base: origin/main</span><span class="pill">Merge: pending</span><span class="pill">Root alignment: pending</span><span class="pill">Production deploy: not applicable</span></div>
+      </header>
+
+      <section class="panel"><h2>Executive Summary</h2>
+        <p>The README was a 334-line wall of text. Roughly 200 of those lines were harness and graphify reference material: command lists, artifact paths, proof status values, behavior scenario names, threshold config keys, and CI wiring. The product description was buried under delivery tooling detail.</p>
+        <p>This change moves that material into focused docs — <code>docs/harness.md</code> gains a command and artifact reference, <code>docs/graphify.md</code> is new, and <code>docs/deployment/vps-production.md</code> absorbs the VPS access prerequisites. The README becomes an overview that links out.</p>
+        <p>The non-obvious part: the README had not grown by neglect. Three harness contracts pinned that content in place, so any attempt to slim it failed <code>harness:check</code>, <code>harness:audit</code>, and <code>harness:test</code>. Those contracts were retargeted at the docs that now own the content, and the prose-level assertions were loosened to token-level assertions so the docs can be reworded without a test edit.</p>
+      </section>
+
+      <section class="panel"><h2>Problem And Context</h2>
+        <p>Three mechanisms kept reference detail in the README:</p>
+        <ol>
+          <li><code>RUNTIME_SCENARIO_DOCS</code> in <code>scripts/harness-check.ts</code> listed <code>README.md</code> as a doc that must carry the runtime behavior scenario list, kept in sync with the scenario registry.</li>
+          <li>Two tests in <code>scripts/pre-push-review.test.ts</code> asserted roughly 25 <strong>verbatim sentences</strong> in the README, for example <code>"`bun run pr:athena:prepare` starts with that same generated-artifact repair step"</code>.</li>
+          <li>Fixture repos in <code>scripts/harness-check.test.ts</code> and <code>scripts/harness-audit.test.ts</code> modelled the README as the scenario-list home, so the audit failed when the real README stopped matching that shape.</li>
+        </ol>
+        <p>The effect was ratchet-like. Every new harness capability appended a paragraph to the README, and no paragraph could be removed without editing a test. The README was structurally required to grow.</p>
+      </section>
+
+      <section class="panel"><h2>Mental Model</h2>
+        <p>A documentation contract has two parts: <em>which file</em> must contain something, and <em>how tightly</em> the content is specified.</p>
+        <p>Both were wrong here. The file was the README, which should be an orientation surface rather than a reference. And the specification was whole sentences, which makes the assertion break on any rewording — so the cheapest way to satisfy it is always to append rather than revise.</p>
+        <div class="callout"><strong>The rule this change encodes:</strong> point docs contracts at the doc that owns the topic, and assert on tokens (command names, artifact paths, config keys) rather than sentences. A test that breaks on rewording is too tight; a test that only checks a file mentions something is still meaningful.</div>
+      </section>
+
+      <section class="panel"><h2>Before And After</h2>
+        <h3>Before</h3>
+        <pre><code>README.md (334 lines)
+  product overview          ~45 lines
+  setup                     ~15 lines
+  VPS prerequisites         ~50 lines
+  harness reference        ~150 lines   &lt;- gated by 3 contracts
+  graphify reference        ~35 lines   &lt;- gated by 1 test
+
+docs/harness.md            388 lines    concepts, but no command reference
+docs/graphify.md           (did not exist)</code></pre>
+        <h3>After</h3>
+        <pre><code>README.md (150 lines)
+  product overview + honest status
+  setup, docs index, backend shape
+  daily operations vocabulary
+  delivery gates summary       -> links out
+
+docs/harness.md            575 lines    + Command And Artifact Reference
+docs/graphify.md           109 lines    new: commands, artifacts, python runtime
+docs/deployment/
+  vps-production.md                     + Prerequisites section</code></pre>
+      </section>
+
+      <section class="panel">
+        <h2>Key Files</h2>
+        <table>
+          <thead><tr><th>File</th><th>Why it matters</th></tr></thead>
+          <tbody>
+            <tr><td><code>README.md</code></td><td>Rewritten as an overview: what Athena is, an honest status table naming what is missing, setup, a documentation index, backend shape, daily-ops vocabulary, and delivery gates.</td></tr>
+            <tr><td><code>docs/harness.md</code></td><td>Gains the command table, delivery ladder phases, inferential review modes, behavior scenarios, artifact paths, CI wiring, and Git hooks. Now the canonical harness reference.</td></tr>
+            <tr><td><code>docs/graphify.md</code></td><td>New. Commands, tracked vs ignored artifacts, and the Python interpreter resolution order including the fallback path.</td></tr>
+            <tr><td><code>docs/deployment/vps-production.md</code></td><td>Gains a <code>Prerequisites</code> section with the access that cannot be created from inside the repo.</td></tr>
+            <tr><td><code>scripts/harness-check.ts</code></td><td><code>RUNTIME_SCENARIO_DOCS</code> now points at <code>docs/harness.md</code> instead of <code>README.md</code>. This is the contract retarget.</td></tr>
+            <tr><td><code>scripts/harness-review.ts</code></td><td>Documents the two similarly-named provider flags and extracts two named predicates. Pure refactor — no behavior change.</td></tr>
+            <tr><td><code>scripts/pre-push-review.test.ts</code></td><td>Docs contracts now read <code>docs/harness.md</code> and <code>docs/graphify.md</code>, assert tokens rather than sentences, and a new test asserts the README links to each focused doc.</td></tr>
+            <tr><td><code>scripts/harness-check.test.ts</code></td><td>Fixture writes a minimal <code>docs/harness.md</code>; two new tests lock in that the harness doc is gated and the README is not.</td></tr>
+            <tr><td><code>scripts/harness-audit.test.ts</code></td><td>Fixture updated to the same shape so the audit models the new docs layout.</td></tr>
+            <tr><td><code>scripts/harness-review.test.ts</code></td><td>New <code>validation provider scopes</code> block pinning the asymmetry between the two provider flags.</td></tr>
+            <tr><td><code>docs/solutions/developer-experience/athena-docs-contracts-target-focused-docs-2026-07-18.md</code></td><td>The durable note so the next agent does not re-derive why the README grew.</td></tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="panel"><h2>Corrections Found By Grounding</h2>
+        <p>Rewriting from the code rather than copying the old prose surfaced four claims that had been carried forward inaccurately:</p>
+        <table>
+          <thead><tr><th>Claim</th><th>Reality</th></tr></thead>
+          <tbody>
+            <tr><td><code>thresholds.latency.maxPhaseDurationMs</code> read as a single value</td><td>It is a per-phase map with six keys: <code>boot</code>, <code>readiness</code>, <code>browser</code>, <code>runtime</code>, <code>assertion</code>, <code>cleanup</code>.</td></tr>
+            <tr><td>Local-only artifact list</td><td>Omitted <code>artifacts/harness-delivery-runs/</code>, which is git-ignored and written by every <code>pr:athena</code> run.</td></tr>
+            <tr><td>Tracked graphify artifacts</td><td><code>graphify-out/graph.html</code> is committed but deliberately outside <code>TRACKED_GRAPHIFY_ARTIFACTS</code>, so it is not freshness-gated.</td></tr>
+            <tr><td><code>pr:athena</code> has four phases</td><td>It has five. <code>preflight</code> runs between prepare and validate and was missing from <code>docs/harness.md</code>.</td></tr>
+          </tbody>
+        </table>
+        <p>Separately, <code>.graphify_python</code> pins <code>/opt/homebrew/bin/python3.10</code>, which does not exist on the development machine. Every local rebuild silently takes the <code>python3</code> fallback and prints a warning. <code>docs/graphify.md</code> documents the real four-step resolution order rather than the previous "default <code>python3</code>" claim.</p>
+      </section>
+
+      <section class="panel"><h2>What Intentionally Did Not Change</h2>
+        <ul>
+          <li><strong>No runtime or product behavior.</strong> This change touches documentation, harness sensors, and tests only. No Convex function, route, or component is modified.</li>
+          <li><strong>The provider flags themselves.</strong> <code>--repo-validation-provided-by</code> and <code>--validation-provided-by</code> keep their names and values. Only comments, extracted predicates, and error-message text changed, because both flags are wired into <code>package.json</code> and the CI workflow.</li>
+          <li><strong>The scenario list is still gated.</strong> It moved to <code>docs/harness.md</code>; it was not made optional.</li>
+          <li><strong>No new architecture doc.</strong> The README links to <code>packages/athena-webapp/docs/agent/architecture.md</code>, which is richer than any summary would be.</li>
+          <li><strong>Unrelated working-tree changes stayed behind.</strong> Seventeen modified cash-controls and register-session files under <code>packages/athena-webapp</code> were left on the root checkout and are not part of this branch.</li>
+        </ul>
+      </section>
+
+      <section class="panel"><h2>Review Findings Acted On</h2>
+        <p>A read-only diff analyst reviewed this branch before delivery and found three issues that were fixed rather than noted:</p>
+        <table>
+          <thead><tr><th>Finding</th><th>Response</th></tr></thead>
+          <tbody>
+            <tr><td><strong>The README's links to the new focused docs were not sensor-enforced.</strong> <code>collectReadmeLinkErrors</code> required only the graphify wiki index and packages router. <code>docs/graphify.md</code> had no sensor contract at all, so a rename would leave a dead README link uncaught.</td><td>Added <code>docs/harness.md</code> and <code>docs/graphify.md</code> to the required README link set, with a test asserting both are reported when missing.</td></tr>
+            <tr><td><strong>The scenario-section extractor was left on a hair trigger.</strong> <code>extractRuntimeScenarioSection</code> stops at <code>##</code> but not <code>###</code>. With the list under a <code>###</code> subsection, the scan ran to end of file and swallowed the artifact and CI sections.</td><td>Promoted the list to <code>## Behavior Scenario Reference</code> followed by <code>## Artifacts And CI Reference</code>, which bounds the scan. Documented the constraint in both the doc and the solution note.</td></tr>
+            <tr><td><strong>Token-only assertions lost semantic pinning.</strong> The previous sentence assertions pinned the fail-closed repair behavior; bare tokens would pass on a doc describing the opposite.</td><td>Kept token assertions for churn resistance, and added two concept assertions covering fail-closed repair and the review-then-commit block.</td></tr>
+          </tbody>
+        </table>
+        <p>The analyst also flagged that it had not exhaustively diffed all 322 deleted README lines against the destination docs. That gap was closed separately with a scripted check over 22 facts from the old README; all are present in a destination doc, and the three initial misses were line-wrap artifacts in the check itself, not real losses.</p>
+      </section>
+
+      <section class="panel"><h2>Validation Evidence</h2>
+        <table>
+          <thead><tr><th>Check</th><th>Result</th></tr></thead>
+          <tbody>
+            <tr><td><code>bun run harness:test</code></td><td>516 pass, 0 fail (41 files)</td></tr>
+            <tr><td><code>bun run harness:check</code></td><td>Harness docs check passed</td></tr>
+            <tr><td><code>bun run pr:athena:preflight</code></td><td>Harness contract preflight passed</td></tr>
+            <tr><td><code>bun run graphify:check</code></td><td>Artifacts fresh after clean rebuild in the worktree</td></tr>
+            <tr><td><code>bun run delivery:documentation-check</code></td><td>Solution note accepted with matching diff fingerprint</td></tr>
+            <tr><td>Doc link resolution</td><td>All relative links in README, harness, graphify, and deployment docs resolve</td></tr>
+            <tr><td>Typecheck</td><td>60 pre-existing errors before and after; none introduced</td></tr>
+          </tbody>
+        </table>
+        <p>Two failures were surfaced by the harness during the change and fixed rather than worked around. The sibling-test policy blocked the <code>harness-review.ts</code> edit until <code>harness-review.test.ts</code> gained matching coverage, and the docs contracts blocked the README rewrite until the sensors were retargeted and the fixtures updated.</p>
+        <p>The graphify artifacts were rebuilt in a clean worktree rather than reused from the root checkout, because the root rebuild had absorbed the seventeen unrelated package changes: 10672 nodes there versus 10666 here.</p>
+      </section>
+
+      <section class="panel"><h2>Next-Time Guidance</h2>
+        <ul>
+          <li>When a docs sensor blocks a restructure, check whether the sensor's <em>target</em> is still correct before restoring content to satisfy it.</li>
+          <li>Write docs assertions against tokens, not sentences. If a test would break on rewording, it will cause the doc to grow instead of improve.</li>
+          <li>Reserve README assertions for links and orientation.</li>
+          <li>Verify doc claims against source before copying them into a new home. Four inaccuracies here had survived because prose was moved rather than re-derived.</li>
+          <li>When the working tree carries unrelated changes, build generated artifacts in a clean worktree so they do not encode work you are not shipping.</li>
+        </ul>
+      </section>
+
+      <section class="panel">
+        <h2>Subagent Evidence</h2>
+        <ul>
+          <li><strong>Delivered diff analyst</strong> (read-only explorer over the worktree): produced the changed-file map, confirmed the <code>harness-review.ts</code> predicate extraction is behavior-preserving, and stress-tested whether retargeting <code>RUNTIME_SCENARIO_DOCS</code> or loosening the prose assertions weakens any guarantee.</li>
+          <li><strong>Report reviewer</strong> (read-only): reviewed this report for unsupported claims and quiz quality before delivery.</li>
+          <li><strong>Session context</strong>: supplied directly by the delivery conversation, which contains the full grounding trail — sensor discovery, the two harness-caught failures, and the user decision to retarget the sensor rather than duplicate the scenario list.</li>
+        </ul>
+      </section>
+
+      <section id="quiz" class="panel">
+        <h2>Quiz: Pass Required</h2>
+        <p>You must score at least 8 out of 10 to pass.</p>
+        <form id="changeQuiz" data-threshold="8">
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>1. Why had the README grown to 334 lines?</legend>
+    <label><input type="radio" name="q1" value="0" /> Nobody had taken the time to edit it</label>
+<label><input type="radio" name="q1" value="1" /> Harness contracts required the reference detail to live there, so it could only be appended to</label>
+<label><input type="radio" name="q1" value="2" /> It was generated from the harness registry</label>
+  </fieldset>
+  <div class="answer-detail">Three contracts pinned content to README.md, so slimming it failed harness:check, harness:audit, and harness:test. The growth was structural, not editorial neglect.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>2. Where does the canonical runtime behavior scenario list live after this change?</legend>
+    <label><input type="radio" name="q2" value="0" /> README.md</label>
+<label><input type="radio" name="q2" value="1" /> Nowhere; it is no longer gated</label>
+<label><input type="radio" name="q2" value="2" /> docs/harness.md, via RUNTIME_SCENARIO_DOCS</label>
+  </fieldset>
+  <div class="answer-detail">RUNTIME_SCENARIO_DOCS in scripts/harness-check.ts now names docs/harness.md. The list is still synced against the scenario registry; only its home moved.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>3. How did the docs contracts in pre-push-review.test.ts change?</legend>
+    <label><input type="radio" name="q3" value="0" /> They target the focused docs and assert command/artifact tokens instead of verbatim sentences</label>
+<label><input type="radio" name="q3" value="1" /> They were deleted as redundant</label>
+<label><input type="radio" name="q3" value="2" /> They now assert on the graphify graph.json contents</label>
+  </fieldset>
+  <div class="answer-detail">Sentence-level assertions force append-only growth. Token assertions keep the contract meaningful while allowing the prose to be rewritten.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>4. What is the difference between the two harness-review provider flags?</legend>
+    <label><input type="radio" name="q4" value="0" /> They are aliases; one is a legacy name</label>
+<label><input type="radio" name="q4" value="1" /> --repo-validation-provided-by suppresses only repo-owned commands; --validation-provided-by also prunes package commands</label>
+<label><input type="radio" name="q4" value="2" /> One sets the base ref, the other sets the provider evidence path</label>
+  </fieldset>
+  <div class="answer-detail">They differ in scope, and the longer name is the narrower flag. Under the local pr:athena provider, package validation still runs.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>5. Did the harness-review.ts change alter behavior?</legend>
+    <label><input type="radio" name="q5" value="0" /> Yes, it changed which commands are pruned in CI</label>
+<label><input type="radio" name="q5" value="1" /> Yes, it renamed both CLI flags</label>
+<label><input type="radio" name="q5" value="2" /> No; the predicates are exact extractions of the original conditions</label>
+  </fieldset>
+  <div class="answer-detail">repoOwnedValidationIsProvided and packageValidationIsProvided reproduce the original comparisons exactly. Only comments, structure, and error-message text changed.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>6. What is <code>thresholds.latency.maxPhaseDurationMs</code>?</legend>
+    <label><input type="radio" name="q6" value="0" /> A per-phase map with keys like boot, readiness, browser, runtime, assertion, cleanup</label>
+<label><input type="radio" name="q6" value="1" /> A single millisecond ceiling applied to every phase</label>
+<label><input type="radio" name="q6" value="2" /> A percentage of maxTotalDurationMs</label>
+  </fieldset>
+  <div class="answer-detail">The old README described it as a scalar. Scenarios share preset budgets, so storefront scenarios allow a far longer boot than the sample runtime.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>7. What is the status of <code>graphify-out/graph.html</code>?</legend>
+    <label><input type="radio" name="q7" value="0" /> Git-ignored like the cache directory</label>
+<label><input type="radio" name="q7" value="1" /> Committed, but outside TRACKED_GRAPHIFY_ARTIFACTS so it is not freshness-gated</label>
+<label><input type="radio" name="q7" value="2" /> Tracked and gated like graph.json</label>
+  </fieldset>
+  <div class="answer-detail">It is a browsable convenience view. It can lag the gated artifacts without failing graphify:check.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>8. What happens when <code>.graphify_python</code> names an interpreter that does not exist?</legend>
+    <label><input type="radio" name="q8" value="0" /> graphify:rebuild fails immediately</label>
+<label><input type="radio" name="q8" value="1" /> The tracked artifacts are silently left stale</label>
+<label><input type="radio" name="q8" value="2" /> It warns and falls back to python3</label>
+  </fieldset>
+  <div class="answer-detail">resolveGraphifyPython falls back to python3 and prints a warning. The committed value is a macOS Homebrew path that is absent on the development machine, so this is the normal local path.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>9. Why were the graphify artifacts rebuilt in the worktree rather than copied from the root checkout?</legend>
+    <label><input type="radio" name="q9" value="0" /> The root rebuild had absorbed seventeen unrelated package changes present in that working tree</label>
+<label><input type="radio" name="q9" value="1" /> The root checkout uses a different graphify version</label>
+<label><input type="radio" name="q9" value="2" /> Graphify artifacts cannot be copied between trees</label>
+  </fieldset>
+  <div class="answer-detail">The root tree carried unrelated cash-controls work, giving 10672 nodes versus 10666 in the clean worktree. Shipping that graph would encode changes not in this branch.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>10. What should you do when a docs sensor blocks a restructure?</legend>
+    <label><input type="radio" name="q10" value="0" /> Restore the content to the file the sensor names</label>
+<label><input type="radio" name="q10" value="1" /> Check whether the sensor's target is still correct, and retarget it if the content has a better home</label>
+<label><input type="radio" name="q10" value="2" /> Delete the sensor</label>
+  </fieldset>
+  <div class="answer-detail">Restoring content satisfies the sensor but preserves the ratchet. Deleting it loses the guarantee. Retargeting keeps the invariant and makes it a statement of intent about which doc owns the topic.</div>
+</div>
+
+          <div class="quiz-actions">
+            <button type="button" id="gradeQuiz">Grade quiz</button>
+            <button type="button" class="secondary" id="resetQuiz">Reset</button>
+            <span id="quizResult" aria-live="polite"></span>
+          </div>
+        </form>
+      </section>
+
+    </main>
+    <script>
+      const questions = Array.from(document.querySelectorAll(".quiz-question"));
+      const result = document.getElementById("quizResult");
+      const form = document.getElementById("changeQuiz");
+      const threshold = Number(form.dataset.threshold || 0);
+      function clearGrades() {
+        questions.forEach((question) => {
+          question.classList.remove("correct", "incorrect");
+          question.querySelector(".answer-detail").classList.remove("visible");
+        });
+        result.textContent = "";
+        result.style.color = "";
+      }
+      document.getElementById("gradeQuiz").addEventListener("click", () => {
+        clearGrades();
+        let score = 0;
+        questions.forEach((question, index) => {
+          const selected = document.querySelector(`input[name="q${index + 1}"]:checked`);
+          const isCorrect = selected && Number(selected.value) === Number(question.dataset.answer);
+          if (isCorrect) score += 1;
+          question.classList.add(isCorrect ? "correct" : "incorrect");
+          question.querySelector(".answer-detail").classList.add("visible");
+        });
+        const passed = score >= threshold;
+        result.textContent = passed
+          ? `Passed: ${score}/${questions.length}.`
+          : `Not passed: ${score}/${questions.length}. Review the report and try again.`;
+        result.style.color = passed ? "var(--good)" : "var(--bad)";
+      });
+      document.getElementById("resetQuiz").addEventListener("click", () => {
+        form.reset();
+        clearGrades();
+      });
+    </script>
+  </body>
+</html>

--- a/docs/solutions/developer-experience/athena-docs-contracts-target-focused-docs-2026-07-18.md
+++ b/docs/solutions/developer-experience/athena-docs-contracts-target-focused-docs-2026-07-18.md
@@ -1,0 +1,155 @@
+---
+title: Docs Contracts Should Target Focused Docs, Not README Prose
+date: 2026-07-18
+category: developer-experience
+module: repo-harness
+problem_type: documentation_gap
+component: documentation
+resolution_type: documentation_update
+severity: medium
+applies_when:
+  - Adding a harness sensor or test that asserts documentation content
+  - Splitting a large README into focused docs
+  - A docs check fails because content moved to a different file
+tags: [harness, documentation, readme, sensors, docs-contracts]
+delivery_diff_fingerprint: fa8123077a676427973ee2f27b7527254d049c8729ddd7935943f85ecf1b3445
+---
+
+# Docs Contracts Should Target Focused Docs, Not README Prose
+
+## Problem
+
+The Athena README had grown to 334 lines, most of it harness and graphify
+reference detail: command lists, artifact paths, proof status values, behavior
+scenario names, and CI wiring. It read as an append-only changelog rather than
+an overview, and a newcomer could not find the product description under it.
+
+The growth was not merely editorial drift. Three harness contracts actively
+required that detail to live in `README.md`:
+
+1. `RUNTIME_SCENARIO_DOCS` in `scripts/harness-check.ts` listed `README.md` as a
+   doc that must carry the runtime behavior scenario list, kept in sync with
+   `scripts/harness-behavior-scenarios.ts`.
+2. Two tests in `scripts/pre-push-review.test.ts` asserted roughly 25 **verbatim
+   sentences** in `README.md`, such as
+   `` "`bun run pr:athena:prepare` starts with that same generated-artifact repair step" ``.
+3. Fixture repos in `scripts/harness-check.test.ts` and
+   `scripts/harness-audit.test.ts` modelled the README as the scenario-list home.
+
+Because the sensors pinned prose to the README, every new harness capability had
+to append another paragraph there. Any attempt to slim the README failed
+`harness:check`, `harness:audit`, and `harness:test`.
+
+## Solution
+
+Move the canonical reference into focused docs and **retarget the contracts to
+follow it**, rather than keeping a duplicate list in the README.
+
+- `docs/harness.md` gained a "Command And Artifact Reference" section: the
+  repo-level command table, delivery ladder phases, inferential review modes,
+  behavior scenarios, artifact paths, CI wiring, and Git hooks.
+- `docs/graphify.md` is new and owns graphify commands, tracked vs ignored
+  artifacts, and the Python runtime resolution order.
+- `docs/deployment/vps-production.md` gained a `Prerequisites` section holding
+  the access requirements that previously sat in the README.
+- `scripts/harness-check.ts` now points `RUNTIME_SCENARIO_DOCS` at
+  `docs/harness.md` instead of `README.md`.
+- The two `pre-push-review.test.ts` docs contracts now read `docs/harness.md`
+  and `docs/graphify.md`, and assert on **command and artifact tokens** rather
+  than whole sentences. A new test asserts the README still links to each
+  focused doc.
+- Both fixture repos write a minimal `docs/harness.md` and `docs/graphify.md`,
+  and a short README that links to them.
+- `collectReadmeLinkErrors` now also requires the README to link
+  `docs/harness.md` and `docs/graphify.md`. Without this, moving reference
+  detail out of the README could leave it unreachable, and a renamed doc would
+  leave a dead README link that no sensor caught.
+
+The README is now 150 lines: what Athena is, an honest status table including
+what is missing, setup, a documentation index, backend shape, the daily
+operations vocabulary, and the delivery gates.
+
+### Keep The Scenario Marker Under A `##` Heading
+
+`extractRuntimeScenarioSection` scans from the scenario marker to the next
+`^## ` heading; it does not stop at `###`. When the scenario list sat under a
+`###` subsection, the scan ran to end of file and swallowed the artifact and CI
+sections below it. Any backticked token there shaped like a scenario name
+(`athena-*`, `storefront-*`, `valkey-*`) would then be reported as an unexpected
+scenario.
+
+`docs/harness.md` therefore keeps the list under `## Behavior Scenario
+Reference`, immediately followed by `## Artifacts And CI Reference`, which
+bounds the scan. Preserve that heading level when editing the doc.
+
+## Why This Matters
+
+A docs contract that asserts verbatim prose in a file makes that file grow
+monotonically. Each capability appends a sentence, no sentence can be removed
+without a test edit, and the file drifts from its actual job. Asserting on
+tokens — command names, artifact paths, config keys — keeps the contract
+meaningful while letting the prose be rewritten, condensed, or moved.
+
+Pointing the contract at the doc that *should* own the content also makes the
+sensor a statement of intent: "the harness doc is where runtime scenarios are
+documented" is a more useful invariant than "the README mentions scenarios."
+
+## Prevention
+
+- When adding a docs sensor, target the focused doc that owns the topic. Reserve
+  README assertions for links and orientation, not reference detail.
+- Assert on tokens (`bun run harness:test`, `artifacts/harness-scorecard/`), not
+  on sentences. If a test would break on rewording, it is too tight.
+- When a docs check blocks a restructure, ask whether the sensor's target is
+  still right before restoring content to satisfy it.
+- Grounding matters: this restructure surfaced four inaccuracies that had been
+  copied forward in the README — `maxPhaseDurationMs` is a per-phase map rather
+  than a scalar, `artifacts/harness-delivery-runs/` was missing from the
+  ignored-artifact list, `graphify-out/graph.html` is committed but outside the
+  freshness gate, and `pr:athena` has five delivery phases rather than four
+  (`preflight` was undocumented in `docs/harness.md`). Verify doc claims against
+  the code before copying them into a new home.
+
+## Examples
+
+Before — the contract pinned prose into the README:
+
+```ts
+// scripts/harness-check.ts
+const RUNTIME_SCENARIO_DOCS = [
+  "README.md",
+  "packages/athena-webapp/docs/agent/testing.md",
+  ...
+] as const;
+```
+
+```ts
+// scripts/pre-push-review.test.ts
+expect(readme).toContain(
+  "`bun run pr:athena:prepare` starts with that same generated-artifact repair step",
+);
+```
+
+After — the contract follows the content, and asserts tokens:
+
+```ts
+// scripts/harness-check.ts
+// The canonical runtime scenario list lives in the harness doc, not the README.
+// The README stays a short overview that links out to focused docs.
+const RUNTIME_SCENARIO_DOCS = [
+  "docs/harness.md",
+  "packages/athena-webapp/docs/agent/testing.md",
+  ...
+] as const;
+```
+
+```ts
+// scripts/pre-push-review.test.ts
+const harnessDoc = await readFile(path.join(ROOT_DIR, "docs/harness.md"), "utf8");
+expect(harnessDoc).toContain("pr:athena:prepare");
+```
+
+## Related
+
+- [Repo harness and sensors](../../harness.md)
+- [Graphify](../../graphify.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10666 nodes · 12967 edges · 2559 communities detected
+- 10668 nodes · 12971 edges · 2559 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2733,28 +2733,28 @@ Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 34 - "Community 34"
-Cohesion: 0.12
-Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
+Cohesion: 0.11
+Nodes (26): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+18 more)
 
 ### Community 35 - "Community 35"
 Cohesion: 0.12
-Nodes (26): acquireExpenseQuantityEffectHold(), adjustExpenseQuantityEffectHold(), applyExpenseAvailabilityEffect(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), expenseSessionItemHasTrustedAvailabilityHold(), expenseSessionItemSourceKey() (+18 more)
+Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
 ### Community 36 - "Community 36"
+Cohesion: 0.12
+Nodes (26): acquireExpenseQuantityEffectHold(), adjustExpenseQuantityEffectHold(), applyExpenseAvailabilityEffect(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), expenseSessionItemHasTrustedAvailabilityHold(), expenseSessionItemSourceKey() (+18 more)
+
+### Community 37 - "Community 37"
 Cohesion: 0.16
 Nodes (27): assertRegisterNumberIsAvailable(), buildRuntimeActiveRegisterSessionDirective(), buildRuntimeDrawerAuthorityDirective(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanAppUpdate(), cleanBrowserInfo() (+19 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.14
 Nodes (28): assertCompoundSolutionCheck(), collectAgentDocContents(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSolutionDocContents(), collectSolutionFingerprintFindings() (+20 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.11
-Nodes (24): buildGitProcessEnv(), buildProviderSkip(), collectCommandsForChangedFiles(), commandDisplayName(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs() (+16 more)
 
 ### Community 40 - "Community 40"
 Cohesion: 0.14
@@ -3633,28 +3633,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 259 - "Community 259"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 260 - "Community 260"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 261 - "Community 261"
+### Community 260 - "Community 260"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 262 - "Community 262"
+### Community 261 - "Community 261"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 263 - "Community 263"
+### Community 262 - "Community 262"
 Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 264 - "Community 264"
+### Community 263 - "Community 263"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 264 - "Community 264"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.22
@@ -4277,100 +4277,100 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 420 - "Community 420"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 422 - "Community 422"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 423 - "Community 423"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 423 - "Community 423"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 425 - "Community 425"
-Cohesion: 0.4
-Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 426 - "Community 426"
 Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 427 - "Community 427"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 428 - "Community 428"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 429 - "Community 429"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 430 - "Community 430"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 431 - "Community 431"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 432 - "Community 432"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 430 - "Community 430"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 431 - "Community 431"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 432 - "Community 432"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 433 - "Community 433"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 434 - "Community 434"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 435 - "Community 435"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 436 - "Community 436"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 437 - "Community 437"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 438 - "Community 438"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 439 - "Community 439"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 441 - "Community 441"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 442 - "Community 442"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 442 - "Community 442"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 443 - "Community 443"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 444 - "Community 444"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2633
-- Graph nodes: 10666
-- Graph edges: 12967
+- Graph nodes: 10668
+- Graph edges: 12971
 - Communities: 2559
 
 ## Graph Hotspots

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -25,6 +25,25 @@ async function createFixtureRepo() {
       "",
       "Start with [the Graphify wiki index](./graphify-out/wiki/index.md) for repo and package navigation.",
       "Use [the packages router](./packages/AGENTS.md) for operational package entry docs.",
+      "Read [the harness doc](./docs/harness.md) for delivery gates and runtime scenarios.",
+      "Read [the graphify doc](./docs/graphify.md) for the knowledge graph.",
+      "",
+    ].join("\n"),
+    rootDir
+  );
+
+  await write(
+    "docs/graphify.md",
+    ["# Graphify Knowledge Graph", "", "Graph docs.", ""].join("\n"),
+    rootDir
+  );
+
+  // The canonical runtime scenario list lives in the harness doc; the README
+  // only links to it.
+  await write(
+    "docs/harness.md",
+    [
+      "# Repo Harness And Sensors",
       "",
       "List runtime behavior scenarios with `bun run harness:behavior --list`.",
       "Bundled scenarios include:",

--- a/scripts/harness-check.test.ts
+++ b/scripts/harness-check.test.ts
@@ -56,6 +56,25 @@ async function createFixtureRepo() {
       "",
       "Start with [the Graphify wiki index](./graphify-out/wiki/index.md) for repo and package navigation.",
       "Use [the packages router](./packages/AGENTS.md) for operational package entry docs.",
+      "Read [the harness doc](./docs/harness.md) for delivery gates and runtime scenarios.",
+      "Read [the graphify doc](./docs/graphify.md) for the knowledge graph.",
+      "",
+    ].join("\n"),
+    rootDir
+  );
+
+  await write(
+    "docs/graphify.md",
+    ["# Graphify Knowledge Graph", "", "Graph docs.", ""].join("\n"),
+    rootDir
+  );
+
+  // The canonical runtime scenario list lives in the harness doc; the README
+  // only links to it.
+  await write(
+    "docs/harness.md",
+    [
+      "# Repo Harness And Sensors",
       "",
       "List runtime behavior scenarios with `bun run harness:behavior --list`.",
       "Bundled scenarios include:",
@@ -594,31 +613,36 @@ describe("validateHarnessDocs", () => {
 
   it("reports missing graphify links from the README", async () => {
     const rootDir = await createFixtureRepo();
+    await write("README.md", ["# athena", ""].join("\n"), rootDir);
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Missing required README graphify link in README.md: ./graphify-out/wiki/index.md"
+    );
+  });
+
+  it("requires the README to link the focused harness and graphify docs", async () => {
+    // The README routes to the docs that own the reference detail. Without
+    // these links, moving content out of the README leaves it undiscoverable.
+    const rootDir = await createFixtureRepo();
     await write(
       "README.md",
       [
         "# athena",
         "",
-        "List runtime behavior scenarios with `bun run harness:behavior --list`.",
-      "Bundled scenarios include:",
-      "",
-      "- `sample-runtime-smoke`",
-      "- `athena-admin-shell-boot`",
-      "- `athena-convex-storefront-composition`",
-      "- `athena-convex-storefront-failure-visibility`",
-      "- `athena-qa-live-smoke`",
-      "- `valkey-proxy-local-request-response`",
-      "- `storefront-backend-first-load`",
-      "- `storefront-checkout-bootstrap`",
-      "- `storefront-checkout-validation-blocker`",
-      "- `storefront-checkout-verification-recovery`",
+        "Start with [the Graphify wiki index](./graphify-out/wiki/index.md) for repo and package navigation.",
+        "Use [the packages router](./packages/AGENTS.md) for operational package entry docs.",
         "",
       ].join("\n"),
       rootDir
     );
 
-    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
-      "Missing required README graphify link in README.md: ./graphify-out/wiki/index.md"
+    const errors = await validateHarnessDocs(rootDir);
+
+    expect(errors).toContain(
+      "Missing required README graphify link in README.md: ./docs/harness.md"
+    );
+    expect(errors).toContain(
+      "Missing required README graphify link in README.md: ./docs/graphify.md"
     );
   });
 
@@ -848,5 +872,47 @@ describe("validateHarnessDocs", () => {
     await expect(validateHarnessDocs(rootDir)).resolves.toContain(
       "Runtime behavior scenario docs drift in packages/athena-webapp/docs/agent/testing.md: missing `athena-admin-shell-boot`, `athena-convex-storefront-composition`, `athena-convex-storefront-failure-visibility`, `athena-qa-live-smoke`, `storefront-backend-first-load`, `storefront-checkout-bootstrap`, `storefront-checkout-validation-blocker`, `storefront-checkout-verification-recovery`, `valkey-proxy-local-request-response`. Run `bun run harness:behavior --list` and sync this list to scripts/harness-behavior-scenarios.ts."
     );
+  });
+
+  it("gates the runtime scenario list in the harness doc", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "docs/harness.md",
+      [
+        "# Repo Harness And Sensors",
+        "",
+        "Bundled scenarios include:",
+        "- `sample-runtime-smoke`",
+        "",
+      ].join("\n"),
+      rootDir
+    );
+
+    await expect(validateHarnessDocs(rootDir)).resolves.toContain(
+      "Runtime behavior scenario docs drift in docs/harness.md: missing `athena-admin-shell-boot`, `athena-convex-storefront-composition`, `athena-convex-storefront-failure-visibility`, `athena-qa-live-smoke`, `storefront-backend-first-load`, `storefront-checkout-bootstrap`, `storefront-checkout-validation-blocker`, `storefront-checkout-verification-recovery`, `valkey-proxy-local-request-response`. Run `bun run harness:behavior --list` and sync this list to scripts/harness-behavior-scenarios.ts."
+    );
+  });
+
+  it("does not require the runtime scenario list in the README", async () => {
+    const rootDir = await createFixtureRepo();
+    // The README is a short overview that links to focused docs. It should pass
+    // without carrying the scenario list, which now lives in docs/harness.md.
+    await write(
+      "README.md",
+      [
+        "# athena",
+        "",
+        "Start with [the Graphify wiki index](./graphify-out/wiki/index.md) for repo and package navigation.",
+        "Use [the packages router](./packages/AGENTS.md) for operational package entry docs.",
+        "",
+      ].join("\n"),
+      rootDir
+    );
+
+    const errors = await validateHarnessDocs(rootDir);
+
+    expect(
+      errors.filter((error) => error.includes("runtime behavior scenario"))
+    ).toEqual([]);
   });
 });

--- a/scripts/harness-check.ts
+++ b/scripts/harness-check.ts
@@ -21,8 +21,12 @@ const RUNTIME_SCENARIO_SECTION_MARKERS = [
   "Current shared scenarios include",
   "Bundled scenarios include",
 ] as const;
+const HARNESS_DOC_PATH = "docs/harness.md" as const;
+const GRAPHIFY_DOC_PATH = "docs/graphify.md" as const;
+// The canonical runtime scenario list lives in the harness doc, not the README.
+// The README stays a short overview that links out to focused docs.
 const RUNTIME_SCENARIO_DOCS = [
-  "README.md",
+  HARNESS_DOC_PATH,
   "packages/athena-webapp/docs/agent/testing.md",
   "packages/valkey-proxy-server/docs/agent/testing.md",
   "packages/storefront-webapp/docs/agent/testing.md",
@@ -608,12 +612,18 @@ async function collectTestingDocErrors(
 }
 
 function collectReadmeLinkErrors(filePath: string, linkTargets: Set<string>) {
+  // The README is an overview that routes to focused docs. Require the links
+  // that make the reference material reachable, so moving detail out of the
+  // README cannot leave it undiscoverable. Link targets are also existence
+  // checked, so a renamed doc fails here instead of leaving a dead link.
   return collectMissingRequiredLinkErrors(
     filePath,
     linkTargets,
     [
       toRelativeLinkTarget(filePath, GRAPHIFY_WIKI_INDEX_PATH),
       toRelativeLinkTarget(filePath, PACKAGES_AGENTS_PATH),
+      toRelativeLinkTarget(filePath, HARNESS_DOC_PATH),
+      toRelativeLinkTarget(filePath, GRAPHIFY_DOC_PATH),
     ],
     "README graphify"
   );

--- a/scripts/harness-review.test.ts
+++ b/scripts/harness-review.test.ts
@@ -7,7 +7,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   buildGitProcessEnv,
   getChangedFilesForHarnessReview,
+  packageValidationIsProvided,
   parseHarnessReviewArgs,
+  repoOwnedValidationIsProvided,
   resolveHarnessReviewShell,
   runHarnessReview,
 } from "./harness-review";
@@ -1779,6 +1781,41 @@ describe("runHarnessReview", () => {
       "@athena/webapp:lint:convex:changed",
       "@athena/webapp:test",
     ]);
+  });
+});
+
+describe("validation provider scopes", () => {
+  it("treats both providers as covering the repo-owned validation set", () => {
+    expect(
+      repoOwnedValidationIsProvided({ repoValidationProvidedBy: "pr:athena" })
+    ).toBe(true);
+    expect(
+      repoOwnedValidationIsProvided({
+        validationProvidedBy: "athena-pr-tests",
+      })
+    ).toBe(true);
+  });
+
+  it("treats only the workflow provider as covering package validation", () => {
+    expect(
+      packageValidationIsProvided({ validationProvidedBy: "athena-pr-tests" })
+    ).toBe(true);
+    expect(packageValidationIsProvided({})).toBe(false);
+  });
+
+  it("keeps package validation running under the local pr:athena provider", () => {
+    // This is the distinction between the two near-identically named flags:
+    // pr:athena runs the repo-owned commands itself, but still delegates
+    // package selection to review. Only the CI provider prunes both scopes.
+    const localProvider = { repoValidationProvidedBy: "pr:athena" } as const;
+
+    expect(repoOwnedValidationIsProvided(localProvider)).toBe(true);
+    expect(packageValidationIsProvided(localProvider)).toBe(false);
+  });
+
+  it("suppresses neither scope for standalone fail-closed review", () => {
+    expect(repoOwnedValidationIsProvided({})).toBe(false);
+    expect(packageValidationIsProvided({})).toBe(false);
   });
 });
 

--- a/scripts/harness-review.ts
+++ b/scripts/harness-review.ts
@@ -39,9 +39,32 @@ type LoadedReviewTarget = {
 
 type HarnessReviewLogger = Pick<Console, "log" | "error">;
 
+/**
+ * Two parent runners can tell harness review that some commands already ran.
+ * They are separate flags because they suppress different scopes, and the
+ * narrower one is the local flag despite having the longer name.
+ *
+ * `--repo-validation-provided-by pr:athena` (narrow, local):
+ *   Suppresses only the repo-owned validation set selected for repo-owned
+ *   changed files. Package validation commands still run, because `pr:athena`
+ *   runs the repo-owned commands directly but leaves package selection to
+ *   review.
+ *
+ * `--validation-provided-by athena-pr-tests` (broad, CI):
+ *   Suppresses the repo-owned set *and* prunes the package commands that the
+ *   PR workflow already runs as separate jobs — see
+ *   `isAthenaPrTestsProvidedCommand`. Only validation-map checks and behavior
+ *   scenarios are left.
+ *
+ * Neither flag is a legacy alias of the other; passing the wrong one silently
+ * changes how much work review skips. Standalone review passes neither and
+ * stays fail-closed.
+ */
 type ParsedHarnessReviewArgs = {
   baseRef?: string;
+  /** Narrow: repo-owned commands only. Set by the local `pr:athena` ladder. */
   repoValidationProvidedBy?: "pr:athena";
+  /** Broad: repo-owned commands plus workflow-provided package commands. */
   validationProvidedBy?: "athena-pr-tests";
   providerEvidencePath?: string;
 };
@@ -54,10 +77,36 @@ type HarnessReviewOptions = {
   runPackageScript?: (workspace: string, script: string) => Promise<void>;
   runRawCommand?: (command: string) => Promise<void>;
   runHarnessBehaviorScenario?: (scenario: string) => Promise<void>;
+  /** See {@link ParsedHarnessReviewArgs} for how these two flags differ. */
   repoValidationProvidedBy?: "pr:athena";
   validationProvidedBy?: "athena-pr-tests";
   providerEvidencePath?: string;
 };
+
+/**
+ * Both flags suppress the repo-owned validation set. Read as: "a parent runner
+ * already ran `harness:test`, `delivery:documentation-check`, `test:coverage`,
+ * and `harness:inferential-review` for this same head and base."
+ */
+export function repoOwnedValidationIsProvided(options: {
+  repoValidationProvidedBy?: "pr:athena";
+  validationProvidedBy?: "athena-pr-tests";
+}) {
+  return (
+    options.repoValidationProvidedBy === "pr:athena" ||
+    options.validationProvidedBy === "athena-pr-tests"
+  );
+}
+
+/**
+ * Only the CI flag additionally prunes package commands. The local `pr:athena`
+ * ladder does not, so package validation still runs there.
+ */
+export function packageValidationIsProvided(options: {
+  validationProvidedBy?: "athena-pr-tests";
+}) {
+  return options.validationProvidedBy === "athena-pr-tests";
+}
 
 type LocalProviderCapability =
   | "harness-doc-freshness"
@@ -931,8 +980,7 @@ export async function runHarnessReview(
   }
 
   const unprunedCommands = [
-    ...(options.repoValidationProvidedBy === "pr:athena" ||
-    options.validationProvidedBy === "athena-pr-tests"
+    ...(repoOwnedValidationIsProvided(options)
       ? []
       : repoValidation.selectedCommands.map((command) => ({
           kind: "raw" as const,
@@ -941,7 +989,7 @@ export async function runHarnessReview(
     ...selectedCommands,
   ].filter(
     (command) =>
-      options.validationProvidedBy !== "athena-pr-tests" ||
+      !packageValidationIsProvided(options) ||
       !isAthenaPrTestsProvidedCommand(command)
   );
 
@@ -968,8 +1016,7 @@ export async function runHarnessReview(
   });
 
   if (
-    (options.repoValidationProvidedBy === "pr:athena" ||
-      options.validationProvidedBy === "athena-pr-tests") &&
+    repoOwnedValidationIsProvided(options) &&
     repoValidation.selectedCommands.length > 0
   ) {
     logger.log(
@@ -978,7 +1025,7 @@ export async function runHarnessReview(
   }
 
   if (
-    options.validationProvidedBy === "athena-pr-tests" &&
+    packageValidationIsProvided(options) &&
     selectedCommands.length > unprunedCommands.length
   ) {
     logger.log(
@@ -1060,7 +1107,7 @@ export function parseHarnessReviewArgs(
       const value = argv[index + 1]?.trim();
       if (value !== "pr:athena") {
         throw new Error(
-          "Missing or invalid value for --repo-validation-provided-by. Supported value: pr:athena"
+          "Missing or invalid value for --repo-validation-provided-by. Supported value: pr:athena. This flag suppresses only the repo-owned validation set; package validation still runs. For the broader CI mode that also prunes workflow-provided package commands, use --validation-provided-by athena-pr-tests."
         );
       }
       repoValidationProvidedBy = value;
@@ -1072,7 +1119,7 @@ export function parseHarnessReviewArgs(
       const value = arg.slice("--repo-validation-provided-by=".length).trim();
       if (value !== "pr:athena") {
         throw new Error(
-          "Missing or invalid value for --repo-validation-provided-by. Supported value: pr:athena"
+          "Missing or invalid value for --repo-validation-provided-by. Supported value: pr:athena. This flag suppresses only the repo-owned validation set; package validation still runs. For the broader CI mode that also prunes workflow-provided package commands, use --validation-provided-by athena-pr-tests."
         );
       }
       repoValidationProvidedBy = value;
@@ -1083,7 +1130,7 @@ export function parseHarnessReviewArgs(
       const value = argv[index + 1]?.trim();
       if (value !== "athena-pr-tests") {
         throw new Error(
-          "Missing or invalid value for --validation-provided-by. Supported value: athena-pr-tests"
+          "Missing or invalid value for --validation-provided-by. Supported value: athena-pr-tests. This flag suppresses the repo-owned validation set and prunes package commands the PR workflow runs separately. For the narrower local pr:athena mode, use --repo-validation-provided-by pr:athena."
         );
       }
       validationProvidedBy = value;
@@ -1095,7 +1142,7 @@ export function parseHarnessReviewArgs(
       const value = arg.slice("--validation-provided-by=".length).trim();
       if (value !== "athena-pr-tests") {
         throw new Error(
-          "Missing or invalid value for --validation-provided-by. Supported value: athena-pr-tests"
+          "Missing or invalid value for --validation-provided-by. Supported value: athena-pr-tests. This flag suppresses the repo-owned validation set and prunes package commands the PR workflow runs separately. For the narrower local pr:athena mode, use --repo-validation-provided-by pr:athena."
         );
       }
       validationProvidedBy = value;

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -1021,59 +1021,75 @@ describe("repo harness ergonomics", () => {
     );
   });
 
-  it("documents harness implementation tests as a repo-level command", async () => {
-    const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
+  // These docs contracts assert on docs/harness.md and docs/graphify.md rather
+  // than README.md. The README is a short overview that links out; the harness
+  // and graphify docs are the canonical references. They also assert on command
+  // and artifact tokens rather than whole sentences, so the docs can be reworded
+  // without a test edit while the delivery contract stays documented.
+  it("documents the harness delivery commands in the harness doc", async () => {
+    const harnessDoc = await readFile(
+      path.join(ROOT_DIR, "docs/harness.md"),
+      "utf8",
+    );
 
-    expect(readme).toContain("bun run harness:test");
-    expect(readme).toContain("bun run harness:inferential-review");
-    expect(readme).toContain("HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow");
-    expect(readme).toContain("--persist-history");
-    expect(readme).toContain("bun run harness:self-review --base origin/main");
+    expect(harnessDoc).toContain("bun run harness:test");
+    expect(harnessDoc).toContain("bun run harness:inferential-review");
+    expect(harnessDoc).toContain("HARNESS_INFERENTIAL_SEMANTIC_MODE=shadow");
+    expect(harnessDoc).toContain("--persist-history");
+    expect(harnessDoc).toContain(
+      "bun run harness:self-review --base origin/main",
+    );
   });
 
-  it("documents graphify setup and tracked artifact policy in the README", async () => {
+  it("keeps the README pointing at the focused docs", async () => {
     const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
 
-    expect(readme).toContain(
-      "`pre-commit:generated-artifacts` automatically runs `bun run harness:generate` and `bun run graphify:rebuild`",
+    expect(readme).toContain("./docs/harness.md");
+    expect(readme).toContain("./docs/graphify.md");
+    expect(readme).toContain("./docs/deployment/vps-production.md");
+    expect(readme).toContain("./packages/AGENTS.md");
+    expect(readme).toContain("./graphify-out/wiki/index.md");
+  });
+
+  it("documents the generated-artifact repair flow in the harness doc", async () => {
+    const harnessDoc = await readFile(
+      path.join(ROOT_DIR, "docs/harness.md"),
+      "utf8",
     );
-    expect(readme).toContain(
-      "`bun run pr:athena:prepare` starts with that same generated-artifact repair step",
+
+    // The delivery ladder phases and the fail-closed repair path.
+    expect(harnessDoc).toContain("pre-commit:generated-artifacts");
+    expect(harnessDoc).toContain("pr:athena:prepare");
+    expect(harnessDoc).toContain("pr:athena:validate");
+    expect(harnessDoc).toContain("pr:athena:record-proof");
+    expect(harnessDoc).toContain("bun run harness:generate");
+    expect(harnessDoc).toContain("bun run graphify:check");
+    expect(harnessDoc).toContain("delivery:documentation-check");
+
+    // Evidence artifact paths that agents need in order to find run output.
+    expect(harnessDoc).toContain("artifacts/harness-inferential-review/history/");
+    expect(harnessDoc).toContain("artifacts/harness-behavior/trends/history/");
+
+    // Token presence alone would pass on a doc that described the opposite
+    // behavior, so also assert the two concepts a reader must come away with:
+    // repair is fail-closed, and a stale ref must not reach CI.
+    expect(harnessDoc).toMatch(/fail-closed repair/i);
+    expect(harnessDoc).toMatch(/blocks?[^.]*\breview(ed)?\b[^.]*commit/i);
+  });
+
+  it("documents graphify setup and tracked artifact policy in the graphify doc", async () => {
+    const graphifyDoc = await readFile(
+      path.join(ROOT_DIR, "docs/graphify.md"),
+      "utf8",
     );
-    expect(readme).toContain(
-      "`bun run pr:athena:validate` runs the heavy validation ladder",
-    );
-    expect(readme).toContain(
-      "`bun run pr:athena:record-proof` records the reusable pre-push proof",
-    );
-    expect(readme).toContain(
-      "If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs",
-    );
-    expect(readme).toContain(
-      "Blocks so you can review, commit, and push the repaired generated docs instead of sending a stale ref to CI.",
-    );
-    expect(readme).toContain(
-      "`pre-push:review` starts with `bun run graphify:check`",
-    );
-    expect(readme).toContain(
-      "then runs `bun run delivery:documentation-check`",
-    );
-    expect(readme).toContain(
-      "reports solution-note and landed-change-report policy failures together",
-    );
-    expect(readme).toContain(
-      "runs `bun run graphify:rebuild` once, reruns `bun run graphify:check`, and then stops",
-    );
-    expect(readme).toContain("bun run graphify:check");
-    expect(readme).toContain("bun run graphify:rebuild");
-    expect(readme).toContain("bun run harness:generate");
-    expect(readme).toContain(".graphify_python");
-    expect(readme).toContain(".graphify-requirements.txt");
-    expect(readme).toContain("graphify-out/GRAPH_REPORT.md");
-    expect(readme).toContain("graphify-out/graph.json");
-    expect(readme).toContain("graphify-out/cache");
-    expect(readme).toContain("artifacts/harness-inferential-review/history/");
-    expect(readme).toContain("artifacts/harness-behavior/trends/history/");
+
+    expect(graphifyDoc).toContain("bun run graphify:check");
+    expect(graphifyDoc).toContain("bun run graphify:rebuild");
+    expect(graphifyDoc).toContain(".graphify_python");
+    expect(graphifyDoc).toContain(".graphify-requirements.txt");
+    expect(graphifyDoc).toContain("graphify-out/GRAPH_REPORT.md");
+    expect(graphifyDoc).toContain("graphify-out/graph.json");
+    expect(graphifyDoc).toContain("graphify-out/cache");
   });
 
   it("ignores the generated graphify cache directory", async () => {


### PR DESCRIPTION
## What

The README had grown to 334 lines, most of it harness and graphify reference detail — command lists, artifact paths, proof status values, behavior scenario names, threshold config keys, CI wiring. The product description was buried underneath.

This moves that material into the docs that own it and slims the README to 150 lines.

| Doc | Change |
| --- | --- |
| `README.md` | Rewritten as an overview: what Athena is, an honest status table naming what is missing, setup, docs index, backend shape, daily-ops vocabulary, delivery gates |
| `docs/harness.md` | New command / artifact / CI reference section, plus the previously undocumented `pr:athena:preflight` phase |
| `docs/graphify.md` | **New** — commands, tracked vs ignored artifacts, Python runtime resolution order |
| `docs/deployment/vps-production.md` | New `Prerequisites` section absorbing the VPS access requirements |

## Why this needed code changes

The README had not grown by neglect. Three harness contracts **required** that content to live in `README.md`:

1. `RUNTIME_SCENARIO_DOCS` in `scripts/harness-check.ts` gated the runtime scenario list in the README.
2. Two tests in `scripts/pre-push-review.test.ts` asserted ~25 **verbatim sentences** in the README.
3. Fixture repos in `harness-check.test.ts` and `harness-audit.test.ts` modelled the README as the scenario-list home.

Every new harness capability had to append a paragraph, and none could be removed without editing a test — the README was structurally required to grow. So the contracts are retargeted to follow the content:

- `RUNTIME_SCENARIO_DOCS` → `docs/harness.md`. Still fail-closed on a missing file or missing marker; the guarantee moved, it did not weaken.
- `collectReadmeLinkErrors` now also requires the README to link `docs/harness.md` and `docs/graphify.md`, so relocated detail cannot become unreachable.
- The pre-push docs contracts read the focused docs and assert **command/artifact tokens** rather than sentences, plus two concept assertions so a doc describing the opposite behavior still fails.

## Also included

`scripts/harness-review.ts` documents the two similarly-named provider flags, which differ in **scope** rather than being aliases — the longer name (`--repo-validation-provided-by`) is the *narrower* flag. Two named predicates replace four inline boolean expressions. This is behavior-preserving; a new `validation provider scopes` test block pins the asymmetry.

## Corrections found by grounding

Rewriting from source rather than copying prose surfaced four inherited inaccuracies:

- `thresholds.latency.maxPhaseDurationMs` is a **per-phase map** (6 keys), not a scalar
- `artifacts/harness-delivery-runs/` was missing from the ignored-artifact list
- `graphify-out/graph.html` is committed but **outside** the freshness gate
- `pr:athena` has **five** phases; `preflight` was undocumented

Also: `.graphify_python` pins `/opt/homebrew/bin/python3.10`, which does not exist on the dev machine — every local rebuild silently takes the `python3` fallback. `docs/graphify.md` documents the real resolution order.

## Review

A read-only diff analyst reviewed the branch pre-delivery and found three issues, all fixed rather than noted: the unenforced README links (above), a hair-trigger in `extractRuntimeScenarioSection` (it stops at `##` but not `###`, so the scenario scan ran to EOF — the doc now keeps the list under `## Behavior Scenario Reference` bounded by `## Artifacts And CI Reference`), and the loss of semantic pinning from token-only assertions.

A scripted check verified 22 facts from the old README all survive in a destination doc.

## Validation

- `bun run harness:test` — 516 pass, 0 fail
- `bun run harness:check`, `pr:athena:preflight`, `graphify:check` — pass
- `bun run delivery:documentation-check` — pass (solution note + landed-change report with matching fingerprints)
- Report quiz verified in-browser: grades 10/10, enforces the 8/10 threshold, reset works
- No runtime or product behavior changes; docs, harness sensors, and tests only

📄 Landed-change report: `docs/reports/2026-07-18-readme-focused-docs-report.html`
📝 Solution note: `docs/solutions/developer-experience/athena-docs-contracts-target-focused-docs-2026-07-18.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
