### PR TITLE
feat(operations): screenshot fixtures for Daily Operations/Opening Handoff/EOD Review + POS gate-flash fixes

### DIFF
--- a/docs/plans/2026-07-19-001-feat-operations-screenshot-fixtures-plan.md
+++ b/docs/plans/2026-07-19-001-feat-operations-screenshot-fixtures-plan.md
@@ -1,0 +1,170 @@
+# Operations workspace screenshot fixtures
+
+Date: 2026-07-19
+Status: proposed
+Scope: `packages/athena-webapp` — Daily Operations, Opening Handoff, EOD Review
+
+## Goal
+
+Capture product screenshots of the three operations workspaces telling an arbitrary,
+authored story — for Daily Operations specifically, a defined sales history and a
+defined current day — rendered inside the real application chrome.
+
+## What changed from the audit
+
+The feasibility audit (2026-07-19, read-only) recommended a snapshot-override seam on
+the three `XView` guards. The follow-up chrome audit refines that: **the chrome and the
+workspace need different data sources, and that split is the design.**
+
+The app shell has no router-level auth gate. `Layout` (`src/routes/-authed-layout.tsx:643`)
+returns `null` and redirects to `/login` until `useAuth()` resolves a real Convex user
+(`:744-794`). `AppSidebar` hard-bails at `src/components/app-sidebar.tsx:310` unless
+`useGetActiveStore()` and `useGetActiveOrganization()` both resolve. So real chrome
+requires a real session against a real store, no matter what we do to the workspace.
+
+That is not an obstacle — it is the cheapest correct answer. Sign in normally (dev store
+or `/demo`), let the chrome render from real data, and override only the workspace
+snapshot. No Convex interception, no Storybook router/provider stack, no seeding.
+
+## Non-goals
+
+- Seeding backdated data into Convex. The server sweep found two behavioral clock
+  couplings on read paths (V26-1082, V26-1083) that would corrupt seeded historic days.
+  Those are tracked separately and are not prerequisites for this work, because this
+  plan never executes the affected queries.
+- Making an arbitrary date read as "today" on the server. Client-only.
+- Interactive demos. These fixtures are for capture, not for driving.
+- Storybook. `.storybook-athena/main.ts:10-17` deliberately strips the TanStack Router
+  plugins and `preview.ts` mounts no Convex provider; real chrome is out of reach there
+  without disproportionate work.
+
+## Work
+
+### 1. Centralize the operating-date clock
+
+`getLocalOperatingDate` and `getLocalOperatingDateRange` are duplicated verbatim in all
+three files: `DailyOperationsView.tsx:477/485`, `DailyOpeningView.tsx:264/272`,
+`DailyCloseView.tsx:853/891`.
+
+Extract to one module (suggested: `src/lib/operations/operatingDate.ts`) taking an
+optional `now`. Thread an optional override to the residual clock reads in the render
+trees:
+
+- `DailyOperationsView.tsx:3110` — `getLocalOperatingDate()` inside `WeekMetricsStrip`,
+  decides week-nav bounds and which bar reads as the current day.
+- Calendar `latestSelectableDate` defaults: `DailyOperationsView.tsx:3033`,
+  `DailyOpeningView.tsx:1763`, `DailyCloseView.tsx:3336`.
+
+`DailyCloseViewContentProps.latestSelectableOperatingDate` (`DailyCloseView.tsx:325`)
+already exists and is exercised at `DailyCloseView.test.tsx:1183` — match that naming, or
+rename all three together. Note the existing internal asymmetry
+(`latestSelectableOperatingDate` on props vs `latestSelectableDate` internally).
+
+This is a pure refactor. Behavior with no override must be byte-identical.
+
+### 2. Snapshot-override prop on the three guards
+
+`DailyOperationsView:4660`, `DailyOpeningView:2331`, `DailyCloseView:4503` currently take
+zero props and resolve query refs at runtime, forwarding them to a module-private
+`XConnectedView`. Add one optional prop per guard that short-circuits `ConnectedView` and
+renders `XViewContent` directly from a supplied snapshot.
+
+The Content components are already exported and already driven by synthetic props in
+their sibling `.test.tsx` files — those are the reference for prop shape. Two callbacks
+are required and need no-op stubs: `DailyOpeningViewContent.onStartDay`,
+`DailyCloseViewContent.onComplete`.
+
+When the override is present no Convex query runs, which is what keeps V26-1082 and
+V26-1083 off this path entirely.
+
+### 3. Fixture registry
+
+One module per workspace, typed against the exported snapshot types
+(`DailyOperationsSnapshot:216`, `DailyOpeningSnapshot:134`, `DailyCloseSnapshot:167`).
+
+`src/components/landing/story/demoDayFixtures.ts` is the existing precedent — a 383-line
+hand-built `DailyCloseSnapshot` fixture already consumed by five landing scenes. Extend
+that pattern rather than inventing a second one.
+
+Sales history for Daily Operations is `snapshot.weekMetrics` (`:325-341`), one row per
+day: `operatingDate`, `salesTotal`, `transactionCount`, `currentDayCashTotal`,
+`expenseTotal`, `paymentTotals[]`, `isClosed`, `isReopened`, `isSelected`. Authoring that
+array *is* authoring the sales history.
+
+Gate to respect: the week strip only renders when `hasHydratedWeekAnalytics`
+(`DailyOperationsView.tsx:3527-3529`) — set `hasDetailSnapshot: true` with non-empty
+`weekMetrics`, or pass `cachedWeekMetrics` directly. Otherwise it falls through to a
+request-to-load stub.
+
+One serialization constraint: `DailyOpeningItem.metadata[].value` is `ReactNode`
+(`DailyOpeningView.tsx:122`). Use the `Record<string, unknown>` branch of that union to
+keep fixtures pure data. `DailyCloseItem` has no such issue (`value: string`).
+
+### 4. Dev-gated activation
+
+A search param on the three existing routes (suggested `?fixture=<name>`) resolved
+against the registry and passed into the guard.
+
+The router uses generated file-based routing, so route files are emitted unconditionally
+and the guard must be in-component: `import.meta.env.DEV` (the established idiom —
+`src/main.tsx:17`, `src/components/Navbar.tsx:14`). In production the param must be
+inert and the fixture modules must not reach the bundle. Verify the second part by
+inspecting the prod build output, not by reading the import graph.
+
+## Known fidelity gap — needs a decision
+
+**The sidebar will show real counts while the workspace shows fixture data.**
+
+`AppSidebar` computes its badges from live Convex queries keyed on the real
+`activeStore._id` — open work items and pending approvals at `app-sidebar.tsx:285` and
+`:300`, plus order/review/catalog counts. Those queries are untouched by a workspace-level
+override. A fixture depicting twelve pending approvals will sit beside a sidebar badge
+reading whatever the signed-in store actually has, possibly zero.
+
+Three options, in increasing cost:
+
+1. **Accept it.** Fine if screenshots crop out the sidebar or the numbers happen not to
+   contradict. Zero work.
+2. **Choose a signed-in store whose real counts roughly match the story.** Zero code,
+   some setup friction, fragile over time.
+3. **Extend the override to the sidebar counts.** Faithful, and the cleanest chokepoint
+   is `useGetActiveStore` / `useGetActiveOrganization` plus the two count queries — but it
+   widens the change from three leaf components into shared chrome used by every route.
+
+Recommend starting at (1) and escalating only if a screenshot actually shows the conflict.
+Deciding this before implementation matters, because (3) changes the shape of the work.
+
+## Sensors
+
+- Existing `DailyOperationsView.test.tsx`, `DailyOpeningView.test.tsx`,
+  `DailyCloseView.test.tsx` must pass unchanged — they are the regression guard for the
+  step-1 refactor.
+- Typecheck and build.
+- Prod build inspected for fixture-module absence.
+- `bun run pr:athena`.
+- Runtime: load each workspace with and without the param; without it, behavior and
+  network activity must be identical to today.
+
+## Risks
+
+- **Prod leakage.** A fixture path that renders authored operational numbers inside real
+  chrome is a misleading-data risk if it ever activates outside dev. The dev gate and the
+  bundle check are the mitigations; treat both as required, not optional.
+- **Refactor blast radius.** Step 1 touches three 2k-4k line files that own money-adjacent
+  close and opening flows. It is a pure extraction, but the diff will be wide.
+- **Fixture drift.** Snapshot types will evolve and hand-built fixtures will rot. Typing
+  them against the exported types means drift surfaces as a typecheck failure rather than
+  a broken screenshot.
+
+## Sequencing
+
+Step 1 stands alone and is independently mergeable — it is a refactor with no feature
+attached, and shipping it separately keeps the wide diff reviewable on its own terms.
+Steps 2-4 are one change; splitting them yields a seam with nothing driving it.
+
+## Decisions (2026-07-19)
+
+1. Sidebar fidelity — **option 1, accept the gap.** No chrome-level override. Escalate
+   only if a captured screenshot actually shows a contradiction.
+2. Capture session — **`/demo` against a dev store.**
+3. Fixture location — **`src/stories/`**, not beside the components.

--- a/docs/reports/2026-07-19-operations-screenshot-fixtures-pos-flash-fixes-report.html
+++ b/docs/reports/2026-07-19-operations-screenshot-fixtures-pos-flash-fixes-report.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="fcaf5e5dfd76e8298d1437d318320257df9e34d9b02dbb0b117c15b7d5b3ec2f">
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="51a63d57b7c3442e7515f02803af82060ab1c59847f19d5c4b9e5336803ea094">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/docs/reports/2026-07-19-operations-screenshot-fixtures-pos-flash-fixes-report.html
+++ b/docs/reports/2026-07-19-operations-screenshot-fixtures-pos-flash-fixes-report.html
@@ -1,0 +1,313 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="fcaf5e5dfd76e8298d1437d318320257df9e34d9b02dbb0b117c15b7d5b3ec2f">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Operations Screenshot Fixtures + POS Gate-Flash Fixes</title>
+    <style>
+      :root {
+        --ink: #1f2933;
+        --muted: #596674;
+        --line: #d9e2ec;
+        --paper: #ffffff;
+        --soft: #f6f8fb;
+        --accent: #1d4ed8;
+        --accent-soft: #dbeafe;
+        --good: #166534;
+        --bad: #b91c1c;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--soft);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      main { max-width: 1120px; margin: 0 auto; padding: 48px 24px 72px; }
+      header { border-bottom: 1px solid var(--line); margin-bottom: 28px; padding-bottom: 28px; }
+      h1, h2, h3 { line-height: 1.18; letter-spacing: 0; }
+      h1 { font-size: 42px; max-width: 880px; margin: 0 0 16px; }
+      h2 { font-size: 28px; margin: 0 0 16px; }
+      p { margin: 0 0 14px; }
+      .lede { color: var(--muted); font-size: 18px; max-width: 880px; }
+      .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 20px; }
+      .pill { border: 1px solid var(--line); border-radius: 999px; background: var(--paper); color: var(--muted); font-size: 13px; padding: 6px 10px; }
+      .panel { background: var(--paper); border: 1px solid var(--line); border-radius: 8px; margin: 18px 0; padding: 22px; }
+      code { background: #eef2f7; border: 1px solid #d8dee8; border-radius: 5px; padding: 1px 5px; }
+      pre { overflow: auto; background: #111827; color: #e5e7eb; border-radius: 8px; padding: 16px; }
+      pre code { background: transparent; border: 0; color: inherit; padding: 0; }
+      table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+      th, td { border-bottom: 1px solid var(--line); padding: 11px 12px; text-align: left; vertical-align: top; }
+      th { background: #eef2f7; color: var(--muted); font-size: 13px; text-transform: uppercase; }
+      tr:last-child td { border-bottom: 0; }
+      .quiz-question { border-top: 1px solid var(--line); padding: 18px 0; }
+      .quiz-question:first-child { border-top: 0; }
+      fieldset { border: 0; margin: 0; padding: 0; }
+      legend { font-weight: 700; margin-bottom: 10px; }
+      label { display: block; border: 1px solid var(--line); border-radius: 8px; background: #fbfdff; margin: 8px 0; padding: 10px 12px; cursor: pointer; }
+      @media (hover: hover) and (pointer: fine) {
+        label:hover { border-color: #b6c5d8; }
+      }
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 8px;
+        background: var(--accent);
+        color: #ffffff;
+        cursor: pointer;
+        font-weight: 700;
+        padding: 11px 16px;
+        transition: transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+      }
+      button:active { transform: scale(0.97); }
+      button.secondary { background: #475569; }
+      .quiz-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
+      #quizResult { font-weight: 700; }
+      .answer-detail { display: none; border-top: 1px dashed var(--line); color: var(--muted); margin-top: 10px; padding-top: 10px; }
+      .answer-detail.visible { display: block; }
+      .correct { border-color: #86efac !important; background: #f0fdf4 !important; }
+      .incorrect { border-color: #fecaca !important; background: #fef2f2 !important; }
+      @media (prefers-reduced-motion: reduce) { button { transition-duration: 0ms; } }
+      @media (max-width: 820px) { h1 { font-size: 32px; } main { padding: 32px 16px 56px; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Operations Screenshot Fixtures + POS Gate-Flash Fixes</h1>
+        <p class="lede">A dev-only fixture seam for Daily Operations/Opening Handoff/EOD Review screenshots, plus four unrelated POS/demo bugs found and fixed along the way</p>
+        <div class="meta"><span class="pill">Branch feat/operations-screenshot-fixtures</span><span class="pill">Delivery candidate</span><span class="pill">Not yet merged</span><span class="pill">No production deploy</span></div>
+      </header>
+      <section class="panel"><h2>What is being delivered</h2>
+<p>This branch has two parts riding together. The first is a dev-only fixture mechanism so the Daily Operations, Opening Handoff, and EOD Review workspaces can be screenshotted against fully-authored data (a plausible busy Saturday, a specific carry-forward pattern, a specific closeout variance) instead of whatever happens to be live in a dev store&#x27;s Convex data. The second is four unrelated POS/demo bugs that surfaced while driving those screenshots through the real app chrome: an Expense register infinite render loop, expense transactions silently failing to sync in the shared-demo experience, and two separate gate-flash bugs in the POS register view (drawer-not-saved, and register-closed-locally).</p>
+<p>Status: delivery candidate, not yet merged into main. No production deploy has happened or is pending — the fixture code is dev-only and inert in production builds; the bug fixes are ordinary source changes that ship on merge.</p>
+</section>
+<section class="panel"><h2>Why it mattered</h2>
+<p>Screenshots are a small ask, but doing it right required a real seam: sign in normally and let the full app chrome render from live data, then substitute only the workspace&#x27;s own data with an authored fixture. The alternative — seeding backdated rows into Convex — was explicitly rejected. Two known read-path defects (tracked separately as V26-1082/V26-1083) mean the server can read &quot;today&quot; against the wrong clock in some cases, so backdating real rows risked corrupting the very history being staged for a screenshot, in a way that would be hard to notice and easy to ship.</p>
+<p>The bug fixes matter independently of the fixture work: an infinite render loop burns CPU and can crash a worker; expenses silently failing to sync in the demo experience means a manager can add an expense that just vanishes; and both gate-flash bugs make a normal POS operator flow (closing a drawer, opening a replacement) briefly show contradictory or alarming UI before settling — exactly the kind of thing a cashier notices and a screenshot would have caught.</p>
+</section>
+<section class="panel"><h2>The mental model</h2>
+<p>Think of the fixture mechanism as a single clock plus a single data-substitution point. Before this branch, each of the three workspaces derived &quot;today&quot; independently from `new Date()` at roughly thirty call sites, and always queried Convex directly. After: every one of those thirty call sites now reads through one function, `getOperatingClockNow()`, defined in `operatingDate.ts`. A dev-only hook can override that clock and, separately, hand the view a fully-formed `fixture` prop that makes it skip the Convex query and render pre-built props directly. Production code paths never call the override — they just call the same clock function, which defaults to `new Date()` when nothing has overridden it.</p>
+<p>The gate-flash bugs share a different mental model: a UI gate (drawer-not-saved, register-closed) is meant to represent a *resting* state, but the state machine underneath briefly passes through a transitional value on its way from one resting state to the next. The bug in both cases was treating a transitional value as if it were a resting one — showing the gate during a hand-off it wasn&#x27;t built to represent.</p>
+</section>
+<section class="panel"><h2>Before vs after: the fixture seam</h2>
+<p>Before: three copies of near-identical &quot;what&#x27;s the operating date for this workspace&quot; logic across DailyOperationsView.tsx, DailyOpeningView.tsx, and DailyCloseView.tsx, each reading `new Date()` directly, with no way to freeze a moment in time or substitute the data driving the screen.</p>
+<p>After: `operatingDate.ts` is the one place that logic lives, exposing `getLocalOperatingDate`, `getLocalOperatingDateRange`, `getLocalDateFromOperatingDate`, and `getLocalOperatingDateRangeFromSearch` as pure helpers, plus a settable `operatingClockOverride` behind `setOperatingClockOverride`/`getOperatingClockNow`. A dev-only hook (`devFixtureActivation.ts`&#x27;s `useWorkspaceFixture`, wrapped per-workspace as `useDailyOperationsFixture`/`useDailyOpeningFixture`/`useDailyCloseFixture`) resolves a `?fixture=&lt;name&gt;` search param via a dynamic `import()` gated on `import.meta.env.DEV`, pins the clock to that fixture&#x27;s authored moment, and hands the view a `fixture` prop typed against the workspace&#x27;s own real content-props type. When present, the view renders directly from that prop and skips its Convex query entirely.</p>
+<p>The static-import approach was tried first and rejected: Vite folds `import.meta.env.DEV` to `false` in a production build, but Rollup still keeps a statically-imported module reachable, so the authored fixture strings would still ship in the production bundle. Switching to a dynamic `import()` behind the same dev check was verified by grepping the built `dist/` output for fixture strings — none found.</p>
+</section>
+<section class="panel"><h2>Layer-by-layer: how a fixture screenshot actually renders</h2>
+<p>1. The route (e.g. `.../operations/index.tsx`) declares `fixture: z.string().optional()` in its search schema and reads it via `Route.useSearch()`.</p>
+<p>2. It calls the workspace-specific hook (`useDailyOperationsFixture(fixtureName)`), which resolves to `{ clock, props }` from a dynamic import and calls `setOperatingClockOverride(clock)` as a side effect, then returns `{ fixture: props, isResolving }`.</p>
+<p>3. The route holds its render (`if (isResolving) return null`) so the workspace component is never mounted mid-resolution — it never takes a half-frame detour through the live Convex path before the fixture is ready.</p>
+<p>4. The workspace component (`DailyOperationsView`, etc.) receives `fixture` as a prop; when set, it renders `&lt;DailyOperationsViewContent {...fixture} /&gt;` directly instead of wiring up its normal Convex query hook.</p>
+<p>5. Anywhere in that content tree that needs &quot;today&quot; (date pickers&#x27; selectable bounds, header labels) calls `getOperatingClockNow()`, which now returns the fixture&#x27;s authored clock instead of the real wall clock — so the whole rendered screen, including date-picker constraints, is internally consistent with the fixture&#x27;s story.</p>
+</section>
+<section class="panel"><h2>The four bug fixes: root cause and mechanism</h2>
+<p>**1. Expense register infinite render loop.** Two stacked loops, the first masking the second. The POS local store&#x27;s Proxy facade returns a brand-new function object from its `get` trap on every property access — so `localStore.listEvents` is a *different* function reference every render. Reading it inline inside `useExpenseRegisterViewModel.ts` fed that ever-changing reference into an effect&#x27;s dependency array, causing re-render → new function reference → effect fires again → loop. Fixed with `useMemo(() =&gt; localStore.listEvents, [localStore])`, keyed on the stable store singleton rather than the churning Proxy trap output. Once that loop stopped, a second, previously-masked loop appeared: `eventAppendToken` was being used both as the input that triggers the sync runtime *and* as the value that runtime&#x27;s own change-notification bumped — direct self-feedback. Fixed by splitting it into an append-only `eventAppendToken` (drives the trigger) and a separate `localReadRefreshToken` (carries settle notifications), with consumers seeing their sum.</p>
+<p>**2. Demo expense transactions not syncing.** Two independent Convex-side gates, both already open for register/sale events, were never extended to expense events. First, `ingestLocalEvents` rejects any shared-demo upload missing an `expectedDemoEpoch` (a retryable `precondition_failed`) — fixed by forwarding `sharedDemoContext.restore.epoch` from the expense view model into the expense local runtime. Second, expense events map to a capability (`expense.manage`) that wasn&#x27;t yet in the shared-demo allow-list — added to `capabilityCatalog.ts`&#x27;s `SHARED_DEMO_ALLOWED_CAPABILITIES`, plus a matching entry in `policy.ts`&#x27;s function-inventory registering `pos/public/sync:ingestLocalEvents` against that capability (required by an existing coverage self-audit test).</p>
+<p>**3. Drawer-not-saved gate flashing after opening a replacement drawer.** Opening a replacement drawer re-settles cloud register authority across two snapshots in sequence. The first pass runs against a transitional snapshot — where the just-closed session&#x27;s old mapping and the brand-new session briefly coexist — and that pass reports what looks like a failure before the second, settled pass succeeds. The first attempted fix suppressed the wrong reason code (`candidate_invalid`); live browser instrumentation of the actual gate state during a real replacement-drawer open showed the transient reason was actually `mapping_invalidated`. The landed fix in `hasBlockingAuthorityPersistenceFailure` narrows blocking to exactly two genuine-failure reasons (`write_failed`, `snapshot_invalid`); `mapping_invalidated` and `candidate_invalid` are now explicitly treated as non-blocking re-settles rather than save failures.</p>
+<p>**4. Register-closed-locally gate flashing during closeout, plus a visual redesign.** During a closeout submit, the drawer-gate view model briefly returns `null` for about 21ms while it hands off from the closeout view to the &quot;open a replacement drawer&quot; view. The old code rendered the locally-closed notice unconditionally whenever sync status said `locally_closed_pending_sync`, so it filled that ~21ms gap with a full card before the replacement-drawer gate took over — a visible flash. The first hypothesis (a `canOpenReplacement` derivation flipping late) was disproven by instrumentation: that value was `false` for the entire window. The actual cause was the locally-closed notice&#x27;s render condition simply not checking whether a drawer-gate flow was already active. The fix adds `!viewModel.drawerGate` to the card&#x27;s render condition, plus a 200ms settle timer so the resting-state card only appears once the drawer-gate transition has genuinely finished (a neutral placeholder fills the brief gap instead). Alongside the flash fix, the card itself was redesigned per product review: smaller, a quieter cloud icon instead of a warning-colored one, adaptive copy that reflects pending-count or in-flight syncing, and a self-resetting retry button — while keeping the same outer workspace frame every other gate state uses.</p>
+</section>
+<section class="panel"><h2>Failure boundaries</h2>
+<p>The fixture clock override (`operatingClockOverride` in `operatingDate.ts`) is a plain module-level mutable variable with no environment guard inside the file itself. Safety rests entirely on the fact that only `devFixtureActivation.ts` ever calls `setOperatingClockOverride`, and that module&#x27;s callers are gated by `import.meta.env.DEV`. Nothing inside `operatingDate.ts` would stop a future caller outside that dev-gated path from pinning the clock in production — this is a convention, not an enforced boundary, and is worth a lint/review note if the fixture surface grows.</p>
+<p>The 200ms settle delay in the register-closed gate and the 2-second optimistic-retry window in the redesigned card are both timing heuristics, not state-driven guarantees. Under network conditions slower or faster than what was manually tested, either window could reintroduce a brief flash (settle delay too short) or show a stale &quot;Syncing…&quot; state after the real sync already finished (retry window too long/short). They were tuned against the live demo environment&#x27;s actual transition timings, not derived from a hard invariant.</p>
+<p>`hasBlockingAuthorityPersistenceFailure` now treats `mapping_invalidated` and `candidate_invalid` as always non-blocking. If a future genuine failure mode is ever represented with one of those two reason strings, it would be silently swallowed by this gate — the fix is correct for the currently-understood state machine, but it is a semantic commitment, not just a bug fix, and future authority-persistence work should treat those two reason strings as reserved for transitional re-settles.</p>
+</section>
+<section class="panel"><h2>Validation</h2>
+<p>Each of the four bug fixes was verified with direct browser instrumentation of the live demo/POS flow — console-logging the actual gate-relevant state (sync status, drawer-gate mode, blocking reasons) across the real user interaction (closeout submit, drawer-open, expense add) — rather than relying on static code reading or a subagent&#x27;s traced hypothesis. This mattered: on three separate occasions (the expense loop, the drawer-not-saved flash, and the register-closed flash) the first plausible-sounding root-cause theory was wrong, and only live instrumentation of the actual runtime state during the failing interaction surfaced the real cause.</p>
+<p>Local checks run clean on the rebased branch: `tsc --noEmit` (typecheck) passes with no errors; `bun run lint:frontend:changed` passes with no warnings on every file touched by the branch; and the full relevant unit-test set — `registerUiState.test.ts` (12 tests), `operatingDate.test.ts` (14 tests), `useExpenseRegisterViewModel.test.ts` (41 tests), `DailyOpeningView.test.tsx` (25 tests), `DailyOperationsView.test.tsx` (86 tests), and `DailyCloseView.test.tsx` (56 tests) — all pass, 234 tests total across those six files.</p>
+<p>The branch was rebased onto `origin/main` after an upstream PR (#684, &quot;clean eod/opening handoff&quot;) landed touching the same operations view files; the rebase produced one real content conflict (a route search-schema that had dropped the `fixture` search param) resolved by keeping both the upstream cleanup and the fixture param, plus a mechanical `graphify-out/graph.json` conflict resolved by taking the incoming generated artifact (regenerated automatically by the commit hook regardless). Full typecheck and the affected test suites were re-run after the rebase and remained green.</p>
+</section>
+<section class="panel"><h2>Next-time guidance</h2>
+<p>When a POS/register gate flickers between states, instrument the live runtime state directly (console-log the exact view-model fields the render condition reads, across the real interaction) before forming a theory from reading the code. All three gate-flash-style bugs on this branch had a wrong first theory that looked reasonable from the code alone, and each was only correctly diagnosed once the actual state sequence was captured from a real browser session.</p>
+<p>If you add a fourth workspace fixture (or extend these three further), route it through the same `operatingDate.ts` clock and `devFixtureActivation.ts` dynamic-import pattern rather than inventing a parallel mechanism — the dynamic-import-behind-dev-check shape exists specifically because the more obvious static-import approach was tried and found to leak fixture strings into production bundles.</p>
+<p>Treat the 200ms settle delay and 2-second retry window in the register-closed gate as tuned constants, not architectural guarantees — if either transition is observed to still flash (or to show a stale syncing state) under different network conditions, adjust the timing rather than assuming the underlying precedence fix is wrong.</p>
+</section>
+      
+<section class="panel">
+  <h2>Key Files</h2>
+  <table>
+    <thead><tr><th>File</th><th>Why It Matters</th></tr></thead>
+    <tbody><tr><td><code>packages/athena-webapp/src/lib/operations/operatingDate.ts</code></td><td>The single clock and date-derivation seam every operations workspace now reads through; holds the fixture clock override.</td></tr>
+<tr><td><code>packages/athena-webapp/src/stories/operations/devFixtureActivation.ts</code></td><td>Dev-only, dynamic-import-gated hook that resolves ?fixture= to a clock + props and pins the workspace to it.</td></tr>
+<tr><td><code>packages/athena-webapp/src/stories/operations/operationsFixtureContext.ts</code></td><td>Shared identity/dates/totals so the three authored fixtures can&#x27;t drift against each other.</td></tr>
+<tr><td><code>packages/athena-webapp/src/stories/operations/dailyOperationsFixtures.ts</code></td><td>The authored busy-Saturday Daily Operations story, including store-day timeline events and register sessions.</td></tr>
+<tr><td><code>packages/athena-webapp/src/stories/operations/openingHandoffFixtures.ts</code></td><td>Authored Opening Handoff fixture, including carry-forward row data matched to production copy/behavior.</td></tr>
+<tr><td><code>packages/athena-webapp/src/stories/operations/eodReviewFixtures.ts</code></td><td>Authored EOD Review fixture, including a specific closeout variance story.</td></tr>
+<tr><td><code>packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts</code></td><td>Splits the self-feeding token into an append-only trigger and a separate refresh signal; fixes the second, masked render loop.</td></tr>
+<tr><td><code>packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts</code></td><td>Memoizes the Proxy-facade method read and plumbs expectedDemoEpoch through to the local runtime.</td></tr>
+<tr><td><code>packages/athena-webapp/convex/sharedDemo/capabilityCatalog.ts</code></td><td>Adds expense.manage to the shared-demo capability allow-list, unblocking expense sync in the demo experience.</td></tr>
+<tr><td><code>packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts</code></td><td>hasBlockingAuthorityPersistenceFailure now excludes transitional re-settle reasons from blocking the drawer gate.</td></tr>
+<tr><td><code>packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx</code></td><td>Redesigns the locally-closed card and fixes its flash by yielding to an active drawer-gate flow with a settle delay.</td></tr></tbody>
+  </table>
+</section>
+
+      
+<section class="panel">
+  <h2>Subagent Evidence</h2>
+  <ul><li><strong>delivered diff analysis (Explore agent):</strong> Read the actual git diff against origin/main for all 25 substantive files, confirmed the fixture mechanism&#x27;s before/after architecture, traced the mechanism of each of the four bug fixes to specific lines, enumerated the test files added/extended, and flagged the unguarded clock-override and timing-heuristic risks used in the Failure Boundaries section.</li>
+<li><strong>session/decision-history analysis (general-purpose agent):</strong> Read the plan doc&#x27;s stated goals and rejected alternatives (no Convex data seeding, due to V26-1082/1083 clock-read defects), reconstructed the actual 12-commit decision sequence, and confirmed the three wrong-first-theory diagnoses (Proxy-facade churn, mapping_invalidated vs candidate_invalid, canOpenReplacement disproven by instrumentation) used in the Validation and Next-time Guidance sections.</li></ul>
+</section>
+
+      
+<section id="quiz" class="panel">
+  <h2>Quiz: Pass Required</h2>
+  <p>You must score at least 8 out of 10 to pass.</p>
+  <form id="changeQuiz" data-threshold="8">
+    
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>1. Why was seeding backdated Convex data rejected as an approach for authoring the Daily Operations fixture?</legend>
+    <label><input type="radio" name="q1" value="0" /> Convex doesn&#x27;t support historical timestamps</label>
+<label><input type="radio" name="q1" value="1" /> Two known server-side clock-read defects (V26-1082/1083) could corrupt the seeded history</label>
+<label><input type="radio" name="q1" value="2" /> It would have required a schema migration</label>
+<label><input type="radio" name="q1" value="3" /> The demo store doesn&#x27;t allow writes</label>
+  </fieldset>
+  <div class="answer-detail">The plan doc explicitly names this as the reason: seeding real rows into Convex risked interacting with two known behavioral clock couplings on read paths, corrupting the very history being staged.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>2. Why does the fixture mechanism use a dynamic `import()` instead of a static import gated by `import.meta.env.DEV`?</legend>
+    <label><input type="radio" name="q2" value="0" /> Dynamic imports are faster at runtime</label>
+<label><input type="radio" name="q2" value="1" /> Static imports don&#x27;t support TypeScript types</label>
+<label><input type="radio" name="q2" value="2" /> Vite folds the DEV check to false, but Rollup still keeps a statically-imported module reachable, so fixture strings would still ship in production</label>
+<label><input type="radio" name="q2" value="3" /> Convex requires dynamic imports for its query hooks</label>
+  </fieldset>
+  <div class="answer-detail">This was tried and empirically disproven by grepping the built dist/ output — a static import leaked fixture strings into the production bundle despite the DEV check.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>3. What is the single seam that every &#x27;today&#x27; derivation in the three operations workspaces now reads through?</legend>
+    <label><input type="radio" name="q3" value="0" /> A Convex query field</label>
+<label><input type="radio" name="q3" value="1" /> getOperatingClockNow() in operatingDate.ts</label>
+<label><input type="radio" name="q3" value="2" /> A React context provider</label>
+<label><input type="radio" name="q3" value="3" /> The browser&#x27;s Date.now()</label>
+  </fieldset>
+  <div class="answer-detail">operatingDate.ts centralizes the previously-triplicated date logic; getOperatingClockNow() returns the real clock by default and the fixture-pinned clock only when a dev fixture has set an override.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>4. What was the actual root cause of the Expense register infinite render loop, after the first loop was fixed?</legend>
+    <label><input type="radio" name="q4" value="0" /> A missing key prop in a list</label>
+<label><input type="radio" name="q4" value="1" /> eventAppendToken feeding both the sync trigger and its own change-notification target — direct self-feedback</label>
+<label><input type="radio" name="q4" value="2" /> A Convex query re-subscribing every render</label>
+<label><input type="radio" name="q4" value="3" /> React 18 StrictMode double-invoking effects</label>
+  </fieldset>
+  <div class="answer-detail">This second, masked loop only appeared after the Proxy-facade memoization fix stopped the first loop; it was fixed by splitting the token into an append-only trigger and a separate refresh signal.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>5. What was the actual transient reason code behind the drawer-not-saved gate flash, and how was it found?</legend>
+    <label><input type="radio" name="q5" value="0" /> candidate_invalid, found by reading the state machine&#x27;s type definitions</label>
+<label><input type="radio" name="q5" value="1" /> mapping_invalidated, found by instrumenting the live gate state during a real replacement-drawer open</label>
+<label><input type="radio" name="q5" value="2" /> write_failed, found in the error logs</label>
+<label><input type="radio" name="q5" value="3" /> snapshot_invalid, found via a failing unit test</label>
+  </fieldset>
+  <div class="answer-detail">The first fix guessed candidate_invalid and didn&#x27;t work; live browser instrumentation of the actual state during the real interaction showed the transient reason was mapping_invalidated.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>6. What disproved the initial theory for the register-closed-locally gate flash?</legend>
+    <label><input type="radio" name="q6" value="0" /> A code review comment</label>
+<label><input type="radio" name="q6" value="1" /> Live instrumentation showing the canOpenReplacement derivation was false throughout the entire flash window</label>
+<label><input type="radio" name="q6" value="2" /> A failing typecheck</label>
+<label><input type="radio" name="q6" value="3" /> The bug reproduced in a unit test but not in the browser</label>
+  </fieldset>
+  <div class="answer-detail">Direct instrumentation captured the canOpenReplacement value across the whole transition and it was false the entire time, ruling out the first hypothesis and pointing to the drawer-gate null-gap instead.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>7. What actually fills the ~21ms gap where viewModel.drawerGate is null during a closeout submit, after this branch&#x27;s fix?</legend>
+    <label><input type="radio" name="q7" value="0" /> The locally-closed card, same as before</label>
+<label><input type="radio" name="q7" value="1" /> A neutral placeholder div, shown until a 200ms settle timer confirms the transition has genuinely finished</label>
+<label><input type="radio" name="q7" value="2" /> Nothing — the screen goes blank</label>
+<label><input type="radio" name="q7" value="3" /> The onboarding workspace</label>
+  </fieldset>
+  <div class="answer-detail">isLocalClosedRestCandidate requires !viewModel.drawerGate, and a 200ms settle timer delays showing the actual card so a neutral frame covers the brief gap instead.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>8. What local validation was run on this branch before it was considered ready to push?</legend>
+    <label><input type="radio" name="q8" value="0" /> Only a manual browser check, no automated tests</label>
+<label><input type="radio" name="q8" value="1" /> tsc --noEmit, lint:frontend:changed, and the full relevant unit-test set across six test files (234 tests), all passing, re-verified after a rebase onto origin/main</label>
+<label><input type="radio" name="q8" value="2" /> Only the newly-added tests, not the full suite</label>
+<label><input type="radio" name="q8" value="3" /> CI was the only validation; nothing ran locally</label>
+  </fieldset>
+  <div class="answer-detail">Typecheck, lint, and 234 tests across registerUiState, operatingDate, useExpenseRegisterViewModel, DailyOpeningView, DailyOperationsView, and DailyCloseView all passed, both before and after the rebase.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>9. What is the recommended approach if a POS register gate is observed flickering between UI states in the future?</legend>
+    <label><input type="radio" name="q9" value="0" /> Read the component&#x27;s render conditions carefully and reason out the fix from the code alone</label>
+<label><input type="radio" name="q9" value="1" /> Add a longer timeout and move on</label>
+<label><input type="radio" name="q9" value="2" /> Instrument the live runtime state directly across the real interaction before forming a root-cause theory — all three gate-flash bugs here had a wrong first theory from code-reading alone</label>
+<label><input type="radio" name="q9" value="3" /> File it as low-priority since gates always flicker briefly</label>
+  </fieldset>
+  <div class="answer-detail">This branch had three separate cases where a plausible code-reading-based theory was wrong, and only direct browser instrumentation of the actual state sequence found the real cause.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>10. What is the deploy/merge status of this branch as described in this report?</legend>
+    <label><input type="radio" name="q10" value="0" /> Already merged and deployed to production</label>
+<label><input type="radio" name="q10" value="1" /> A delivery candidate, not yet merged into main, with no production deploy pending</label>
+<label><input type="radio" name="q10" value="2" /> Merged but deploy is blocked on a separate approval</label>
+<label><input type="radio" name="q10" value="3" /> Abandoned in favor of a different approach</label>
+  </fieldset>
+  <div class="answer-detail">This report describes a delivery candidate. It does not claim merge, deploy, or root-alignment status that hasn&#x27;t actually occurred.</div>
+</div>
+
+    <div class="quiz-actions">
+      <button type="button" id="gradeQuiz">Grade quiz</button>
+      <button type="button" class="secondary" id="resetQuiz">Reset</button>
+      <span id="quizResult" aria-live="polite"></span>
+    </div>
+  </form>
+</section>
+
+    </main>
+    <script>
+      const questions = Array.from(document.querySelectorAll(".quiz-question"));
+      const result = document.getElementById("quizResult");
+      const form = document.getElementById("changeQuiz");
+      const threshold = Number(form.dataset.threshold || 0);
+      function clearGrades() {
+        questions.forEach((question) => {
+          question.classList.remove("correct", "incorrect");
+          question.querySelector(".answer-detail").classList.remove("visible");
+        });
+        result.textContent = "";
+        result.style.color = "";
+      }
+      document.getElementById("gradeQuiz").addEventListener("click", () => {
+        clearGrades();
+        let score = 0;
+        questions.forEach((question, index) => {
+          const selected = document.querySelector(`input[name="q${index + 1}"]:checked`);
+          const isCorrect = selected && Number(selected.value) === Number(question.dataset.answer);
+          if (isCorrect) score += 1;
+          question.classList.add(isCorrect ? "correct" : "incorrect");
+          question.querySelector(".answer-detail").classList.add("visible");
+        });
+        const passed = score >= threshold;
+        result.textContent = passed
+          ? `Passed: ${score}/${questions.length}.`
+          : `Not passed: ${score}/${questions.length}. Review the report and try again.`;
+        result.style.color = passed ? "var(--good)" : "var(--bad)";
+      });
+      document.getElementById("resetQuiz").addEventListener("click", () => {
+        form.reset();
+        clearGrades();
+      });
+    </script>
+  </body>
+</html>

--- a/docs/solutions/workflow-issues/athena-pos-gate-flash-instrument-before-theorize-2026-07-19.md
+++ b/docs/solutions/workflow-issues/athena-pos-gate-flash-instrument-before-theorize-2026-07-19.md
@@ -1,0 +1,114 @@
+---
+title: Athena POS Gate Flashes — Instrument the Live State Before Theorizing
+date: 2026-07-19
+category: workflow-issues
+module: athena-webapp
+problem_type: workflow_issue
+component: development_workflow
+resolution_type: workflow_improvement
+severity: medium
+applies_when:
+  - A POS register or drawer gate briefly flickers to the wrong UI state before settling
+  - A render loop or transient state bug looks explainable from reading the code alone
+tags: [pos, register-gate, debugging, instrumentation, transitional-state]
+delivery_diff_fingerprint: fcaf5e5dfd76e8298d1437d318320257df9e34d9b02dbb0b117c15b7d5b3ec2f
+---
+
+# Athena POS Gate Flashes — Instrument the Live State Before Theorizing
+
+## Problem
+
+Athena's POS register view renders a chain of exclusive UI gates (drawer-not-saved,
+register-closed-locally, onboarding, drawer-open) chosen by a ternary chain over
+several view-model fields. When the underlying state machine passes through a
+transitional value on its way from one resting state to the next, a gate whose
+render condition doesn't distinguish "resting" from "transitional" briefly shows —
+a visible flash a cashier or manager notices, even though the final settled state
+is correct.
+
+## Symptoms
+
+- The "drawer not saved" gate flashes for a frame or two after opening a
+  replacement drawer, even though the drawer opens successfully.
+- The "register closed locally" gate flashes during a closeout submit, before the
+  "open a replacement drawer" gate renders — even though the closeout is correct.
+- An Expense register view enters an infinite render loop with no obviously wrong
+  code on first read.
+- In all three cases, the first root-cause theory formed by reading the code was
+  wrong.
+
+## What Didn't Work
+
+- Reading `hasBlockingAuthorityPersistenceFailure`'s reason-code list and guessing
+  which reason was transitional (`candidate_invalid`) — the real transient reason
+  was a different one (`mapping_invalidated`) that only showed up when the actual
+  gate state was captured during a real replacement-drawer open.
+- Hypothesizing that a derived boolean (`activeCloseoutCanOpenReplacementDrawer`)
+  flipped late and caused the register-closed flash — direct instrumentation
+  showed that value was `false` for the entire flash window, disproving the
+  theory outright.
+- Trusting a subagent's traced explanation of the Expense render loop over direct
+  evidence — the trace was plausible but pointed at the wrong layer; the actual
+  cause (a Proxy facade returning a new function identity on every access) only
+  surfaced once the render was instrumented directly in the browser.
+
+## Solution
+
+Console-log the exact view-model fields a gate's render condition reads, across
+the real failing interaction, before writing a fix:
+
+```tsx
+if (import.meta.env.DEV) {
+  console.log("[gate-debug]", {
+    showGate: someGateCondition,
+    syncStatus: localCloseoutSyncStatus?.status,
+    drawerGate: viewModel.drawerGate?.mode ?? null,
+  });
+}
+```
+
+Reproduce the interaction in a real browser session (sign in, drive the actual
+closeout/drawer-open/expense-add flow), capture the sequence of values, and only
+then identify which values are transitional versus resting. For the register-closed
+flash, this showed `drawerGate` genuinely drops to `null` for about 21ms during the
+hand-off between two drawer-gate views — a real gap, not a symptom of the wrong
+derivation. The fix made the gate's render condition depend on the co-occurring
+signal (`!viewModel.drawerGate`) rather than only the value that seemed relevant
+from reading the code, and added a short settle delay to bridge the residual gap.
+
+## Why This Matters
+
+Transitional-state bugs are, by definition, invisible to static code reading: the
+code correctly transitions through the offending value, and nothing in the source
+marks that value as "don't render a gate for this." Only capturing the live
+sequence of values during the actual interaction reveals which value is the
+transitional one. All three bugs on this branch had a plausible, code-reading-based
+first theory that was wrong; all three were correctly diagnosed only after direct
+instrumentation of the real runtime state.
+
+## Prevention
+
+- When a gate/render-loop bug is reported as "flashes briefly" or "loops
+  intermittently," instrument the actual state before proposing a fix — don't
+  treat a plausible trace (yours or a subagent's) as verified until it's been
+  checked against live captured state.
+- Prefer a temporary `console.log` gated by `import.meta.env.DEV` (or direct
+  browser instrumentation) over reasoning from the ternary chain alone; remove the
+  temporary log once the fix is verified.
+- After a fix, re-run the exact interaction and confirm the previously-flashing
+  state never renders across the transition, not just that the final settled
+  state looks right in a screenshot.
+
+## Examples
+
+The register-closed-locally gate fix in `POSRegisterView.tsx` added
+`!viewModel.drawerGate` to its render condition and a 200ms settle timer
+(`isLocalClosedRestSettled`), verified by capturing `{candidate, settled, sync,
+gate}` across a full closeout-to-replacement-drawer cycle and confirming the card
+never rendered mid-transition. The drawer-not-saved fix in `registerUiState.ts`'s
+`hasBlockingAuthorityPersistenceFailure` was corrected the same way, after the
+first attempt suppressed the wrong reason code.
+
+## Related
+
+- [Athena Cross-Layer Delivery Needs Bounded Reads and Contract Proof](athena-cross-layer-delivery-contracts-2026-07-18.md)

--- a/docs/solutions/workflow-issues/athena-pos-gate-flash-instrument-before-theorize-2026-07-19.md
+++ b/docs/solutions/workflow-issues/athena-pos-gate-flash-instrument-before-theorize-2026-07-19.md
@@ -11,7 +11,7 @@ applies_when:
   - A POS register or drawer gate briefly flickers to the wrong UI state before settling
   - A render loop or transient state bug looks explainable from reading the code alone
 tags: [pos, register-gate, debugging, instrumentation, transitional-state]
-delivery_diff_fingerprint: fcaf5e5dfd76e8298d1437d318320257df9e34d9b02dbb0b117c15b7d5b3ec2f
+delivery_diff_fingerprint: 51a63d57b7c3442e7515f02803af82060ab1c59847f19d5c4b9e5336803ea094
 ---
 
 # Athena POS Gate Flashes — Instrument the Live State Before Theorizing

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10806 nodes · 13087 edges · 2603 communities detected
+- 10807 nodes · 13088 edges · 2603 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3645,112 +3645,112 @@ Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
 ### Community 251 - "Community 251"
+Cohesion: 0.25
+Nodes (2): handleKeyDown(), isDebugShortcut()
+
+### Community 252 - "Community 252"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.36
 Nodes (7): browserLocks(), clearCurrentPosLocalStorageEngine(), createCurrentPosLocalStorageEngineStore(), maintenanceResult(), maintenanceUnavailableResult(), openCurrentPosLocalStorageEngine(), runCurrentPosLocalStorageEngineOperation()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.25
 Nodes (2): canClearExactCloudClosedDrawer(), hasCommandIdentity()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.22
 Nodes (0):
-
-### Community 265 - "Community 265"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 266 - "Community 266"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 267 - "Community 267"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 268 - "Community 268"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.32
 Nodes (4): createProductsQueryCtx(), createSkuMutationCtx(), pendingCheckoutEvidence(), pendingCheckoutItem()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.39
 Nodes (5): convertCloseoutRecords(), convertPayments(), migratePosAmountTableWithCtx(), pesewasPatchForRow(), upsertMigrationRun()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 277 - "Community 277"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 278 - "Community 278"
 Cohesion: 0.25
@@ -3761,64 +3761,64 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 280 - "Community 280"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 281 - "Community 281"
 Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
 
 ### Community 282 - "Community 282"
-Cohesion: 0.46
-Nodes (7): canonicalReportingFactSemanticFingerprint(), normalizedCloseSnapshot(), normalizedCurrency(), normalizedOptionalString(), normalizeReportingFactSemantics(), reportingFactKnownMaterialMatches(), reportingPeriodLineage()
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
 ### Community 283 - "Community 283"
 Cohesion: 0.46
-Nodes (6): failedProjectionWorkPatch(), markFactProjectionPendingWithCtx(), markInventoryEffectProjectionPendingWithCtx(), pendingProjectionWorkPatch(), scheduleFactProjectionBatchWithCtx(), scheduleInventoryEffectProjectionWithCtx()
+Nodes (7): canonicalReportingFactSemanticFingerprint(), normalizedCloseSnapshot(), normalizedCurrency(), normalizedOptionalString(), normalizeReportingFactSemantics(), reportingFactKnownMaterialMatches(), reportingPeriodLineage()
 
 ### Community 284 - "Community 284"
+Cohesion: 0.46
+Nodes (6): failedProjectionWorkPatch(), markFactProjectionPendingWithCtx(), markInventoryEffectProjectionPendingWithCtx(), pendingProjectionWorkPatch(), scheduleFactProjectionBatchWithCtx(), scheduleInventoryEffectProjectionWithCtx()
+
+### Community 285 - "Community 285"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.46
 Nodes (7): bindSharedDemoRegisterBaselineWithCtx(), browserSessionNote(), buildSharedDemoRegisterCashBaseline(), buildSharedDemoRegisterNarrative(), buildSharedDemoStoreSchedule(), ensureSharedDemoStoreScheduleWithCtx(), planSharedDemoRegisterAllocation()
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.5
 Nodes (7): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getRegisterSessionTraceIdentity(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx(), requireAdminWorkflowTraceAccess(), requireFullAdminOrManagerElevationTraceAccess()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.43
 Nodes (7): clearAthenaAuthSyncHandoff(), failAthenaAuthSyncHandoff(), getAthenaAuthSyncHandoffStatus(), normalizeAuthSyncRedirect(), parseHandoff(), readRawHandoff(), startAthenaAuthSyncHandoff()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 294 - "Community 294"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 295 - "Community 295"
 Cohesion: 0.25
@@ -5021,36 +5021,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 595 - "Community 595"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (1): buildCtx()
 
 ### Community 596 - "Community 596"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 597 - "Community 597"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 598 - "Community 598"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 599 - "Community 599"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 599 - "Community 599"
+### Community 600 - "Community 600"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 600 - "Community 600"
+### Community 601 - "Community 601"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 601 - "Community 601"
+### Community 602 - "Community 602"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 602 - "Community 602"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 603 - "Community 603"
 Cohesion: 0.5
@@ -5062,7 +5062,7 @@ Nodes (0):
 
 ### Community 605 - "Community 605"
 Cohesion: 0.5
-Nodes (1): buildCtx()
+Nodes (0):
 
 ### Community 606 - "Community 606"
 Cohesion: 0.5

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2674 files · ~0 words
+- 2677 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10799 nodes · 13080 edges · 2600 communities detected
+- 10805 nodes · 13086 edges · 2603 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2610,6 +2610,9 @@
 - [[_COMMUNITY_Community 2597|Community 2597]]
 - [[_COMMUNITY_Community 2598|Community 2598]]
 - [[_COMMUNITY_Community 2599|Community 2599]]
+- [[_COMMUNITY_Community 2600|Community 2600]]
+- [[_COMMUNITY_Community 2601|Community 2601]]
+- [[_COMMUNITY_Community 2602|Community 2602]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -3346,20 +3349,20 @@ Cohesion: 0.17
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 177 - "Community 177"
+Cohesion: 0.26
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+
+### Community 178 - "Community 178"
 Cohesion: 0.23
 Nodes (6): buildOperationalWorkItem(), createOperationalWorkItemWithCtx(), metadataArrayCount(), metadataNumber(), projectOperationalWorkItemForQueue(), sanitizeOperationalWorkItemDetails()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.21
 Nodes (6): authoritativeDeficitPosition(), baseArgs(), deficitLotSeed(), ledgeredDeficitLotSeed(), ledgeredDeficitPosition(), receipt()
-
-### Community 180 - "Community 180"
-Cohesion: 0.26
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.29
@@ -3394,80 +3397,80 @@ Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 189 - "Community 189"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 190 - "Community 190"
 Cohesion: 0.31
 Nodes (9): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), ensurePaymentAllocationReportingWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), matchesExistingAllocation(), matchesKeyedAllocation(), paymentAllocationReportingIdentity() (+1 more)
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.2
 Nodes (2): formatOperatingDate(), formatRegisterCloseoutVarianceAlertOperatingDate()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.29
 Nodes (7): assertAuthorizedPosBackfillLineage(), assertField(), authorizationEnvelope(), authorizeStoreTimezoneWithCtx(), fnv1a(), requireAuthorizedLineageWithCtx(), storeTimezoneAuthorizationContentHash()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.22
 Nodes (4): buildStoreIntradayProjection(), checkpointAtOrBefore(), persistedCheckpointAt(), safeAdd()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.47
 Nodes (10): getTerminalRuntimeMaterialSignature(), projectActiveRegisterSession(), projectAppUpdate(), projectDrawerAuthority(), projectLocalStore(), projectStaffAuthority(), projectStatus(), projectSync() (+2 more)
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.24
 Nodes (5): getSharedDemoRegisterNumber(), getSharedDemoRegisterNumberCandidates(), getSharedDemoRestoreEpochStorageKey(), provisionSharedDemoRegister(), resetSharedDemoFirstVisitBrowserState()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.29
 Nodes (8): allowValue(), classifyPressure(), observePosLocalStorageHealth(), safeCapacity(), safeTimestamp(), storageHealthFreshness(), toSafePosLocalStorageHealthDiagnostic(), unknownEngineHealth()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.2
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.2
 Nodes (2): formatHeaderCount(), formatSkuActivityHeaderTitle()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 207 - "Community 207"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.18
@@ -3686,28 +3689,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 262 - "Community 262"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 263 - "Community 263"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 264 - "Community 264"
+### Community 263 - "Community 263"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 265 - "Community 265"
+### Community 264 - "Community 264"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 266 - "Community 266"
+### Community 265 - "Community 265"
 Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 267 - "Community 267"
+### Community 266 - "Community 266"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 267 - "Community 267"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 268 - "Community 268"
 Cohesion: 0.22
@@ -4802,112 +4805,112 @@ Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 541 - "Community 541"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), useWorkspaceFixture()
 
 ### Community 542 - "Community 542"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 543 - "Community 543"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 544 - "Community 544"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 545 - "Community 545"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 546 - "Community 546"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 546 - "Community 546"
+### Community 547 - "Community 547"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 547 - "Community 547"
+### Community 548 - "Community 548"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 548 - "Community 548"
+### Community 549 - "Community 549"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 549 - "Community 549"
+### Community 550 - "Community 550"
 Cohesion: 0.6
 Nodes (4): checkRegisterSessionAuthorityWriters(), collectRegisterSessionAuthorityWriterFindings(), listTypeScriptFiles(), normalizePath()
-
-### Community 550 - "Community 550"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 551 - "Community 551"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 552 - "Community 552"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 553 - "Community 553"
 Cohesion: 0.5
 Nodes (2): createSiblingPolicyFixture(), runGit()
 
-### Community 553 - "Community 553"
+### Community 554 - "Community 554"
 Cohesion: 0.6
 Nodes (3): errorMessage(), formatHumanReport(), runHarnessContractPreflight()
 
-### Community 554 - "Community 554"
+### Community 555 - "Community 555"
 Cohesion: 0.7
 Nodes (4): buildOperationalWorkRepairInvocation(), main(), parseOperationalWorkRepairArgs(), requireValue()
-
-### Community 555 - "Community 555"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 556 - "Community 556"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 557 - "Community 557"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 558 - "Community 558"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 558 - "Community 558"
+### Community 559 - "Community 559"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 559 - "Community 559"
+### Community 560 - "Community 560"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
-
-### Community 560 - "Community 560"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 561 - "Community 561"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 562 - "Community 562"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 563 - "Community 563"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 563 - "Community 563"
+### Community 564 - "Community 564"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 564 - "Community 564"
+### Community 565 - "Community 565"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 565 - "Community 565"
+### Community 566 - "Community 566"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 566 - "Community 566"
+### Community 567 - "Community 567"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 567 - "Community 567"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 568 - "Community 568"
 Cohesion: 0.5
@@ -4922,20 +4925,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 571 - "Community 571"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 572 - "Community 572"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 572 - "Community 572"
+### Community 573 - "Community 573"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 573 - "Community 573"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 574 - "Community 574"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 575 - "Community 575"
 Cohesion: 0.5
@@ -4962,32 +4965,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 581 - "Community 581"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 582 - "Community 582"
 Cohesion: 0.67
 Nodes (2): audit(), boundedText()
 
-### Community 582 - "Community 582"
+### Community 583 - "Community 583"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 583 - "Community 583"
+### Community 584 - "Community 584"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 584 - "Community 584"
+### Community 585 - "Community 585"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 585 - "Community 585"
+### Community 586 - "Community 586"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 586 - "Community 586"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 587 - "Community 587"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 588 - "Community 588"
 Cohesion: 0.5
@@ -4998,24 +5001,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 590 - "Community 590"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
-
-### Community 591 - "Community 591"
-Cohesion: 0.67
-Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
-
-### Community 592 - "Community 592"
-Cohesion: 0.67
-Nodes (2): assertAppLoginEmailApproved(), authorizeEmailOtp()
-
-### Community 593 - "Community 593"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 591 - "Community 591"
+Cohesion: 0.83
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+
+### Community 592 - "Community 592"
+Cohesion: 0.67
+Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
+
+### Community 593 - "Community 593"
+Cohesion: 0.67
+Nodes (2): assertAppLoginEmailApproved(), authorizeEmailOtp()
+
 ### Community 594 - "Community 594"
 Cohesion: 0.5
-Nodes (1): buildCtx()
+Nodes (0):
 
 ### Community 595 - "Community 595"
 Cohesion: 0.83
@@ -5059,59 +5062,59 @@ Nodes (0):
 
 ### Community 605 - "Community 605"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 606 - "Community 606"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 607 - "Community 607"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 608 - "Community 608"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 609 - "Community 609"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 610 - "Community 610"
-Cohesion: 0.83
-Nodes (3): actorRefWithCtx(), preflightReportingRunAccessWithCtx(), recordReportingDirectAccessDenialWithCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 611 - "Community 611"
 Cohesion: 0.83
-Nodes (3): assertMinor(), lineFact(), recognizeCommerceEvent()
+Nodes (3): actorRefWithCtx(), preflightReportingRunAccessWithCtx(), recordReportingDirectAccessDenialWithCtx()
 
 ### Community 612 - "Community 612"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): assertMinor(), lineFact(), recognizeCommerceEvent()
 
 ### Community 613 - "Community 613"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 614 - "Community 614"
-Cohesion: 0.67
-Nodes (2): buildReportingRun(), createReportingRunWithCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 615 - "Community 615"
 Cohesion: 0.67
-Nodes (2): getMetricContract(), validateMetricContractVersion()
+Nodes (2): buildReportingRun(), createReportingRunWithCtx()
 
 ### Community 616 - "Community 616"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getMetricContract(), validateMetricContractVersion()
 
 ### Community 617 - "Community 617"
-Cohesion: 0.67
-Nodes (2): completeCoverage(), emptyPresetContext()
-
-### Community 618 - "Community 618"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 618 - "Community 618"
+Cohesion: 0.67
+Nodes (2): completeCoverage(), emptyPresetContext()
 
 ### Community 619 - "Community 619"
 Cohesion: 0.5
@@ -5122,16 +5125,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 621 - "Community 621"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 622 - "Community 622"
 Cohesion: 0.83
 Nodes (3): createOpaqueTicket(), encodeBase64Url(), hashSharedDemoTicket()
 
-### Community 622 - "Community 622"
+### Community 623 - "Community 623"
 Cohesion: 0.67
 Nodes (2): runHourlyRestoreWithCtx(), sharedDemoRestoreEnabled()
-
-### Community 623 - "Community 623"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 624 - "Community 624"
 Cohesion: 0.5
@@ -5142,16 +5145,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 626 - "Community 626"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 627 - "Community 627"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 627 - "Community 627"
+### Community 628 - "Community 628"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 628 - "Community 628"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 629 - "Community 629"
 Cohesion: 0.5
@@ -5162,44 +5165,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 631 - "Community 631"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 632 - "Community 632"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 633 - "Community 633"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 634 - "Community 634"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 635 - "Community 635"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 636 - "Community 636"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 637 - "Community 637"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 637 - "Community 637"
+### Community 638 - "Community 638"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 638 - "Community 638"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 639 - "Community 639"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 640 - "Community 640"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 641 - "Community 641"
 Cohesion: 0.5
@@ -5234,16 +5237,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 649 - "Community 649"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 650 - "Community 650"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 651 - "Community 651"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 652 - "Community 652"
 Cohesion: 0.5
@@ -5258,12 +5261,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 655 - "Community 655"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 656 - "Community 656"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 656 - "Community 656"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 657 - "Community 657"
 Cohesion: 0.5
@@ -5290,12 +5293,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 663 - "Community 663"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 664 - "Community 664"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 664 - "Community 664"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 665 - "Community 665"
 Cohesion: 0.5
@@ -5306,116 +5309,116 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 667 - "Community 667"
-Cohesion: 0.67
-Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
-
-### Community 668 - "Community 668"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 668 - "Community 668"
+Cohesion: 0.67
+Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
 
 ### Community 669 - "Community 669"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 670 - "Community 670"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 672 - "Community 672"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 673 - "Community 673"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 674 - "Community 674"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 674 - "Community 674"
+### Community 675 - "Community 675"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 675 - "Community 675"
+### Community 676 - "Community 676"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 676 - "Community 676"
+### Community 677 - "Community 677"
 Cohesion: 0.67
 Nodes (2): coarseDevice(), emitLandingFunnelEvent()
 
-### Community 677 - "Community 677"
+### Community 678 - "Community 678"
 Cohesion: 0.83
 Nodes (3): getRecoveryHomePath(), isPublicRoutePath(), normalizePathname()
 
-### Community 678 - "Community 678"
+### Community 679 - "Community 679"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 679 - "Community 679"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 680 - "Community 680"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 681 - "Community 681"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 682 - "Community 682"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 683 - "Community 683"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 684 - "Community 684"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 684 - "Community 684"
+### Community 685 - "Community 685"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 685 - "Community 685"
+### Community 686 - "Community 686"
 Cohesion: 0.67
 Nodes (2): buildPosLocalStoreFixtureSnapshot(), fixtureIntegrity()
 
-### Community 686 - "Community 686"
+### Community 687 - "Community 687"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 687 - "Community 687"
+### Community 688 - "Community 688"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 688 - "Community 688"
+### Community 689 - "Community 689"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 689 - "Community 689"
+### Community 690 - "Community 690"
 Cohesion: 0.67
 Nodes (2): assessPosLocalStoreClear(), hasValidClearInspectionCounts()
 
-### Community 690 - "Community 690"
+### Community 691 - "Community 691"
 Cohesion: 0.83
 Nodes (3): isVersioned(), reconcileRegisterLifecycleServerAuthority(), sameAuthorityPayload()
-
-### Community 691 - "Community 691"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 692 - "Community 692"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 693 - "Community 693"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 694 - "Community 694"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 694 - "Community 694"
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 695 - "Community 695"
 Cohesion: 0.5
@@ -5430,28 +5433,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 698 - "Community 698"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 699 - "Community 699"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 699 - "Community 699"
+### Community 700 - "Community 700"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 700 - "Community 700"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 701 - "Community 701"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 702 - "Community 702"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 703 - "Community 703"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 704 - "Community 704"
 Cohesion: 0.5
@@ -5482,63 +5485,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 711 - "Community 711"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 712 - "Community 712"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 713 - "Community 713"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 714 - "Community 714"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 714 - "Community 714"
+### Community 715 - "Community 715"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 715 - "Community 715"
+### Community 716 - "Community 716"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 716 - "Community 716"
+### Community 717 - "Community 717"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 717 - "Community 717"
+### Community 718 - "Community 718"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 718 - "Community 718"
+### Community 719 - "Community 719"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 719 - "Community 719"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 720 - "Community 720"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 721 - "Community 721"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 722 - "Community 722"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 722 - "Community 722"
+### Community 723 - "Community 723"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 723 - "Community 723"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 724 - "Community 724"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 725 - "Community 725"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 726 - "Community 726"
@@ -5550,12 +5553,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 728 - "Community 728"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 729 - "Community 729"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 729 - "Community 729"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 730 - "Community 730"
 Cohesion: 0.67
@@ -5598,12 +5601,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 740 - "Community 740"
-Cohesion: 1.0
-Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
-
-### Community 741 - "Community 741"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 741 - "Community 741"
+Cohesion: 1.0
+Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
 
 ### Community 742 - "Community 742"
 Cohesion: 0.67
@@ -5630,52 +5633,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 748 - "Community 748"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 749 - "Community 749"
 Cohesion: 1.0
 Nodes (2): isAthenaAppLoginEmailApproved(), normalizeAthenaAppLoginEmail()
 
-### Community 749 - "Community 749"
+### Community 750 - "Community 750"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 750 - "Community 750"
-Cohesion: 1.0
-Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 751 - "Community 751"
 Cohesion: 1.0
-Nodes (2): resolveLocalSyncReview(), resolveLocalSyncReviewWithCtx()
+Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Nodes (2): resolveLocalSyncReview(), resolveLocalSyncReviewWithCtx()
 
 ### Community 753 - "Community 753"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 754 - "Community 754"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 755 - "Community 755"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 756 - "Community 756"
 Cohesion: 1.0
-Nodes (2): classifyTerminalHealthAlertConditions(), resolveTerminalHealthAlertTransitions()
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 757 - "Community 757"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalHealthAlertConditions(), resolveTerminalHealthAlertTransitions()
 
 ### Community 758 - "Community 758"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 759 - "Community 759"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 760 - "Community 760"
 Cohesion: 0.67
@@ -5690,16 +5693,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 763 - "Community 763"
-Cohesion: 1.0
-Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 764 - "Community 764"
 Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
 
 ### Community 765 - "Community 765"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 766 - "Community 766"
 Cohesion: 0.67
@@ -5726,12 +5729,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 772 - "Community 772"
-Cohesion: 1.0
-Nodes (2): evaluateAttention(), reason()
-
-### Community 773 - "Community 773"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 773 - "Community 773"
+Cohesion: 1.0
+Nodes (2): evaluateAttention(), reason()
 
 ### Community 774 - "Community 774"
 Cohesion: 0.67
@@ -5750,28 +5753,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 778 - "Community 778"
-Cohesion: 1.0
-Nodes (2): buildDailyProjection(), integer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 779 - "Community 779"
 Cohesion: 1.0
-Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
+Nodes (2): buildDailyProjection(), integer()
 
 ### Community 780 - "Community 780"
 Cohesion: 1.0
-Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
+Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
 
 ### Community 781 - "Community 781"
 Cohesion: 1.0
-Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
+Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
 
 ### Community 782 - "Community 782"
 Cohesion: 1.0
-Nodes (2): reconcileProjection(), unitFor()
+Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
 
 ### Community 783 - "Community 783"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reconcileProjection(), unitFor()
 
 ### Community 784 - "Community 784"
 Cohesion: 0.67
@@ -5790,12 +5793,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 788 - "Community 788"
-Cohesion: 1.0
-Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
-
-### Community 789 - "Community 789"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 789 - "Community 789"
+Cohesion: 1.0
+Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
 
 ### Community 790 - "Community 790"
 Cohesion: 0.67
@@ -5810,16 +5813,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 793 - "Community 793"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 794 - "Community 794"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 795 - "Community 795"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 796 - "Community 796"
 Cohesion: 0.67
@@ -5830,28 +5833,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 798 - "Community 798"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 799 - "Community 799"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 800 - "Community 800"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 801 - "Community 801"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 802 - "Community 802"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 803 - "Community 803"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 803 - "Community 803"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 804 - "Community 804"
 Cohesion: 0.67
@@ -5859,11 +5862,11 @@ Nodes (0):
 
 ### Community 805 - "Community 805"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 806 - "Community 806"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 807 - "Community 807"
 Cohesion: 0.67
@@ -5878,12 +5881,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 810 - "Community 810"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 811 - "Community 811"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 811 - "Community 811"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 812 - "Community 812"
 Cohesion: 0.67
@@ -5911,23 +5914,23 @@ Nodes (0):
 
 ### Community 818 - "Community 818"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 819 - "Community 819"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 820 - "Community 820"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 821 - "Community 821"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 822 - "Community 822"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 822 - "Community 822"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 823 - "Community 823"
 Cohesion: 0.67
@@ -5935,11 +5938,11 @@ Nodes (0):
 
 ### Community 824 - "Community 824"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 825 - "Community 825"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 826 - "Community 826"
 Cohesion: 0.67
@@ -5954,12 +5957,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 829 - "Community 829"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 830 - "Community 830"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 830 - "Community 830"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 831 - "Community 831"
 Cohesion: 0.67
@@ -5970,16 +5973,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 833 - "Community 833"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 834 - "Community 834"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 835 - "Community 835"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 836 - "Community 836"
 Cohesion: 0.67
@@ -6043,79 +6046,79 @@ Nodes (0):
 
 ### Community 851 - "Community 851"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 852 - "Community 852"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 853 - "Community 853"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 854 - "Community 854"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 855 - "Community 855"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 856 - "Community 856"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 857 - "Community 857"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 858 - "Community 858"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 859 - "Community 859"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 859 - "Community 859"
+### Community 860 - "Community 860"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 860 - "Community 860"
+### Community 861 - "Community 861"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 861 - "Community 861"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 862 - "Community 862"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 863 - "Community 863"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 864 - "Community 864"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 865 - "Community 865"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 866 - "Community 866"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 867 - "Community 867"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 868 - "Community 868"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 869 - "Community 869"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 870 - "Community 870"
 Cohesion: 0.67
@@ -6147,11 +6150,11 @@ Nodes (0):
 
 ### Community 877 - "Community 877"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 878 - "Community 878"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 879 - "Community 879"
 Cohesion: 0.67
@@ -6166,12 +6169,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 882 - "Community 882"
-Cohesion: 1.0
-Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
-
-### Community 883 - "Community 883"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 883 - "Community 883"
+Cohesion: 1.0
+Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
 
 ### Community 884 - "Community 884"
 Cohesion: 0.67
@@ -6186,16 +6189,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 887 - "Community 887"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 888 - "Community 888"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 888 - "Community 888"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 889 - "Community 889"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 890 - "Community 890"
 Cohesion: 0.67
@@ -6206,12 +6209,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 892 - "Community 892"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
-
-### Community 893 - "Community 893"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 893 - "Community 893"
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 894 - "Community 894"
 Cohesion: 0.67
@@ -6230,28 +6233,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 898 - "Community 898"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 899 - "Community 899"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 900 - "Community 900"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 901 - "Community 901"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 902 - "Community 902"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 903 - "Community 903"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 903 - "Community 903"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 904 - "Community 904"
 Cohesion: 0.67
@@ -6282,16 +6285,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 911 - "Community 911"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 912 - "Community 912"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 913 - "Community 913"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 914 - "Community 914"
 Cohesion: 0.67
@@ -6302,60 +6305,60 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 916 - "Community 916"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 917 - "Community 917"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 918 - "Community 918"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 919 - "Community 919"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 920 - "Community 920"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 921 - "Community 921"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 922 - "Community 922"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 923 - "Community 923"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 924 - "Community 924"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 925 - "Community 925"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 926 - "Community 926"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 927 - "Community 927"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 928 - "Community 928"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 929 - "Community 929"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 930 - "Community 930"
 Cohesion: 0.67
@@ -6370,12 +6373,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 933 - "Community 933"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 934 - "Community 934"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 934 - "Community 934"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 935 - "Community 935"
 Cohesion: 0.67
@@ -6386,12 +6389,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 937 - "Community 937"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 938 - "Community 938"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 938 - "Community 938"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 939 - "Community 939"
 Cohesion: 0.67
@@ -6458,16 +6461,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 955 - "Community 955"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 956 - "Community 956"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 957 - "Community 957"
+### Community 956 - "Community 956"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 957 - "Community 957"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 958 - "Community 958"
 Cohesion: 1.0
@@ -6482,24 +6485,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 961 - "Community 961"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 962 - "Community 962"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 962 - "Community 962"
+### Community 963 - "Community 963"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 963 - "Community 963"
+### Community 964 - "Community 964"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 964 - "Community 964"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 965 - "Community 965"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 966 - "Community 966"
 Cohesion: 1.0
@@ -8003,11 +8006,11 @@ Nodes (0):
 
 ### Community 1341 - "Community 1341"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1342 - "Community 1342"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1343 - "Community 1343"
 Cohesion: 1.0
@@ -13037,518 +13040,530 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2600 - "Community 2600"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2601 - "Community 2601"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2602 - "Community 2602"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 965`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
+- **Thin community `Community 966`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 967`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 968`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 969`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 970`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 971`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 972`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 973`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 974`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 975`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 976`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 977`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 978`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 979`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `OrderEmailPreview()`, `OrderEmail.tsx`
+- **Thin community `Community 980`** (2 nodes): `OrderEmailPreview()`, `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `PosTerminalHealthAlert.tsx`, `PosTerminalHealthAlert()`
+- **Thin community `Community 981`** (2 nodes): `PosTerminalHealthAlert.tsx`, `PosTerminalHealthAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `RegisterCloseoutMatchReportPreview.tsx`, `RegisterCloseoutMatchReportPreview()`
+- **Thin community `Community 982`** (2 nodes): `RegisterCloseoutMatchReportPreview.tsx`, `RegisterCloseoutMatchReportPreview()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `RegisterCloseoutVarianceAlertPreview.tsx`, `RegisterCloseoutVarianceAlertPreview()`
+- **Thin community `Community 983`** (2 nodes): `RegisterCloseoutVarianceAlertPreview.tsx`, `RegisterCloseoutVarianceAlertPreview()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 984`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
+- **Thin community `Community 985`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 986`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
+- **Thin community `Community 987`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 988`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 989`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 990`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 991`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 992`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 993`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
+- **Thin community `Community 994`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
+- **Thin community `Community 995`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 996`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 997`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 998`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 999`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 1000`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 1001`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 1002`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
+- **Thin community `Community 1003`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 1004`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 1005`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 1006`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
+- **Thin community `Community 1007`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 1008`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
+- **Thin community `Community 1009`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 1010`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 1011`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 1012`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
+- **Thin community `Community 1013`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
+- **Thin community `Community 1014`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
+- **Thin community `Community 1015`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `createCtx()`, `migratePosAmountsToPesewas.test.ts`
+- **Thin community `Community 1016`** (2 nodes): `createCtx()`, `migratePosAmountsToPesewas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 1017`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 1018`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 1019`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 1020`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 1021`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 1022`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 1023`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 1024`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `workItem()`, `logicalOperationalWork.test.ts`
+- **Thin community `Community 1025`** (2 nodes): `workItem()`, `logicalOperationalWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 1026`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
+- **Thin community `Community 1027`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
+- **Thin community `Community 1028`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `posTerminalHealthAlertEmail.ts`, `sendPosTerminalHealthAlertToAdminsWithCtx()`
+- **Thin community `Community 1029`** (2 nodes): `posTerminalHealthAlertEmail.ts`, `sendPosTerminalHealthAlertToAdminsWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `registerCloseoutVarianceEmail.test.ts`, `getHandler()`
+- **Thin community `Community 1030`** (2 nodes): `registerCloseoutVarianceEmail.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
+- **Thin community `Community 1031`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 1032`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 1033`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 1034`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 1035`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `redactSensitiveDiagnosticText()`, `diagnosticRedaction.ts`
+- **Thin community `Community 1036`** (2 nodes): `redactSensitiveDiagnosticText()`, `diagnosticRedaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 1037`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 1038`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
+- **Thin community `Community 1039`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
+- **Thin community `Community 1040`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `resolveLocalSyncReview.test.ts`, `createFakeRepository()`
+- **Thin community `Community 1041`** (2 nodes): `resolveLocalSyncReview.test.ts`, `createFakeRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 1042`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 1043`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
+- **Thin community `Community 1044`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
+- **Thin community `Community 1045`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 1046`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 1047`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 1048`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
+- **Thin community `Community 1049`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 1050`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 1051`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 1052`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 1053`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `remoteAssistRepository.ts`, `createRemoteAssistRepository()`
+- **Thin community `Community 1054`** (2 nodes): `remoteAssistRepository.ts`, `createRemoteAssistRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1055`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 1056`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 1057`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 1058`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `context()`, `access.test.ts`
+- **Thin community `Community 1059`** (2 nodes): `context()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `current()`, `coverage.test.ts`
+- **Thin community `Community 1060`** (2 nodes): `current()`, `coverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `context()`, `directAccess.test.ts`
+- **Thin community `Community 1061`** (2 nodes): `context()`, `directAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `rows()`, `evidence.test.ts`
+- **Thin community `Community 1062`** (2 nodes): `rows()`, `evidence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `context()`, `evidenceAccess.test.ts`
+- **Thin community `Community 1063`** (2 nodes): `context()`, `evidenceAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
+- **Thin community `Community 1064`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `context()`, `commerceEffects.test.ts`
+- **Thin community `Community 1065`** (2 nodes): `context()`, `commerceEffects.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
+- **Thin community `Community 1066`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
+- **Thin community `Community 1067`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `processing.ts`, `processBoundedBatch()`
+- **Thin community `Community 1068`** (2 nodes): `processing.ts`, `processBoundedBatch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
+- **Thin community `Community 1069`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
+- **Thin community `Community 1070`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
+- **Thin community `Community 1071`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `reportingDestination()`, `destinations.ts`
+- **Thin community `Community 1072`** (2 nodes): `reportingDestination()`, `destinations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
+- **Thin community `Community 1073`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
+- **Thin community `Community 1074`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
+- **Thin community `Community 1075`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
+- **Thin community `Community 1076`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
+- **Thin community `Community 1077`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `settlement.ts`, `adaptSettlement()`
+- **Thin community `Community 1078`** (2 nodes): `settlement.ts`, `adaptSettlement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
+- **Thin community `Community 1079`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
+- **Thin community `Community 1080`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 1081`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 1082`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `contextFor()`, `actor.test.ts`
+- **Thin community `Community 1083`** (2 nodes): `contextFor()`, `actor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `invoke()`, `enforcement.test.ts`
+- **Thin community `Community 1084`** (2 nodes): `invoke()`, `enforcement.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `posStoreReadAccessCoverage.test.ts`, `source()`
+- **Thin community `Community 1085`** (2 nodes): `posStoreReadAccessCoverage.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
+- **Thin community `Community 1086`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `public.ts`, `selectSharedDemoRegisterBootstrapRecords()`
+- **Thin community `Community 1087`** (2 nodes): `public.ts`, `selectSharedDemoRegisterBootstrapRecords()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `readBoundary.test.ts`, `invoke()`
+- **Thin community `Community 1088`** (2 nodes): `readBoundary.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
+- **Thin community `Community 1089`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 1090`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 1091`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 1092`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 1093`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 1094`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 1095`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 1096`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 1097`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 1098`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 1099`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 1100`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 1101`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 1102`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 1103`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 1104`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 1105`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 1106`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 1107`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 1108`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 1109`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 1110`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 1111`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 1112`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 1113`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 1114`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 1115`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 1116`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `posTerminalRegistrationError.ts`, `isPosRegisterNumberConflict()`
+- **Thin community `Community 1117`** (2 nodes): `posTerminalRegistrationError.ts`, `isPosRegisterNumberConflict()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
+- **Thin community `Community 1118`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 1119`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `sharedDemoActionError.ts`, `isSharedDemoActionDeniedData()`
+- **Thin community `Community 1120`** (2 nodes): `sharedDemoActionError.ts`, `isSharedDemoActionDeniedData()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 1121`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 1122`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 1123`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 1124`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 1125`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 1126`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 1127`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 1128`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 1129`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 1130`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 1131`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 1132`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 1133`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 1134`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 1135`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 1136`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
+- **Thin community `Community 1137`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 1138`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
+- **Thin community `Community 1139`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 1140`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 1141`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 1142`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 1143`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 1144`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 1145`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1146`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 1147`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 1148`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 1149`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 1150`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 1151`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 1152`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 1153`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 1154`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 1155`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 1156`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `isEmailNotApprovedError()`, `LoginForm.tsx`
+- **Thin community `Community 1157`** (2 nodes): `isEmailNotApprovedError()`, `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 1158`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 1159`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 1160`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 1161`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 1162`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 1163`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 1164`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 1165`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 1166`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 1167`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `RegisterSessionIdentity.tsx`, `RegisterSessionIdentity()`
+- **Thin community `Community 1168`** (2 nodes): `RegisterSessionIdentity.tsx`, `RegisterSessionIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `registerSessionIdentityPresentation.ts`, `formatRegisterHeaderName()`
+- **Thin community `Community 1169`** (2 nodes): `registerSessionIdentityPresentation.ts`, `formatRegisterHeaderName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 1170`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 1171`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 1172`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 1173`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 1174`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 1175`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 1176`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `AutomationRevealScene()`, `AutomationRevealScene.tsx`
+- **Thin community `Community 1177`** (2 nodes): `AutomationRevealScene()`, `AutomationRevealScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `CashControlsScene()`, `CashControlsScene.tsx`
+- **Thin community `Community 1178`** (2 nodes): `CashControlsScene()`, `CashControlsScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `DailyOperationsScene()`, `DailyOperationsScene.tsx`
+- **Thin community `Community 1179`** (2 nodes): `DailyOperationsScene()`, `DailyOperationsScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `EodReviewScene()`, `EodReviewScene.tsx`
+- **Thin community `Community 1180`** (2 nodes): `EodReviewScene()`, `EodReviewScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `HeroDayArcScene()`, `HeroDayArcScene.tsx`
+- **Thin community `Community 1181`** (2 nodes): `HeroDayArcScene()`, `HeroDayArcScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `OpeningHandoffScene()`, `OpeningHandoffScene.tsx`
+- **Thin community `Community 1182`** (2 nodes): `OpeningHandoffScene()`, `OpeningHandoffScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `PosSaleScene.tsx`, `PosSaleScene()`
+- **Thin community `Community 1183`** (2 nodes): `PosSaleScene.tsx`, `PosSaleScene()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
+- **Thin community `Community 1184`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
+- **Thin community `Community 1185`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
+- **Thin community `Community 1186`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `useForcedLightTheme.ts`, `useForcedLightTheme()`
+- **Thin community `Community 1187`** (2 nodes): `useForcedLightTheme.ts`, `useForcedLightTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 1188`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 1189`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 1190`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 1191`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 1192`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 1193`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 1194`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 1195`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 1196`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
+- **Thin community `Community 1197`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 1198`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 1199`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 1200`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 1201`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 1202`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 1203`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 1204`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
+- **Thin community `Community 1205`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 1206`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 1207`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 1208`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 1209`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 1210`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 1211`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 1212`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 1213`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 1214`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 1215`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 1216`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 1217`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 1218`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 1219`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 1220`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -13584,431 +13599,429 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 1221`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
+- **Thin community `Community 1222`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 1223`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 1224`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 1225`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 1226`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 1227`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 1228`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 1229`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
+- **Thin community `Community 1230`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 1231`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 1232`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 1233`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 1234`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 1235`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 1236`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 1237`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 1238`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 1239`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 1240`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 1241`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 1242`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 1243`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 1244`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 1245`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 1246`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 1247`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 1248`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 1249`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
+- **Thin community `Community 1250`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
+- **Thin community `Community 1251`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
+- **Thin community `Community 1252`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
+- **Thin community `Community 1253`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
+- **Thin community `Community 1254`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
+- **Thin community `Community 1255`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 1256`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1257`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1258`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1259`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
+- **Thin community `Community 1260`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1261`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
+- **Thin community `Community 1262`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
+- **Thin community `Community 1263`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
+- **Thin community `Community 1264`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
+- **Thin community `Community 1265`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
+- **Thin community `Community 1266`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
+- **Thin community `Community 1267`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
+- **Thin community `Community 1268`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
+- **Thin community `Community 1269`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
+- **Thin community `Community 1270`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
+- **Thin community `Community 1271`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 1272`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 1273`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 1274`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 1275`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 1276`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 1277`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 1278`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 1279`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 1280`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 1281`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 1282`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 1283`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 1284`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 1285`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 1286`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 1287`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 1288`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 1289`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 1290`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 1291`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1292`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1293`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1294`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
+- **Thin community `Community 1295`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1296`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1297`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1298`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1299`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1300`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1301`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1302`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1303`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1304`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1305`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1306`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1307`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1308`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1309`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1310`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1311`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
+- **Thin community `Community 1312`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1313`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1314`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1315`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1316`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1317`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1318`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1319`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1320`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1321`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1322`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1323`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1324`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1325`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1326`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1327`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1328`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1329`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1330`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1331`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1332`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1333`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1334`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1335`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1336`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1337`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1338`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1339`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1340`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1341`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1342`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1343`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1344`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1345`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1346`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1347`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1348`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1349`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
+- **Thin community `Community 1350`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1351`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1352`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1353`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1354`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1355`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1356`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1357`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
+- **Thin community `Community 1358`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
+- **Thin community `Community 1359`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
+- **Thin community `Community 1360`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
+- **Thin community `Community 1361`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
+- **Thin community `Community 1362`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
+- **Thin community `Community 1363`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
+- **Thin community `Community 1364`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
+- **Thin community `Community 1365`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
+- **Thin community `Community 1366`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1367`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1368`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
+- **Thin community `Community 1369`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1370`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1371`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
+- **Thin community `Community 1372`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1373`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1374`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1375`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1376`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
+- **Thin community `Community 1377`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
+- **Thin community `Community 1378`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1379`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1380`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1381`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1382`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1383`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1384`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1385`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1386`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1387`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1388`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1389`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1390`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
+- **Thin community `Community 1391`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
+- **Thin community `Community 1392`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `-walkthrough-page.tsx`, `WalkthroughPage()`
+- **Thin community `Community 1393`** (2 nodes): `-walkthrough-page.tsx`, `WalkthroughPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1394`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1395`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1396`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1397`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1398`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1399`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1400`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1401`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
+- **Thin community `Community 1402`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1403`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1404`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1405`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1406`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
+- **Thin community `Community 1407`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1408`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1409`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1410`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1411`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
+- **Thin community `Community 1412`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
+- **Thin community `Community 1413`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
+- **Thin community `Community 1414`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1415`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
+- **Thin community `Community 1416`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1417`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
+- **Thin community `Community 1418`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1419`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1420`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1421`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1422`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1423`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1424`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1425`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1426`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1427`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1428`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1429`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1430`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1431`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `at()`, `dailyOperationsFixtures.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `useDailyOperationsFixture()`, `devFixtureActivation.ts`
+- **Thin community `Community 1432`** (2 nodes): `momentAt()`, `operationsFixtureContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1433`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -16040,309 +16053,315 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2447`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2448`** (1 nodes): `dailyOperationsFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2449`** (1 nodes): `eodReviewFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `setup.ts`
+- **Thin community `Community 2450`** (1 nodes): `openingHandoffFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2451`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `types.ts`
+- **Thin community `Community 2452`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2453`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2454`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2455`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2456`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2457`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2458`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2459`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `types.ts`
+- **Thin community `Community 2460`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2461`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2462`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2463`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2464`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2465`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2466`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2467`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2468`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `schema.ts`
+- **Thin community `Community 2469`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2470`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2471`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2472`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2473`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2474`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2475`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2476`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2477`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2478`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `types.ts`
+- **Thin community `Community 2479`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2480`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2481`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2482`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2483`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2484`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2485`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2486`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `constants.ts`
+- **Thin community `Community 2487`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2488`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `About.tsx`
+- **Thin community `Community 2489`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2490`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2491`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2492`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2493`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2494`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2495`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2496`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2497`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2498`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2499`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `types.ts`
+- **Thin community `Community 2500`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2501`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2502`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2503`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2504`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2505`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2506`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2507`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2508`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2509`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2510`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2511`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `button.tsx`
+- **Thin community `Community 2512`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `card.tsx`
+- **Thin community `Community 2513`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2514`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `command.tsx`
+- **Thin community `Community 2515`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2516`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2517`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2518`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `form.tsx`
+- **Thin community `Community 2519`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2520`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2521`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2522`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2523`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `input.tsx`
+- **Thin community `Community 2524`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `label.tsx`
+- **Thin community `Community 2525`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2526`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2527`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2528`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2528`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `index.ts`
+- **Thin community `Community 2529`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `types.ts`
+- **Thin community `Community 2530`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2531`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2532`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2533`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2534`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `select.tsx`
+- **Thin community `Community 2535`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2536`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2537`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2537`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `table.tsx`
+- **Thin community `Community 2538`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2539`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2540`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2541`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2542`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2543`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2543`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2544`** (1 nodes): `config.ts`
+- **Thin community `Community 2544`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2545`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2545`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2546`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2547`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2548`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2549`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `constants.ts`
+- **Thin community `Community 2550`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `countries.ts`
+- **Thin community `Community 2551`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2552`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2553`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2554`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2555`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `index.ts`
+- **Thin community `Community 2556`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2557`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `store.ts`
+- **Thin community `Community 2558`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `bag.ts`
+- **Thin community `Community 2559`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2560`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `category.ts`
+- **Thin community `Community 2561`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `organization.ts`
+- **Thin community `Community 2562`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `product.ts`
+- **Thin community `Community 2563`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `store.ts`
+- **Thin community `Community 2564`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2565`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `user.ts`
+- **Thin community `Community 2566`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `states.ts`
+- **Thin community `Community 2567`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2568`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2569`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2570`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2571`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2572`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2573`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2574`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2574`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2575`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2576`** (1 nodes): `index.tsx`
+- **Thin community `Community 2576`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2577`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `index.tsx`
+- **Thin community `Community 2578`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2579`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2580`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2581`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2582`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2583`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `index.tsx`
+- **Thin community `Community 2584`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2585`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2586`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2586`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2587`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2588`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2589`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2589`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `index.js`
+- **Thin community `Community 2590`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2591`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2592`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2593`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2594`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2595`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2596`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2596`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2597`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2597`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2598`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2598`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2599`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2599`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2600`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2601`** (1 nodes): `harness-repo-validation.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2602`** (1 nodes): `operational-work-repair.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10805 nodes · 13086 edges · 2603 communities detected
+- 10806 nodes · 13087 edges · 2603 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3397,80 +3397,80 @@ Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 189 - "Community 189"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 190 - "Community 190"
 Cohesion: 0.31
 Nodes (9): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), ensurePaymentAllocationReportingWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), matchesExistingAllocation(), matchesKeyedAllocation(), paymentAllocationReportingIdentity() (+1 more)
 
-### Community 191 - "Community 191"
+### Community 190 - "Community 190"
 Cohesion: 0.2
 Nodes (2): formatOperatingDate(), formatRegisterCloseoutVarianceAlertOperatingDate()
 
-### Community 192 - "Community 192"
+### Community 191 - "Community 191"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 193 - "Community 193"
+### Community 192 - "Community 192"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 194 - "Community 194"
+### Community 193 - "Community 193"
 Cohesion: 0.29
 Nodes (7): assertAuthorizedPosBackfillLineage(), assertField(), authorizationEnvelope(), authorizeStoreTimezoneWithCtx(), fnv1a(), requireAuthorizedLineageWithCtx(), storeTimezoneAuthorizationContentHash()
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.22
 Nodes (4): buildStoreIntradayProjection(), checkpointAtOrBefore(), persistedCheckpointAt(), safeAdd()
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.47
 Nodes (10): getTerminalRuntimeMaterialSignature(), projectActiveRegisterSession(), projectAppUpdate(), projectDrawerAuthority(), projectLocalStore(), projectStaffAuthority(), projectStatus(), projectSync() (+2 more)
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 199 - "Community 199"
+### Community 198 - "Community 198"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 200 - "Community 200"
+### Community 199 - "Community 199"
 Cohesion: 0.24
 Nodes (5): getSharedDemoRegisterNumber(), getSharedDemoRegisterNumberCandidates(), getSharedDemoRestoreEpochStorageKey(), provisionSharedDemoRegister(), resetSharedDemoFirstVisitBrowserState()
 
-### Community 201 - "Community 201"
+### Community 200 - "Community 200"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.29
 Nodes (8): allowValue(), classifyPressure(), observePosLocalStorageHealth(), safeCapacity(), safeTimestamp(), storageHealthFreshness(), toSafePosLocalStorageHealthDiagnostic(), unknownEngineHealth()
 
-### Community 203 - "Community 203"
+### Community 202 - "Community 202"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.2
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 205 - "Community 205"
+### Community 204 - "Community 204"
 Cohesion: 0.2
 Nodes (2): formatHeaderCount(), formatSkuActivityHeaderTitle()
 
-### Community 206 - "Community 206"
+### Community 205 - "Community 205"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 207 - "Community 207"
+### Community 206 - "Community 206"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 207 - "Community 207"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.18
@@ -3702,15 +3702,15 @@ Nodes (0):
 
 ### Community 265 - "Community 265"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 266 - "Community 266"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 267 - "Community 267"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 268 - "Community 268"
 Cohesion: 0.22
@@ -4333,100 +4333,100 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 423 - "Community 423"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 424 - "Community 424"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 425 - "Community 425"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 426 - "Community 426"
 Cohesion: 0.73
 Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 426 - "Community 426"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 427 - "Community 427"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 428 - "Community 428"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 429 - "Community 429"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 430 - "Community 430"
+### Community 429 - "Community 429"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
+
+### Community 430 - "Community 430"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 431 - "Community 431"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 432 - "Community 432"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 433 - "Community 433"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 434 - "Community 434"
+### Community 433 - "Community 433"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 435 - "Community 435"
+### Community 434 - "Community 434"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 436 - "Community 436"
+### Community 435 - "Community 435"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 437 - "Community 437"
+### Community 436 - "Community 436"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+
+### Community 437 - "Community 437"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 439 - "Community 439"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 440 - "Community 440"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 441 - "Community 441"
+### Community 440 - "Community 440"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 442 - "Community 442"
+### Community 441 - "Community 441"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 442 - "Community 442"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 443 - "Community 443"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 444 - "Community 444"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 445 - "Community 445"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 446 - "Community 446"
+### Community 445 - "Community 445"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 446 - "Community 446"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.53
@@ -5437,28 +5437,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 699 - "Community 699"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 700 - "Community 700"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 700 - "Community 700"
+### Community 701 - "Community 701"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 701 - "Community 701"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 702 - "Community 702"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 703 - "Community 703"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 704 - "Community 704"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 705 - "Community 705"
 Cohesion: 0.5
@@ -5489,63 +5489,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 712 - "Community 712"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 713 - "Community 713"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 714 - "Community 714"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 715 - "Community 715"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 715 - "Community 715"
+### Community 716 - "Community 716"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 716 - "Community 716"
+### Community 717 - "Community 717"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 717 - "Community 717"
+### Community 718 - "Community 718"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 718 - "Community 718"
+### Community 719 - "Community 719"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 719 - "Community 719"
+### Community 720 - "Community 720"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 720 - "Community 720"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 721 - "Community 721"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 722 - "Community 722"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 723 - "Community 723"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 723 - "Community 723"
+### Community 724 - "Community 724"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 724 - "Community 724"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 725 - "Community 725"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 726 - "Community 726"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 727 - "Community 727"
@@ -5557,12 +5557,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 729 - "Community 729"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 730 - "Community 730"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 730 - "Community 730"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 731 - "Community 731"
 Cohesion: 0.67
@@ -5605,12 +5605,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 741 - "Community 741"
-Cohesion: 1.0
-Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
-
-### Community 742 - "Community 742"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 742 - "Community 742"
+Cohesion: 1.0
+Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
 
 ### Community 743 - "Community 743"
 Cohesion: 0.67
@@ -5637,52 +5637,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 749 - "Community 749"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 750 - "Community 750"
 Cohesion: 1.0
 Nodes (2): isAthenaAppLoginEmailApproved(), normalizeAthenaAppLoginEmail()
 
-### Community 750 - "Community 750"
+### Community 751 - "Community 751"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 751 - "Community 751"
-Cohesion: 1.0
-Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
-Nodes (2): resolveLocalSyncReview(), resolveLocalSyncReviewWithCtx()
+Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 753 - "Community 753"
 Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Nodes (2): resolveLocalSyncReview(), resolveLocalSyncReviewWithCtx()
 
 ### Community 754 - "Community 754"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 755 - "Community 755"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 756 - "Community 756"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 757 - "Community 757"
 Cohesion: 1.0
-Nodes (2): classifyTerminalHealthAlertConditions(), resolveTerminalHealthAlertTransitions()
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 758 - "Community 758"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalHealthAlertConditions(), resolveTerminalHealthAlertTransitions()
 
 ### Community 759 - "Community 759"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 760 - "Community 760"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 761 - "Community 761"
 Cohesion: 0.67
@@ -5697,16 +5697,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 764 - "Community 764"
-Cohesion: 1.0
-Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 765 - "Community 765"
 Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
 
 ### Community 766 - "Community 766"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 767 - "Community 767"
 Cohesion: 0.67
@@ -5733,12 +5733,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 773 - "Community 773"
-Cohesion: 1.0
-Nodes (2): evaluateAttention(), reason()
-
-### Community 774 - "Community 774"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 774 - "Community 774"
+Cohesion: 1.0
+Nodes (2): evaluateAttention(), reason()
 
 ### Community 775 - "Community 775"
 Cohesion: 0.67
@@ -5757,28 +5757,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 779 - "Community 779"
-Cohesion: 1.0
-Nodes (2): buildDailyProjection(), integer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 780 - "Community 780"
 Cohesion: 1.0
-Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
+Nodes (2): buildDailyProjection(), integer()
 
 ### Community 781 - "Community 781"
 Cohesion: 1.0
-Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
+Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
 
 ### Community 782 - "Community 782"
 Cohesion: 1.0
-Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
+Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
 
 ### Community 783 - "Community 783"
 Cohesion: 1.0
-Nodes (2): reconcileProjection(), unitFor()
+Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
 
 ### Community 784 - "Community 784"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reconcileProjection(), unitFor()
 
 ### Community 785 - "Community 785"
 Cohesion: 0.67
@@ -5797,12 +5797,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 789 - "Community 789"
-Cohesion: 1.0
-Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
-
-### Community 790 - "Community 790"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 790 - "Community 790"
+Cohesion: 1.0
+Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
 
 ### Community 791 - "Community 791"
 Cohesion: 0.67
@@ -5817,16 +5817,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 794 - "Community 794"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 795 - "Community 795"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 796 - "Community 796"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 797 - "Community 797"
 Cohesion: 0.67
@@ -5837,28 +5837,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 799 - "Community 799"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 800 - "Community 800"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 801 - "Community 801"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 802 - "Community 802"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 803 - "Community 803"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 804 - "Community 804"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 804 - "Community 804"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 805 - "Community 805"
 Cohesion: 0.67
@@ -5866,11 +5866,11 @@ Nodes (0):
 
 ### Community 806 - "Community 806"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 807 - "Community 807"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 808 - "Community 808"
 Cohesion: 0.67
@@ -5885,12 +5885,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 811 - "Community 811"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 812 - "Community 812"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 812 - "Community 812"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 813 - "Community 813"
 Cohesion: 0.67
@@ -5918,23 +5918,23 @@ Nodes (0):
 
 ### Community 819 - "Community 819"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 820 - "Community 820"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 821 - "Community 821"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 822 - "Community 822"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 823 - "Community 823"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 823 - "Community 823"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 824 - "Community 824"
 Cohesion: 0.67
@@ -5942,11 +5942,11 @@ Nodes (0):
 
 ### Community 825 - "Community 825"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 826 - "Community 826"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 827 - "Community 827"
 Cohesion: 0.67
@@ -5961,12 +5961,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 830 - "Community 830"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 831 - "Community 831"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 831 - "Community 831"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 832 - "Community 832"
 Cohesion: 0.67
@@ -5977,16 +5977,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 834 - "Community 834"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 835 - "Community 835"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 836 - "Community 836"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 837 - "Community 837"
 Cohesion: 0.67
@@ -6050,79 +6050,79 @@ Nodes (0):
 
 ### Community 852 - "Community 852"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 853 - "Community 853"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 854 - "Community 854"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 855 - "Community 855"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 856 - "Community 856"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 857 - "Community 857"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 858 - "Community 858"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 859 - "Community 859"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 860 - "Community 860"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 860 - "Community 860"
+### Community 861 - "Community 861"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 861 - "Community 861"
+### Community 862 - "Community 862"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 862 - "Community 862"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 863 - "Community 863"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 864 - "Community 864"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 865 - "Community 865"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 866 - "Community 866"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 867 - "Community 867"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 868 - "Community 868"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 869 - "Community 869"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 870 - "Community 870"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 871 - "Community 871"
 Cohesion: 0.67
@@ -6154,11 +6154,11 @@ Nodes (0):
 
 ### Community 878 - "Community 878"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 879 - "Community 879"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 880 - "Community 880"
 Cohesion: 0.67
@@ -6173,12 +6173,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 883 - "Community 883"
-Cohesion: 1.0
-Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
-
-### Community 884 - "Community 884"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 884 - "Community 884"
+Cohesion: 1.0
+Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
 
 ### Community 885 - "Community 885"
 Cohesion: 0.67
@@ -6193,16 +6193,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 888 - "Community 888"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 889 - "Community 889"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 889 - "Community 889"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 890 - "Community 890"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 891 - "Community 891"
 Cohesion: 0.67
@@ -6213,12 +6213,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 893 - "Community 893"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
-
-### Community 894 - "Community 894"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 894 - "Community 894"
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 895 - "Community 895"
 Cohesion: 0.67
@@ -6237,28 +6237,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 899 - "Community 899"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 900 - "Community 900"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 901 - "Community 901"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 902 - "Community 902"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 903 - "Community 903"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 904 - "Community 904"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 904 - "Community 904"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 905 - "Community 905"
 Cohesion: 0.67

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2672 files · ~0 words
+- 2674 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10794 nodes · 13077 edges · 2598 communities detected
+- 10799 nodes · 13080 edges · 2600 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2608,6 +2608,8 @@
 - [[_COMMUNITY_Community 2595|Community 2595]]
 - [[_COMMUNITY_Community 2596|Community 2596]]
 - [[_COMMUNITY_Community 2597|Community 2597]]
+- [[_COMMUNITY_Community 2598|Community 2598]]
+- [[_COMMUNITY_Community 2599|Community 2599]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -3344,20 +3346,20 @@ Cohesion: 0.17
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 177 - "Community 177"
-Cohesion: 0.26
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 178 - "Community 178"
 Cohesion: 0.23
 Nodes (6): buildOperationalWorkItem(), createOperationalWorkItemWithCtx(), metadataArrayCount(), metadataNumber(), projectOperationalWorkItemForQueue(), sanitizeOperationalWorkItemDetails()
 
-### Community 179 - "Community 179"
+### Community 178 - "Community 178"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 180 - "Community 180"
+### Community 179 - "Community 179"
 Cohesion: 0.21
 Nodes (6): authoritativeDeficitPosition(), baseArgs(), deficitLotSeed(), ledgeredDeficitLotSeed(), ledgeredDeficitPosition(), receipt()
+
+### Community 180 - "Community 180"
+Cohesion: 0.26
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.29
@@ -3392,80 +3394,80 @@ Cohesion: 0.29
 Nodes (8): activeSchedulesOverlap(), findActiveScheduleForStoreAt(), getStoreScheduleContextForStoreAtWithCtx(), listActiveSchedulesForStore(), resolveStoreOperatingRangeForDateWithCtx(), toDraft(), toSummary(), upsertStoreScheduleCommandWithCtx()
 
 ### Community 189 - "Community 189"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 190 - "Community 190"
 Cohesion: 0.31
 Nodes (9): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), ensurePaymentAllocationReportingWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), matchesExistingAllocation(), matchesKeyedAllocation(), paymentAllocationReportingIdentity() (+1 more)
 
-### Community 191 - "Community 191"
+### Community 190 - "Community 190"
 Cohesion: 0.2
 Nodes (2): formatOperatingDate(), formatRegisterCloseoutVarianceAlertOperatingDate()
 
-### Community 192 - "Community 192"
+### Community 191 - "Community 191"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 193 - "Community 193"
+### Community 192 - "Community 192"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 194 - "Community 194"
+### Community 193 - "Community 193"
 Cohesion: 0.29
 Nodes (7): assertAuthorizedPosBackfillLineage(), assertField(), authorizationEnvelope(), authorizeStoreTimezoneWithCtx(), fnv1a(), requireAuthorizedLineageWithCtx(), storeTimezoneAuthorizationContentHash()
 
-### Community 195 - "Community 195"
+### Community 194 - "Community 194"
 Cohesion: 0.22
 Nodes (4): buildStoreIntradayProjection(), checkpointAtOrBefore(), persistedCheckpointAt(), safeAdd()
 
-### Community 196 - "Community 196"
+### Community 195 - "Community 195"
 Cohesion: 0.47
 Nodes (10): getTerminalRuntimeMaterialSignature(), projectActiveRegisterSession(), projectAppUpdate(), projectDrawerAuthority(), projectLocalStore(), projectStaffAuthority(), projectStatus(), projectSync() (+2 more)
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 199 - "Community 199"
+### Community 198 - "Community 198"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 200 - "Community 200"
+### Community 199 - "Community 199"
 Cohesion: 0.24
 Nodes (5): getSharedDemoRegisterNumber(), getSharedDemoRegisterNumberCandidates(), getSharedDemoRestoreEpochStorageKey(), provisionSharedDemoRegister(), resetSharedDemoFirstVisitBrowserState()
 
-### Community 201 - "Community 201"
+### Community 200 - "Community 200"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.29
 Nodes (8): allowValue(), classifyPressure(), observePosLocalStorageHealth(), safeCapacity(), safeTimestamp(), storageHealthFreshness(), toSafePosLocalStorageHealthDiagnostic(), unknownEngineHealth()
 
-### Community 203 - "Community 203"
+### Community 202 - "Community 202"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.2
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 205 - "Community 205"
+### Community 204 - "Community 204"
 Cohesion: 0.2
 Nodes (2): formatHeaderCount(), formatSkuActivityHeaderTitle()
 
-### Community 206 - "Community 206"
+### Community 205 - "Community 205"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 207 - "Community 207"
+### Community 206 - "Community 206"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 207 - "Community 207"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 208 - "Community 208"
 Cohesion: 0.18
@@ -3684,24 +3686,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 262 - "Community 262"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 263 - "Community 263"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 265 - "Community 265"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
 ### Community 266 - "Community 266"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 267 - "Community 267"
 Cohesion: 0.39
@@ -4328,100 +4330,100 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 423 - "Community 423"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 425 - "Community 425"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 426 - "Community 426"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 426 - "Community 426"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 428 - "Community 428"
-Cohesion: 0.4
-Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 430 - "Community 430"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 432 - "Community 432"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 433 - "Community 433"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 434 - "Community 434"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 435 - "Community 435"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 433 - "Community 433"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 434 - "Community 434"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 435 - "Community 435"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 436 - "Community 436"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 437 - "Community 437"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 439 - "Community 439"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 440 - "Community 440"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 442 - "Community 442"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 444 - "Community 444"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 445 - "Community 445"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 445 - "Community 445"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 446 - "Community 446"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 0.53
@@ -13027,6 +13029,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2598 - "Community 2598"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2599 - "Community 2599"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -13936,2399 +13946,2403 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1400`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1401`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1402`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1403`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1404`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
+- **Thin community `Community 1405`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1406`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1407`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1408`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1409`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
+- **Thin community `Community 1410`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
+- **Thin community `Community 1411`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
+- **Thin community `Community 1412`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1413`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
+- **Thin community `Community 1414`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1415`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
+- **Thin community `Community 1416`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1417`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1418`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1419`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1420`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1421`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1422`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1423`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1424`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1425`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1426`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1427`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1428`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1429`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1430`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1431`** (2 nodes): `at()`, `dailyOperationsFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1432`** (2 nodes): `useDailyOperationsFixture()`, `devFixtureActivation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1433`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1434`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1435`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1436`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1437`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1438`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1439`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1440`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1441`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1442`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1443`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1444`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1445`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1446`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1447`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1448`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1449`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1450`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1451`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1452`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1453`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1454`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1455`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1456`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1457`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1458`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1459`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1460`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1461`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1462`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1463`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1464`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1465`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1466`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1467`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1468`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1469`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1470`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1471`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1472`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1473`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1474`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1475`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1476`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1477`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1478`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1479`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1480`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1481`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1482`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1483`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1484`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1485`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1486`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1487`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1488`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1489`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1490`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1491`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1492`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1493`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1494`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1495`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1496`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1497`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1498`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1499`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1500`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1501`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1502`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1503`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1504`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1505`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1506`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1507`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1508`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1509`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1510`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1511`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1512`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1513`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1514`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1515`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1516`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1517`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1518`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1519`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1520`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1521`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1522`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1523`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1524`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1525`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1526`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1527`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1528`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1529`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1530`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1531`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1532`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1533`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1534`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1535`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1536`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1537`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1538`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1539`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1540`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1541`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1542`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1543`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1544`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1545`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1546`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1547`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1548`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1549`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1550`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1551`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1552`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1553`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1554`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1555`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1556`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
+- **Thin community `Community 1557`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1558`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1559`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `api.js`
+- **Thin community `Community 1560`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1561`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1562`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `server.js`
+- **Thin community `Community 1563`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `app.ts`
+- **Thin community `Community 1564`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1565`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1566`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `SharedDemoTicket.test.ts`
+- **Thin community `Community 1567`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1568`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1569`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `auth.ts`
+- **Thin community `Community 1570`** (1 nodes): `SharedDemoTicket.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1572`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1573`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `countries.ts`
+- **Thin community `Community 1574`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `email.ts`
+- **Thin community `Community 1575`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1576`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `payment.ts`
+- **Thin community `Community 1577`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `types.ts`
+- **Thin community `Community 1579`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1580`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `crons.ts`
+- **Thin community `Community 1582`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1583`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `internal.ts`
+- **Thin community `Community 1584`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1587`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1589`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
+- **Thin community `Community 1591`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1592`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1593`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `NewOrderAdmin.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `OrderEmail.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1597`** (1 nodes): `NewOrderAdmin.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `OrderEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `env.ts`
+- **Thin community `Community 1600`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1601`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `auth.ts`
+- **Thin community `Community 1602`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `colors.ts`
+- **Thin community `Community 1604`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `index.ts`
+- **Thin community `Community 1605`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1607`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1608`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `products.ts`
+- **Thin community `Community 1609`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `stores.ts`
+- **Thin community `Community 1611`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `bag.ts`
+- **Thin community `Community 1614`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `guest.ts`
+- **Thin community `Community 1615`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `index.ts`
+- **Thin community `Community 1617`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `me.ts`
+- **Thin community `Community 1618`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `offers.ts`
+- **Thin community `Community 1619`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1620`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1621`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1622`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1623`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1624`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1625`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1627`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1628`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `user.ts`
+- **Thin community `Community 1629`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1630`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `index.ts`
+- **Thin community `Community 1631`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1632`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `http.ts`
+- **Thin community `Community 1633`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `access.ts`
+- **Thin community `Community 1634`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1635`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1637`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `index.ts`
+- **Thin community `Community 1638`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1639`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `types.ts`
+- **Thin community `Community 1640`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `athenaUser.test.ts`
+- **Thin community `Community 1641`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1642`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `categories.ts`
+- **Thin community `Community 1643`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `colors.ts`
+- **Thin community `Community 1644`** (1 nodes): `athenaUser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1645`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1646`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1647`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `organizationMembers.test.ts`
+- **Thin community `Community 1648`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1649`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1650`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `pos.ts`
+- **Thin community `Community 1651`** (1 nodes): `organizationMembers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1652`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1653`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1654`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1655`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1656`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1657`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1658`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `stores.test.ts`
+- **Thin community `Community 1659`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1660`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1661`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1662`** (1 nodes): `stores.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `storeMemberAccess.test.ts`
+- **Thin community `Community 1663`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1664`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1665`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `storeMemberAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1669`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1670`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1671`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1672`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1673`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1674`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `types.ts`
+- **Thin community `Community 1675`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
+- **Thin community `Community 1676`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1677`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1678`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1679`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1680`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1682`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1683`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1684`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `appLoginEmailAllowlist.test.ts`
+- **Thin community `Community 1685`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1686`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1687`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1688`** (1 nodes): `appLoginEmailAllowlist.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1689`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `dto.ts`
+- **Thin community `Community 1690`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1691`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1692`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1693`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1694`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1695`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `types.ts`
+- **Thin community `Community 1696`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `facts.ts`
+- **Thin community `Community 1697`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `types.ts`
+- **Thin community `Community 1698`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1699`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `terminalHealthAlerts.test.ts`
+- **Thin community `Community 1700`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1701`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1702`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1703`** (1 nodes): `terminalHealthAlerts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1704`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1705`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `register.ts`
+- **Thin community `Community 1706`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1707`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1708`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1709`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `activation.test.ts`
+- **Thin community `Community 1710`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `attentionRules.test.ts`
+- **Thin community `Community 1711`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `commerceRecognition.test.ts`
+- **Thin community `Community 1712`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `customRangeRequests.test.ts`
+- **Thin community `Community 1713`** (1 nodes): `activation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `export.test.ts`
+- **Thin community `Community 1714`** (1 nodes): `attentionRules.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `factFingerprint.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `commerceRecognition.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `factIdentity.test.ts`
+- **Thin community `Community 1716`** (1 nodes): `customRangeRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1717`** (1 nodes): `export.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `integrity.test.ts`
+- **Thin community `Community 1718`** (1 nodes): `factFingerprint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `corrections.test.ts`
+- **Thin community `Community 1719`** (1 nodes): `factIdentity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `corrections.ts`
+- **Thin community `Community 1720`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `deficitResolutionWork.test.ts`
+- **Thin community `Community 1721`** (1 nodes): `integrity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `types.ts`
+- **Thin community `Community 1722`** (1 nodes): `corrections.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `authorizedPosBackfill.test.ts`
+- **Thin community `Community 1723`** (1 nodes): `corrections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `backfillAuthorization.test.ts`
+- **Thin community `Community 1724`** (1 nodes): `deficitResolutionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `cutover.test.ts`
+- **Thin community `Community 1725`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `inventoryRebuild.test.ts`
+- **Thin community `Community 1726`** (1 nodes): `authorizedPosBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `legacyCompatibility.test.ts`
+- **Thin community `Community 1727`** (1 nodes): `backfillAuthorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `posCensusBackfill.test.ts`
+- **Thin community `Community 1728`** (1 nodes): `cutover.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `posSourceReconciliationGate.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `inventoryRebuild.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `processing.test.ts`
+- **Thin community `Community 1730`** (1 nodes): `legacyCompatibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `runLedger.test.ts`
+- **Thin community `Community 1731`** (1 nodes): `posCensusBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `metricContracts.test.ts`
+- **Thin community `Community 1732`** (1 nodes): `posSourceReconciliationGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `periods.test.ts`
+- **Thin community `Community 1733`** (1 nodes): `processing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `projectionWork.test.ts`
+- **Thin community `Community 1734`** (1 nodes): `runLedger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `attention.test.ts`
+- **Thin community `Community 1735`** (1 nodes): `metricContracts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `currentInventory.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `periods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `customRange.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `projectionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `daily.test.ts`
+- **Thin community `Community 1738`** (1 nodes): `attention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `dailyCloseTrust.test.ts`
+- **Thin community `Community 1739`** (1 nodes): `currentInventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `factContributions.test.ts`
+- **Thin community `Community 1740`** (1 nodes): `customRange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `inventory.test.ts`
+- **Thin community `Community 1741`** (1 nodes): `daily.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `processor.test.ts`
+- **Thin community `Community 1742`** (1 nodes): `dailyCloseTrust.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `reconciliation.test.ts`
+- **Thin community `Community 1743`** (1 nodes): `factContributions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `skuDay.test.ts`
+- **Thin community `Community 1744`** (1 nodes): `inventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `skuInsights.test.ts`
+- **Thin community `Community 1745`** (1 nodes): `processor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `storeIntraday.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `reconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1747`** (1 nodes): `skuDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `destinations.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `skuInsights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `items.ts`
+- **Thin community `Community 1749`** (1 nodes): `storeIntraday.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `reportingReadModels.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `skuAttributionSequence.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `destinations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `types.ts`
+- **Thin community `Community 1752`** (1 nodes): `items.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `sourceAdapters.test.ts`
+- **Thin community `Community 1753`** (1 nodes): `reportingReadModels.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `storeTimeAuthority.test.ts`
+- **Thin community `Community 1754`** (1 nodes): `skuAttributionSequence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `schema.ts`
+- **Thin community `Community 1755`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `automation.ts`
+- **Thin community `Community 1756`** (1 nodes): `sourceAdapters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1757`** (1 nodes): `storeTimeAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1758`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `index.ts`
+- **Thin community `Community 1759`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1760`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1761`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1762`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1763`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1764`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1765`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1766`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `category.ts`
+- **Thin community `Community 1767`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `color.ts`
+- **Thin community `Community 1768`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1769`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1770`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `index.ts`
+- **Thin community `Community 1771`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1772`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1773`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1774`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1775`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `organization.ts`
+- **Thin community `Community 1776`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1777`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `posRegisterCatalogRevision.ts`
+- **Thin community `Community 1778`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `product.ts`
+- **Thin community `Community 1779`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1780`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1781`** (1 nodes): `posRegisterCatalogRevision.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1782`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `store.ts`
+- **Thin community `Community 1783`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1784`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `storeTimezone.ts`
+- **Thin community `Community 1785`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1786`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `landingFunnelEvent.ts`
+- **Thin community `Community 1787`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `walkthroughRequest.ts`
+- **Thin community `Community 1788`** (1 nodes): `storeTimezone.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `index.ts`
+- **Thin community `Community 1789`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1790`** (1 nodes): `landingFunnelEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1791`** (1 nodes): `walkthroughRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1792`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1793`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1794`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1795`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1796`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `index.ts`
+- **Thin community `Community 1797`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1798`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1799`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1800`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1801`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `oversizedOperationalWorkRepair.ts`
+- **Thin community `Community 1802`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1803`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1804`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1805`** (1 nodes): `oversizedOperationalWorkRepair.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1806`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1807`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1808`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1809`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `customer.ts`
+- **Thin community `Community 1810`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1811`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1812`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1813`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1814`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `index.ts`
+- **Thin community `Community 1815`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `posAmountMigrationRun.ts`
+- **Thin community `Community 1816`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `posClientEvent.ts`
+- **Thin community `Community 1817`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `posLifecycleJournal.ts`
+- **Thin community `Community 1818`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1819`** (1 nodes): `posAmountMigrationRun.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1820`** (1 nodes): `posClientEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1821`** (1 nodes): `posLifecycleJournal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1822`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1823`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1824`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1825`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1826`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
+- **Thin community `Community 1827`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `posRegisterMappingAuthority.ts`
+- **Thin community `Community 1828`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 1829`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 1830`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1831`** (1 nodes): `posRegisterMappingAuthority.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1832`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1834`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1835`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1836`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1837`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1838`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1839`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1840`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1841`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1842`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `index.ts`
+- **Thin community `Community 1843`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1844`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1845`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `facts.ts`
+- **Thin community `Community 1846`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `index.ts`
+- **Thin community `Community 1847`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `inventoryValuation.ts`
+- **Thin community `Community 1848`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `maintenance.ts`
+- **Thin community `Community 1849`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `projections.ts`
+- **Thin community `Community 1850`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `index.ts`
+- **Thin community `Community 1851`** (1 nodes): `inventoryValuation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1852`** (1 nodes): `maintenance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1853`** (1 nodes): `projections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1854`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1855`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1856`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `sharedDemo.ts`
+- **Thin community `Community 1857`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `staffMessages.ts`
+- **Thin community `Community 1858`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1859`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `index.ts`
+- **Thin community `Community 1860`** (1 nodes): `sharedDemo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1861`** (1 nodes): `staffMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1862`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1863`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1864`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1865`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1866`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `bag.ts`
+- **Thin community `Community 1867`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1868`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1869`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1870`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `guest.ts`
+- **Thin community `Community 1871`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `index.ts`
+- **Thin community `Community 1872`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `offer.ts`
+- **Thin community `Community 1873`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1874`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1875`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `review.ts`
+- **Thin community `Community 1876`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1877`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1878`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1879`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1880`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1881`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1882`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1883`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1884`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `authBoundary.test.ts`
+- **Thin community `Community 1885`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1886`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `domainRestore.test.ts`
+- **Thin community `Community 1887`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `foundation.test.ts`
+- **Thin community `Community 1888`** (1 nodes): `authBoundary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `openingBaseline.test.ts`
+- **Thin community `Community 1889`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `policy.test.ts`
+- **Thin community `Community 1890`** (1 nodes): `domainRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `provision.test.ts`
+- **Thin community `Community 1891`** (1 nodes): `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1892`** (1 nodes): `openingBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `registerBaseline.test.ts`
+- **Thin community `Community 1893`** (1 nodes): `policy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `reporting.test.ts`
+- **Thin community `Community 1894`** (1 nodes): `provision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `scheduledRestore.test.ts`
+- **Thin community `Community 1895`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
+- **Thin community `Community 1896`** (1 nodes): `registerBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `bag.ts`
+- **Thin community `Community 1897`** (1 nodes): `reporting.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1898`** (1 nodes): `scheduledRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `customer.ts`
+- **Thin community `Community 1899`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `guest.ts`
+- **Thin community `Community 1900`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1901`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1902`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1903`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1904`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1905`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1906`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1907`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `users.ts`
+- **Thin community `Community 1908`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `payment.ts`
+- **Thin community `Community 1909`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1910`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1911`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1912`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1913`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1914`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1915`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1916`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `index.ts`
+- **Thin community `Community 1917`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1918`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1919`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1920`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1921`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `auth.ts`
+- **Thin community `Community 1922`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1923`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1924`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1925`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1926`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1927`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1928`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1929`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `index.ts`
+- **Thin community `Community 1930`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1931`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `terminalRuntimeMaterial.test.ts`
+- **Thin community `Community 1932`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 1933`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1934`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1935`** (1 nodes): `terminalRuntimeMaterial.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `reportingContract.ts`
+- **Thin community `Community 1936`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1937`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1938`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1939`** (1 nodes): `reportingContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1940`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1941`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1942`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 1943`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1944`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 1945`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1946`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1947`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1948`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1949`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1950`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1951`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1952`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1953`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1954`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 1955`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1956`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1957`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `CopyImagesView.test.tsx`
+- **Thin community `Community 1958`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `constants.ts`
+- **Thin community `Community 1959`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1960`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1961`** (1 nodes): `CopyImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1962`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `types.ts`
+- **Thin community `Community 1963`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `AnalyticsView.test.tsx`
+- **Thin community `Community 1964`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1965`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1966`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1967`** (1 nodes): `AnalyticsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1968`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1969`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1970`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1971`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1972`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1973`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1974`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1975`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1976`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1977`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1978`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1979`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1980`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1981`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1982`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1983`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1984`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `constants.ts`
+- **Thin community `Community 1985`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1986`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1987`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1988`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `data.ts`
+- **Thin community `Community 1989`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1990`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1991`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1992`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1993`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1994`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1995`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1996`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1997`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1998`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1999`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 2000`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `constants.ts`
+- **Thin community `Community 2001`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2002`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2003`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2004`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `data.ts`
+- **Thin community `Community 2005`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 2006`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2007`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 2008`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 2009`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2010`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2011`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2012`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2013`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2014`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2015`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `constants.ts`
+- **Thin community `Community 2016`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2017`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2018`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2019`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2020`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 2021`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 2022`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 2023`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 2024`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 2025`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 2026`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 2027`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 2028`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2029`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2030`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2031`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 2032`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 2033`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 2034`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 2035`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 2036`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 2037`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `Home.test.tsx`
+- **Thin community `Community 2038`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 2039`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `ShopLookImageUploader.test.tsx`
+- **Thin community `Community 2040`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2041`** (1 nodes): `Home.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `demoDay.test.ts`
+- **Thin community `Community 2042`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 2043`** (1 nodes): `ShopLookImageUploader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 2044`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 2045`** (1 nodes): `demoDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 2046`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `openWorkInventoryReport.test.ts`
+- **Thin community `Community 2047`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 2048`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 2049`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 2050`** (1 nodes): `openWorkInventoryReport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `CustomerDetailsView.test.tsx`
+- **Thin community `Community 2051`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `CustomerDetailsView.tsx`
+- **Thin community `Community 2052`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `OrderDetailsView.test.tsx`
+- **Thin community `Community 2053`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 2054`** (1 nodes): `CustomerDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 2055`** (1 nodes): `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 2056`** (1 nodes): `OrderDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `OrdersView.test.tsx`
+- **Thin community `Community 2057`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 2058`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 2059`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `constants.ts`
+- **Thin community `Community 2060`** (1 nodes): `OrdersView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2061`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2062`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2063`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `data.ts`
+- **Thin community `Community 2064`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `orderColumns.test.tsx`
+- **Thin community `Community 2065`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 2066`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2067`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `constants.ts`
+- **Thin community `Community 2068`** (1 nodes): `orderColumns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2069`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2070`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2071`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2072`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `data.ts`
+- **Thin community `Community 2073`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 2074`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `constants.ts`
+- **Thin community `Community 2075`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2076`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2077`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2078`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2079`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `data.ts`
+- **Thin community `Community 2080`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 2081`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 2082`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 2083`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 2084`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 2085`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 2086`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 2087`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 2088`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 2089`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 2090`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 2091`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 2092`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 2093`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 2094`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 2095`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 2096`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 2097`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 2098`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 2099`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 2100`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 2101`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 2102`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 2103`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 2104`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 2105`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 2106`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 2107`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2108`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 2108`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `types.ts`
+- **Thin community `Community 2109`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 2110`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 2111`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 2112`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 2113`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `ImagesView.test.tsx`
+- **Thin community `Community 2114`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 2115`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 2116`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `productStockPresentation.test.ts`
+- **Thin community `Community 2117`** (1 nodes): `ImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 2118`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 2119`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 2120`** (1 nodes): `productStockPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 2121`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 2122`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 2123`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 2124`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2125`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 2125`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2126`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 2126`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2127`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2127`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2128`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2128`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2129`** (1 nodes): `data-table-toolbar.test.tsx`
+- **Thin community `Community 2129`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2130`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2130`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2131`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2131`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2132`** (1 nodes): `data.ts`
+- **Thin community `Community 2132`** (1 nodes): `data-table-toolbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2133`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 2133`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2134`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 2134`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2135`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 2135`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2136`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 2136`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2137`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 2137`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2138`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 2138`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2139`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2139`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2140`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2140`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2141`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2141`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2142`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2142`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2143`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2143`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2144`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2144`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2145`** (1 nodes): `constants.ts`
+- **Thin community `Community 2145`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2146`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2146`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2147`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2147`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2148`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2148`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2149`** (1 nodes): `data.ts`
+- **Thin community `Community 2149`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2150`** (1 nodes): `types.ts`
+- **Thin community `Community 2150`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2151`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 2151`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2152`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 2152`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2153`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 2153`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2154`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 2154`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2155`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 2155`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2156`** (1 nodes): `index.ts`
+- **Thin community `Community 2156`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2157`** (1 nodes): `CustomRangeStatus.test.tsx`
+- **Thin community `Community 2157`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2158`** (1 nodes): `InventoryMovementSummary.tsx`
+- **Thin community `Community 2158`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2159`** (1 nodes): `ReportAttentionList.tsx`
+- **Thin community `Community 2159`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2160`** (1 nodes): `ReportPeriodControl.test.tsx`
+- **Thin community `Community 2160`** (1 nodes): `CustomRangeStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2161`** (1 nodes): `ReportsInventoryView.test.tsx`
+- **Thin community `Community 2161`** (1 nodes): `InventoryMovementSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2162`** (1 nodes): `ReportsInventoryView.tsx`
+- **Thin community `Community 2162`** (1 nodes): `ReportAttentionList.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2163`** (1 nodes): `ReportsItemsView.test.tsx`
+- **Thin community `Community 2163`** (1 nodes): `ReportPeriodControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2164`** (1 nodes): `ReportsItemsView.tsx`
+- **Thin community `Community 2164`** (1 nodes): `ReportsInventoryView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2165`** (1 nodes): `ReportsLayout.test.tsx`
+- **Thin community `Community 2165`** (1 nodes): `ReportsInventoryView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2166`** (1 nodes): `ReportsOverviewView.test.tsx`
+- **Thin community `Community 2166`** (1 nodes): `ReportsItemsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2167`** (1 nodes): `ReportsSkuDetailView.test.tsx`
+- **Thin community `Community 2167`** (1 nodes): `ReportsItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2168`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
+- **Thin community `Community 2168`** (1 nodes): `ReportsLayout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2169`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
+- **Thin community `Community 2169`** (1 nodes): `ReportsOverviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2170`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
+- **Thin community `Community 2170`** (1 nodes): `ReportsSkuDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2171`** (1 nodes): `ReportsWorkspaceControls.tsx`
+- **Thin community `Community 2171`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2172`** (1 nodes): `RevenueContribution.tsx`
+- **Thin community `Community 2172`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2173`** (1 nodes): `reportPresentation.test.ts`
+- **Thin community `Community 2173`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2174`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2174`** (1 nodes): `ReportsWorkspaceControls.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2175`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2175`** (1 nodes): `RevenueContribution.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2176`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2176`** (1 nodes): `reportPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2177`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2177`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2178`** (1 nodes): `SharedDemoExperience.test.tsx`
+- **Thin community `Community 2178`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2179`** (1 nodes): `SharedDemoOwnerHome.tsx`
+- **Thin community `Community 2179`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2180`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
+- **Thin community `Community 2180`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2181`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
+- **Thin community `Community 2181`** (1 nodes): `SharedDemoExperience.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2182`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
+- **Thin community `Community 2182`** (1 nodes): `SharedDemoOwnerHome.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2183`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
+- **Thin community `Community 2183`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2184`** (1 nodes): `index.tsx`
+- **Thin community `Community 2184`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2185`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2185`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2186`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2186`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2187`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2187`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2188`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2188`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2189`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2189`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2190`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2190`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2191`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2191`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2192`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2192`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2193`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 2193`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2194`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2194`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2195`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2195`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2196`** (1 nodes): `index.tsx`
+- **Thin community `Community 2196`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2197`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2197`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2198`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2198`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2199`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2199`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2200`** (1 nodes): `button.tsx`
+- **Thin community `Community 2200`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2201`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2201`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2202`** (1 nodes): `card.tsx`
+- **Thin community `Community 2202`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2203`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2203`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2204`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2204`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2205`** (1 nodes): `command.tsx`
+- **Thin community `Community 2205`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2206`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2206`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2207`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2207`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2208`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2208`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2209`** (1 nodes): `form.tsx`
+- **Thin community `Community 2209`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2210`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2210`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2211`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2211`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2212`** (1 nodes): `input.tsx`
+- **Thin community `Community 2212`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2213`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2213`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2214`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2214`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2215`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2215`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2216`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2216`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2217`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2217`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2218`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2218`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2219`** (1 nodes): `select.tsx`
+- **Thin community `Community 2219`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2220`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2220`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2221`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2221`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2222`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2222`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2223`** (1 nodes): `table.tsx`
+- **Thin community `Community 2223`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2224`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2224`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2225`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2225`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2226`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2226`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2227`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2227`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2228`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2228`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2229`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2229`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2230`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2230`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2231`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2231`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2232`** (1 nodes): `constants.ts`
+- **Thin community `Community 2232`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2233`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2233`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2234`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2234`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2235`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2235`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2236`** (1 nodes): `data.ts`
+- **Thin community `Community 2236`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2237`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2237`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2238`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2238`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2239`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2239`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2240`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2240`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2241`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2241`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2242`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2242`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2243`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2243`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2244`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2244`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2245`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2245`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2246`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2246`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2247`** (1 nodes): `index.ts`
+- **Thin community `Community 2247`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2248`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2248`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2249`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2249`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2250`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2250`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2251`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2251`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2252`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2252`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2253`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2253`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2254`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2254`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2255`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2255`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2256`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2256`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2257`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2257`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2258`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2258`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2259`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2259`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2260`** (1 nodes): `useSharedDemoContext.test.ts`
+- **Thin community `Community 2260`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2261`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2261`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2262`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2262`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2263`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2263`** (1 nodes): `useSharedDemoContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2264`** (1 nodes): `index.ts`
+- **Thin community `Community 2264`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2265`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2265`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2266`** (1 nodes): `index.ts`
+- **Thin community `Community 2266`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2267`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2267`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2268`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2268`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2269`** (1 nodes): `aws.ts`
+- **Thin community `Community 2269`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2270`** (1 nodes): `constants.ts`
+- **Thin community `Community 2270`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2271`** (1 nodes): `countries.ts`
+- **Thin community `Community 2271`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2272`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2272`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2273`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2273`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2274`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2274`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2275`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2275`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2276`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2276`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2277`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2277`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2278`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2278`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2279`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2279`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2280`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2280`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2281`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2281`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2282`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2282`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2283`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2283`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2284`** (1 nodes): `operatingDate.test.ts`
+- **Thin community `Community 2284`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2285`** (1 nodes): `dto.ts`
+- **Thin community `Community 2285`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2286`** (1 nodes): `ports.ts`
+- **Thin community `Community 2286`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2287`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2287`** (1 nodes): `operatingDate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2288`** (1 nodes): `results.test.ts`
+- **Thin community `Community 2288`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2289`** (1 nodes): `constants.ts`
+- **Thin community `Community 2289`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2290`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2290`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2291`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2291`** (1 nodes): `results.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2292`** (1 nodes): `index.ts`
+- **Thin community `Community 2292`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2293`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2293`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2294`** (1 nodes): `types.ts`
+- **Thin community `Community 2294`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2295`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2295`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2296`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2296`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2297`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2297`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2298`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2298`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2299`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2299`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2300`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2300`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2301`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2301`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2302`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2302`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2303`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2303`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2304`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2304`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2305`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2305`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2306`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2306`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2307`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2307`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2308`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2308`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2309`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2309`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2310`** (1 nodes): `registerCatalogPinRuntime.test.ts`
+- **Thin community `Community 2310`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2311`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2311`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2312`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
+- **Thin community `Community 2312`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2313`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2313`** (1 nodes): `registerCatalogPinRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2314`** (1 nodes): `runtimeCounters.test.ts`
+- **Thin community `Community 2314`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2315`** (1 nodes): `telemetryBuffer.test.ts`
+- **Thin community `Community 2315`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2316`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2316`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2317`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2317`** (1 nodes): `runtimeCounters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2318`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2318`** (1 nodes): `telemetryBuffer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2319`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2319`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2320`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2320`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2321`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2321`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2322`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2322`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2323`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2323`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2324`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2324`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2325`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2325`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2326`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2326`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2327`** (1 nodes): `index.ts`
+- **Thin community `Community 2327`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2328`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2328`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2329`** (1 nodes): `category.ts`
+- **Thin community `Community 2329`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2330`** (1 nodes): `product.ts`
+- **Thin community `Community 2330`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2331`** (1 nodes): `store.ts`
+- **Thin community `Community 2331`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2332`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2332`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2333`** (1 nodes): `user.ts`
+- **Thin community `Community 2333`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2334`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2334`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2335`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2335`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2336`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2336`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2337`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2337`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2338`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `main.tsx`
+- **Thin community `Community 2339`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2340`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2341`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2342`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2343`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2344`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `-app-entry-route.tsx`
+- **Thin community `Community 2345`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `-privacy-page.tsx`
+- **Thin community `Community 2346`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `-public-layout.tsx`
+- **Thin community `Community 2347`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2348`** (1 nodes): `-app-entry-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `-shared-demo-entry.tsx`
+- **Thin community `Community 2349`** (1 nodes): `-privacy-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2350`** (1 nodes): `-public-layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2351`** (1 nodes): `index.tsx`
+- **Thin community `Community 2351`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `index.tsx`
+- **Thin community `Community 2352`** (1 nodes): `-shared-demo-entry.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `index.tsx`
+- **Thin community `Community 2353`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2354`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2355`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2356`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2357`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2358`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `index.tsx`
+- **Thin community `Community 2359`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2360`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2361`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2362`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2362`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `home.tsx`
+- **Thin community `Community 2363`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2364`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2365`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2366`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `index.tsx`
+- **Thin community `Community 2367`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `review.tsx`
+- **Thin community `Community 2368`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2369`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2370`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `index.tsx`
+- **Thin community `Community 2371`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2372`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2373`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2374`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `index.tsx`
+- **Thin community `Community 2375`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2376`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2377`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2378`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2379`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2380`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2381`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2382`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2383`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2384`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2385`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2386`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2387`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2388`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2389`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2390`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `index.tsx`
+- **Thin community `Community 2391`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2392`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `new.tsx`
+- **Thin community `Community 2393`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `new.tsx`
+- **Thin community `Community 2394`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2395`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2396`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `index.tsx`
+- **Thin community `Community 2397`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `new.tsx`
+- **Thin community `Community 2398`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `items.tsx`
+- **Thin community `Community 2399`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `search.test.ts`
+- **Thin community `Community 2400`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `storefront.tsx`
+- **Thin community `Community 2401`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `index.tsx`
+- **Thin community `Community 2402`** (1 nodes): `search.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2403`** (1 nodes): `storefront.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2404`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2405`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2406`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `index.tsx`
+- **Thin community `Community 2407`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2408`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2409`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2410`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `index.tsx`
+- **Thin community `Community 2411`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2412`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2413`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 2414`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2415`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `app.tsx`
+- **Thin community `Community 2416`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2417`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `demo.tsx`
+- **Thin community `Community 2418`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2419`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `index.tsx`
+- **Thin community `Community 2420`** (1 nodes): `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2421`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2422`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2423`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2424`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2425`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2426`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2427`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2428`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `walkthrough.tsx`
+- **Thin community `Community 2429`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2430`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2431`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2431`** (1 nodes): `walkthrough.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2432`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2433`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2434`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2435`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2436`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2437`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2438`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2439`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2440`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2441`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2442`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2443`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2444`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2445`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2446`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2447`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `setup.ts`
+- **Thin community `Community 2448`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2449`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `types.ts`
+- **Thin community `Community 2450`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2451`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2452`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2453`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2454`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2455`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2456`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2457`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `types.ts`
+- **Thin community `Community 2458`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2459`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2460`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2461`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2462`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2463`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2464`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2465`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2466`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `schema.ts`
+- **Thin community `Community 2467`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2468`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2469`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2470`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2471`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2472`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2473`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2474`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2475`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2476`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `types.ts`
+- **Thin community `Community 2477`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2478`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2479`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2480`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2481`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2482`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2483`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2484`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `constants.ts`
+- **Thin community `Community 2485`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2486`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `About.tsx`
+- **Thin community `Community 2487`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2488`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2489`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2490`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2491`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2492`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2493`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2494`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2495`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2496`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2497`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `types.ts`
+- **Thin community `Community 2498`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2499`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2500`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2501`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2502`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2503`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2504`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2505`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2506`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2507`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2508`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2509`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `button.tsx`
+- **Thin community `Community 2510`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `card.tsx`
+- **Thin community `Community 2511`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2512`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `command.tsx`
+- **Thin community `Community 2513`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2514`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2515`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2516`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `form.tsx`
+- **Thin community `Community 2517`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2518`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2519`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2520`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2521`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `input.tsx`
+- **Thin community `Community 2522`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `label.tsx`
+- **Thin community `Community 2523`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2524`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2525`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2526`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `index.ts`
+- **Thin community `Community 2527`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2528`** (1 nodes): `types.ts`
+- **Thin community `Community 2528`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2529`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2530`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2531`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2532`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `select.tsx`
+- **Thin community `Community 2533`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2534`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2535`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `table.tsx`
+- **Thin community `Community 2536`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2537`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2537`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2538`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2539`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2540`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2541`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `config.ts`
+- **Thin community `Community 2542`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2543`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2543`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2544`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2544`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2545`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2545`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2546`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2547`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `constants.ts`
+- **Thin community `Community 2548`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `countries.ts`
+- **Thin community `Community 2549`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2550`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2551`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2552`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2553`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `index.ts`
+- **Thin community `Community 2554`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2555`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `store.ts`
+- **Thin community `Community 2556`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `bag.ts`
+- **Thin community `Community 2557`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2558`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `category.ts`
+- **Thin community `Community 2559`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `organization.ts`
+- **Thin community `Community 2560`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `product.ts`
+- **Thin community `Community 2561`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `store.ts`
+- **Thin community `Community 2562`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2563`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `user.ts`
+- **Thin community `Community 2564`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `states.ts`
+- **Thin community `Community 2565`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2566`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2567`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2568`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2569`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2570`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2571`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2572`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2573`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2574`** (1 nodes): `index.tsx`
+- **Thin community `Community 2574`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2575`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2576`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2577`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2578`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2579`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2580`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2581`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `index.tsx`
+- **Thin community `Community 2582`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2583`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2584`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2585`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2586`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2586`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2587`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `index.js`
+- **Thin community `Community 2588`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2589`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2589`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2590`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2591`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2592`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2593`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2594`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2595`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2596`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2596`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2597`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2597`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2598`** (1 nodes): `harness-repo-validation.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2599`** (1 nodes): `operational-work-repair.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2670 files · ~0 words
+- 2672 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10800 nodes · 13111 edges · 2596 communities detected
+- 10794 nodes · 13079 edges · 2598 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2606,6 +2606,8 @@
 - [[_COMMUNITY_Community 2593|Community 2593]]
 - [[_COMMUNITY_Community 2594|Community 2594]]
 - [[_COMMUNITY_Community 2595|Community 2595]]
+- [[_COMMUNITY_Community 2596|Community 2596]]
+- [[_COMMUNITY_Community 2597|Community 2597]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2646,16 +2648,16 @@ Cohesion: 0.06
 Nodes (86): buildFinding(), buildGitProcessEnv(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectConvexQueryWriteBoundaryFindings(), collectConvexReturnValidatorContractFindings() (+78 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.04
-Nodes (44): buildDailyCloseExpenseSearch(), buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), compareSummaryPaymentTotals(), formatOperationalWorkTypeLabel(), getBucketCountClassName(), getCarryForwardSelectionId() (+36 more)
-
-### Community 4 - "Community 4"
 Cohesion: 0.06
 Nodes (68): buildLegacyOperationalExplanation(), buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildStaticOperationalExplanation(), buildTerminalAppUpdatePresentation(), buildTerminalOperationalExplanationPresentation(), buildTerminalRecoveryPresentation() (+60 more)
 
-### Community 5 - "Community 5"
+### Community 4 - "Community 4"
 Cohesion: 0.05
 Nodes (68): attentionSeverity(), automationRunClassification(), automationStatusBucketForRun(), buildApprovalsLane(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents() (+60 more)
+
+### Community 5 - "Community 5"
+Cohesion: 0.04
+Nodes (36): canReopenDailyClose(), cn(), compareSummaryPaymentTotals(), formatOperationalWorkTypeLabel(), getBucketCountClassName(), getCarryForwardSelectionId(), getCarryForwardWorkItemId(), getCarryForwardWorkItemIds() (+28 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.05
@@ -2703,51 +2705,51 @@ Nodes (27): buildDisplaySafeConflictSummary(), buildTerminalSyncReviewSummary(),
 
 ### Community 17 - "Community 17"
 Cohesion: 0.07
-Nodes (23): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatOperationalWorkTypeLabel(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue() (+15 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.07
 Nodes (24): Boolean(), buildMissingDraftResult(), formatCatalogSetupProductName(), formatOpenWorkHeaderTitle(), formatQueueWorkItemValue(), formatWorkItemTitle(), getOpenWorkMixEntries(), getQueueWorkItemInventoryReviewLineCount() (+16 more)
 
-### Community 19 - "Community 19"
+### Community 18 - "Community 18"
 Cohesion: 0.09
 Nodes (28): buildRosterRecoveryPreview(), buildTerminalAppUpdatePreview(), buildTerminalHealthSummary(), buildTerminalOperationalStateForSummary(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), createTerminalCloudRepairQueryRepository(), formatRuntimeAppUpdateAssetSummary() (+20 more)
 
-### Community 20 - "Community 20"
+### Community 19 - "Community 19"
 Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
-### Community 21 - "Community 21"
-Cohesion: 0.08
-Nodes (25): applyTodayRefreshSnapshot(), buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), formatOnlineOrderTimelineFallbackMessage(), formatPendingApprovalsLabel(), formatTimelineMessage() (+17 more)
-
-### Community 22 - "Community 22"
+### Community 20 - "Community 20"
 Cohesion: 0.07
 Nodes (14): addConflictLink(), arrayDetail(), buildActivityReadModelPage(), buildActivitySummary(), buildContinueCursor(), buildEventSummary(), buildRegisterSessionActivityPage(), countLabel() (+6 more)
 
-### Community 23 - "Community 23"
+### Community 21 - "Community 21"
+Cohesion: 0.07
+Nodes (19): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatOperationalWorkTypeLabel(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue() (+11 more)
+
+### Community 22 - "Community 22"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 24 - "Community 24"
+### Community 23 - "Community 23"
 Cohesion: 0.07
 Nodes (10): arrayDetail(), buildCashControlsDashboardSnapshot(), buildReviewedSaleProjectionEvent(), getCompletedTransactionForRegisterMappingRepair(), normalizeReviewedNonCashOverpaymentPayload(), numberDetail(), recordDetail(), roundCurrencyAmount() (+2 more)
 
-### Community 25 - "Community 25"
+### Community 24 - "Community 24"
 Cohesion: 0.11
 Nodes (34): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), boundedNumber(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildInventoryImportEvidenceSource(), buildPendingCheckoutEvidenceSource() (+26 more)
 
-### Community 26 - "Community 26"
+### Community 25 - "Community 25"
 Cohesion: 0.14
 Nodes (35): asRecord(), calculateLocalSaleExpectedCashDelta(), canUploadedRegisterOpenReplaceBlockedDrawer(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale() (+27 more)
 
-### Community 27 - "Community 27"
+### Community 26 - "Community 26"
 Cohesion: 0.1
 Nodes (24): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), buildCatalogRepresentedPendingCheckoutProductSignatures(), buildLocalAvailabilityEventIndex(), buildLocalPendingCheckoutDefinitionEventIdsByItemId(), cartItemLineEventKey(), cartItemLineKey(), cartItemsFromLocalRegisterModel() (+16 more)
 
-### Community 28 - "Community 28"
+### Community 27 - "Community 27"
 Cohesion: 0.1
 Nodes (31): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildInventorySnapshotRowsForProductSkusWithCtx(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle() (+23 more)
+
+### Community 28 - "Community 28"
+Cohesion: 0.07
+Nodes (16): applyTodayRefreshSnapshot(), buildDailyCloseSearch(), formatOnlineOrderTimelineFallbackMessage(), formatPendingApprovalsLabel(), formatTimelineMessage(), getPendingApprovalsCountLabel(), getSaturdayWeekEndOperatingDate(), getSundayWeekStartOperatingDate() (+8 more)
 
 ### Community 29 - "Community 29"
 Cohesion: 0.12
@@ -3682,28 +3684,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 262 - "Community 262"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 263 - "Community 263"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 264 - "Community 264"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 265 - "Community 265"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 266 - "Community 266"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+### Community 263 - "Community 263"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 267 - "Community 267"
+### Community 264 - "Community 264"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 265 - "Community 265"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 266 - "Community 266"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 267 - "Community 267"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 268 - "Community 268"
 Cohesion: 0.22
@@ -4498,56 +4500,56 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 466 - "Community 466"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+
+### Community 467 - "Community 467"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 468 - "Community 468"
+### Community 469 - "Community 469"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 469 - "Community 469"
+### Community 470 - "Community 470"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 472 - "Community 472"
-Cohesion: 0.7
-Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 474 - "Community 474"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 475 - "Community 475"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 475 - "Community 475"
+### Community 476 - "Community 476"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 476 - "Community 476"
-Cohesion: 0.6
-Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.6
-Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
+Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
 ### Community 478 - "Community 478"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.4
@@ -4558,92 +4560,92 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 481 - "Community 481"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 482 - "Community 482"
+### Community 483 - "Community 483"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 483 - "Community 483"
+### Community 484 - "Community 484"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 484 - "Community 484"
+### Community 485 - "Community 485"
 Cohesion: 0.7
 Nodes (4): canonicalReportingBusinessEventKey(), canonicalReportingFactIdentity(), canonicalReportingFactKey(), requiredIdentityPart()
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
 Cohesion: 0.6
 Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.7
 Nodes (4): backfillAuthorizationEnvelopeHash(), backfillAuthorizationMatches(), fnv1a(), normalizeEnvelope()
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.5
 Nodes (2): fnv1a(), sourceDerivedPosCensusHash()
 
-### Community 488 - "Community 488"
+### Community 489 - "Community 489"
 Cohesion: 0.6
 Nodes (3): indexRows(), reconcilePosSourceFacts(), sum()
 
-### Community 489 - "Community 489"
+### Community 490 - "Community 490"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 490 - "Community 490"
+### Community 491 - "Community 491"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 491 - "Community 491"
+### Community 492 - "Community 492"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 492 - "Community 492"
+### Community 493 - "Community 493"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 494 - "Community 494"
+### Community 495 - "Community 495"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 495 - "Community 495"
+### Community 496 - "Community 496"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 496 - "Community 496"
+### Community 497 - "Community 497"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 497 - "Community 497"
+### Community 498 - "Community 498"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
-### Community 498 - "Community 498"
+### Community 499 - "Community 499"
 Cohesion: 0.5
 Nodes (2): sharedDemoPickupOrderAmount(), sharedDemoProductBySku()
-
-### Community 499 - "Community 499"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 500 - "Community 500"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 501 - "Community 501"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 502 - "Community 502"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 502 - "Community 502"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.4
@@ -4654,12 +4656,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 505 - "Community 505"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 506 - "Community 506"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 506 - "Community 506"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 507 - "Community 507"
 Cohesion: 0.4
@@ -4674,12 +4676,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 510 - "Community 510"
-Cohesion: 0.7
-Nodes (4): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), routeTemplateMatches()
-
-### Community 511 - "Community 511"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 511 - "Community 511"
+Cohesion: 0.7
+Nodes (4): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), routeTemplateMatches()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.4
@@ -4690,92 +4692,92 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 514 - "Community 514"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
-
-### Community 515 - "Community 515"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 515 - "Community 515"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 516 - "Community 516"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 517 - "Community 517"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 518 - "Community 518"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 519 - "Community 519"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 520 - "Community 520"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 521 - "Community 521"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 521 - "Community 521"
+### Community 522 - "Community 522"
 Cohesion: 0.6
 Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
 
-### Community 522 - "Community 522"
+### Community 523 - "Community 523"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 523 - "Community 523"
+### Community 524 - "Community 524"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 524 - "Community 524"
+### Community 525 - "Community 525"
+Cohesion: 0.7
+Nodes (4): getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange(), getLocalOperatingDateRangeFromSearch()
+
+### Community 526 - "Community 526"
 Cohesion: 0.5
 Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
-### Community 525 - "Community 525"
+### Community 527 - "Community 527"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 526 - "Community 526"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
-
-### Community 527 - "Community 527"
-Cohesion: 0.8
-Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 529 - "Community 529"
-Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Cohesion: 0.8
+Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
 ### Community 530 - "Community 530"
 Cohesion: 0.6
-Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 531 - "Community 531"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 532 - "Community 532"
+Cohesion: 0.6
+Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
+
+### Community 533 - "Community 533"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 532 - "Community 532"
+### Community 534 - "Community 534"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 533 - "Community 533"
+### Community 535 - "Community 535"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 534 - "Community 534"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 535 - "Community 535"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 536 - "Community 536"
 Cohesion: 0.4
@@ -4783,35 +4785,35 @@ Nodes (0):
 
 ### Community 537 - "Community 537"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 538 - "Community 538"
-Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 539 - "Community 539"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 540 - "Community 540"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 541 - "Community 541"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
-
-### Community 542 - "Community 542"
-Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
-
-### Community 543 - "Community 543"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 542 - "Community 542"
+Cohesion: 0.7
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+
+### Community 543 - "Community 543"
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+
 ### Community 544 - "Community 544"
-Cohesion: 0.6
-Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 545 - "Community 545"
 Cohesion: 0.4
@@ -4819,87 +4821,87 @@ Nodes (0):
 
 ### Community 546 - "Community 546"
 Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
 ### Community 547 - "Community 547"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 548 - "Community 548"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 548 - "Community 548"
+### Community 549 - "Community 549"
 Cohesion: 0.6
 Nodes (4): checkRegisterSessionAuthorityWriters(), collectRegisterSessionAuthorityWriterFindings(), listTypeScriptFiles(), normalizePath()
-
-### Community 549 - "Community 549"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 550 - "Community 550"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 551 - "Community 551"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 552 - "Community 552"
 Cohesion: 0.5
 Nodes (2): createSiblingPolicyFixture(), runGit()
 
-### Community 552 - "Community 552"
+### Community 553 - "Community 553"
 Cohesion: 0.6
 Nodes (3): errorMessage(), formatHumanReport(), runHarnessContractPreflight()
 
-### Community 553 - "Community 553"
+### Community 554 - "Community 554"
 Cohesion: 0.7
 Nodes (4): buildOperationalWorkRepairInvocation(), main(), parseOperationalWorkRepairArgs(), requireValue()
-
-### Community 554 - "Community 554"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 555 - "Community 555"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 556 - "Community 556"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 557 - "Community 557"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 557 - "Community 557"
+### Community 558 - "Community 558"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 558 - "Community 558"
+### Community 559 - "Community 559"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
-
-### Community 559 - "Community 559"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 560 - "Community 560"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 561 - "Community 561"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 562 - "Community 562"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 562 - "Community 562"
+### Community 563 - "Community 563"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 563 - "Community 563"
+### Community 564 - "Community 564"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 564 - "Community 564"
+### Community 565 - "Community 565"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 565 - "Community 565"
+### Community 566 - "Community 566"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 566 - "Community 566"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 567 - "Community 567"
 Cohesion: 0.5
@@ -4914,20 +4916,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 570 - "Community 570"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 571 - "Community 571"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 571 - "Community 571"
+### Community 572 - "Community 572"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 572 - "Community 572"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 573 - "Community 573"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 574 - "Community 574"
 Cohesion: 0.5
@@ -4954,32 +4956,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 580 - "Community 580"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 581 - "Community 581"
 Cohesion: 0.67
 Nodes (2): audit(), boundedText()
 
-### Community 581 - "Community 581"
+### Community 582 - "Community 582"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 582 - "Community 582"
+### Community 583 - "Community 583"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 583 - "Community 583"
+### Community 584 - "Community 584"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 584 - "Community 584"
+### Community 585 - "Community 585"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 585 - "Community 585"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 586 - "Community 586"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 587 - "Community 587"
 Cohesion: 0.5
@@ -4990,56 +4992,56 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 589 - "Community 589"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 590 - "Community 590"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 590 - "Community 590"
+### Community 591 - "Community 591"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 591 - "Community 591"
+### Community 592 - "Community 592"
 Cohesion: 0.67
 Nodes (2): assertAppLoginEmailApproved(), authorizeEmailOtp()
 
-### Community 592 - "Community 592"
+### Community 593 - "Community 593"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 593 - "Community 593"
+### Community 594 - "Community 594"
 Cohesion: 0.5
 Nodes (1): buildCtx()
 
-### Community 594 - "Community 594"
+### Community 595 - "Community 595"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 595 - "Community 595"
+### Community 596 - "Community 596"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 596 - "Community 596"
+### Community 597 - "Community 597"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 597 - "Community 597"
+### Community 598 - "Community 598"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 598 - "Community 598"
+### Community 599 - "Community 599"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 599 - "Community 599"
+### Community 600 - "Community 600"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 600 - "Community 600"
+### Community 601 - "Community 601"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 601 - "Community 601"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 602 - "Community 602"
 Cohesion: 0.5
@@ -5054,56 +5056,56 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 605 - "Community 605"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 606 - "Community 606"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 607 - "Community 607"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 608 - "Community 608"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 609 - "Community 609"
-Cohesion: 0.83
-Nodes (3): actorRefWithCtx(), preflightReportingRunAccessWithCtx(), recordReportingDirectAccessDenialWithCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 610 - "Community 610"
 Cohesion: 0.83
-Nodes (3): assertMinor(), lineFact(), recognizeCommerceEvent()
+Nodes (3): actorRefWithCtx(), preflightReportingRunAccessWithCtx(), recordReportingDirectAccessDenialWithCtx()
 
 ### Community 611 - "Community 611"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): assertMinor(), lineFact(), recognizeCommerceEvent()
 
 ### Community 612 - "Community 612"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 613 - "Community 613"
-Cohesion: 0.67
-Nodes (2): buildReportingRun(), createReportingRunWithCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 614 - "Community 614"
 Cohesion: 0.67
-Nodes (2): getMetricContract(), validateMetricContractVersion()
+Nodes (2): buildReportingRun(), createReportingRunWithCtx()
 
 ### Community 615 - "Community 615"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getMetricContract(), validateMetricContractVersion()
 
 ### Community 616 - "Community 616"
-Cohesion: 0.67
-Nodes (2): completeCoverage(), emptyPresetContext()
-
-### Community 617 - "Community 617"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 617 - "Community 617"
+Cohesion: 0.67
+Nodes (2): completeCoverage(), emptyPresetContext()
 
 ### Community 618 - "Community 618"
 Cohesion: 0.5
@@ -5114,16 +5116,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 620 - "Community 620"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 621 - "Community 621"
 Cohesion: 0.83
 Nodes (3): createOpaqueTicket(), encodeBase64Url(), hashSharedDemoTicket()
 
-### Community 621 - "Community 621"
+### Community 622 - "Community 622"
 Cohesion: 0.67
 Nodes (2): runHourlyRestoreWithCtx(), sharedDemoRestoreEnabled()
-
-### Community 622 - "Community 622"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 623 - "Community 623"
 Cohesion: 0.5
@@ -5134,16 +5136,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 625 - "Community 625"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 626 - "Community 626"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 626 - "Community 626"
+### Community 627 - "Community 627"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 627 - "Community 627"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 628 - "Community 628"
 Cohesion: 0.5
@@ -5154,44 +5156,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 630 - "Community 630"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 631 - "Community 631"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 632 - "Community 632"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 633 - "Community 633"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 634 - "Community 634"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 635 - "Community 635"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 636 - "Community 636"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 636 - "Community 636"
+### Community 637 - "Community 637"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 637 - "Community 637"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 638 - "Community 638"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 639 - "Community 639"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 640 - "Community 640"
 Cohesion: 0.5
@@ -5226,16 +5228,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 648 - "Community 648"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 649 - "Community 649"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 650 - "Community 650"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 651 - "Community 651"
 Cohesion: 0.5
@@ -5250,12 +5252,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 654 - "Community 654"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 655 - "Community 655"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 655 - "Community 655"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.5
@@ -5282,12 +5284,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 662 - "Community 662"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 663 - "Community 663"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 663 - "Community 663"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 664 - "Community 664"
 Cohesion: 0.5
@@ -5298,116 +5300,116 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 666 - "Community 666"
-Cohesion: 0.67
-Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
-
-### Community 667 - "Community 667"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 667 - "Community 667"
+Cohesion: 0.67
+Nodes (2): formatTraceTimestamp(), RelativeTraceTimestamp()
 
 ### Community 668 - "Community 668"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 669 - "Community 669"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 670 - "Community 670"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 671 - "Community 671"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 672 - "Community 672"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 673 - "Community 673"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 673 - "Community 673"
+### Community 674 - "Community 674"
 Cohesion: 0.67
 Nodes (2): useUpdateCoordinator(), useUpdateCoordinatorSnapshot()
 
-### Community 674 - "Community 674"
+### Community 675 - "Community 675"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 675 - "Community 675"
+### Community 676 - "Community 676"
 Cohesion: 0.67
 Nodes (2): coarseDevice(), emitLandingFunnelEvent()
 
-### Community 676 - "Community 676"
+### Community 677 - "Community 677"
 Cohesion: 0.83
 Nodes (3): getRecoveryHomePath(), isPublicRoutePath(), normalizePathname()
 
-### Community 677 - "Community 677"
+### Community 678 - "Community 678"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 678 - "Community 678"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 679 - "Community 679"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 680 - "Community 680"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 681 - "Community 681"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 682 - "Community 682"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 683 - "Community 683"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 683 - "Community 683"
+### Community 684 - "Community 684"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 684 - "Community 684"
+### Community 685 - "Community 685"
 Cohesion: 0.67
 Nodes (2): buildPosLocalStoreFixtureSnapshot(), fixtureIntegrity()
 
-### Community 685 - "Community 685"
+### Community 686 - "Community 686"
 Cohesion: 0.83
 Nodes (3): completedEvent(), event(), item()
 
-### Community 686 - "Community 686"
+### Community 687 - "Community 687"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 687 - "Community 687"
+### Community 688 - "Community 688"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 688 - "Community 688"
+### Community 689 - "Community 689"
 Cohesion: 0.67
 Nodes (2): assessPosLocalStoreClear(), hasValidClearInspectionCounts()
 
-### Community 689 - "Community 689"
+### Community 690 - "Community 690"
 Cohesion: 0.83
 Nodes (3): isVersioned(), reconcileRegisterLifecycleServerAuthority(), sameAuthorityPayload()
-
-### Community 690 - "Community 690"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 691 - "Community 691"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 692 - "Community 692"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 693 - "Community 693"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 693 - "Community 693"
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 694 - "Community 694"
 Cohesion: 0.5
@@ -5422,28 +5424,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 697 - "Community 697"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 698 - "Community 698"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 698 - "Community 698"
+### Community 699 - "Community 699"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 699 - "Community 699"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 700 - "Community 700"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 701 - "Community 701"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 702 - "Community 702"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 703 - "Community 703"
 Cohesion: 0.5
@@ -5474,63 +5476,63 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 710 - "Community 710"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 711 - "Community 711"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 712 - "Community 712"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 713 - "Community 713"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 713 - "Community 713"
+### Community 714 - "Community 714"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 714 - "Community 714"
+### Community 715 - "Community 715"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 715 - "Community 715"
+### Community 716 - "Community 716"
 Cohesion: 0.67
 Nodes (2): write(), writePublicQueryWithReturns()
 
-### Community 716 - "Community 716"
+### Community 717 - "Community 717"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 717 - "Community 717"
+### Community 718 - "Community 718"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 718 - "Community 718"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 719 - "Community 719"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 720 - "Community 720"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 721 - "Community 721"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 721 - "Community 721"
+### Community 722 - "Community 722"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 722 - "Community 722"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 723 - "Community 723"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 724 - "Community 724"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 725 - "Community 725"
@@ -5542,12 +5544,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 727 - "Community 727"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 728 - "Community 728"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 728 - "Community 728"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 729 - "Community 729"
 Cohesion: 0.67
@@ -5590,12 +5592,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 739 - "Community 739"
-Cohesion: 1.0
-Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
-
-### Community 740 - "Community 740"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 740 - "Community 740"
+Cohesion: 1.0
+Nodes (2): appendFunnelAggregateWithCtx(), appendFunnelEventWithCtx()
 
 ### Community 741 - "Community 741"
 Cohesion: 0.67
@@ -5622,52 +5624,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 747 - "Community 747"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 748 - "Community 748"
 Cohesion: 1.0
 Nodes (2): isAthenaAppLoginEmailApproved(), normalizeAthenaAppLoginEmail()
 
-### Community 748 - "Community 748"
+### Community 749 - "Community 749"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 749 - "Community 749"
-Cohesion: 1.0
-Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 750 - "Community 750"
 Cohesion: 1.0
-Nodes (2): resolveLocalSyncReview(), resolveLocalSyncReviewWithCtx()
+Nodes (2): closedRegisterReplayConflict(), repairConflict()
 
 ### Community 751 - "Community 751"
 Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Nodes (2): resolveLocalSyncReview(), resolveLocalSyncReviewWithCtx()
 
 ### Community 752 - "Community 752"
 Cohesion: 1.0
-Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 753 - "Community 753"
 Cohesion: 1.0
-Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
+Nodes (2): collectTerminalOperationalFacts(), toRegisterSessionLink()
 
 ### Community 754 - "Community 754"
 Cohesion: 1.0
-Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
+Nodes (2): resolveTerminalCloudRepair(), selectLatestSafeDuplicateOpenConflict()
 
 ### Community 755 - "Community 755"
 Cohesion: 1.0
-Nodes (2): classifyTerminalHealthAlertConditions(), resolveTerminalHealthAlertTransitions()
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 756 - "Community 756"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): classifyTerminalHealthAlertConditions(), resolveTerminalHealthAlertTransitions()
 
 ### Community 757 - "Community 757"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 758 - "Community 758"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 759 - "Community 759"
 Cohesion: 0.67
@@ -5682,16 +5684,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 762 - "Community 762"
-Cohesion: 1.0
-Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 763 - "Community 763"
 Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Nodes (2): createRegisterLifecycleAuthorityStatusReadRepository(), createRegisterLifecycleAuthorityStatusRepository()
 
 ### Community 764 - "Community 764"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 765 - "Community 765"
 Cohesion: 0.67
@@ -5718,12 +5720,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 771 - "Community 771"
-Cohesion: 1.0
-Nodes (2): evaluateAttention(), reason()
-
-### Community 772 - "Community 772"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 772 - "Community 772"
+Cohesion: 1.0
+Nodes (2): evaluateAttention(), reason()
 
 ### Community 773 - "Community 773"
 Cohesion: 0.67
@@ -5742,28 +5744,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 777 - "Community 777"
-Cohesion: 1.0
-Nodes (2): buildDailyProjection(), integer()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 778 - "Community 778"
 Cohesion: 1.0
-Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
+Nodes (2): buildDailyProjection(), integer()
 
 ### Community 779 - "Community 779"
 Cohesion: 1.0
-Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
+Nodes (2): buildDailyCloseTrustSummary(), materializeDailyCloseTrustWithCtx()
 
 ### Community 780 - "Community 780"
 Cohesion: 1.0
-Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
+Nodes (2): deriveFactMetricContributions(), merchandiseCostContributions()
 
 ### Community 781 - "Community 781"
 Cohesion: 1.0
-Nodes (2): reconcileProjection(), unitFor()
+Nodes (2): currentInventoryMetricRows(), projectInventoryPositionWithCtx()
 
 ### Community 782 - "Community 782"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reconcileProjection(), unitFor()
 
 ### Community 783 - "Community 783"
 Cohesion: 0.67
@@ -5782,12 +5784,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 787 - "Community 787"
-Cohesion: 1.0
-Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
-
-### Community 788 - "Community 788"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 788 - "Community 788"
+Cohesion: 1.0
+Nodes (2): getSharedDemoReportsOverviewWithCtx(), summarizeSharedDemoReport()
 
 ### Community 789 - "Community 789"
 Cohesion: 0.67
@@ -5802,16 +5804,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 792 - "Community 792"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 793 - "Community 793"
 Cohesion: 1.0
-Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 794 - "Community 794"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): scheduleCatalogSummaryDirtyMarker(), updateOnlineOrderItem()
 
 ### Community 795 - "Community 795"
 Cohesion: 0.67
@@ -5822,28 +5824,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 797 - "Community 797"
-Cohesion: 1.0
-Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 798 - "Community 798"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): buildLookup(), buildOrderReturnExchangeTraceSeed()
 
 ### Community 799 - "Community 799"
 Cohesion: 1.0
-Nodes (2): addLookup(), buildServiceCaseTraceSeed()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 800 - "Community 800"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): addLookup(), buildServiceCaseTraceSeed()
 
 ### Community 801 - "Community 801"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
-
-### Community 802 - "Community 802"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 802 - "Community 802"
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 803 - "Community 803"
 Cohesion: 0.67
@@ -5851,11 +5853,11 @@ Nodes (0):
 
 ### Community 804 - "Community 804"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 805 - "Community 805"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 806 - "Community 806"
 Cohesion: 0.67
@@ -5870,12 +5872,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 809 - "Community 809"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 810 - "Community 810"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 810 - "Community 810"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 811 - "Community 811"
 Cohesion: 0.67
@@ -5903,23 +5905,23 @@ Nodes (0):
 
 ### Community 817 - "Community 817"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 818 - "Community 818"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 819 - "Community 819"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 820 - "Community 820"
-Cohesion: 1.0
-Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
-
-### Community 821 - "Community 821"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 821 - "Community 821"
+Cohesion: 1.0
+Nodes (2): getSkuImageUrl(), HomepagePlacementProductImage()
 
 ### Community 822 - "Community 822"
 Cohesion: 0.67
@@ -5927,11 +5929,11 @@ Nodes (0):
 
 ### Community 823 - "Community 823"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 824 - "Community 824"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 825 - "Community 825"
 Cohesion: 0.67
@@ -5946,12 +5948,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 828 - "Community 828"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
-
-### Community 829 - "Community 829"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 829 - "Community 829"
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 830 - "Community 830"
 Cohesion: 0.67
@@ -5962,16 +5964,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 832 - "Community 832"
-Cohesion: 1.0
-Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 833 - "Community 833"
 Cohesion: 1.0
-Nodes (2): buildTodaySummary(), renderStorePulse()
+Nodes (2): ExpenseCompletionPanel(), isLocalExpenseReportNumber()
 
 ### Community 834 - "Community 834"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildTodaySummary(), renderStorePulse()
 
 ### Community 835 - "Community 835"
 Cohesion: 0.67
@@ -6035,79 +6037,79 @@ Nodes (0):
 
 ### Community 850 - "Community 850"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 851 - "Community 851"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 852 - "Community 852"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 853 - "Community 853"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 854 - "Community 854"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 855 - "Community 855"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 856 - "Community 856"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 857 - "Community 857"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 858 - "Community 858"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 858 - "Community 858"
+### Community 859 - "Community 859"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 859 - "Community 859"
+### Community 860 - "Community 860"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 860 - "Community 860"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 861 - "Community 861"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 862 - "Community 862"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 863 - "Community 863"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 864 - "Community 864"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 865 - "Community 865"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 866 - "Community 866"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 867 - "Community 867"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 868 - "Community 868"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 869 - "Community 869"
 Cohesion: 0.67
@@ -6139,11 +6141,11 @@ Nodes (0):
 
 ### Community 876 - "Community 876"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 877 - "Community 877"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 878 - "Community 878"
 Cohesion: 0.67
@@ -6158,12 +6160,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 881 - "Community 881"
-Cohesion: 1.0
-Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
-
-### Community 882 - "Community 882"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 882 - "Community 882"
+Cohesion: 1.0
+Nodes (2): sharedDemoQueryArgs(), useSharedDemoContext()
 
 ### Community 883 - "Community 883"
 Cohesion: 0.67
@@ -6178,16 +6180,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 886 - "Community 886"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 887 - "Community 887"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 887 - "Community 887"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
 ### Community 888 - "Community 888"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 889 - "Community 889"
 Cohesion: 0.67
@@ -6198,12 +6200,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 891 - "Community 891"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
-
-### Community 892 - "Community 892"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 892 - "Community 892"
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 893 - "Community 893"
 Cohesion: 0.67
@@ -6222,28 +6224,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 897 - "Community 897"
-Cohesion: 1.0
-Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 898 - "Community 898"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): deriveLocalSaleBlocker(), hasSaleUsableActiveRegisterSession()
 
 ### Community 899 - "Community 899"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 900 - "Community 900"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 901 - "Community 901"
-Cohesion: 1.0
-Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
-
-### Community 902 - "Community 902"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 902 - "Community 902"
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 903 - "Community 903"
 Cohesion: 0.67
@@ -6274,16 +6276,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 910 - "Community 910"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 911 - "Community 911"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
 
 ### Community 912 - "Community 912"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 913 - "Community 913"
 Cohesion: 0.67
@@ -6294,60 +6296,60 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 915 - "Community 915"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 916 - "Community 916"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 917 - "Community 917"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 918 - "Community 918"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 919 - "Community 919"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 920 - "Community 920"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 921 - "Community 921"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 922 - "Community 922"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 923 - "Community 923"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 924 - "Community 924"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 925 - "Community 925"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 926 - "Community 926"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 927 - "Community 927"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 928 - "Community 928"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 929 - "Community 929"
 Cohesion: 0.67
@@ -6362,12 +6364,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 932 - "Community 932"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 933 - "Community 933"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 933 - "Community 933"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 934 - "Community 934"
 Cohesion: 0.67
@@ -6378,12 +6380,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 936 - "Community 936"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 937 - "Community 937"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 937 - "Community 937"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 938 - "Community 938"
 Cohesion: 0.67
@@ -6450,16 +6452,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 954 - "Community 954"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 955 - "Community 955"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 956 - "Community 956"
+### Community 955 - "Community 955"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 956 - "Community 956"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 957 - "Community 957"
 Cohesion: 1.0
@@ -6474,24 +6476,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 960 - "Community 960"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 961 - "Community 961"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 961 - "Community 961"
+### Community 962 - "Community 962"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 962 - "Community 962"
+### Community 963 - "Community 963"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 963 - "Community 963"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 964 - "Community 964"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 965 - "Community 965"
 Cohesion: 1.0
@@ -7995,11 +7997,11 @@ Nodes (0):
 
 ### Community 1340 - "Community 1340"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1341 - "Community 1341"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1342 - "Community 1342"
 Cohesion: 1.0
@@ -13017,518 +13019,526 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2596 - "Community 2596"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2597 - "Community 2597"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 964`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
+- **Thin community `Community 965`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 966`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 967`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 968`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 969`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 970`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 971`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 972`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 973`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 974`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 975`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 976`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 977`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 978`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `OrderEmailPreview()`, `OrderEmail.tsx`
+- **Thin community `Community 979`** (2 nodes): `OrderEmailPreview()`, `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `PosTerminalHealthAlert.tsx`, `PosTerminalHealthAlert()`
+- **Thin community `Community 980`** (2 nodes): `PosTerminalHealthAlert.tsx`, `PosTerminalHealthAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `RegisterCloseoutMatchReportPreview.tsx`, `RegisterCloseoutMatchReportPreview()`
+- **Thin community `Community 981`** (2 nodes): `RegisterCloseoutMatchReportPreview.tsx`, `RegisterCloseoutMatchReportPreview()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `RegisterCloseoutVarianceAlertPreview.tsx`, `RegisterCloseoutVarianceAlertPreview()`
+- **Thin community `Community 982`** (2 nodes): `RegisterCloseoutVarianceAlertPreview.tsx`, `RegisterCloseoutVarianceAlertPreview()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 983`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
+- **Thin community `Community 984`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 985`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
+- **Thin community `Community 986`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 987`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 988`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 989`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 990`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 991`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 992`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
+- **Thin community `Community 993`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
+- **Thin community `Community 994`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 995`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 996`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 997`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 998`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 999`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 1000`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 1001`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
+- **Thin community `Community 1002`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 1003`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 1004`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 1005`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
+- **Thin community `Community 1006`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 1007`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
+- **Thin community `Community 1008`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 1009`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 1010`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 1011`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
+- **Thin community `Community 1012`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
+- **Thin community `Community 1013`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
+- **Thin community `Community 1014`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `createCtx()`, `migratePosAmountsToPesewas.test.ts`
+- **Thin community `Community 1015`** (2 nodes): `createCtx()`, `migratePosAmountsToPesewas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 1016`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 1017`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 1018`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 1019`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 1020`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 1021`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
+- **Thin community `Community 1022`** (2 nodes): `money()`, `dailyManagerReportEmail.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 1023`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `workItem()`, `logicalOperationalWork.test.ts`
+- **Thin community `Community 1024`** (2 nodes): `workItem()`, `logicalOperationalWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 1025`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
+- **Thin community `Community 1026`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
+- **Thin community `Community 1027`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `posTerminalHealthAlertEmail.ts`, `sendPosTerminalHealthAlertToAdminsWithCtx()`
+- **Thin community `Community 1028`** (2 nodes): `posTerminalHealthAlertEmail.ts`, `sendPosTerminalHealthAlertToAdminsWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `registerCloseoutVarianceEmail.test.ts`, `getHandler()`
+- **Thin community `Community 1029`** (2 nodes): `registerCloseoutVarianceEmail.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
+- **Thin community `Community 1030`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 1031`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 1032`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 1033`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 1034`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `redactSensitiveDiagnosticText()`, `diagnosticRedaction.ts`
+- **Thin community `Community 1035`** (2 nodes): `redactSensitiveDiagnosticText()`, `diagnosticRedaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 1036`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 1037`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
+- **Thin community `Community 1038`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
+- **Thin community `Community 1039`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `resolveLocalSyncReview.test.ts`, `createFakeRepository()`
+- **Thin community `Community 1040`** (2 nodes): `resolveLocalSyncReview.test.ts`, `createFakeRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 1041`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 1042`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
+- **Thin community `Community 1043`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
+- **Thin community `Community 1044`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 1045`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 1046`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 1047`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
+- **Thin community `Community 1048`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 1049`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 1050`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 1051`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 1052`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `remoteAssistRepository.ts`, `createRemoteAssistRepository()`
+- **Thin community `Community 1053`** (2 nodes): `remoteAssistRepository.ts`, `createRemoteAssistRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1054`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 1055`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 1056`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 1057`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `context()`, `access.test.ts`
+- **Thin community `Community 1058`** (2 nodes): `context()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `current()`, `coverage.test.ts`
+- **Thin community `Community 1059`** (2 nodes): `current()`, `coverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `context()`, `directAccess.test.ts`
+- **Thin community `Community 1060`** (2 nodes): `context()`, `directAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `rows()`, `evidence.test.ts`
+- **Thin community `Community 1061`** (2 nodes): `rows()`, `evidence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `context()`, `evidenceAccess.test.ts`
+- **Thin community `Community 1062`** (2 nodes): `context()`, `evidenceAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
+- **Thin community `Community 1063`** (2 nodes): `sanitizeConflictEvidence()`, `integrity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `context()`, `commerceEffects.test.ts`
+- **Thin community `Community 1064`** (2 nodes): `context()`, `commerceEffects.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
+- **Thin community `Community 1065`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
+- **Thin community `Community 1066`** (2 nodes): `posSourceReconciliation.test.ts`, `row()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `processing.ts`, `processBoundedBatch()`
+- **Thin community `Community 1067`** (2 nodes): `processing.ts`, `processBoundedBatch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
+- **Thin community `Community 1068`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
+- **Thin community `Community 1069`** (2 nodes): `buildCurrentInventoryProjection()`, `currentInventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
+- **Thin community `Community 1070`** (2 nodes): `skuDay.ts`, `buildSkuDayProjection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `reportingDestination()`, `destinations.ts`
+- **Thin community `Community 1071`** (2 nodes): `reportingDestination()`, `destinations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
+- **Thin community `Community 1072`** (2 nodes): `buildOverviewReadModel()`, `overview.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
+- **Thin community `Community 1073`** (2 nodes): `scheduling.ts`, `scheduleReportingWorkBestEffort()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
+- **Thin community `Community 1074`** (2 nodes): `schemaIndexes.test.ts`, `indexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
+- **Thin community `Community 1075`** (2 nodes): `pos.ts`, `adaptPosCompleted()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
+- **Thin community `Community 1076`** (2 nodes): `service.ts`, `adaptServiceCompletion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `settlement.ts`, `adaptSettlement()`
+- **Thin community `Community 1077`** (2 nodes): `settlement.ts`, `adaptSettlement()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
+- **Thin community `Community 1078`** (2 nodes): `storefront.ts`, `adaptStorefrontStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
+- **Thin community `Community 1079`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 1080`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 1081`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `contextFor()`, `actor.test.ts`
+- **Thin community `Community 1082`** (2 nodes): `contextFor()`, `actor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `invoke()`, `enforcement.test.ts`
+- **Thin community `Community 1083`** (2 nodes): `invoke()`, `enforcement.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `posStoreReadAccessCoverage.test.ts`, `source()`
+- **Thin community `Community 1084`** (2 nodes): `posStoreReadAccessCoverage.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
+- **Thin community `Community 1085`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `public.ts`, `selectSharedDemoRegisterBootstrapRecords()`
+- **Thin community `Community 1086`** (2 nodes): `public.ts`, `selectSharedDemoRegisterBootstrapRecords()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `readBoundary.test.ts`, `invoke()`
+- **Thin community `Community 1087`** (2 nodes): `readBoundary.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
+- **Thin community `Community 1088`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 1089`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 1090`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 1091`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 1092`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 1093`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 1094`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 1095`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 1096`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 1097`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 1098`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 1099`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 1100`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 1101`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 1102`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 1103`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 1104`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 1105`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 1106`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 1107`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 1108`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 1109`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 1110`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 1111`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 1112`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 1113`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 1114`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 1115`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `posTerminalRegistrationError.ts`, `isPosRegisterNumberConflict()`
+- **Thin community `Community 1116`** (2 nodes): `posTerminalRegistrationError.ts`, `isPosRegisterNumberConflict()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
+- **Thin community `Community 1117`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 1118`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `sharedDemoActionError.ts`, `isSharedDemoActionDeniedData()`
+- **Thin community `Community 1119`** (2 nodes): `sharedDemoActionError.ts`, `isSharedDemoActionDeniedData()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 1120`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 1121`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 1122`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 1123`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 1124`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 1125`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 1126`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 1127`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 1128`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 1129`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 1130`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 1131`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 1132`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 1133`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 1134`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 1135`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
+- **Thin community `Community 1136`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 1137`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
+- **Thin community `Community 1138`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 1139`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 1140`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 1141`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 1142`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 1143`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 1144`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1145`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 1146`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 1147`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 1148`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 1149`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 1150`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 1151`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 1152`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 1153`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 1154`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 1155`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `isEmailNotApprovedError()`, `LoginForm.tsx`
+- **Thin community `Community 1156`** (2 nodes): `isEmailNotApprovedError()`, `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 1157`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 1158`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 1159`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 1160`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 1161`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 1162`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 1163`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 1164`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 1165`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 1166`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `RegisterSessionIdentity.tsx`, `RegisterSessionIdentity()`
+- **Thin community `Community 1167`** (2 nodes): `RegisterSessionIdentity.tsx`, `RegisterSessionIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `registerSessionIdentityPresentation.ts`, `formatRegisterHeaderName()`
+- **Thin community `Community 1168`** (2 nodes): `registerSessionIdentityPresentation.ts`, `formatRegisterHeaderName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 1169`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 1170`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 1171`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 1172`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 1173`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 1174`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 1175`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `AutomationRevealScene()`, `AutomationRevealScene.tsx`
+- **Thin community `Community 1176`** (2 nodes): `AutomationRevealScene()`, `AutomationRevealScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `CashControlsScene()`, `CashControlsScene.tsx`
+- **Thin community `Community 1177`** (2 nodes): `CashControlsScene()`, `CashControlsScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `DailyOperationsScene()`, `DailyOperationsScene.tsx`
+- **Thin community `Community 1178`** (2 nodes): `DailyOperationsScene()`, `DailyOperationsScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `EodReviewScene()`, `EodReviewScene.tsx`
+- **Thin community `Community 1179`** (2 nodes): `EodReviewScene()`, `EodReviewScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `HeroDayArcScene()`, `HeroDayArcScene.tsx`
+- **Thin community `Community 1180`** (2 nodes): `HeroDayArcScene()`, `HeroDayArcScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `OpeningHandoffScene()`, `OpeningHandoffScene.tsx`
+- **Thin community `Community 1181`** (2 nodes): `OpeningHandoffScene()`, `OpeningHandoffScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `PosSaleScene.tsx`, `PosSaleScene()`
+- **Thin community `Community 1182`** (2 nodes): `PosSaleScene.tsx`, `PosSaleScene()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
+- **Thin community `Community 1183`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
+- **Thin community `Community 1184`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
+- **Thin community `Community 1185`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `useForcedLightTheme.ts`, `useForcedLightTheme()`
+- **Thin community `Community 1186`** (2 nodes): `useForcedLightTheme.ts`, `useForcedLightTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 1187`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 1188`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 1189`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 1190`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 1191`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 1192`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 1193`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 1194`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 1195`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
+- **Thin community `Community 1196`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 1197`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 1198`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 1199`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 1200`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 1201`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 1202`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 1203`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
+- **Thin community `Community 1204`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 1205`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 1206`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 1207`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 1208`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 1209`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 1210`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 1211`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 1212`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 1213`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 1214`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 1215`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 1216`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 1217`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 1218`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 1219`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -13564,2759 +13574,2761 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 1220`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
+- **Thin community `Community 1221`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 1222`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 1223`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 1224`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 1225`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 1226`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 1227`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 1228`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
+- **Thin community `Community 1229`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 1230`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 1231`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 1232`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 1233`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 1234`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 1235`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 1236`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 1237`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 1238`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 1239`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 1240`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 1241`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 1242`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 1243`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 1244`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 1245`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 1246`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 1247`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 1248`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
+- **Thin community `Community 1249`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
+- **Thin community `Community 1250`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
+- **Thin community `Community 1251`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
+- **Thin community `Community 1252`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
+- **Thin community `Community 1253`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
+- **Thin community `Community 1254`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 1255`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1256`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1257`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1258`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
+- **Thin community `Community 1259`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1260`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
+- **Thin community `Community 1261`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
+- **Thin community `Community 1262`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
+- **Thin community `Community 1263`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
+- **Thin community `Community 1264`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
+- **Thin community `Community 1265`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
+- **Thin community `Community 1266`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
+- **Thin community `Community 1267`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
+- **Thin community `Community 1268`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
+- **Thin community `Community 1269`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
+- **Thin community `Community 1270`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 1271`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 1272`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 1273`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 1274`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 1275`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 1276`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 1277`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 1278`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 1279`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 1280`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 1281`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 1282`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 1283`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 1284`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 1285`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 1286`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 1287`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 1288`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 1289`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 1290`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1291`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1292`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1293`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
+- **Thin community `Community 1294`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1295`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1296`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1297`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1298`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1299`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1300`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1301`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1302`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1303`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1304`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1305`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1306`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1307`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1308`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1309`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1310`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
+- **Thin community `Community 1311`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1312`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1313`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1314`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1315`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1316`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1317`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1318`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1319`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1320`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1321`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1322`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1323`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1324`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1325`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1326`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1327`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1328`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1329`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1330`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1331`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1332`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1333`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1334`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1335`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1336`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1337`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1338`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1339`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1340`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1341`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1342`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1343`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1344`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1345`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1346`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1347`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1348`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
+- **Thin community `Community 1349`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1350`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1351`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1352`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1353`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1354`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1355`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1356`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
+- **Thin community `Community 1357`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
+- **Thin community `Community 1358`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
+- **Thin community `Community 1359`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
+- **Thin community `Community 1360`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
+- **Thin community `Community 1361`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
+- **Thin community `Community 1362`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
+- **Thin community `Community 1363`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
+- **Thin community `Community 1364`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
+- **Thin community `Community 1365`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1366`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1367`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
+- **Thin community `Community 1368`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1369`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1370`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
+- **Thin community `Community 1371`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1372`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1373`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1374`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1375`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
+- **Thin community `Community 1376`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
+- **Thin community `Community 1377`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1378`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1379`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1380`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1381`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1382`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1383`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1384`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1385`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1386`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1387`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1388`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1389`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
+- **Thin community `Community 1390`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
+- **Thin community `Community 1391`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `-walkthrough-page.tsx`, `WalkthroughPage()`
+- **Thin community `Community 1392`** (2 nodes): `-walkthrough-page.tsx`, `WalkthroughPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1393`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1394`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1395`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1396`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1397`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1398`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1399`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1400`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1401`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1402`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1403`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1404`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
+- **Thin community `Community 1405`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1406`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1407`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1408`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1409`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
+- **Thin community `Community 1410`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
+- **Thin community `Community 1411`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
+- **Thin community `Community 1412`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1413`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
+- **Thin community `Community 1414`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1415`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
+- **Thin community `Community 1416`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1417`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1418`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1419`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1420`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1421`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1422`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1423`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1424`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1425`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1426`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1427`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1428`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1429`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1430`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1431`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1432`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1433`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1434`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1435`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1436`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1437`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1438`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1439`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1440`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1441`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1442`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1443`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1444`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1445`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1446`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1447`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1448`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1449`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1450`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1451`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1452`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1453`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1454`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1455`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1456`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1457`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1458`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1459`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1460`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1461`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1462`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1463`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1464`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1465`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1466`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1467`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1468`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1469`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1470`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1471`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1472`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1473`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1474`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1475`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1476`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1477`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1478`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1479`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1480`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1481`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1482`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1483`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1484`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1485`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1486`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1487`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1488`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1489`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1490`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1491`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1492`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1493`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1494`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1495`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1496`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1497`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1498`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1499`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1500`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1501`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1502`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1503`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1504`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1505`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1506`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1507`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1508`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1509`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1510`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1511`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1512`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1513`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1514`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1515`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1516`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1517`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1518`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1519`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1520`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1521`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1522`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1523`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1524`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1525`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1526`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1527`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1528`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1529`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1530`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1531`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1532`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1533`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1534`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1535`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1536`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1537`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1538`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1539`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1540`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1541`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1542`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1543`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1544`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1545`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1546`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1547`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1548`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1549`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1550`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1551`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1552`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1553`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1554`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1555`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1556`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
+- **Thin community `Community 1557`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1558`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1559`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `api.js`
+- **Thin community `Community 1560`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1561`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1562`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `server.js`
+- **Thin community `Community 1563`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `app.ts`
+- **Thin community `Community 1564`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1565`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1566`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `SharedDemoTicket.test.ts`
+- **Thin community `Community 1567`** (1 nodes): `SharedDemoTicket.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1568`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1569`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `auth.ts`
+- **Thin community `Community 1570`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1572`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1573`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `countries.ts`
+- **Thin community `Community 1574`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `email.ts`
+- **Thin community `Community 1575`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1576`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `payment.ts`
+- **Thin community `Community 1577`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `types.ts`
+- **Thin community `Community 1579`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1580`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `crons.ts`
+- **Thin community `Community 1582`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1583`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `internal.ts`
+- **Thin community `Community 1584`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1587`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1589`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
+- **Thin community `Community 1591`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1592`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1593`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `NewOrderAdmin.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `NewOrderAdmin.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `OrderEmail.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `OrderEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1597`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1598`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `env.ts`
+- **Thin community `Community 1600`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1601`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `auth.ts`
+- **Thin community `Community 1602`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `colors.ts`
+- **Thin community `Community 1604`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `index.ts`
+- **Thin community `Community 1605`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1607`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1608`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `products.ts`
+- **Thin community `Community 1609`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `stores.ts`
+- **Thin community `Community 1611`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `bag.ts`
+- **Thin community `Community 1614`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `guest.ts`
+- **Thin community `Community 1615`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `index.ts`
+- **Thin community `Community 1617`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `me.ts`
+- **Thin community `Community 1618`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `offers.ts`
+- **Thin community `Community 1619`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1620`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1621`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1622`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1623`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1624`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1625`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1627`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1628`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `user.ts`
+- **Thin community `Community 1629`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1630`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `index.ts`
+- **Thin community `Community 1631`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1632`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `http.ts`
+- **Thin community `Community 1633`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `access.ts`
+- **Thin community `Community 1634`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1635`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1637`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `index.ts`
+- **Thin community `Community 1638`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1639`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `types.ts`
+- **Thin community `Community 1640`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `athenaUser.test.ts`
+- **Thin community `Community 1641`** (1 nodes): `athenaUser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1642`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `categories.ts`
+- **Thin community `Community 1643`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `colors.ts`
+- **Thin community `Community 1644`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1645`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1646`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1647`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `organizationMembers.test.ts`
+- **Thin community `Community 1648`** (1 nodes): `organizationMembers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1649`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1650`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `pos.ts`
+- **Thin community `Community 1651`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1652`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1653`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1654`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1655`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1656`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1657`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1658`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `stores.test.ts`
+- **Thin community `Community 1659`** (1 nodes): `stores.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1660`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1661`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1662`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `storeMemberAccess.test.ts`
+- **Thin community `Community 1663`** (1 nodes): `storeMemberAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1664`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1665`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1669`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1670`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1671`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1672`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1673`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1674`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `types.ts`
+- **Thin community `Community 1675`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
+- **Thin community `Community 1676`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1677`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1678`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1679`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1680`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1682`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1683`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1684`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `appLoginEmailAllowlist.test.ts`
+- **Thin community `Community 1685`** (1 nodes): `appLoginEmailAllowlist.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1686`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1687`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1688`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1689`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `dto.ts`
+- **Thin community `Community 1690`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1691`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1692`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1693`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1694`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1695`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `types.ts`
+- **Thin community `Community 1696`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `facts.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `types.ts`
+- **Thin community `Community 1697`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1698`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `terminalHealthAlerts.test.ts`
+- **Thin community `Community 1699`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1700`** (1 nodes): `terminalHealthAlerts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `types.ts`
+- **Thin community `Community 1701`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1702`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1703`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1704`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `register.ts`
+- **Thin community `Community 1705`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1706`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1707`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1708`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `activation.test.ts`
+- **Thin community `Community 1709`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `attentionRules.test.ts`
+- **Thin community `Community 1710`** (1 nodes): `activation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `commerceRecognition.test.ts`
+- **Thin community `Community 1711`** (1 nodes): `attentionRules.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `customRangeRequests.test.ts`
+- **Thin community `Community 1712`** (1 nodes): `commerceRecognition.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `export.test.ts`
+- **Thin community `Community 1713`** (1 nodes): `customRangeRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `factFingerprint.test.ts`
+- **Thin community `Community 1714`** (1 nodes): `export.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `factIdentity.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `factFingerprint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1716`** (1 nodes): `factIdentity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `integrity.test.ts`
+- **Thin community `Community 1717`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `corrections.test.ts`
+- **Thin community `Community 1718`** (1 nodes): `integrity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `corrections.ts`
+- **Thin community `Community 1719`** (1 nodes): `corrections.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `deficitResolutionWork.test.ts`
+- **Thin community `Community 1720`** (1 nodes): `corrections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `types.ts`
+- **Thin community `Community 1721`** (1 nodes): `deficitResolutionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `authorizedPosBackfill.test.ts`
+- **Thin community `Community 1722`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `backfillAuthorization.test.ts`
+- **Thin community `Community 1723`** (1 nodes): `authorizedPosBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `cutover.test.ts`
+- **Thin community `Community 1724`** (1 nodes): `backfillAuthorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `inventoryRebuild.test.ts`
+- **Thin community `Community 1725`** (1 nodes): `cutover.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `legacyCompatibility.test.ts`
+- **Thin community `Community 1726`** (1 nodes): `inventoryRebuild.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `posCensusBackfill.test.ts`
+- **Thin community `Community 1727`** (1 nodes): `legacyCompatibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `posSourceReconciliationGate.test.ts`
+- **Thin community `Community 1728`** (1 nodes): `posCensusBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `processing.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `posSourceReconciliationGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `runLedger.test.ts`
+- **Thin community `Community 1730`** (1 nodes): `processing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `metricContracts.test.ts`
+- **Thin community `Community 1731`** (1 nodes): `runLedger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `periods.test.ts`
+- **Thin community `Community 1732`** (1 nodes): `metricContracts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `projectionWork.test.ts`
+- **Thin community `Community 1733`** (1 nodes): `periods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `attention.test.ts`
+- **Thin community `Community 1734`** (1 nodes): `projectionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `currentInventory.test.ts`
+- **Thin community `Community 1735`** (1 nodes): `attention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `customRange.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `currentInventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `daily.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `customRange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `dailyCloseTrust.test.ts`
+- **Thin community `Community 1738`** (1 nodes): `daily.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `factContributions.test.ts`
+- **Thin community `Community 1739`** (1 nodes): `dailyCloseTrust.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `inventory.test.ts`
+- **Thin community `Community 1740`** (1 nodes): `factContributions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `processor.test.ts`
+- **Thin community `Community 1741`** (1 nodes): `inventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `reconciliation.test.ts`
+- **Thin community `Community 1742`** (1 nodes): `processor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `skuDay.test.ts`
+- **Thin community `Community 1743`** (1 nodes): `reconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `skuInsights.test.ts`
+- **Thin community `Community 1744`** (1 nodes): `skuDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `storeIntraday.test.ts`
+- **Thin community `Community 1745`** (1 nodes): `skuInsights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `storeIntraday.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `destinations.test.ts`
+- **Thin community `Community 1747`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `items.ts`
+- **Thin community `Community 1748`** (1 nodes): `destinations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `reportingReadModels.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `items.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `skuAttributionSequence.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `reportingReadModels.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `types.ts`
+- **Thin community `Community 1751`** (1 nodes): `skuAttributionSequence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `sourceAdapters.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `storeTimeAuthority.test.ts`
+- **Thin community `Community 1753`** (1 nodes): `sourceAdapters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `schema.ts`
+- **Thin community `Community 1754`** (1 nodes): `storeTimeAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `automation.ts`
+- **Thin community `Community 1755`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1756`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1757`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `index.ts`
+- **Thin community `Community 1758`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1759`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1760`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1761`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1762`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1763`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1764`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1765`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `category.ts`
+- **Thin community `Community 1766`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `color.ts`
+- **Thin community `Community 1767`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1768`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1769`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `index.ts`
+- **Thin community `Community 1770`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1771`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1772`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1773`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1774`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `organization.ts`
+- **Thin community `Community 1775`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1776`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `posRegisterCatalogRevision.ts`
+- **Thin community `Community 1777`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `product.ts`
+- **Thin community `Community 1778`** (1 nodes): `posRegisterCatalogRevision.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1779`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1780`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1781`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `store.ts`
+- **Thin community `Community 1782`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1783`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `storeTimezone.ts`
+- **Thin community `Community 1784`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1785`** (1 nodes): `storeTimezone.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `landingFunnelEvent.ts`
+- **Thin community `Community 1786`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `walkthroughRequest.ts`
+- **Thin community `Community 1787`** (1 nodes): `landingFunnelEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `index.ts`
+- **Thin community `Community 1788`** (1 nodes): `walkthroughRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1789`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1790`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1791`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1792`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1793`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1794`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1795`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `index.ts`
+- **Thin community `Community 1796`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1797`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1798`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1799`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1800`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `oversizedOperationalWorkRepair.ts`
+- **Thin community `Community 1801`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1802`** (1 nodes): `oversizedOperationalWorkRepair.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1803`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1804`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1805`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1806`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1807`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1808`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `customer.ts`
+- **Thin community `Community 1809`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1810`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1811`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1812`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1813`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `index.ts`
+- **Thin community `Community 1814`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `posAmountMigrationRun.ts`
+- **Thin community `Community 1815`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `posClientEvent.ts`
+- **Thin community `Community 1816`** (1 nodes): `posAmountMigrationRun.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `posLifecycleJournal.ts`
+- **Thin community `Community 1817`** (1 nodes): `posClientEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1818`** (1 nodes): `posLifecycleJournal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1819`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1820`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1821`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1822`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1823`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1824`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1825`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
+- **Thin community `Community 1826`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `posRegisterMappingAuthority.ts`
+- **Thin community `Community 1827`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 1828`** (1 nodes): `posRegisterMappingAuthority.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 1829`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1830`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1831`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1833`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1834`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1835`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1836`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1837`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1838`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1839`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1840`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1841`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `index.ts`
+- **Thin community `Community 1842`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1843`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1844`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `facts.ts`
+- **Thin community `Community 1845`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `index.ts`
+- **Thin community `Community 1846`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `inventoryValuation.ts`
+- **Thin community `Community 1847`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `maintenance.ts`
+- **Thin community `Community 1848`** (1 nodes): `inventoryValuation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `projections.ts`
+- **Thin community `Community 1849`** (1 nodes): `maintenance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `index.ts`
+- **Thin community `Community 1850`** (1 nodes): `projections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1851`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1852`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1853`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1854`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1855`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `sharedDemo.ts`
+- **Thin community `Community 1856`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `staffMessages.ts`
+- **Thin community `Community 1857`** (1 nodes): `sharedDemo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1858`** (1 nodes): `staffMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `index.ts`
+- **Thin community `Community 1859`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1860`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1861`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1862`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1863`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1864`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1865`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `bag.ts`
+- **Thin community `Community 1866`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1867`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1868`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1869`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `guest.ts`
+- **Thin community `Community 1870`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `index.ts`
+- **Thin community `Community 1871`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `offer.ts`
+- **Thin community `Community 1872`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1873`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1874`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `review.ts`
+- **Thin community `Community 1875`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1876`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1877`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1878`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1879`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1880`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1881`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1882`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1883`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `authBoundary.test.ts`
+- **Thin community `Community 1884`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1885`** (1 nodes): `authBoundary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `domainRestore.test.ts`
+- **Thin community `Community 1886`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `foundation.test.ts`
+- **Thin community `Community 1887`** (1 nodes): `domainRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `openingBaseline.test.ts`
+- **Thin community `Community 1888`** (1 nodes): `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `policy.test.ts`
+- **Thin community `Community 1889`** (1 nodes): `openingBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `provision.test.ts`
+- **Thin community `Community 1890`** (1 nodes): `policy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1891`** (1 nodes): `provision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `registerBaseline.test.ts`
+- **Thin community `Community 1892`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `reporting.test.ts`
+- **Thin community `Community 1893`** (1 nodes): `registerBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `scheduledRestore.test.ts`
+- **Thin community `Community 1894`** (1 nodes): `reporting.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
+- **Thin community `Community 1895`** (1 nodes): `scheduledRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `bag.ts`
+- **Thin community `Community 1896`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1897`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `customer.ts`
+- **Thin community `Community 1898`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `guest.ts`
+- **Thin community `Community 1899`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1900`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1901`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1902`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1903`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1904`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1905`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1906`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `users.ts`
+- **Thin community `Community 1907`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `payment.ts`
+- **Thin community `Community 1908`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1909`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1910`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1911`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1912`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1913`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1914`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1915`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `index.ts`
+- **Thin community `Community 1916`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1917`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1918`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1919`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1920`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `auth.ts`
+- **Thin community `Community 1921`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1922`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1923`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1924`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1925`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1926`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1927`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1928`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `index.ts`
+- **Thin community `Community 1929`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1930`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `terminalRuntimeMaterial.test.ts`
+- **Thin community `Community 1931`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 1932`** (1 nodes): `terminalRuntimeMaterial.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1933`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1934`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `reportingContract.ts`
+- **Thin community `Community 1935`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1936`** (1 nodes): `reportingContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1937`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1938`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1939`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1940`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1941`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 1942`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1943`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 1944`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1945`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1946`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1947`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1948`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1949`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1950`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1951`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1952`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1953`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 1954`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1955`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1956`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `CopyImagesView.test.tsx`
+- **Thin community `Community 1957`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `constants.ts`
+- **Thin community `Community 1958`** (1 nodes): `CopyImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1959`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1960`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1961`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `types.ts`
+- **Thin community `Community 1962`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `AnalyticsView.test.tsx`
+- **Thin community `Community 1963`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1964`** (1 nodes): `AnalyticsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1965`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1966`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1967`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1968`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1969`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1970`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1971`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1972`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1973`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1974`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1975`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1976`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1977`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1978`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1979`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1980`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1981`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1982`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1983`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `constants.ts`
+- **Thin community `Community 1984`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1985`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1986`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1987`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `data.ts`
+- **Thin community `Community 1988`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1989`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1990`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1991`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1992`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1993`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1994`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1995`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1996`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 1997`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 1998`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1999`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `constants.ts`
+- **Thin community `Community 2000`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2001`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2002`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2003`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `data.ts`
+- **Thin community `Community 2004`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 2005`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2006`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 2007`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 2008`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2009`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2010`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2011`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2012`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2013`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2014`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `constants.ts`
+- **Thin community `Community 2015`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2016`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2017`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2018`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2019`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 2020`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 2021`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 2022`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 2023`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 2024`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 2025`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 2026`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 2027`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2028`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2029`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2030`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 2031`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 2032`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 2033`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 2034`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 2035`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 2036`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `Home.test.tsx`
+- **Thin community `Community 2037`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 2038`** (1 nodes): `Home.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `ShopLookImageUploader.test.tsx`
+- **Thin community `Community 2039`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2040`** (1 nodes): `ShopLookImageUploader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `demoDay.test.ts`
+- **Thin community `Community 2041`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 2042`** (1 nodes): `demoDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 2043`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 2044`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 2045`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `openWorkInventoryReport.test.ts`
+- **Thin community `Community 2046`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 2047`** (1 nodes): `openWorkInventoryReport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 2048`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 2049`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `CustomerDetailsView.test.tsx`
+- **Thin community `Community 2050`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `CustomerDetailsView.tsx`
+- **Thin community `Community 2051`** (1 nodes): `CustomerDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `OrderDetailsView.test.tsx`
+- **Thin community `Community 2052`** (1 nodes): `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 2053`** (1 nodes): `OrderDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 2054`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 2055`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `OrdersView.test.tsx`
+- **Thin community `Community 2056`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 2057`** (1 nodes): `OrdersView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 2058`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `constants.ts`
+- **Thin community `Community 2059`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2060`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2061`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2062`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `data.ts`
+- **Thin community `Community 2063`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `orderColumns.test.tsx`
+- **Thin community `Community 2064`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 2065`** (1 nodes): `orderColumns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2066`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `constants.ts`
+- **Thin community `Community 2067`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2068`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2069`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2070`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2071`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `data.ts`
+- **Thin community `Community 2072`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 2073`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `constants.ts`
+- **Thin community `Community 2074`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2075`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2076`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2077`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2078`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `data.ts`
+- **Thin community `Community 2079`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 2080`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 2081`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 2082`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 2083`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 2084`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 2085`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 2086`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 2087`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 2088`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 2089`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 2090`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 2091`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 2092`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 2093`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 2094`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 2095`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 2096`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 2097`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 2098`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 2099`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 2100`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 2101`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 2102`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 2103`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 2104`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 2105`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 2106`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 2107`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2108`** (1 nodes): `types.ts`
+- **Thin community `Community 2108`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 2109`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 2110`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 2111`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 2112`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `ImagesView.test.tsx`
+- **Thin community `Community 2113`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 2114`** (1 nodes): `ImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 2115`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `productStockPresentation.test.ts`
+- **Thin community `Community 2116`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 2117`** (1 nodes): `productStockPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 2118`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 2119`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 2120`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 2121`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 2122`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 2123`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 2124`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2125`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 2125`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2126`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2126`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2127`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2127`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2128`** (1 nodes): `data-table-toolbar.test.tsx`
+- **Thin community `Community 2128`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2129`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2129`** (1 nodes): `data-table-toolbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2130`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2130`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2131`** (1 nodes): `data.ts`
+- **Thin community `Community 2131`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2132`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 2132`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2133`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 2133`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2134`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 2134`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2135`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 2135`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2136`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 2136`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2137`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 2137`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2138`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2138`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2139`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2139`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2140`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2140`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2141`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2141`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2142`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2142`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2143`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2143`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2144`** (1 nodes): `constants.ts`
+- **Thin community `Community 2144`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2145`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2145`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2146`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2146`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2147`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2147`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2148`** (1 nodes): `data.ts`
+- **Thin community `Community 2148`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2149`** (1 nodes): `types.ts`
+- **Thin community `Community 2149`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2150`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 2150`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2151`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 2151`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2152`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 2152`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2153`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 2153`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2154`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 2154`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2155`** (1 nodes): `index.ts`
+- **Thin community `Community 2155`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2156`** (1 nodes): `CustomRangeStatus.test.tsx`
+- **Thin community `Community 2156`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2157`** (1 nodes): `InventoryMovementSummary.tsx`
+- **Thin community `Community 2157`** (1 nodes): `CustomRangeStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2158`** (1 nodes): `ReportAttentionList.tsx`
+- **Thin community `Community 2158`** (1 nodes): `InventoryMovementSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2159`** (1 nodes): `ReportPeriodControl.test.tsx`
+- **Thin community `Community 2159`** (1 nodes): `ReportAttentionList.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2160`** (1 nodes): `ReportsInventoryView.test.tsx`
+- **Thin community `Community 2160`** (1 nodes): `ReportPeriodControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2161`** (1 nodes): `ReportsInventoryView.tsx`
+- **Thin community `Community 2161`** (1 nodes): `ReportsInventoryView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2162`** (1 nodes): `ReportsItemsView.test.tsx`
+- **Thin community `Community 2162`** (1 nodes): `ReportsInventoryView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2163`** (1 nodes): `ReportsItemsView.tsx`
+- **Thin community `Community 2163`** (1 nodes): `ReportsItemsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2164`** (1 nodes): `ReportsLayout.test.tsx`
+- **Thin community `Community 2164`** (1 nodes): `ReportsItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2165`** (1 nodes): `ReportsOverviewView.test.tsx`
+- **Thin community `Community 2165`** (1 nodes): `ReportsLayout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2166`** (1 nodes): `ReportsSkuDetailView.test.tsx`
+- **Thin community `Community 2166`** (1 nodes): `ReportsOverviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2167`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
+- **Thin community `Community 2167`** (1 nodes): `ReportsSkuDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2168`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
+- **Thin community `Community 2168`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2169`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
+- **Thin community `Community 2169`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2170`** (1 nodes): `ReportsWorkspaceControls.tsx`
+- **Thin community `Community 2170`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2171`** (1 nodes): `RevenueContribution.tsx`
+- **Thin community `Community 2171`** (1 nodes): `ReportsWorkspaceControls.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2172`** (1 nodes): `reportPresentation.test.ts`
+- **Thin community `Community 2172`** (1 nodes): `RevenueContribution.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2173`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2173`** (1 nodes): `reportPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2174`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2174`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2175`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2175`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2176`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2176`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2177`** (1 nodes): `SharedDemoExperience.test.tsx`
+- **Thin community `Community 2177`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2178`** (1 nodes): `SharedDemoOwnerHome.tsx`
+- **Thin community `Community 2178`** (1 nodes): `SharedDemoExperience.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2179`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
+- **Thin community `Community 2179`** (1 nodes): `SharedDemoOwnerHome.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2180`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
+- **Thin community `Community 2180`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2181`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
+- **Thin community `Community 2181`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2182`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
+- **Thin community `Community 2182`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2183`** (1 nodes): `index.tsx`
+- **Thin community `Community 2183`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2184`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2184`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2185`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2185`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2186`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2186`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2187`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2187`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2188`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2188`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2189`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2189`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2190`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2190`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2191`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2191`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2192`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 2192`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2193`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2193`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2194`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2194`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2195`** (1 nodes): `index.tsx`
+- **Thin community `Community 2195`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2196`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2196`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2197`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2197`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2198`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2198`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2199`** (1 nodes): `button.tsx`
+- **Thin community `Community 2199`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2200`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2200`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2201`** (1 nodes): `card.tsx`
+- **Thin community `Community 2201`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2202`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2202`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2203`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2203`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2204`** (1 nodes): `command.tsx`
+- **Thin community `Community 2204`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2205`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2205`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2206`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2206`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2207`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2207`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2208`** (1 nodes): `form.tsx`
+- **Thin community `Community 2208`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2209`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2209`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2210`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2210`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2211`** (1 nodes): `input.tsx`
+- **Thin community `Community 2211`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2212`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2212`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2213`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2213`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2214`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2214`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2215`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2215`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2216`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2216`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2217`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2217`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2218`** (1 nodes): `select.tsx`
+- **Thin community `Community 2218`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2219`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2219`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2220`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2220`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2221`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2221`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2222`** (1 nodes): `table.tsx`
+- **Thin community `Community 2222`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2223`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2223`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2224`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2224`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2225`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2225`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2226`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2226`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2227`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2227`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2228`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2228`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2229`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2229`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2230`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2230`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2231`** (1 nodes): `constants.ts`
+- **Thin community `Community 2231`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2232`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2232`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2233`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2233`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2234`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2234`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2235`** (1 nodes): `data.ts`
+- **Thin community `Community 2235`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2236`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2236`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2237`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2237`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2238`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2238`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2239`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2239`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2240`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2240`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2241`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2241`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2242`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2242`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2243`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2243`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2244`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2244`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2245`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2245`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2246`** (1 nodes): `index.ts`
+- **Thin community `Community 2246`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2247`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2247`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2248`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2248`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2249`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2249`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2250`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2250`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2251`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2251`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2252`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2252`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2253`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2253`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2254`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2254`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2255`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2255`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2256`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2256`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2257`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2257`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2258`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2258`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2259`** (1 nodes): `useSharedDemoContext.test.ts`
+- **Thin community `Community 2259`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2260`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2260`** (1 nodes): `useSharedDemoContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2261`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2261`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2262`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2262`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2263`** (1 nodes): `index.ts`
+- **Thin community `Community 2263`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2264`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2264`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2265`** (1 nodes): `index.ts`
+- **Thin community `Community 2265`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2266`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2266`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2267`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2267`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2268`** (1 nodes): `aws.ts`
+- **Thin community `Community 2268`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2269`** (1 nodes): `constants.ts`
+- **Thin community `Community 2269`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2270`** (1 nodes): `countries.ts`
+- **Thin community `Community 2270`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2271`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2271`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2272`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2272`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2273`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2273`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2274`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2274`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2275`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2275`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2276`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2276`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2277`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2277`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2278`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2278`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2279`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2279`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2280`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2280`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2281`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2281`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2282`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2282`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2283`** (1 nodes): `dto.ts`
+- **Thin community `Community 2283`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2284`** (1 nodes): `ports.ts`
+- **Thin community `Community 2284`** (1 nodes): `operatingDate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2285`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2285`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2286`** (1 nodes): `results.test.ts`
+- **Thin community `Community 2286`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2287`** (1 nodes): `constants.ts`
+- **Thin community `Community 2287`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2288`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2288`** (1 nodes): `results.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2289`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2289`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2290`** (1 nodes): `index.ts`
+- **Thin community `Community 2290`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2291`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2291`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2292`** (1 nodes): `types.ts`
+- **Thin community `Community 2292`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2293`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2293`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2294`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2294`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2295`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2295`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2296`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2296`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2297`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2297`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2298`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2298`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2299`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2299`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2300`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2300`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2301`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2301`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2302`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2302`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2303`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2303`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2304`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2304`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2305`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2305`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2306`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2306`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2307`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2307`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2308`** (1 nodes): `registerCatalogPinRuntime.test.ts`
+- **Thin community `Community 2308`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2309`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2309`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2310`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
+- **Thin community `Community 2310`** (1 nodes): `registerCatalogPinRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2311`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2311`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2312`** (1 nodes): `runtimeCounters.test.ts`
+- **Thin community `Community 2312`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2313`** (1 nodes): `telemetryBuffer.test.ts`
+- **Thin community `Community 2313`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2314`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2314`** (1 nodes): `runtimeCounters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2315`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2315`** (1 nodes): `telemetryBuffer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2316`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2316`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2317`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2317`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2318`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2318`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2319`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2319`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2320`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2320`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2321`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2321`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2322`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2322`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2323`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2323`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2324`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2324`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2325`** (1 nodes): `index.ts`
+- **Thin community `Community 2325`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2326`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2326`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2327`** (1 nodes): `category.ts`
+- **Thin community `Community 2327`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2328`** (1 nodes): `product.ts`
+- **Thin community `Community 2328`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2329`** (1 nodes): `store.ts`
+- **Thin community `Community 2329`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2330`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2330`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2331`** (1 nodes): `user.ts`
+- **Thin community `Community 2331`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2332`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2332`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2333`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2333`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2334`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2334`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2335`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2335`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2336`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2336`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2337`** (1 nodes): `main.tsx`
+- **Thin community `Community 2337`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2338`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2339`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2340`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2341`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2342`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `-app-entry-route.tsx`
+- **Thin community `Community 2343`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `-privacy-page.tsx`
+- **Thin community `Community 2344`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `-public-layout.tsx`
+- **Thin community `Community 2345`** (1 nodes): `-app-entry-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2346`** (1 nodes): `-privacy-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `-shared-demo-entry.tsx`
+- **Thin community `Community 2347`** (1 nodes): `-public-layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2348`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `index.tsx`
+- **Thin community `Community 2349`** (1 nodes): `-shared-demo-entry.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `index.tsx`
+- **Thin community `Community 2350`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2351`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2352`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2353`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2354`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2355`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2356`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `index.tsx`
+- **Thin community `Community 2357`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2358`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2359`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2360`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `home.tsx`
+- **Thin community `Community 2361`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2362`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2362`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2363`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2364`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `index.tsx`
+- **Thin community `Community 2365`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `review.tsx`
+- **Thin community `Community 2366`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2367`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2368`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `index.tsx`
+- **Thin community `Community 2369`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2370`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2371`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2372`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `index.tsx`
+- **Thin community `Community 2373`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2374`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2375`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2376`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2377`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2378`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2379`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2380`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2381`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2382`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2383`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2384`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2385`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2386`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2387`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2388`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `index.tsx`
+- **Thin community `Community 2389`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2390`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `new.tsx`
+- **Thin community `Community 2391`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `new.tsx`
+- **Thin community `Community 2392`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2393`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2394`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `index.tsx`
+- **Thin community `Community 2395`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `new.tsx`
+- **Thin community `Community 2396`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `items.tsx`
+- **Thin community `Community 2397`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `search.test.ts`
+- **Thin community `Community 2398`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `storefront.tsx`
+- **Thin community `Community 2399`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `index.tsx`
+- **Thin community `Community 2400`** (1 nodes): `search.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2401`** (1 nodes): `storefront.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2402`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2403`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2404`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `index.tsx`
+- **Thin community `Community 2405`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2406`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2407`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2408`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `index.tsx`
+- **Thin community `Community 2409`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2410`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2411`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 2412`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2413`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `app.tsx`
+- **Thin community `Community 2414`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2415`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `demo.tsx`
+- **Thin community `Community 2416`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2417`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `index.tsx`
+- **Thin community `Community 2418`** (1 nodes): `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2419`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2420`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2421`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2422`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2423`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2424`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2425`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2426`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `walkthrough.tsx`
+- **Thin community `Community 2427`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2428`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2429`** (1 nodes): `walkthrough.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2430`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2431`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2431`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2432`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2433`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2434`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2435`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2436`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2437`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2438`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2439`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2440`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2441`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2442`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2443`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2444`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2445`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `setup.ts`
+- **Thin community `Community 2446`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2447`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `types.ts`
+- **Thin community `Community 2448`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2449`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2450`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2451`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2452`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2453`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2454`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2455`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `types.ts`
+- **Thin community `Community 2456`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2457`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2458`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2459`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2460`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2461`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2462`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2463`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2464`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `schema.ts`
+- **Thin community `Community 2465`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2466`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2467`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2468`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2469`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2470`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2471`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2472`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2473`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2474`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `types.ts`
+- **Thin community `Community 2475`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2476`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2477`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2478`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2479`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2480`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2481`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2482`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `constants.ts`
+- **Thin community `Community 2483`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2484`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `About.tsx`
+- **Thin community `Community 2485`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2486`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2487`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2488`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2489`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2490`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2491`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2492`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2493`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2494`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2495`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `types.ts`
+- **Thin community `Community 2496`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2497`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2498`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2499`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2500`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2501`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2502`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2503`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2504`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2505`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2506`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2507`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `button.tsx`
+- **Thin community `Community 2508`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `card.tsx`
+- **Thin community `Community 2509`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2510`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `command.tsx`
+- **Thin community `Community 2511`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2512`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2513`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2514`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `form.tsx`
+- **Thin community `Community 2515`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2516`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2517`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2518`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2519`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `input.tsx`
+- **Thin community `Community 2520`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `label.tsx`
+- **Thin community `Community 2521`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2522`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2523`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2524`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `index.ts`
+- **Thin community `Community 2525`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `types.ts`
+- **Thin community `Community 2526`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2527`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2528`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2528`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2529`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2530`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `select.tsx`
+- **Thin community `Community 2531`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2532`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2533`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `table.tsx`
+- **Thin community `Community 2534`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2535`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2536`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2537`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2537`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2538`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2539`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `config.ts`
+- **Thin community `Community 2540`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2541`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2542`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2543`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2543`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2544`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2544`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2545`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2545`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `constants.ts`
+- **Thin community `Community 2546`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `countries.ts`
+- **Thin community `Community 2547`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2548`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2549`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2550`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2551`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `index.ts`
+- **Thin community `Community 2552`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2553`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `store.ts`
+- **Thin community `Community 2554`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `bag.ts`
+- **Thin community `Community 2555`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2556`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `category.ts`
+- **Thin community `Community 2557`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `organization.ts`
+- **Thin community `Community 2558`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `product.ts`
+- **Thin community `Community 2559`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `store.ts`
+- **Thin community `Community 2560`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2561`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `user.ts`
+- **Thin community `Community 2562`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `states.ts`
+- **Thin community `Community 2563`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2564`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2565`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2566`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2567`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2568`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2569`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2570`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2571`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `index.tsx`
+- **Thin community `Community 2572`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2573`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2574`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2575`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2576`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2576`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2577`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2578`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2579`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `index.tsx`
+- **Thin community `Community 2580`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2581`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2582`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2583`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2584`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2585`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2586`** (1 nodes): `index.js`
+- **Thin community `Community 2586`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2587`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2588`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2589`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2589`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2590`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2591`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2592`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2593`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2594`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2595`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2596`** (1 nodes): `harness-repo-validation.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2597`** (1 nodes): `operational-work-repair.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -16331,8 +16343,8 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
-- **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
+- **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.05 - nodes in this community are weakly interconnected._
+- **Should `Community 5` be split into smaller, more focused modules?**
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10794 nodes · 13079 edges · 2598 communities detected
+- 10794 nodes · 13077 edges · 2598 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2657,7 +2657,7 @@ Nodes (68): attentionSeverity(), automationRunClassification(), automationStatus
 
 ### Community 5 - "Community 5"
 Cohesion: 0.04
-Nodes (36): canReopenDailyClose(), cn(), compareSummaryPaymentTotals(), formatOperationalWorkTypeLabel(), getBucketCountClassName(), getCarryForwardSelectionId(), getCarryForwardWorkItemId(), getCarryForwardWorkItemIds() (+28 more)
+Nodes (33): canReopenDailyClose(), cn(), compareSummaryPaymentTotals(), formatOperationalWorkTypeLabel(), getBucketCountClassName(), getCarryForwardSelectionId(), getCarryForwardWorkItemId(), getCarryForwardWorkItemIds() (+25 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.05
@@ -3344,20 +3344,20 @@ Cohesion: 0.17
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 177 - "Community 177"
+Cohesion: 0.26
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+
+### Community 178 - "Community 178"
 Cohesion: 0.23
 Nodes (6): buildOperationalWorkItem(), createOperationalWorkItemWithCtx(), metadataArrayCount(), metadataNumber(), projectOperationalWorkItemForQueue(), sanitizeOperationalWorkItemDetails()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.21
 Nodes (6): authoritativeDeficitPosition(), baseArgs(), deficitLotSeed(), ledgeredDeficitLotSeed(), ledgeredDeficitPosition(), receipt()
-
-### Community 180 - "Community 180"
-Cohesion: 0.26
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.29
@@ -3684,24 +3684,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 262 - "Community 262"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 263 - "Community 263"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 264 - "Community 264"
+### Community 263 - "Community 263"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 265 - "Community 265"
+### Community 264 - "Community 264"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 266 - "Community 266"
+### Community 265 - "Community 265"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 266 - "Community 266"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 267 - "Community 267"
 Cohesion: 0.39
@@ -4072,96 +4072,96 @@ Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
 ### Community 359 - "Community 359"
-Cohesion: 0.52
-Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
+Cohesion: 0.43
+Nodes (4): getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange(), getLocalOperatingDateRangeFromSearch()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Nodes (5): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), normalizeNonCashOverpayment(), roundPosAmount()
 
 ### Community 361 - "Community 361"
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+
+### Community 362 - "Community 362"
 Cohesion: 0.33
 Nodes (2): buildRuntimeSyncDebug(), getReviewDiagnosticsEvents()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.38
 Nodes (3): getRegisterLifecycleAuthorityRolloutPolicy(), isRolloutMode(), resolveRegisterLifecycleAuthorityRolloutPolicy()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.52
 Nodes (6): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isDuplicateLocalIdReviewItem(), isDuplicatePosSessionSaleReviewItem(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 364 - "Community 364"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 365 - "Community 365"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 366 - "Community 366"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 367 - "Community 367"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.48
 Nodes (6): collectDeliverableDiffFingerprint(), gitEnv(), isDeliverableFingerprintPath(), normalizeRepoPath(), runGit(), sortUniquePaths()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.43
 Nodes (4): createPackage(), installFixturePackages(), writeFixtureManifests(), writeJson()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.47
 Nodes (3): canonical(), isValidBody(), text()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 380 - "Community 380"
-Cohesion: 0.6
-Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
 ### Community 381 - "Community 381"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.6
+Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
 ### Community 382 - "Community 382"
 Cohesion: 0.33
@@ -4172,140 +4172,140 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 384 - "Community 384"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 385 - "Community 385"
 Cohesion: 0.6
 Nodes (4): cleanEventText(), cleanOptionalEventText(), sanitizeClientEventMetadata(), truncate()
 
-### Community 385 - "Community 385"
+### Community 386 - "Community 386"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 386 - "Community 386"
+### Community 387 - "Community 387"
 Cohesion: 0.4
 Nodes (2): mergeProjectionHealthState(), upsertProjectionHealthWithCtx()
 
-### Community 387 - "Community 387"
+### Community 388 - "Community 388"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 388 - "Community 388"
+### Community 389 - "Community 389"
 Cohesion: 0.67
 Nodes (5): comparisonFor(), localDate(), resolveReportPeriod(), shiftDate(), weekday()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.6
 Nodes (4): advanceSkuAttributionAppliedWithCtx(), allocateSkuAttributionSequenceWithCtx(), currentSkuAttributionCursorWithCtx(), markSkuAttributionAppliedWithCtx()
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.4
 Nodes (2): localDate(), resolveStoreTimeAuthority()
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 392 - "Community 392"
+### Community 393 - "Community 393"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.53
 Nodes (4): buildOnlineOrderReportedReturns(), buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 395 - "Community 395"
+### Community 396 - "Community 396"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 396 - "Community 396"
+### Community 397 - "Community 397"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 397 - "Community 397"
+### Community 398 - "Community 398"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 398 - "Community 398"
+### Community 399 - "Community 399"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 399 - "Community 399"
+### Community 400 - "Community 400"
 Cohesion: 0.47
 Nodes (3): canUploadPosLocalSyncLocalEventType(), getPosLocalSyncEventContractForLocalEventType(), getPosLocalSyncEventTypeForLocalEventType()
 
-### Community 400 - "Community 400"
+### Community 401 - "Community 401"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 401 - "Community 401"
+### Community 402 - "Community 402"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 404 - "Community 404"
+### Community 405 - "Community 405"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 406 - "Community 406"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 408 - "Community 408"
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
+
+### Community 409 - "Community 409"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 411 - "Community 411"
+### Community 412 - "Community 412"
 Cohesion: 0.4
 Nodes (2): makeQueueSnapshot(), makeWorkItem()
 
-### Community 412 - "Community 412"
+### Community 413 - "Community 413"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 413 - "Community 413"
+### Community 414 - "Community 414"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 0.47
 Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.4
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 417 - "Community 417"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 418 - "Community 418"
 Cohesion: 0.33
@@ -4316,16 +4316,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 420 - "Community 420"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 421 - "Community 421"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 421 - "Community 421"
+### Community 422 - "Community 422"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 422 - "Community 422"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.33
@@ -4420,140 +4420,140 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 446 - "Community 446"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 447 - "Community 447"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.47
 Nodes (3): assertDeliveryDocumentationCheck(), findingsFrom(), isPolicyFailure()
 
-### Community 450 - "Community 450"
+### Community 451 - "Community 451"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.53
 Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
 
-### Community 452 - "Community 452"
+### Community 453 - "Community 453"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 454 - "Community 454"
+### Community 455 - "Community 455"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 455 - "Community 455"
+### Community 456 - "Community 456"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 456 - "Community 456"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 457 - "Community 457"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 458 - "Community 458"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 459 - "Community 459"
-Cohesion: 0.6
-Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 460 - "Community 460"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
 
 ### Community 461 - "Community 461"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
 ### Community 462 - "Community 462"
-Cohesion: 0.5
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 463 - "Community 463"
 Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 464 - "Community 464"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 466 - "Community 466"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 467 - "Community 467"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 468 - "Community 468"
+### Community 469 - "Community 469"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 469 - "Community 469"
+### Community 470 - "Community 470"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 472 - "Community 472"
+### Community 473 - "Community 473"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 473 - "Community 473"
-Cohesion: 0.7
-Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 475 - "Community 475"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 476 - "Community 476"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 476 - "Community 476"
+### Community 477 - "Community 477"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 477 - "Community 477"
-Cohesion: 0.6
-Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
 ### Community 478 - "Community 478"
 Cohesion: 0.6
-Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
+Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
 ### Community 479 - "Community 479"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
 
 ### Community 480 - "Community 480"
 Cohesion: 0.4
@@ -4564,92 +4564,92 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 482 - "Community 482"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 483 - "Community 483"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 483 - "Community 483"
+### Community 484 - "Community 484"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 484 - "Community 484"
+### Community 485 - "Community 485"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
 Cohesion: 0.7
 Nodes (4): canonicalReportingBusinessEventKey(), canonicalReportingFactIdentity(), canonicalReportingFactKey(), requiredIdentityPart()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.6
 Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.7
 Nodes (4): backfillAuthorizationEnvelopeHash(), backfillAuthorizationMatches(), fnv1a(), normalizeEnvelope()
 
-### Community 488 - "Community 488"
+### Community 489 - "Community 489"
 Cohesion: 0.5
 Nodes (2): fnv1a(), sourceDerivedPosCensusHash()
 
-### Community 489 - "Community 489"
+### Community 490 - "Community 490"
 Cohesion: 0.6
 Nodes (3): indexRows(), reconcilePosSourceFacts(), sum()
 
-### Community 490 - "Community 490"
+### Community 491 - "Community 491"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 491 - "Community 491"
+### Community 492 - "Community 492"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 492 - "Community 492"
+### Community 493 - "Community 493"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 494 - "Community 494"
+### Community 495 - "Community 495"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 495 - "Community 495"
+### Community 496 - "Community 496"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 496 - "Community 496"
+### Community 497 - "Community 497"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 497 - "Community 497"
+### Community 498 - "Community 498"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 498 - "Community 498"
+### Community 499 - "Community 499"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
-### Community 499 - "Community 499"
+### Community 500 - "Community 500"
 Cohesion: 0.5
 Nodes (2): sharedDemoPickupOrderAmount(), sharedDemoProductBySku()
-
-### Community 500 - "Community 500"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 501 - "Community 501"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 502 - "Community 502"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 503 - "Community 503"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 503 - "Community 503"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.4
@@ -4660,12 +4660,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 506 - "Community 506"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 507 - "Community 507"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 507 - "Community 507"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 508 - "Community 508"
 Cohesion: 0.4
@@ -4680,12 +4680,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 511 - "Community 511"
-Cohesion: 0.7
-Nodes (4): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), routeTemplateMatches()
-
-### Community 512 - "Community 512"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 512 - "Community 512"
+Cohesion: 0.7
+Nodes (4): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), routeTemplateMatches()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.4
@@ -4696,48 +4696,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 515 - "Community 515"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
-
-### Community 516 - "Community 516"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 516 - "Community 516"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 518 - "Community 518"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
-
-### Community 519 - "Community 519"
-Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
-
-### Community 520 - "Community 520"
-Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
-
-### Community 521 - "Community 521"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
-
-### Community 522 - "Community 522"
-Cohesion: 0.6
-Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
-
-### Community 523 - "Community 523"
-Cohesion: 0.4
-Nodes (1): MockImage
-
-### Community 524 - "Community 524"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 525 - "Community 525"
+### Community 519 - "Community 519"
+Cohesion: 0.5
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+
+### Community 520 - "Community 520"
+Cohesion: 0.5
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
+
+### Community 521 - "Community 521"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 522 - "Community 522"
 Cohesion: 0.7
-Nodes (4): getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange(), getLocalOperatingDateRangeFromSearch()
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+
+### Community 523 - "Community 523"
+Cohesion: 0.6
+Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
+
+### Community 524 - "Community 524"
+Cohesion: 0.4
+Nodes (1): MockImage
+
+### Community 525 - "Community 525"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 526 - "Community 526"
 Cohesion: 0.5

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2677
-- Graph nodes: 10806
-- Graph edges: 13087
+- Graph nodes: 10807
+- Graph edges: 13088
 - Communities: 2603
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2677
-- Graph nodes: 10805
-- Graph edges: 13086
+- Graph nodes: 10806
+- Graph edges: 13087
 - Communities: 2603
 
 ## Graph Hotspots

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2674
-- Graph nodes: 10799
-- Graph edges: 13080
-- Communities: 2600
+- Code files discovered: 2677
+- Graph nodes: 10805
+- Graph edges: 13086
+- Communities: 2603
 
 ## Graph Hotspots
 - `dailyClose.ts` (92 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,18 +7,18 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2670
-- Graph nodes: 10800
-- Graph edges: 13111
-- Communities: 2596
+- Code files discovered: 2672
+- Graph nodes: 10794
+- Graph edges: 13079
+- Communities: 2598
 
 ## Graph Hotspots
 - `dailyClose.ts` (92 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `harness-inferential-review.ts` (88 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `posLocalStore.ts` (86 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
-- `DailyCloseView.tsx` (77 edges, Community 3) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `terminalHealthPresentation.ts` (76 edges, Community 4) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
-- `dailyOperations.ts` (75 edges, Community 5) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `terminalHealthPresentation.ts` (76 edges, Community 3) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `dailyOperations.ts` (75 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `DailyCloseView.tsx` (73 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `backfill.ts` (69 edges, Community 6) - [`packages/athena-webapp/convex/reporting/maintenance/backfill.ts`](../../packages/athena-webapp/convex/reporting/maintenance/backfill.ts)
 - `projectLocalEvents.ts` (67 edges, Community 7) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -9,7 +9,7 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 ## Repo Summary
 - Code files discovered: 2672
 - Graph nodes: 10794
-- Graph edges: 13079
+- Graph edges: 13077
 - Communities: 2598
 
 ## Graph Hotspots
@@ -18,7 +18,7 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `posLocalStore.ts` (86 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 3) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (75 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (73 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (71 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `backfill.ts` (69 edges, Community 6) - [`packages/athena-webapp/convex/reporting/maintenance/backfill.ts`](../../packages/athena-webapp/convex/reporting/maintenance/backfill.ts)
 - `projectLocalEvents.ts` (67 edges, Community 7) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2672
-- Graph nodes: 10794
-- Graph edges: 13077
-- Communities: 2598
+- Code files discovered: 2674
+- Graph nodes: 10799
+- Graph edges: 13080
+- Communities: 2600
 
 ## Graph Hotspots
 - `dailyClose.ts` (92 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `dailyClose.ts` (92 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `posLocalStore.ts` (86 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
-- `DailyCloseView.tsx` (77 edges, Community 3) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `terminalHealthPresentation.ts` (76 edges, Community 4) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
-- `dailyOperations.ts` (75 edges, Community 5) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `terminalHealthPresentation.ts` (76 edges, Community 3) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
+- `dailyOperations.ts` (75 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `DailyCloseView.tsx` (73 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `posLocalStore.ts` (86 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 - `terminalHealthPresentation.ts` (76 edges, Community 3) - [`packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`](../../../packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts)
 - `dailyOperations.ts` (75 edges, Community 4) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `DailyCloseView.tsx` (73 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (71 edges, Community 5) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 126) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 268) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 269) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 126) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 126) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 126) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/sharedDemo/capabilityCatalog.ts
+++ b/packages/athena-webapp/convex/sharedDemo/capabilityCatalog.ts
@@ -62,6 +62,10 @@ export const SHARED_DEMO_ALLOWED_CAPABILITIES = [
   "cash.control.write",
   "catalog.quick_add",
   "daily_operations.write",
+  // Recording expenses is a first-class POS operation the demo exposes (the
+  // /pos/expense route). Without this grant, expense event sync is rejected while
+  // sales (pos.sale.complete) succeed.
+  "expense.manage",
   "inventory.adjust",
   "orders.fulfill",
   "pos.sale.complete",

--- a/packages/athena-webapp/convex/sharedDemo/policy.test.ts
+++ b/packages/athena-webapp/convex/sharedDemo/policy.test.ts
@@ -27,6 +27,7 @@ describe("shared demo policy", () => {
       "cash.control.write",
       "catalog.quick_add",
       "daily_operations.write",
+      "expense.manage",
       "inventory.adjust",
       "orders.fulfill",
       "pos.sale.complete",
@@ -34,6 +35,7 @@ describe("shared demo policy", () => {
       "staff.authenticate",
       "staff.communication.write",
     ]);
+    expect(requireSharedDemoCapability("expense.manage")).toBe("expense.manage");
     expect(requireSharedDemoCapability("pos.sale.complete")).toBe("pos.sale.complete");
     expect(requireSharedDemoCapability("reports.read")).toBe("reports.read");
     expect(() => requireSharedDemoCapability("billing.update" as never)).toThrow(

--- a/packages/athena-webapp/convex/sharedDemo/policy.ts
+++ b/packages/athena-webapp/convex/sharedDemo/policy.ts
@@ -96,6 +96,9 @@ export const SHARED_DEMO_PUBLIC_FUNCTION_INVENTORY = [
   { functionName: "operations/staffMessages:postStaffMessage", capability: "staff.communication.write" },
   { functionName: "operations/dailyOpening:startStoreDay", capability: "daily_operations.write" },
   { functionName: "pos/public/terminals:registerTerminal", capability: "daily_operations.write" },
+  // Expense recording reaches the server only through local-event sync; ingestLocalEvents
+  // enforces expense.manage for expense_recorded events.
+  { functionName: "pos/public/sync:ingestLocalEvents", capability: "expense.manage" },
   { functionName: "reporting/public:getReportsOverview", capability: "reports.read" },
   { functionName: "operations/staffCredentials:createStaffCredential", capability: "identity.manage" },
   { functionName: "operations/staffProfiles:createStaffProfile", capability: "staff.manage" },

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -13,7 +13,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 49 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.test.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 9 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 266 file(s); key children: access, app-messages, app-update, aws.ts, behaviorUtils.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 268 file(s); key children: access, app-messages, app-update, aws.ts, behaviorUtils.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 42 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 4 file(s); key children: formatNumber.ts, index.ts, versionChecker.test.ts, versionChecker.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -551,6 +551,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/moneyEntryAudit.test.ts`](../../src/lib/moneyEntryAudit.test.ts)
 - [`src/lib/navigation/appEntryRoutes.test.ts`](../../src/lib/navigation/appEntryRoutes.test.ts)
 - [`src/lib/navigation/storeEntryRoute.test.ts`](../../src/lib/navigation/storeEntryRoute.test.ts)
+- [`src/lib/operations/operatingDate.test.ts`](../../src/lib/operations/operatingDate.test.ts)
 - [`src/lib/pos/application/bootstrapRegister.test.ts`](../../src/lib/pos/application/bootstrapRegister.test.ts)
 - [`src/lib/pos/application/posLocalStorePort.test.ts`](../../src/lib/pos/application/posLocalStorePort.test.ts)
 - [`src/lib/pos/application/results.test.ts`](../../src/lib/pos/application/results.test.ts)

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -38,6 +38,7 @@ import {
   getLocalOperatingDate,
   getLocalOperatingDateRange,
   getLocalOperatingDateRangeFromSearch,
+  getOperatingClockNow,
 } from "@/lib/operations/operatingDate";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
@@ -3526,7 +3527,7 @@ function OperatingDatePicker({
   const latestSelectableDate = useMemo(() => {
     if (latestSelectableDateProp) return latestSelectableDateProp;
 
-    const today = new Date();
+    const today = getOperatingClockNow();
 
     return new Date(today.getFullYear(), today.getMonth(), today.getDate());
   }, [latestSelectableDateProp]);

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -33,6 +33,12 @@ import {
   type NormalizedCommandResult,
 } from "@/lib/errors/runCommand";
 import { getOrigin } from "@/lib/navigationUtils";
+import {
+  getLocalDateFromOperatingDate,
+  getLocalOperatingDate,
+  getLocalOperatingDateRange,
+  getLocalOperatingDateRangeFromSearch,
+} from "@/lib/operations/operatingDate";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import type {
@@ -837,33 +843,6 @@ function DailyCloseFinancialValue({
   );
 }
 
-function getLocalDateFromOperatingDate(operatingDate: string) {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(operatingDate);
-
-  if (!match) return undefined;
-
-  const [, year, month, day] = match;
-  const parsed = new Date(Number(year), Number(month) - 1, Number(day));
-
-  if (
-    parsed.getFullYear() !== Number(year) ||
-    parsed.getMonth() !== Number(month) - 1 ||
-    parsed.getDate() !== Number(day)
-  ) {
-    return undefined;
-  }
-
-  return parsed;
-}
-
-function getLocalOperatingDate(date = new Date()) {
-  const localDate = new Date(
-    date.getTime() - date.getTimezoneOffset() * 60_000,
-  );
-
-  return localDate.toISOString().slice(0, 10);
-}
-
 function buildDailyCloseTransactionSearch({
   operatingDate,
   paymentMethod,
@@ -892,37 +871,6 @@ function getDailyCloseSalesMetricLabels(operatingDate: string) {
     cash: isCurrentOperatingDate ? "Today's cash" : "Cash",
     netSales: isCurrentOperatingDate ? "Today's net sales" : "Net sales",
   };
-}
-
-function getLocalOperatingDateRange(date = new Date()) {
-  const localStart = new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-  );
-  const localEnd = new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate() + 1,
-  );
-
-  return {
-    operatingDate: getLocalOperatingDate(date),
-    startAt: localStart.getTime(),
-    endAt: localEnd.getTime(),
-  };
-}
-
-function getLocalOperatingDateRangeFromSearch(operatingDate?: unknown) {
-  if (typeof operatingDate === "string") {
-    const localDate = getLocalDateFromOperatingDate(operatingDate);
-
-    if (localDate) {
-      return getLocalOperatingDateRange(localDate);
-    }
-  }
-
-  return getLocalOperatingDateRange();
 }
 
 function normalizeCommandMessage(

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -325,7 +325,7 @@ type BucketConfig = {
   value: BucketStatus;
 };
 
-type DailyCloseViewContentProps = {
+export type DailyCloseViewContentProps = {
   canViewSummaryComparisons?: boolean;
   currency: string;
   hasFinancialDetailsAccess: boolean;
@@ -4716,8 +4716,21 @@ function DailyCloseConnectedView({
   );
 }
 
-export function DailyCloseView() {
+export function DailyCloseView({
+  fixture,
+}: {
+  /**
+   * Renders the workspace from a supplied prop bag instead of Convex, for screenshot
+   * fixtures. When set, no snapshot query runs. Development only — see
+   * `src/stories/operations`.
+   */
+  fixture?: DailyCloseViewContentProps;
+} = {}) {
   const dailyCloseApi = getDailyCloseApi();
+
+  if (fixture) {
+    return <DailyCloseViewContent {...fixture} />;
+  }
 
   if (
     !dailyCloseApi.getDailyCloseSnapshot ||

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -709,6 +709,54 @@ describe("DailyOpeningViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hides group-internal member and source counts on carry-forward rows", () => {
+    window.history.pushState(
+      {},
+      "",
+      "/wigclub/store/osu/operations/opening?tab=carry-forward",
+    );
+    mockedRouter.search = { tab: "carry-forward" };
+
+    renderContent({
+      ...attentionSnapshot,
+      carryForwardItems: [
+        {
+          category: "carry_forward",
+          id: "carry_forward_group:0",
+          key: "carry_forward_group:0",
+          metadata: {
+            memberCount: 1,
+            oldestActionableAt: Date.UTC(2026, 6, 17, 19, 15),
+            priority: "normal",
+            sourceCount: 1,
+            status: "open",
+            type: "synced_sale_inventory_review",
+          },
+          subject: {
+            id: "synced_sale_inventory_review:kente-scarf",
+            label: "Review inventory for Kente Scarf",
+            type: "logical_operational_work_group",
+          },
+          title: "Review inventory for Kente Scarf",
+        },
+      ],
+      reviewItems: [],
+      summary: {
+        blockerCount: 0,
+        carryForwardCount: 1,
+        readyCount: 1,
+        reviewCount: 0,
+      },
+    });
+
+    expect(screen.queryByText("Member Count")).not.toBeInTheDocument();
+    expect(screen.queryByText("Source Count")).not.toBeInTheDocument();
+    // Operator-facing metadata still renders (Opening humanizes oldestActionableAt to
+    // "Oldest Actionable At"; the "Open since" label is EOD Review's rewrite).
+    expect(screen.getAllByText("Priority").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Oldest Actionable At").length).toBeGreaterThan(0);
+  });
+
   it("paginates opening tab content in five-item pages", async () => {
     const user = userEvent.setup();
     const carryForwardItems = Array.from({ length: 7 }, (_, index) => ({

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -31,6 +31,7 @@ import {
   getLocalDateFromOperatingDate,
   getLocalOperatingDateRange,
   getLocalOperatingDateRangeFromSearch,
+  getOperatingClockNow,
 } from "@/lib/operations/operatingDate";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
@@ -1706,7 +1707,7 @@ function OperatingDatePicker({
   const latestSelectableDate = useMemo(() => {
     if (latestSelectableDateProp) return latestSelectableDateProp;
 
-    const today = new Date();
+    const today = getOperatingClockNow();
 
     return new Date(today.getFullYear(), today.getMonth(), today.getDate());
   }, [latestSelectableDateProp]);

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -186,7 +186,7 @@ type StartDayArgs = {
 
 type BucketStatus = "blocked" | "carry-forward" | "ready" | "review";
 
-type DailyOpeningViewContentProps = {
+export type DailyOpeningViewContentProps = {
   currency: string;
   hasFullAdminAccess: boolean;
   isAuthenticated: boolean;
@@ -2274,8 +2274,21 @@ function DailyOpeningConnectedView({
   );
 }
 
-export function DailyOpeningView() {
+export function DailyOpeningView({
+  fixture,
+}: {
+  /**
+   * Renders the workspace from a supplied prop bag instead of Convex, for screenshot
+   * fixtures. When set, no snapshot query runs. Development only — see
+   * `src/stories/operations`.
+   */
+  fixture?: DailyOpeningViewContentProps;
+} = {}) {
   const dailyOpeningApi = getDailyOpeningApi();
+
+  if (fixture) {
+    return <DailyOpeningViewContent {...fixture} />;
+  }
 
   if (
     !dailyOpeningApi.getDailyOpeningSnapshot ||

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -27,6 +27,11 @@ import {
   type NormalizedCommandResult,
 } from "@/lib/errors/runCommand";
 import { getOrigin } from "@/lib/navigationUtils";
+import {
+  getLocalDateFromOperatingDate,
+  getLocalOperatingDateRange,
+  getLocalOperatingDateRangeFromSearch,
+} from "@/lib/operations/operatingDate";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import type {
@@ -259,64 +264,6 @@ function getDailyOpeningApi(): DailyOpeningApi {
       }
     ).dailyOpening ?? {}
   );
-}
-
-function getLocalOperatingDate(date = new Date()) {
-  const localDate = new Date(
-    date.getTime() - date.getTimezoneOffset() * 60_000,
-  );
-
-  return localDate.toISOString().slice(0, 10);
-}
-
-function getLocalOperatingDateRange(date = new Date()) {
-  const localStart = new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-  );
-  const localEnd = new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate() + 1,
-  );
-
-  return {
-    endAt: localEnd.getTime(),
-    operatingDate: getLocalOperatingDate(date),
-    startAt: localStart.getTime(),
-  };
-}
-
-function getLocalDateFromOperatingDate(operatingDate: string) {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(operatingDate);
-
-  if (!match) return undefined;
-
-  const [, year, month, day] = match;
-  const parsed = new Date(Number(year), Number(month) - 1, Number(day));
-
-  if (
-    parsed.getFullYear() !== Number(year) ||
-    parsed.getMonth() !== Number(month) - 1 ||
-    parsed.getDate() !== Number(day)
-  ) {
-    return undefined;
-  }
-
-  return parsed;
-}
-
-function getLocalOperatingDateRangeFromSearch(operatingDate?: unknown) {
-  if (typeof operatingDate === "string") {
-    const localDate = getLocalDateFromOperatingDate(operatingDate);
-
-    if (localDate) {
-      return getLocalOperatingDateRange(localDate);
-    }
-  }
-
-  return getLocalOperatingDateRange();
 }
 
 function formatOperatingDate(operatingDate?: string | null) {

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -537,6 +537,11 @@ function formatMetadataDisplayValue({
 
 const technicalOpeningMetadataLabels = new Set([
   "frozenmembercount",
+  // Logical work-group internals: not operator-facing, and they render as bogus currency
+  // in the numeric metadata formatter. EOD Review already omits these from carry-forward
+  // rows; keep Opening Handoff consistent.
+  "membercount",
+  "sourcecount",
   "unresolvedmembercount",
 ]);
 

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -4257,4 +4257,59 @@ describe("DailyOperationsView", () => {
       screen.queryByText("getDailyOperationsSnapshot"),
     ).not.toBeInTheDocument();
   });
+
+  it("renders a supplied fixture without issuing any snapshot query", () => {
+    mockedHooks.useQuery.mockClear();
+
+    render(
+      <DailyOperationsView
+        fixture={{
+          currency: "GHS",
+          hasDetailSnapshot: true,
+          hasFinancialDetailsAccess: true,
+          hasFullAdminAccess: true,
+          isAuthenticated: true,
+          isLoadingAccess: false,
+          isLoadingSnapshot: false,
+          orgUrlSlug: "wigclub",
+          snapshot: operatingSnapshot,
+          storePulseWindow: "today",
+          storeUrlSlug: "osu",
+        }}
+      />,
+    );
+
+    expect(mockedHooks.useQuery).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText("Daily Operations unavailable"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("prefers the fixture even when the generated API is unavailable", () => {
+    (
+      mockedApi as { getDailyOperationsSnapshot?: unknown }
+    ).getDailyOperationsSnapshot = undefined;
+
+    render(
+      <DailyOperationsView
+        fixture={{
+          currency: "GHS",
+          hasDetailSnapshot: true,
+          hasFinancialDetailsAccess: true,
+          hasFullAdminAccess: true,
+          isAuthenticated: true,
+          isLoadingAccess: false,
+          isLoadingSnapshot: false,
+          orgUrlSlug: "wigclub",
+          snapshot: operatingSnapshot,
+          storePulseWindow: "today",
+          storeUrlSlug: "osu",
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByText("Daily Operations unavailable"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -39,6 +39,7 @@ import {
   getLocalOperatingDate,
   getLocalOperatingDateRange,
   getLocalOperatingDateRangeFromSearch,
+  getOperatingClockNow,
 } from "@/lib/operations/operatingDate";
 import { formatStoredAmount } from "@/lib/pos/displayAmounts";
 import { cn } from "@/lib/utils";
@@ -2978,7 +2979,7 @@ function OperatingDatePicker({
   const latestSelectableDate = useMemo(() => {
     if (latestSelectableDateProp) return latestSelectableDateProp;
 
-    const today = new Date();
+    const today = getOperatingClockNow();
 
     return new Date(today.getFullYear(), today.getMonth(), today.getDate());
   }, [latestSelectableDateProp]);

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -352,7 +352,7 @@ export type DailyOperationsSnapshot = {
   weekSnapshots?: DailyOperationsSnapshot[];
 };
 
-type DailyOperationsViewContentProps = {
+export type DailyOperationsViewContentProps = {
   cachedPriorWeekBoundaryMetric?:
     DailyOperationsSnapshot["weekMetrics"][number] | null;
   cachedWeekAnalyticsFetchedAt?: number;
@@ -4605,8 +4605,21 @@ function DailyOperationsConnectedView({
   );
 }
 
-export function DailyOperationsView() {
+export function DailyOperationsView({
+  fixture,
+}: {
+  /**
+   * Renders the workspace from a supplied prop bag instead of Convex, for screenshot
+   * fixtures. When set, no snapshot query runs. Development only — see
+   * `src/stories/operations`.
+   */
+  fixture?: DailyOperationsViewContentProps;
+} = {}) {
   const dailyOperationsApi = getDailyOperationsApi();
+
+  if (fixture) {
+    return <DailyOperationsViewContent {...fixture} />;
+  }
 
   if (!dailyOperationsApi.getDailyOperationsSnapshot) {
     return <DailyOperationsApiPendingView />;

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -34,6 +34,12 @@ import type { LucideIcon } from "lucide-react";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { getOrigin } from "@/lib/navigationUtils";
+import {
+  getLocalDateFromOperatingDate,
+  getLocalOperatingDate,
+  getLocalOperatingDateRange,
+  getLocalOperatingDateRangeFromSearch,
+} from "@/lib/operations/operatingDate";
 import { formatStoredAmount } from "@/lib/pos/displayAmounts";
 import { cn } from "@/lib/utils";
 import { api } from "~/convex/_generated/api";
@@ -474,52 +480,6 @@ function getDailyOperationsApi(): DailyOperationsApi {
   );
 }
 
-function getLocalOperatingDate(date = new Date()) {
-  const localDate = new Date(
-    date.getTime() - date.getTimezoneOffset() * 60_000,
-  );
-
-  return localDate.toISOString().slice(0, 10);
-}
-
-function getLocalOperatingDateRange(date = new Date()) {
-  const localStart = new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate(),
-  );
-  const localEnd = new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate() + 1,
-  );
-
-  return {
-    endAt: localEnd.getTime(),
-    operatingDate: getLocalOperatingDate(date),
-    startAt: localStart.getTime(),
-  };
-}
-
-function getLocalDateFromOperatingDate(operatingDate: string) {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(operatingDate);
-
-  if (!match) return undefined;
-
-  const [, year, month, day] = match;
-  const parsed = new Date(Number(year), Number(month) - 1, Number(day));
-
-  if (
-    parsed.getFullYear() !== Number(year) ||
-    parsed.getMonth() !== Number(month) - 1 ||
-    parsed.getDate() !== Number(day)
-  ) {
-    return undefined;
-  }
-
-  return parsed;
-}
-
 function shiftLocalOperatingDate(operatingDate: string, offsetDays: number) {
   const parsed = getLocalDateFromOperatingDate(operatingDate);
 
@@ -543,18 +503,6 @@ function getSaturdayWeekEndOperatingDate(operatingDate: string) {
     getSundayWeekStartOperatingDate(operatingDate),
     6,
   );
-}
-
-function getLocalOperatingDateRangeFromSearch(operatingDate?: unknown) {
-  if (typeof operatingDate === "string") {
-    const localDate = getLocalDateFromOperatingDate(operatingDate);
-
-    if (localDate) {
-      return getLocalOperatingDateRange(localDate);
-    }
-  }
-
-  return getLocalOperatingDateRange();
 }
 
 function getOperatingTimezoneOffsetMinutes(operatingDate: string) {

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -1994,7 +1994,12 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    expect(screen.getByText("Register closed locally")).toBeInTheDocument();
+    // The locally closed notice only renders once a brief settle window confirms no
+    // drawer-gate transition is still in flight; see POSRegisterView's
+    // isLocalClosedRestSettled.
+    expect(
+      await screen.findByText("Register closed locally"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         "This register was closed locally. Athena will reconcile the closeout after sync.",

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -1643,39 +1643,58 @@ function LocalRegisterClosedWorkspace({
 }: {
   syncStatus: NonNullable<RegisterViewModel["syncStatus"]>;
 }) {
+  const [isRetrying, setIsRetrying] = useState(false);
+  const pendingCount = syncStatus.pendingEventCount ?? 0;
+  // Context-aware: reflect an in-flight sync from the runtime, or an optimistic window right
+  // after a manual retry (the gate unmounts if the sync clears; otherwise it settles back).
+  const isSyncing = isRetrying || syncStatus.status === "syncing";
+  const canRetry = Boolean(syncStatus.onRetrySync) && !isSyncing;
+
+  const handleRetry = () => {
+    if (!syncStatus.onRetrySync || isSyncing) {
+      return;
+    }
+    setIsRetrying(true);
+    syncStatus.onRetrySync();
+    window.setTimeout(() => setIsRetrying(false), 2_000);
+  };
+
+  const detail = isSyncing
+    ? "Syncing the closeout to Athena…"
+    : pendingCount > 0
+      ? `${pendingCount} ${
+          pendingCount === 1 ? "change" : "changes"
+        } waiting to reconcile once sync completes.`
+      : syncStatus.description;
+
   return (
-    <section className="flex h-full min-h-0 items-start justify-center overflow-y-auto rounded-lg border border-border bg-surface-raised px-6 py-10 text-center sm:px-8 sm:pt-20">
-      <div className="w-[min(100%,40rem)]">
-        <div className="mx-auto flex max-w-2xl flex-col rounded-lg border border-border bg-surface-raised p-8 shadow-surface">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border border-warning/30 bg-warning/10 text-warning">
-            <Cloud aria-hidden className="h-5 w-5" />
+    <div className="flex h-full min-h-0 items-center justify-center overflow-y-auto rounded-lg border border-border bg-background p-6">
+      <div className="w-full max-w-sm rounded-lg bg-surface-raised p-6 text-center">
+        <span className="mx-auto flex h-9 w-9 items-center justify-center rounded-full bg-muted/50 text-muted-foreground">
+          <Cloud aria-hidden className="h-4 w-4" />
+        </span>
+        <p className="mt-4 text-sm font-medium text-foreground">
+          Register closed locally
+        </p>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">{detail}</p>
+        {syncStatus.onRetrySync ? (
+          <div className="mt-4 flex justify-center">
+            <button
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-background px-3 text-xs font-medium text-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:opacity-60"
+              disabled={!canRetry}
+              onClick={handleRetry}
+              type="button"
+            >
+              <RefreshCw
+                aria-hidden
+                className={cn("h-3.5 w-3.5", isSyncing && "animate-spin")}
+              />
+              {isSyncing ? "Syncing…" : "Retry sync"}
+            </button>
           </div>
-          <div className="mt-6 space-y-layout-xs">
-            <p className="text-xs font-medium uppercase tracking-[0.18em] text-warning">
-              Pending sync
-            </p>
-            <h2 className="font-display text-2xl font-semibold text-foreground">
-              Register closed locally
-            </h2>
-            <p className="text-sm leading-6 text-muted-foreground">
-              {syncStatus.description}
-            </p>
-          </div>
-          {syncStatus.onRetrySync ? (
-            <div className="mt-6 flex justify-center">
-              <button
-                className="inline-flex h-10 items-center justify-center gap-2 rounded-md border border-border bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                onClick={syncStatus.onRetrySync}
-                type="button"
-              >
-                <RefreshCw className="h-4 w-4" />
-                Retry sync
-              </button>
-            </div>
-          ) : null}
-        </div>
+        ) : null}
       </div>
-    </section>
+    </div>
   );
 }
 
@@ -1953,6 +1972,27 @@ function ResolvedPOSRegisterViewContent({
     isPosWorkflow &&
     !viewModel.checkout.isTransactionCompleted &&
     localCloseoutSyncStatus?.status === "locally_closed_pending_sync";
+  // The locally-closed notice is a resting state: it must yield to any active drawer-gate
+  // flow (closeout submit, opening a replacement drawer). Right after a closeout submit, the
+  // drawer gate briefly drops to null while it hands off from the closeout view to the "open
+  // replacement drawer" view; without a settle delay the resting notice would flash into that
+  // ~1-frame gap before the replacement gate renders.
+  const isLocalClosedRestCandidate =
+    isLocallyClosedPendingSync &&
+    Boolean(localCloseoutSyncStatus) &&
+    !viewModel.drawerGate;
+  const [isLocalClosedRestSettled, setIsLocalClosedRestSettled] =
+    useState(false);
+  useEffect(() => {
+    if (!isLocalClosedRestCandidate) {
+      setIsLocalClosedRestSettled(false);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setIsLocalClosedRestSettled(true);
+    }, 200);
+    return () => window.clearTimeout(timer);
+  }, [isLocalClosedRestCandidate]);
   const isPosRegisterLocked =
     isPosWorkflow && isAwaitingCashierAuth && !isLocallyClosedPendingSync;
   const shouldShowOnboarding =
@@ -2530,10 +2570,14 @@ function ResolvedPOSRegisterViewContent({
                   !shouldRenderWorkspaceSidebar && "lg:col-span-2",
                 )}
               >
-                {isLocallyClosedPendingSync && localCloseoutSyncStatus ? (
-                  <LocalRegisterClosedWorkspace
-                    syncStatus={localCloseoutSyncStatus}
-                  />
+                {isLocalClosedRestCandidate && localCloseoutSyncStatus ? (
+                  isLocalClosedRestSettled ? (
+                    <LocalRegisterClosedWorkspace
+                      syncStatus={localCloseoutSyncStatus}
+                    />
+                  ) : (
+                    <div className="h-full min-h-0 rounded-lg border border-border bg-background" />
+                  )
                 ) : shouldShowOnboarding ? (
                   <POSOnboardingWorkspace onboarding={onboardingState} />
                 ) : isPosReadinessGuardSettling ? (

--- a/packages/athena-webapp/src/hooks/useExpenseLocalRuntime.test.ts
+++ b/packages/athena-webapp/src/hooks/useExpenseLocalRuntime.test.ts
@@ -16,7 +16,12 @@ const runtimeMocks = vi.hoisted(() => {
     indexedDbAdapter,
     localStore,
     memoryAdapter,
-    usePosLocalSyncRuntimeStatus: vi.fn(() => null),
+    usePosLocalSyncRuntimeStatus: vi.fn<
+      (input?: {
+        eventAppendToken?: number;
+        onLocalEventsChanged?: () => void;
+      }) => null
+    >(() => null),
   };
 });
 
@@ -155,6 +160,42 @@ describe("useExpenseLocalRuntime", () => {
         terminalId: "terminal-1",
       }),
     );
+  });
+
+  it("does not re-arm the sync trigger when the runtime reports settled events", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: {},
+    });
+
+    // Reproduce a drain that settles events on every trigger: whenever the sync runtime
+    // receives a changed append token, it calls onLocalEventsChanged (as the real drain
+    // does). The trigger token fed to the runtime must still stabilise — if a settle
+    // re-armed it, this would loop into "Maximum update depth exceeded".
+    const seenTriggerTokens: number[] = [];
+    runtimeMocks.usePosLocalSyncRuntimeStatus.mockImplementation((input) => {
+      const token = input?.eventAppendToken ?? 0;
+      const isNewToken = seenTriggerTokens.at(-1) !== token;
+      seenTriggerTokens.push(token);
+      if (isNewToken && seenTriggerTokens.length < 200) {
+        input?.onLocalEventsChanged?.();
+      }
+      return null;
+    });
+
+    const { useExpenseLocalRuntime } = await importRuntime();
+
+    const { result } = renderRuntime(useExpenseLocalRuntime);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The append-only trigger token settled to 0 (no real appends), so the runtime saw a
+    // bounded number of renders rather than a runaway loop.
+    expect(seenTriggerTokens.length).toBeLessThan(50);
+    expect(seenTriggerTokens.at(-1)).toBe(0);
+    // The exposed signal still advanced from the settle refresh.
+    expect(result.current.eventAppendToken).toBeGreaterThan(0);
   });
 
   it("notifies every expense runtime consumer when any gateway appends an event", async () => {

--- a/packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts
+++ b/packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts
@@ -29,6 +29,10 @@ function createLocalId(kind: string) {
 }
 
 export function useExpenseLocalRuntime(input: {
+  // The shared demo's restore epoch. `ingestLocalEvents` rejects demo uploads that omit
+  // it (retryable `precondition_failed`), so without it expense batches retry forever and
+  // never sync. Register plumbs the same value through — see useRegisterLocalRuntime.
+  expectedDemoEpoch?: number;
   staffProfileId?: Id<"staffProfile"> | null;
   storeId?: Id<"store"> | null;
   syncEnabled?: boolean;
@@ -70,6 +74,7 @@ export function useExpenseLocalRuntime(input: {
   const syncRuntime = usePosLocalSyncRuntimeStatus({
     drainOnAppend: syncEnabled,
     eventAppendToken,
+    expectedDemoEpoch: syncEnabled ? input.expectedDemoEpoch : undefined,
     mode: "status-only",
     // A background settle refreshes the local read model but is NOT a new append, so it
     // must not feed back into the sync trigger (`eventAppendToken`).

--- a/packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts
+++ b/packages/athena-webapp/src/hooks/useExpenseLocalRuntime.ts
@@ -34,12 +34,20 @@ export function useExpenseLocalRuntime(input: {
   syncEnabled?: boolean;
   terminalId?: Id<"posTerminal"> | null;
 }) {
+  // `eventAppendToken` is the sync runtime's *trigger* — it must be bumped only by real
+  // local event appends, never by the runtime's own settle callback, or the runtime would
+  // re-arm itself into an infinite drain loop. `localReadRefreshToken` carries the
+  // settle-refresh signal instead, mirroring the register runtime's two-token split.
   const [eventAppendToken, setEventAppendToken] = useState(0);
+  const [localReadRefreshToken, setLocalReadRefreshToken] = useState(0);
   const localStore = useMemo(() => getExpenseLocalStore(), []);
   const storeFactory = useCallback(() => localStore, [localStore]);
 
   const noteEventAppended = useCallback(() => {
     setEventAppendToken((current) => current + 1);
+  }, []);
+  const noteLocalReadRefresh = useCallback(() => {
+    setLocalReadRefreshToken((current) => current + 1);
   }, []);
 
   useEffect(() => {
@@ -63,9 +71,9 @@ export function useExpenseLocalRuntime(input: {
     drainOnAppend: syncEnabled,
     eventAppendToken,
     mode: "status-only",
-    onLocalEventsChanged: syncEnabled
-      ? notifyExpenseLocalEventAppended
-      : undefined,
+    // A background settle refreshes the local read model but is NOT a new append, so it
+    // must not feed back into the sync trigger (`eventAppendToken`).
+    onLocalEventsChanged: syncEnabled ? noteLocalReadRefresh : undefined,
     source: "sync-runtime",
     staffProfileId: syncEnabled ? input.staffProfileId : null,
     storeFactory,
@@ -75,7 +83,11 @@ export function useExpenseLocalRuntime(input: {
 
   return {
     expenseLocalGateway,
-    eventAppendToken,
+    // Consumers watch this as a single "local state changed" signal: it advances on both
+    // real appends and background settles. Both counters only increment, so the sum
+    // strictly increases whenever either fires. The sync runtime is fed the raw
+    // append-only token above, so exposing the combined value here cannot re-arm it.
+    eventAppendToken: eventAppendToken + localReadRefreshToken,
     localStore,
     noteEventAppended,
     syncRuntime,

--- a/packages/athena-webapp/src/lib/operations/operatingDate.test.ts
+++ b/packages/athena-webapp/src/lib/operations/operatingDate.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getLocalDateFromOperatingDate,
+  getLocalOperatingDate,
+  getLocalOperatingDateRange,
+  getLocalOperatingDateRangeFromSearch,
+} from "./operatingDate";
+
+describe("getLocalOperatingDate", () => {
+  it("formats the local calendar day rather than the UTC day", () => {
+    const date = new Date(2026, 4, 14, 13, 30);
+
+    expect(getLocalOperatingDate(date)).toBe("2026-05-14");
+  });
+
+  it("stays on the local day near midnight, where the UTC day may differ", () => {
+    expect(getLocalOperatingDate(new Date(2026, 4, 14, 0, 5))).toBe("2026-05-14");
+    expect(getLocalOperatingDate(new Date(2026, 4, 14, 23, 55))).toBe("2026-05-14");
+  });
+
+  it("defaults to now", () => {
+    const now = new Date();
+
+    expect(getLocalOperatingDate()).toBe(getLocalOperatingDate(now));
+  });
+});
+
+describe("getLocalOperatingDateRange", () => {
+  it("spans local midnight to the next local midnight", () => {
+    const range = getLocalOperatingDateRange(new Date(2026, 4, 14, 13, 30));
+
+    expect(new Date(range.startAt)).toEqual(new Date(2026, 4, 14));
+    expect(new Date(range.endAt)).toEqual(new Date(2026, 4, 15));
+    expect(range.operatingDate).toBe("2026-05-14");
+  });
+
+  it("produces a window that contains the supplied instant", () => {
+    const date = new Date(2026, 4, 14, 13, 30);
+    const range = getLocalOperatingDateRange(date);
+
+    expect(range.startAt).toBeLessThanOrEqual(date.getTime());
+    expect(range.endAt).toBeGreaterThan(date.getTime());
+  });
+});
+
+describe("getLocalDateFromOperatingDate", () => {
+  it("parses a well-formed operating date to local midnight", () => {
+    expect(getLocalDateFromOperatingDate("2026-05-14")).toEqual(
+      new Date(2026, 4, 14),
+    );
+  });
+
+  it("rejects malformed input", () => {
+    expect(getLocalDateFromOperatingDate("2026-5-14")).toBeUndefined();
+    expect(getLocalDateFromOperatingDate("14-05-2026")).toBeUndefined();
+    expect(getLocalDateFromOperatingDate("not-a-date")).toBeUndefined();
+    expect(getLocalDateFromOperatingDate("")).toBeUndefined();
+  });
+
+  it("rejects well-formed dates that do not exist", () => {
+    expect(getLocalDateFromOperatingDate("2026-02-30")).toBeUndefined();
+    expect(getLocalDateFromOperatingDate("2026-13-01")).toBeUndefined();
+  });
+});
+
+describe("getLocalOperatingDateRangeFromSearch", () => {
+  it("uses the supplied operating date when parseable", () => {
+    expect(getLocalOperatingDateRangeFromSearch("2026-05-14")).toEqual(
+      getLocalOperatingDateRange(new Date(2026, 4, 14)),
+    );
+  });
+
+  it("falls back to the current day for absent or unusable values", () => {
+    const today = getLocalOperatingDate();
+
+    expect(getLocalOperatingDateRangeFromSearch().operatingDate).toBe(today);
+    expect(getLocalOperatingDateRangeFromSearch(undefined).operatingDate).toBe(today);
+    expect(getLocalOperatingDateRangeFromSearch("2026-02-30").operatingDate).toBe(today);
+    expect(getLocalOperatingDateRangeFromSearch(20260514).operatingDate).toBe(today);
+  });
+});

--- a/packages/athena-webapp/src/lib/operations/operatingDate.test.ts
+++ b/packages/athena-webapp/src/lib/operations/operatingDate.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   getLocalDateFromOperatingDate,
   getLocalOperatingDate,
   getLocalOperatingDateRange,
   getLocalOperatingDateRangeFromSearch,
+  getOperatingClockNow,
+  setOperatingClockOverride,
 } from "./operatingDate";
+
+afterEach(() => {
+  setOperatingClockOverride(null);
+});
 
 describe("getLocalOperatingDate", () => {
   it("formats the local calendar day rather than the UTC day", () => {
@@ -61,6 +67,40 @@ describe("getLocalDateFromOperatingDate", () => {
   it("rejects well-formed dates that do not exist", () => {
     expect(getLocalDateFromOperatingDate("2026-02-30")).toBeUndefined();
     expect(getLocalDateFromOperatingDate("2026-13-01")).toBeUndefined();
+  });
+});
+
+describe("setOperatingClockOverride", () => {
+  it("pins what the helpers treat as today", () => {
+    setOperatingClockOverride(new Date(2026, 4, 14, 9, 0));
+
+    expect(getLocalOperatingDate()).toBe("2026-05-14");
+    expect(getLocalOperatingDateRange().operatingDate).toBe("2026-05-14");
+    expect(getLocalOperatingDateRangeFromSearch().operatingDate).toBe("2026-05-14");
+  });
+
+  it("restores the real clock when cleared", () => {
+    setOperatingClockOverride(new Date(2026, 4, 14));
+    setOperatingClockOverride(null);
+
+    expect(getLocalOperatingDate()).toBe(getLocalOperatingDate(new Date()));
+  });
+
+  it("defends against later mutation of the supplied date", () => {
+    const pinned = new Date(2026, 4, 14);
+    setOperatingClockOverride(pinned);
+
+    pinned.setFullYear(2030);
+
+    expect(getLocalOperatingDate()).toBe("2026-05-14");
+  });
+
+  it("does not hand out a mutable reference to the pinned instant", () => {
+    setOperatingClockOverride(new Date(2026, 4, 14));
+
+    getOperatingClockNow().setFullYear(2030);
+
+    expect(getLocalOperatingDate()).toBe("2026-05-14");
   });
 });
 

--- a/packages/athena-webapp/src/lib/operations/operatingDate.ts
+++ b/packages/athena-webapp/src/lib/operations/operatingDate.ts
@@ -8,13 +8,36 @@
  * search param when present.
  */
 
+let operatingClockOverride: Date | null = null;
+
+/**
+ * Pins what these helpers treat as "now", so a fixture can render as the current day.
+ *
+ * Screenshot fixtures only — the operations workspaces derive "today" from the browser
+ * clock in ~30 module-level call sites, so an override is the only practical seam short
+ * of threading a `now` through all of them. Pass `null` to restore the real clock.
+ *
+ * Callers are responsible for gating this to development; the mechanism is deliberately
+ * unguarded so it stays testable.
+ */
+export function setOperatingClockOverride(date: Date | null) {
+  operatingClockOverride = date ? new Date(date.getTime()) : null;
+}
+
+/** The current instant, honouring any override set by `setOperatingClockOverride`. */
+export function getOperatingClockNow() {
+  return operatingClockOverride
+    ? new Date(operatingClockOverride.getTime())
+    : new Date();
+}
+
 /**
  * The store-local calendar day for `date`, as `YYYY-MM-DD`.
  *
  * Shifts by the local UTC offset before formatting so the ISO slice yields the local
  * day rather than the UTC one.
  */
-export function getLocalOperatingDate(date = new Date()) {
+export function getLocalOperatingDate(date = getOperatingClockNow()) {
   const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
 
   return localDate.toISOString().slice(0, 10);
@@ -25,7 +48,7 @@ export function getLocalOperatingDate(date = new Date()) {
  *
  * `startAt`/`endAt` are epoch millis and are sent to the server as the snapshot range.
  */
-export function getLocalOperatingDateRange(date = new Date()) {
+export function getLocalOperatingDateRange(date = getOperatingClockNow()) {
   const localStart = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   const localEnd = new Date(
     date.getFullYear(),

--- a/packages/athena-webapp/src/lib/operations/operatingDate.ts
+++ b/packages/athena-webapp/src/lib/operations/operatingDate.ts
@@ -1,0 +1,80 @@
+/**
+ * Operating-date derivation shared by the operations workspaces (Daily Operations,
+ * Opening Handoff, EOD Review).
+ *
+ * These were previously duplicated verbatim in `DailyOperationsView`,
+ * `DailyOpeningView`, and `DailyCloseView`. The operating date is the store's local
+ * calendar day, derived from the browser clock and overridden by the `operatingDate`
+ * search param when present.
+ */
+
+/**
+ * The store-local calendar day for `date`, as `YYYY-MM-DD`.
+ *
+ * Shifts by the local UTC offset before formatting so the ISO slice yields the local
+ * day rather than the UTC one.
+ */
+export function getLocalOperatingDate(date = new Date()) {
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+
+  return localDate.toISOString().slice(0, 10);
+}
+
+/**
+ * The local midnight-to-midnight window containing `date`, plus its operating date.
+ *
+ * `startAt`/`endAt` are epoch millis and are sent to the server as the snapshot range.
+ */
+export function getLocalOperatingDateRange(date = new Date()) {
+  const localStart = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const localEnd = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate() + 1,
+  );
+
+  return {
+    endAt: localEnd.getTime(),
+    operatingDate: getLocalOperatingDate(date),
+    startAt: localStart.getTime(),
+  };
+}
+
+/**
+ * Parses a `YYYY-MM-DD` operating date into a local `Date`, or `undefined` when the
+ * string is malformed or names a date that does not exist (e.g. `2026-02-30`).
+ */
+export function getLocalDateFromOperatingDate(operatingDate: string) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(operatingDate);
+
+  if (!match) return undefined;
+
+  const [, year, month, day] = match;
+  const parsed = new Date(Number(year), Number(month) - 1, Number(day));
+
+  if (
+    parsed.getFullYear() !== Number(year) ||
+    parsed.getMonth() !== Number(month) - 1 ||
+    parsed.getDate() !== Number(day)
+  ) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+/**
+ * Resolves the operating range from an untrusted search-param value, falling back to
+ * the current local day when the value is absent or unparseable.
+ */
+export function getLocalOperatingDateRangeFromSearch(operatingDate?: unknown) {
+  if (typeof operatingDate === "string") {
+    const localDate = getLocalDateFromOperatingDate(operatingDate);
+
+    if (localDate) {
+      return getLocalOperatingDateRange(localDate);
+    }
+  }
+
+  return getLocalOperatingDateRange();
+}

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts
@@ -20,20 +20,32 @@ const catalogGatewayMocks = vi.hoisted(() => ({
   useConvexRegisterCatalog: vi.fn(),
   useConvexRegisterCatalogAvailability: vi.fn(),
 }));
-const localRuntimeMocks = vi.hoisted(() => ({
-  addItem: vi.fn(),
-  clearCart: vi.fn(),
-  completeExpense: vi.fn(),
-  holdSession: vi.fn(),
-  removeItem: vi.fn(),
-  resumeSession: vi.fn(),
-  startSession: vi.fn(),
-  updateItem: vi.fn(),
-  voidSession: vi.fn(),
-  listEvents: vi.fn(),
-  hasListEvents: { current: false },
-  eventAppendToken: { current: 0 },
-}));
+const localRuntimeMocks = vi.hoisted(() => {
+  const listEvents = vi.fn();
+  return {
+    addItem: vi.fn(),
+    clearCart: vi.fn(),
+    completeExpense: vi.fn(),
+    holdSession: vi.fn(),
+    removeItem: vi.fn(),
+    resumeSession: vi.fn(),
+    startSession: vi.fn(),
+    updateItem: vi.fn(),
+    voidSession: vi.fn(),
+    listEvents,
+    hasListEvents: { current: false },
+    eventAppendToken: { current: 0 },
+    // When true, `localStore` is a single stable object whose `listEvents` getter returns
+    // a *fresh* function on every access — reproducing the real Proxy port facade that
+    // caused the infinite render loop.
+    proxyListEvents: { current: false },
+    proxyLocalStore: {
+      get listEvents() {
+        return (...args: unknown[]) => listEvents(...args);
+      },
+    },
+  };
+});
 const terminalMocks = vi.hoisted(() => ({
   terminal: {
     _id: "terminal-1" as Id<"posTerminal">,
@@ -138,11 +150,13 @@ vi.mock("@/hooks/useExpenseLocalRuntime", () => ({
   useExpenseLocalRuntime: () => ({
     expenseLocalGateway: localRuntimeMocks,
     eventAppendToken: localRuntimeMocks.eventAppendToken.current,
-    localStore: localRuntimeMocks.hasListEvents.current
-      ? {
-          listEvents: localRuntimeMocks.listEvents,
-        }
-      : {},
+    localStore: localRuntimeMocks.proxyListEvents.current
+      ? localRuntimeMocks.proxyLocalStore
+      : localRuntimeMocks.hasListEvents.current
+        ? {
+            listEvents: localRuntimeMocks.listEvents,
+          }
+        : {},
     noteEventAppended: () => {
       localRuntimeMocks.eventAppendToken.current += 1;
     },
@@ -422,11 +436,34 @@ describe("useExpenseRegisterViewModel", () => {
     localRuntimeMocks.resumeSession.mockResolvedValue(true);
     localRuntimeMocks.voidSession.mockResolvedValue(true);
     localRuntimeMocks.hasListEvents.current = false;
+    localRuntimeMocks.proxyListEvents.current = false;
     localRuntimeMocks.eventAppendToken.current = 0;
     localRuntimeMocks.listEvents.mockResolvedValue({
       ok: true,
       value: [],
     });
+  });
+
+  it("does not re-render endlessly when the local store returns a fresh listEvents per access", async () => {
+    // Reproduces the real Proxy port facade: a stable `localStore` whose `.listEvents`
+    // yields a new function on every access. Read inline, that churned the read effect's
+    // dependency array into an unbounded render loop ("Maximum update depth exceeded").
+    localRuntimeMocks.proxyListEvents.current = true;
+    localRuntimeMocks.listEvents.mockResolvedValue({ ok: true, value: [] });
+
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      return useExpenseRegisterViewModel();
+    });
+
+    await waitFor(() =>
+      expect(result.current.debug?.localEntryStatus).toBe("ready"),
+    );
+
+    // With the accessor memoised, the view model settles in a handful of renders. Without
+    // the fix this climbs to React's ~50-render bail-out.
+    expect(renderCount).toBeLessThan(20);
   });
 
   it("identifies the shared demo expense workspace", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts
@@ -986,7 +986,7 @@ describe("useExpenseRegisterViewModel", () => {
     expect(source).not.toContain("usePOSBarcodeSearch");
   });
 
-  it("reuses the terminal demo bootstrap instead of subscribing again", () => {
+  it("reuses terminal demo staff and reads the restore epoch for expense sync", () => {
     const currentDir = dirname(fileURLToPath(import.meta.url));
     const source = readFileSync(
       join(currentDir, "useExpenseRegisterViewModel.ts"),
@@ -994,7 +994,11 @@ describe("useExpenseRegisterViewModel", () => {
     );
 
     expect(source).toContain("sharedDemoStaff");
-    expect(source).not.toContain("useSharedDemoContext");
+    // Demo expense uploads are rejected by ingestLocalEvents without the restore epoch,
+    // which is only available from the shared demo context (the terminal's
+    // sharedDemoStaff does not carry it). Register plumbs the same value.
+    expect(source).toContain("useSharedDemoContext");
+    expect(source).toContain("restore?.epoch");
   });
 
   it("optimistically adds expense product selections while the server mutation is pending", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
@@ -214,11 +214,20 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
       storeId: store.storeId,
       terminalId: store.terminalId,
     });
-  const listLocalExpenseEvents = (
-    localStore as {
-      listEvents?: typeof localStore.listEvents;
-    }
-  ).listEvents;
+  // `localStore` is a Proxy facade whose `get` trap returns a *new* function on every
+  // property access (see createPosLocalStoreRuntimePort). Reading `.listEvents` inline on
+  // each render therefore produced a fresh reference, churning the read effect's
+  // dependency array into an infinite render loop. Capture a single stable reference,
+  // keyed on the stable `localStore`.
+  const listLocalExpenseEvents = useMemo(() => {
+    const candidate = (
+      localStore as {
+        listEvents?: typeof localStore.listEvents;
+      }
+    ).listEvents;
+
+    return typeof candidate === "function" ? candidate : undefined;
+  }, [localStore]);
   const [localExpenseReadState, setLocalExpenseReadState] = useState<{
     activeSession: ExpenseLocalSessionReadModel | null;
     loaded: boolean;

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
@@ -8,6 +8,7 @@ import { useExpenseLocalRuntime } from "@/hooks/useExpenseLocalRuntime";
 import { useExpenseStore } from "@/stores/expenseStore";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { useGetTerminal } from "@/hooks/useGetTerminal";
+import { useSharedDemoContext } from "@/hooks/useSharedDemoContext";
 import { useNavigateBack } from "@/hooks/use-navigate-back";
 import {
   useConvexRegisterCatalog,
@@ -192,6 +193,7 @@ function isScopedExpenseLocalEvent(
 export function useExpenseRegisterViewModel(): RegisterViewModel {
   const { activeStore } = useGetActiveStore();
   const terminal = useGetTerminal();
+  const sharedDemoContext = useSharedDemoContext();
   const sharedDemoStaff = (
     terminal as {
       sharedDemoStaff?: {
@@ -210,6 +212,8 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
   );
   const { eventAppendToken, expenseLocalGateway, localStore, syncRuntime } =
     useExpenseLocalRuntime({
+      // Required for demo uploads to pass the ingest epoch gate; see useExpenseLocalRuntime.
+      expectedDemoEpoch: sharedDemoContext?.restore?.epoch,
       staffProfileId: cashierStaffProfileId,
       storeId: store.storeId,
       terminalId: store.terminalId,

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.test.ts
@@ -9,59 +9,32 @@ import {
 describe("hasBlockingAuthorityPersistenceFailure", () => {
   it("never blocks when persistence has not failed", () => {
     for (const status of ["idle", "applying", "ready"] as const) {
+      expect(hasBlockingAuthorityPersistenceFailure({ status })).toBe(false);
+    }
+  });
+
+  it("never blocks a transitional authority re-settle", () => {
+    // The flash case: opening a replacement drawer re-settles cloud authority against a
+    // transitional snapshot. These reasons are not save failures and must not surface the gate.
+    for (const reason of ["mapping_invalidated", "candidate_invalid"] as const) {
       expect(
-        hasBlockingAuthorityPersistenceFailure({
-          hasPendingOptimisticDrawerOpen: true,
-          status,
-        }),
+        hasBlockingAuthorityPersistenceFailure({ reason, status: "failed" }),
       ).toBe(false);
     }
   });
 
-  it("suppresses the transient candidate_invalid failure while a drawer open is pending", () => {
-    // The flash case: replacement drawer just opened, read model not yet settled.
-    expect(
-      hasBlockingAuthorityPersistenceFailure({
-        hasPendingOptimisticDrawerOpen: true,
-        reason: "candidate_invalid",
-        status: "failed",
-      }),
-    ).toBe(false);
-  });
-
-  it("surfaces candidate_invalid once the open has settled", () => {
-    expect(
-      hasBlockingAuthorityPersistenceFailure({
-        hasPendingOptimisticDrawerOpen: false,
-        reason: "candidate_invalid",
-        status: "failed",
-      }),
-    ).toBe(true);
-  });
-
-  it("never suppresses genuine persistence failures, even during a pending open", () => {
-    for (const reason of [
-      "write_failed",
-      "snapshot_invalid",
-      "mapping_invalidated",
-    ] as const) {
+  it("blocks genuine persistence failures", () => {
+    for (const reason of ["write_failed", "snapshot_invalid"] as const) {
       expect(
-        hasBlockingAuthorityPersistenceFailure({
-          hasPendingOptimisticDrawerOpen: true,
-          reason,
-          status: "failed",
-        }),
+        hasBlockingAuthorityPersistenceFailure({ reason, status: "failed" }),
       ).toBe(true);
     }
   });
 
   it("blocks a failure with no reason", () => {
-    expect(
-      hasBlockingAuthorityPersistenceFailure({
-        hasPendingOptimisticDrawerOpen: true,
-        status: "failed",
-      }),
-    ).toBe(true);
+    expect(hasBlockingAuthorityPersistenceFailure({ status: "failed" })).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.test.ts
@@ -3,7 +3,67 @@ import { describe, expect, it } from "vitest";
 import {
   buildRegisterOperationalIdleState,
   buildRegisterUpdateApplyBlockerState,
+  hasBlockingAuthorityPersistenceFailure,
 } from "./registerUiState";
+
+describe("hasBlockingAuthorityPersistenceFailure", () => {
+  it("never blocks when persistence has not failed", () => {
+    for (const status of ["idle", "applying", "ready"] as const) {
+      expect(
+        hasBlockingAuthorityPersistenceFailure({
+          hasPendingOptimisticDrawerOpen: true,
+          status,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("suppresses the transient candidate_invalid failure while a drawer open is pending", () => {
+    // The flash case: replacement drawer just opened, read model not yet settled.
+    expect(
+      hasBlockingAuthorityPersistenceFailure({
+        hasPendingOptimisticDrawerOpen: true,
+        reason: "candidate_invalid",
+        status: "failed",
+      }),
+    ).toBe(false);
+  });
+
+  it("surfaces candidate_invalid once the open has settled", () => {
+    expect(
+      hasBlockingAuthorityPersistenceFailure({
+        hasPendingOptimisticDrawerOpen: false,
+        reason: "candidate_invalid",
+        status: "failed",
+      }),
+    ).toBe(true);
+  });
+
+  it("never suppresses genuine persistence failures, even during a pending open", () => {
+    for (const reason of [
+      "write_failed",
+      "snapshot_invalid",
+      "mapping_invalidated",
+    ] as const) {
+      expect(
+        hasBlockingAuthorityPersistenceFailure({
+          hasPendingOptimisticDrawerOpen: true,
+          reason,
+          status: "failed",
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("blocks a failure with no reason", () => {
+    expect(
+      hasBlockingAuthorityPersistenceFailure({
+        hasPendingOptimisticDrawerOpen: true,
+        status: "failed",
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("buildRegisterOperationalIdleState", () => {
   it.each([

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -310,6 +310,44 @@ export interface RegisterUpdateApplyBlockerState {
 export const REGISTER_UPDATE_APPLY_BLOCKER_PRIORITY: UpdateApplyBlockerPriority =
   "critical-workflow";
 
+/**
+ * Whether a register lifecycle-authority persistence failure should block the drawer
+ * (surface the "Drawer status not saved" gate).
+ *
+ * A `candidate_invalid` failure is transient during a drawer open: opening a replacement
+ * drawer briefly re-derives ambiguous authority candidates while the just-closed session's
+ * "current" cloud mapping and the newly opened session coexist for a render. While that open
+ * has not settled (`hasPendingOptimisticDrawerOpen` — the open is in flight, or an optimistic
+ * local session has not yet been confirmed by the projected read model), the failure is
+ * suppressed so the gate does not flash before the register reaches its ready state.
+ *
+ * Genuine failures (`write_failed`, `snapshot_invalid`, `mapping_invalidated`) always block,
+ * and a persistent `candidate_invalid` resurfaces once the open settles and this guard
+ * releases.
+ */
+export function hasBlockingAuthorityPersistenceFailure(input: {
+  hasPendingOptimisticDrawerOpen: boolean;
+  reason?:
+    | "candidate_invalid"
+    | "mapping_invalidated"
+    | "snapshot_invalid"
+    | "write_failed";
+  status: "idle" | "applying" | "ready" | "failed";
+}): boolean {
+  if (input.status !== "failed") {
+    return false;
+  }
+
+  if (
+    input.reason === "candidate_invalid" &&
+    input.hasPendingOptimisticDrawerOpen
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
 export interface RegisterOperationalIdleInput {
   hasActiveSaleWork: boolean;
   hasCheckoutMutationInFlight: boolean;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -314,19 +314,20 @@ export const REGISTER_UPDATE_APPLY_BLOCKER_PRIORITY: UpdateApplyBlockerPriority 
  * Whether a register lifecycle-authority persistence failure should block the drawer
  * (surface the "Drawer status not saved" gate).
  *
- * A `candidate_invalid` failure is transient during a drawer open: opening a replacement
- * drawer briefly re-derives ambiguous authority candidates while the just-closed session's
- * "current" cloud mapping and the newly opened session coexist for a render. While that open
- * has not settled (`hasPendingOptimisticDrawerOpen` — the open is in flight, or an optimistic
- * local session has not yet been confirmed by the projected read model), the failure is
- * suppressed so the gate does not flash before the register reaches its ready state.
+ * `mapping_invalidated` and `candidate_invalid` are transitional cloud-authority *re-settles*,
+ * not save failures. Opening a (replacement) drawer re-applies authority across two snapshots,
+ * and the first pass — against a transitional snapshot where the just-closed session's
+ * "current" mapping and the newly opened session coexist — reports one of these before the
+ * settled pass succeeds. `mapping_invalidated` means a newer authority superseded this mapping
+ * and `candidate_invalid` means candidates are momentarily ambiguous; in both cases the drawer
+ * is saved locally and the "Drawer status not saved" / Retry gate is the wrong, flashing
+ * surface (a genuinely superseded session is instead surfaced through the lifecycle/sync-review
+ * path, and a genuinely missing drawer through the startup/recovery gates).
  *
- * Genuine failures (`write_failed`, `snapshot_invalid`, `mapping_invalidated`) always block,
- * and a persistent `candidate_invalid` resurfaces once the open settles and this guard
- * releases.
+ * Only `write_failed` and `snapshot_invalid` are genuine persistence failures the operator
+ * should retry, so only those block.
  */
 export function hasBlockingAuthorityPersistenceFailure(input: {
-  hasPendingOptimisticDrawerOpen: boolean;
   reason?:
     | "candidate_invalid"
     | "mapping_invalidated"
@@ -339,8 +340,8 @@ export function hasBlockingAuthorityPersistenceFailure(input: {
   }
 
   if (
-    input.reason === "candidate_invalid" &&
-    input.hasPendingOptimisticDrawerOpen
+    input.reason === "candidate_invalid" ||
+    input.reason === "mapping_invalidated"
   ) {
     return false;
   }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -1783,24 +1783,12 @@ export function useRegisterViewModel(): RegisterViewModel {
   const hasLifecycleReviewDrawerBlock =
     localDrawerAuthorityReason === "lifecycle_rejected";
   const hasLocalSaleAuthorityBlock = Boolean(localSaleAuthorityBlockReason);
-  // Opening a (replacement) drawer briefly re-derives ambiguous authority candidates —
-  // the just-closed session's "current" cloud mapping and the newly opened session coexist
-  // for a render — which momentarily reports `candidate_invalid`. The optimistic local
-  // session already makes the register operable, but this transient would flash the
-  // "Drawer status not saved" gate before the local read model settles. Suppress only that
-  // transient: while the open is in flight, or an optimistic session hasn't yet been
-  // confirmed by the projected read model. Genuine failures (write_failed, snapshot_invalid,
-  // mapping_invalidated) are never suppressed, and a persistent candidate_invalid resurfaces
-  // once the read model catches up and this guard releases.
-  const hasPendingOptimisticDrawerOpen =
-    isOpeningDrawer ||
-    Boolean(
-      localOperableRegisterSession &&
-        localOperableRegisterSession.localRegisterSessionId !==
-          projectedLocalRegisterSession?.localRegisterSessionId,
-    );
+  // Opening a (replacement) drawer re-settles cloud register authority across two snapshots;
+  // the first pass reports a transitional `mapping_invalidated` / `candidate_invalid` before
+  // the settled pass succeeds. Those re-settles are not save failures, so they must not flash
+  // the "Drawer status not saved" gate — only a genuine failure (write_failed / snapshot_invalid)
+  // should. See hasBlockingAuthorityPersistenceFailure.
   const hasAuthorityPersistenceFailure = hasBlockingAuthorityPersistenceFailure({
-    hasPendingOptimisticDrawerOpen,
     reason:
       registerLifecycleAuthorityPersistence.status === "failed"
         ? registerLifecycleAuthorityPersistence.reason

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -81,6 +81,7 @@ import {
   buildRegisterOperationalIdleState,
   buildRegisterUpdateApplyBlockerState,
   EMPTY_REGISTER_CUSTOMER_INFO,
+  hasBlockingAuthorityPersistenceFailure,
 } from "./registerUiState";
 import {
   buildRegisterHeaderState,
@@ -1782,8 +1783,30 @@ export function useRegisterViewModel(): RegisterViewModel {
   const hasLifecycleReviewDrawerBlock =
     localDrawerAuthorityReason === "lifecycle_rejected";
   const hasLocalSaleAuthorityBlock = Boolean(localSaleAuthorityBlockReason);
-  const hasAuthorityPersistenceFailure =
-    registerLifecycleAuthorityPersistence.status === "failed";
+  // Opening a (replacement) drawer briefly re-derives ambiguous authority candidates —
+  // the just-closed session's "current" cloud mapping and the newly opened session coexist
+  // for a render — which momentarily reports `candidate_invalid`. The optimistic local
+  // session already makes the register operable, but this transient would flash the
+  // "Drawer status not saved" gate before the local read model settles. Suppress only that
+  // transient: while the open is in flight, or an optimistic session hasn't yet been
+  // confirmed by the projected read model. Genuine failures (write_failed, snapshot_invalid,
+  // mapping_invalidated) are never suppressed, and a persistent candidate_invalid resurfaces
+  // once the read model catches up and this guard releases.
+  const hasPendingOptimisticDrawerOpen =
+    isOpeningDrawer ||
+    Boolean(
+      localOperableRegisterSession &&
+        localOperableRegisterSession.localRegisterSessionId !==
+          projectedLocalRegisterSession?.localRegisterSessionId,
+    );
+  const hasAuthorityPersistenceFailure = hasBlockingAuthorityPersistenceFailure({
+    hasPendingOptimisticDrawerOpen,
+    reason:
+      registerLifecycleAuthorityPersistence.status === "failed"
+        ? registerLifecycleAuthorityPersistence.reason
+        : undefined,
+    status: registerLifecycleAuthorityPersistence.status,
+  });
   const requiresDrawerGate = Boolean(
     activeStoreId &&
     terminal?._id &&

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close.tsx
@@ -2,8 +2,11 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { DailyCloseView } from "~/src/components/operations/DailyCloseView";
+import { useDailyCloseFixture } from "~/src/stories/operations/devFixtureActivation";
 
 const dailyCloseSearchSchema = z.object({
+  // Development-only screenshot fixtures; inert in production builds.
+  fixture: z.string().optional(),
   operatingDate: z
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)
@@ -22,5 +25,12 @@ export const Route = createFileRoute(
 });
 
 function DailyCloseRoute() {
-  return <DailyCloseView />;
+  const { fixture: fixtureName } = Route.useSearch();
+  const { fixture, isResolving } = useDailyCloseFixture(fixtureName);
+
+  // Hold the render while a fixture loads, so the workspace never briefly takes the
+  // Convex path and issues the queries the fixture exists to avoid.
+  if (isResolving) return null;
+
+  return <DailyCloseView fixture={fixture} />;
 }

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx
@@ -2,15 +2,29 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { DailyOperationsView } from "~/src/components/operations/DailyOperationsView";
+import { useDailyOperationsFixture } from "~/src/stories/operations/devFixtureActivation";
 
 const dailyOperationsSearchSchema = z.object({
+  // Development-only screenshot fixtures; inert in production builds.
+  fixture: z.string().optional(),
   operatingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
   weekEndOperatingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 });
 
+function DailyOperationsRoute() {
+  const { fixture: fixtureName } = Route.useSearch();
+  const { fixture, isResolving } = useDailyOperationsFixture(fixtureName);
+
+  // Hold the render while a fixture loads, so the workspace never briefly takes the
+  // Convex path and issues the queries the fixture exists to avoid.
+  if (isResolving) return null;
+
+  return <DailyOperationsView fixture={fixture} />;
+}
+
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/",
 )({
-  component: DailyOperationsView,
+  component: DailyOperationsRoute,
   validateSearch: dailyOperationsSearchSchema,
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx
@@ -2,8 +2,11 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { DailyOpeningView } from "~/src/components/operations/DailyOpeningView";
+import { useDailyOpeningFixture } from "~/src/stories/operations/devFixtureActivation";
 
 const dailyOpeningSearchSchema = z.object({
+  // Development-only screenshot fixtures; inert in production builds.
+  fixture: z.string().optional(),
   operatingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
   tab: z.enum(["blocked", "carry-forward", "ready", "review"]).optional(),
 });
@@ -16,5 +19,12 @@ export const Route = createFileRoute(
 });
 
 function DailyOpeningRoute() {
-  return <DailyOpeningView />;
+  const { fixture: fixtureName } = Route.useSearch();
+  const { fixture, isResolving } = useDailyOpeningFixture(fixtureName);
+
+  // Hold the render while a fixture loads, so the workspace never briefly takes the
+  // Convex path and issues the queries the fixture exists to avoid.
+  if (isResolving) return null;
+
+  return <DailyOpeningView fixture={fixture} />;
 }

--- a/packages/athena-webapp/src/stories/operations/dailyOperationsFixtures.ts
+++ b/packages/athena-webapp/src/stories/operations/dailyOperationsFixtures.ts
@@ -12,39 +12,21 @@
  */
 
 import type { DailyOperationsViewContentProps } from "@/components/operations/DailyOperationsView";
-import type { Id } from "~/convex/_generated/dataModel";
 
-/** Saturday. The week runs Sunday 2026-07-12 → Saturday 2026-07-18. */
-const OPERATING_DATE = "2026-07-18";
+import {
+  DAY_END,
+  DAY_START,
+  LINK_PARAMS as linkParams,
+  momentAt as at,
+  OPERATING_DATE,
+  ORG_URL_SLUG,
+  REGISTER_DISPLAY_LABEL,
+  STORE_ID,
+  STORE_URL_SLUG,
+} from "./operationsFixtureContext";
 
 /** Mid-afternoon, so the day reads as still trading rather than wrapped up. */
 export const BUSY_SATURDAY_CLOCK = new Date(2026, 6, 18, 15, 20);
-
-const STORE_ID = "demo-store-osu-atelier" as Id<"store">;
-// Matches the shared demo store's actual route params, so links in the fixture resolve
-// against the session a capture is taken in.
-const ORG_URL_SLUG = "demo";
-const STORE_URL_SLUG = "central";
-
-const DAY_START = new Date(2026, 6, 18, 0, 0).getTime();
-const DAY_END = new Date(2026, 6, 19, 0, 0).getTime();
-
-/** Minutes past local midnight → epoch millis, for readable timeline authoring. */
-function at(hour: number, minute: number) {
-  return new Date(2026, 6, 18, hour, minute).getTime();
-}
-
-const linkParams = {
-  orgUrlSlug: ORG_URL_SLUG,
-  storeUrlSlug: STORE_URL_SLUG,
-};
-
-/**
- * Register sessions display as `{terminalName} / Register {registerNumber}` — see
- * `formatTerminalRegisterLinkLabel` in convex/operations/dailyOperations.ts. Values are
- * the shared demo store's terminal name and register number.
- */
-const REGISTER_DISPLAY_LABEL = "Studio Front Register / Register 01";
 
 /**
  * A week that builds toward the weekend — quiet Sunday, steady midweek, a strong

--- a/packages/athena-webapp/src/stories/operations/dailyOperationsFixtures.ts
+++ b/packages/athena-webapp/src/stories/operations/dailyOperationsFixtures.ts
@@ -40,6 +40,13 @@ const linkParams = {
 };
 
 /**
+ * Register sessions display as `{terminalName} / Register {registerNumber}` — see
+ * `formatTerminalRegisterLinkLabel` in convex/operations/dailyOperations.ts. Values are
+ * the shared demo store's terminal name and register number.
+ */
+const REGISTER_DISPLAY_LABEL = "Studio Front Register / Register 01";
+
+/**
  * A week that builds toward the weekend — quiet Sunday, steady midweek, a strong
  * Friday, and a Saturday that is already the best day of the week by mid-afternoon.
  */
@@ -162,27 +169,34 @@ const timeline: NonNullable<
   {
     createdAt: at(15, 12),
     id: "evt-sale-1184",
-    message: "Sale #1184 completed on Register 01 — GHS 350.00.",
+    message: "Sale #1184 synced: 3 sale lines, GH₵350, cash and mobile money.",
     subject: { id: "txn-1184", label: "#1184", type: "pos_transaction" },
     transactionLink: {
       label: "#1184",
       params: linkParams,
       to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/txn-1184",
     },
-    type: "pos_sale_completed",
+    type: "pos_local_sync.sale_projected",
   },
   {
+    // The stored message is "Void requested for Transaction #N."; the daily-operations
+    // snapshot splices in the requester's name at read time
+    // (`normalizeTimelineEventMessage`, convex/operations/dailyOperations.ts). This is
+    // the post-rewrite form the workspace actually renders.
     createdAt: at(14, 47),
-    id: "evt-approval-req",
-    message:
-      "Efua Tetteh requested manager approval for a 15% discount on Sale #1183.",
-    subject: { id: "apr-3391", label: "Discount approval", type: "approval" },
+    id: "evt-void-request",
+    message: "Void requested by Efua Tetteh for Transaction #1183.",
+    subject: {
+      id: "txn-1183",
+      label: "Transaction #1183",
+      type: "pos_transaction",
+    },
     transactionLink: {
       label: "#1183",
       params: linkParams,
       to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/txn-1183",
     },
-    type: "approval_requested",
+    type: "pos_transaction_void_approval_requested",
   },
   {
     createdAt: at(14, 3),
@@ -199,19 +213,19 @@ const timeline: NonNullable<
   {
     createdAt: at(13, 21),
     id: "evt-sale-1179",
-    message: "Sale #1179 completed on Register 01 — GHS 220.00.",
+    message: "Sale #1179 synced: 1 sale line, GH₵220, mobile money.",
     subject: { id: "txn-1179", label: "#1179", type: "pos_transaction" },
     transactionLink: {
       label: "#1179",
       params: linkParams,
       to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/txn-1179",
     },
-    type: "pos_sale_completed",
+    type: "pos_local_sync.sale_projected",
   },
   {
     createdAt: at(12, 40),
     id: "evt-expense",
-    message: "Kwabena Osei recorded a GHS 55.00 expense for packaging supplies.",
+    message: "Kwabena Osei recorded a GH₵55 expense for packaging supplies.",
     subject: { id: "exp-204", label: "Packaging supplies", type: "expense" },
     type: "expense_recorded",
   },
@@ -230,21 +244,49 @@ const timeline: NonNullable<
   {
     createdAt: at(9, 52),
     id: "evt-drawer-open",
-    message: "Efua Tetteh opened Register 01 with a GHS 500.00 float.",
+    message:
+      "Efua Tetteh opened Studio Front Register / Register 01 with a GH₵500 float.",
     registerLink: {
-      label: "Register 01",
+      label: REGISTER_DISPLAY_LABEL,
       params: linkParams,
       to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/session-9931",
     },
-    subject: { id: "session-9931", label: "Register 01", type: "register_session" },
+    subject: {
+      id: "session-9931",
+      label: REGISTER_DISPLAY_LABEL,
+      type: "register_session",
+    },
     type: "register_session_opened",
   },
   {
     createdAt: at(9, 45),
     id: "evt-day-open",
-    message: "Kwabena Osei started the store day.",
+    message: "Athena started the store day automatically.",
     subject: { id: "opening-0718", label: "Store day", type: "daily_opening" },
     type: "store_day_started",
+  },
+];
+
+/**
+ * Opening auto-start, shown in the automation band.
+ *
+ * `outcome: "applied"` is required for an opening-lane status to stay visible once the
+ * day is past `not_opened` (`getVisibleAutomationStatuses`), and `scheduled_later` is
+ * filtered out entirely.
+ */
+const automationStatuses: NonNullable<
+  NonNullable<DailyOperationsViewContentProps["snapshot"]>["automationStatuses"]
+> = [
+  {
+    bucket: "action_taken",
+    id: "auto-opening-0718",
+    lane: "opening",
+    occurredAt: at(9, 45),
+    outcome: "applied",
+    sourceLink: {
+      params: linkParams,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/opening",
+    },
   },
 ];
 
@@ -344,6 +386,22 @@ export const busySaturdayFixture: DailyOperationsViewContentProps = {
   isAuthenticated: true,
   isLoadingAccess: false,
   isLoadingSnapshot: false,
+  // Renders the open-drawer attention row. The workspace synthesises the row label,
+  // severity and link itself; the fixture supplies only the session identity.
+  //
+  // `displayLabel` follows the server's own `{terminalName} / Register {registerNumber}`
+  // construction (convex/operations/dailyOperations.ts), using the shared demo store's
+  // terminal name and register number so it matches what a real session would show.
+  openRegisterSessionsSnapshot: {
+    operatingDate: OPERATING_DATE,
+    sessions: [
+      { displayLabel: REGISTER_DISPLAY_LABEL, id: "session-9931" },
+    ],
+  },
+  // The operating-date trigger is rendered `disabled={disabled || !onChange}`, so the
+  // control only looks live when a handler is present. A fixture has nowhere to navigate
+  // to, so this is a no-op that exists purely to keep the trigger enabled.
+  onOperatingDateChange: () => {},
   orgUrlSlug: ORG_URL_SLUG,
   storePulseWindow: "today",
   storeUrlSlug: STORE_URL_SLUG,
@@ -359,15 +417,23 @@ export const busySaturdayFixture: DailyOperationsViewContentProps = {
     timeline,
   },
   snapshot: {
+    automationStatuses,
     attentionItems: [
       {
-        id: "att-approval",
-        label: "Discount approval waiting",
-        message: "Sale #1183 needs a manager decision before the drawer closes.",
+        // Shape and copy follow `queueAttentionItems` in
+        // convex/operations/dailyOperations.ts: the label is the approval's `reason`
+        // verbatim (set in completeTransaction.ts for a void), and the message is fixed.
+        id: "approval_request:apr-3391:pending",
+        label: "Manager approval is required to void a completed sale.",
+        message: "Resolve the pending approval in Operations.",
         owner: "operations_queue",
         params: linkParams,
-        severity: "warning",
-        source: { id: "apr-3391", label: "Discount approval", type: "approval" },
+        severity: "critical",
+        source: {
+          id: "apr-3391",
+          label: "Manager approval is required to void a completed sale.",
+          type: "approval_request",
+        },
         to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
       },
       {
@@ -400,39 +466,66 @@ export const busySaturdayFixture: DailyOperationsViewContentProps = {
     },
     currency: "GHS",
     endAt: DAY_END,
+    // Lane keys, labels, descriptions and statuses follow `buildLanes` /
+    // `buildApprovalsLane` in convex/operations/dailyOperations.ts. Copy is reproduced
+    // from those branches rather than invented, so the fixture reads like real output.
     lanes: [
       {
         count: 0,
-        description: "Opening checks cleared at 9:45 AM.",
+        description: "Opening Handoff is complete.",
         key: "opening",
-        label: "Opening",
+        label: "Opening Handoff",
         status: "ready",
         to: "/$orgUrlSlug/store/$storeUrlSlug/operations/opening",
       },
       {
-        count: 1,
-        countLabel: "1 waiting",
-        description: "A discount needs a manager decision.",
-        key: "approvals",
-        label: "Store requests",
-        status: "needs_attention",
-        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+        count: 0,
+        description: "The end of day review is available for review.",
+        key: "close",
+        label: "EOD Review",
+        status: "ready",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
       },
       {
         count: 1,
-        countLabel: "1 open",
-        description: "Register 01 is still trading.",
-        key: "registers",
-        label: "Cash controls",
+        countLabel: "1",
+        description: "1 open item.",
+        key: "queue",
+        label: "Open work",
         status: "needs_attention",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/open-work",
+      },
+      {
+        count: 1,
+        countLabel: "1",
+        description: "1 approval pending.",
+        key: "approvals",
+        label: "Approvals",
+        status: "blocked",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+      },
+      {
+        count: 0,
+        description: "No register blockers.",
+        key: "registers",
+        label: "Registers",
+        status: "ready",
         to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls",
       },
       {
         count: 0,
-        description: "Available once the drawer is counted.",
-        key: "close",
-        label: "EOD review",
-        status: "unknown",
+        description: "No unresolved POS sessions.",
+        key: "pos_sessions",
+        label: "POS sessions",
+        status: "ready",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+      },
+      {
+        count: 0,
+        description: "No expense exceptions.",
+        key: "expenses",
+        label: "Expenses",
+        status: "ready",
         to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
       },
     ],
@@ -442,9 +535,11 @@ export const busySaturdayFixture: DailyOperationsViewContentProps = {
       status: "operating",
     },
     operatingDate: OPERATING_DATE,
+    // `primaryAction` in convex/operations/dailyOperations.ts maps lifecycle status to a
+    // fixed label; "operating" falls through to the default.
     primaryAction: {
-      label: "Review store requests",
-      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+      label: "Start EOD Review",
+      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
     },
     startAt: DAY_START,
     storeId: STORE_ID,

--- a/packages/athena-webapp/src/stories/operations/dailyOperationsFixtures.ts
+++ b/packages/athena-webapp/src/stories/operations/dailyOperationsFixtures.ts
@@ -1,0 +1,465 @@
+/**
+ * Screenshot fixtures for the Daily Operations workspace.
+ *
+ * These are authored prop bags, not seeded data — the workspace renders them without
+ * issuing a single Convex query. See
+ * `docs/plans/2026-07-19-001-feat-operations-screenshot-fixtures-plan.md`.
+ *
+ * The story is pinned to the shared demo store (Osu Studio — Atelier, GHS) so a capture
+ * taken against `/demo` reads coherently alongside the real app chrome.
+ *
+ * Money is in minor units (pesewas), matching the rest of the app.
+ */
+
+import type { DailyOperationsViewContentProps } from "@/components/operations/DailyOperationsView";
+import type { Id } from "~/convex/_generated/dataModel";
+
+/** Saturday. The week runs Sunday 2026-07-12 → Saturday 2026-07-18. */
+const OPERATING_DATE = "2026-07-18";
+
+/** Mid-afternoon, so the day reads as still trading rather than wrapped up. */
+export const BUSY_SATURDAY_CLOCK = new Date(2026, 6, 18, 15, 20);
+
+const STORE_ID = "demo-store-osu-atelier" as Id<"store">;
+// Matches the shared demo store's actual route params, so links in the fixture resolve
+// against the session a capture is taken in.
+const ORG_URL_SLUG = "demo";
+const STORE_URL_SLUG = "central";
+
+const DAY_START = new Date(2026, 6, 18, 0, 0).getTime();
+const DAY_END = new Date(2026, 6, 19, 0, 0).getTime();
+
+/** Minutes past local midnight → epoch millis, for readable timeline authoring. */
+function at(hour: number, minute: number) {
+  return new Date(2026, 6, 18, hour, minute).getTime();
+}
+
+const linkParams = {
+  orgUrlSlug: ORG_URL_SLUG,
+  storeUrlSlug: STORE_URL_SLUG,
+};
+
+/**
+ * A week that builds toward the weekend — quiet Sunday, steady midweek, a strong
+ * Friday, and a Saturday that is already the best day of the week by mid-afternoon.
+ */
+const weekMetrics: DailyOperationsViewContentProps["cachedWeekMetrics"] = [
+  {
+    currentDayCashTotal: 48200,
+    currentDayCashTransactionCount: 6,
+    expenseTotal: 0,
+    expenseTransactionCount: 0,
+    isClosed: true,
+    isSelected: false,
+    operatingDate: "2026-07-12",
+    paymentTotals: [
+      { amount: 48200, method: "cash", transactionCount: 6 },
+      { amount: 80300, method: "mobile_money", transactionCount: 7 },
+    ],
+    salesTotal: 128500,
+    transactionCount: 13,
+  },
+  {
+    currentDayCashTotal: 31500,
+    currentDayCashTransactionCount: 4,
+    expenseTotal: 12000,
+    expenseTransactionCount: 1,
+    isClosed: true,
+    isSelected: false,
+    operatingDate: "2026-07-13",
+    paymentTotals: [
+      { amount: 31500, method: "cash", transactionCount: 4 },
+      { amount: 64500, method: "mobile_money", transactionCount: 6 },
+    ],
+    salesTotal: 96000,
+    transactionCount: 10,
+  },
+  {
+    currentDayCashTotal: 42800,
+    currentDayCashTransactionCount: 5,
+    expenseTotal: 0,
+    expenseTransactionCount: 0,
+    isClosed: true,
+    isSelected: false,
+    operatingDate: "2026-07-14",
+    paymentTotals: [
+      { amount: 42800, method: "cash", transactionCount: 5 },
+      { amount: 51600, method: "mobile_money", transactionCount: 5 },
+      { amount: 18000, method: "card", transactionCount: 2 },
+    ],
+    salesTotal: 112400,
+    transactionCount: 12,
+  },
+  {
+    currentDayCashTotal: 55100,
+    currentDayCashTransactionCount: 7,
+    expenseTotal: 6500,
+    expenseTransactionCount: 1,
+    isClosed: true,
+    isSelected: false,
+    operatingDate: "2026-07-15",
+    paymentTotals: [
+      { amount: 55100, method: "cash", transactionCount: 7 },
+      { amount: 66700, method: "mobile_money", transactionCount: 6 },
+      { amount: 22000, method: "card", transactionCount: 2 },
+    ],
+    salesTotal: 143800,
+    transactionCount: 15,
+  },
+  {
+    currentDayCashTotal: 68400,
+    currentDayCashTransactionCount: 8,
+    expenseTotal: 0,
+    expenseTransactionCount: 0,
+    isClosed: true,
+    isSelected: false,
+    operatingDate: "2026-07-16",
+    paymentTotals: [
+      { amount: 68400, method: "cash", transactionCount: 8 },
+      { amount: 83800, method: "mobile_money", transactionCount: 8 },
+      { amount: 35000, method: "card", transactionCount: 3 },
+    ],
+    salesTotal: 187200,
+    transactionCount: 19,
+  },
+  {
+    currentDayCashTotal: 81900,
+    currentDayCashTransactionCount: 10,
+    expenseTotal: 15000,
+    expenseTransactionCount: 2,
+    isClosed: true,
+    isSelected: false,
+    operatingDate: "2026-07-17",
+    paymentTotals: [
+      { amount: 81900, method: "cash", transactionCount: 10 },
+      { amount: 98700, method: "mobile_money", transactionCount: 9 },
+      { amount: 44000, method: "card", transactionCount: 4 },
+    ],
+    salesTotal: 224600,
+    transactionCount: 23,
+  },
+  {
+    currentDayCashTotal: 121400,
+    currentDayCashTransactionCount: 15,
+    expenseTotal: 8500,
+    expenseTransactionCount: 2,
+    isClosed: false,
+    isSelected: true,
+    operatingDate: OPERATING_DATE,
+    paymentTotals: [
+      { amount: 121400, method: "cash", transactionCount: 15 },
+      { amount: 142500, method: "mobile_money", transactionCount: 14 },
+      { amount: 55000, method: "card", transactionCount: 5 },
+    ],
+    salesTotal: 318900,
+    transactionCount: 34,
+  },
+];
+
+const timeline: NonNullable<
+  DailyOperationsViewContentProps["timelinePreviewSnapshot"]
+>["timeline"] = [
+  {
+    createdAt: at(15, 12),
+    id: "evt-sale-1184",
+    message: "Sale #1184 completed on Register 01 — GHS 350.00.",
+    subject: { id: "txn-1184", label: "#1184", type: "pos_transaction" },
+    transactionLink: {
+      label: "#1184",
+      params: linkParams,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/txn-1184",
+    },
+    type: "pos_sale_completed",
+  },
+  {
+    createdAt: at(14, 47),
+    id: "evt-approval-req",
+    message:
+      "Efua Tetteh requested manager approval for a 15% discount on Sale #1183.",
+    subject: { id: "apr-3391", label: "Discount approval", type: "approval" },
+    transactionLink: {
+      label: "#1183",
+      params: linkParams,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/txn-1183",
+    },
+    type: "approval_requested",
+  },
+  {
+    createdAt: at(14, 3),
+    id: "evt-stock-low",
+    message: "Kente Scarf dropped to 2 units in stock.",
+    productLink: {
+      label: "Kente Scarf",
+      params: linkParams,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/products/demo-kente-scarf",
+    },
+    subject: { id: "sku-kente", label: "Kente Scarf", type: "product" },
+    type: "stock_threshold_crossed",
+  },
+  {
+    createdAt: at(13, 21),
+    id: "evt-sale-1179",
+    message: "Sale #1179 completed on Register 01 — GHS 220.00.",
+    subject: { id: "txn-1179", label: "#1179", type: "pos_transaction" },
+    transactionLink: {
+      label: "#1179",
+      params: linkParams,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/txn-1179",
+    },
+    type: "pos_sale_completed",
+  },
+  {
+    createdAt: at(12, 40),
+    id: "evt-expense",
+    message: "Kwabena Osei recorded a GHS 55.00 expense for packaging supplies.",
+    subject: { id: "exp-204", label: "Packaging supplies", type: "expense" },
+    type: "expense_recorded",
+  },
+  {
+    createdAt: at(11, 8),
+    id: "evt-online-order",
+    message: "Online order #A-2231 was marked ready for pickup.",
+    onlineOrderLink: {
+      label: "#A-2231",
+      params: linkParams,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/orders/order-a2231",
+    },
+    subject: { id: "order-a2231", label: "#A-2231", type: "online_order" },
+    type: "online_order_ready",
+  },
+  {
+    createdAt: at(9, 52),
+    id: "evt-drawer-open",
+    message: "Efua Tetteh opened Register 01 with a GHS 500.00 float.",
+    registerLink: {
+      label: "Register 01",
+      params: linkParams,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/session-9931",
+    },
+    subject: { id: "session-9931", label: "Register 01", type: "register_session" },
+    type: "register_session_opened",
+  },
+  {
+    createdAt: at(9, 45),
+    id: "evt-day-open",
+    message: "Kwabena Osei started the store day.",
+    subject: { id: "opening-0718", label: "Store day", type: "daily_opening" },
+    type: "store_day_started",
+  },
+];
+
+/** Fourteen trading days ending on the selected Saturday, for the sales-trend chart. */
+const trend = [
+  { date: "2026-07-05", label: "Jul 5", salesTotal: 114200, transactionCount: 12, itemsSold: 21 },
+  { date: "2026-07-06", label: "Jul 6", salesTotal: 88400, transactionCount: 9, itemsSold: 16 },
+  { date: "2026-07-07", label: "Jul 7", salesTotal: 101600, transactionCount: 11, itemsSold: 19 },
+  { date: "2026-07-08", label: "Jul 8", salesTotal: 132900, transactionCount: 14, itemsSold: 25 },
+  { date: "2026-07-09", label: "Jul 9", salesTotal: 168300, transactionCount: 17, itemsSold: 31 },
+  { date: "2026-07-10", label: "Jul 10", salesTotal: 203100, transactionCount: 21, itemsSold: 38 },
+  { date: "2026-07-11", label: "Jul 11", salesTotal: 287400, transactionCount: 29, itemsSold: 54 },
+  { date: "2026-07-12", label: "Jul 12", salesTotal: 128500, transactionCount: 13, itemsSold: 24 },
+  { date: "2026-07-13", label: "Jul 13", salesTotal: 96000, transactionCount: 10, itemsSold: 18 },
+  { date: "2026-07-14", label: "Jul 14", salesTotal: 112400, transactionCount: 12, itemsSold: 22 },
+  { date: "2026-07-15", label: "Jul 15", salesTotal: 143800, transactionCount: 15, itemsSold: 27 },
+  { date: "2026-07-16", label: "Jul 16", salesTotal: 187200, transactionCount: 19, itemsSold: 35 },
+  { date: "2026-07-17", label: "Jul 17", salesTotal: 224600, transactionCount: 23, itemsSold: 43 },
+  { date: OPERATING_DATE, label: "Jul 18", salesTotal: 318900, transactionCount: 34, itemsSold: 61 },
+].map((day) => ({
+  averageTransaction: Math.round(day.salesTotal / day.transactionCount),
+  date: day.date,
+  hasKnownItemCount: true,
+  label: day.label,
+  totalItemsSold: day.itemsSold,
+  totalSales: day.salesTotal,
+  transactionCount: day.transactionCount,
+}));
+
+const storePulse = {
+  averageTransaction: 9379,
+  date: OPERATING_DATE,
+  operatorSnapshot: {
+    busiestHour: {
+      hour: 14,
+      label: "2 – 3 PM",
+      totalSales: 74500,
+      transactionCount: 8,
+    },
+    comparison: {
+      averageTransactionDeltaPercent: 0.14,
+      currentAverageTransaction: 9379,
+      currentItemsSold: 61,
+      currentSales: 318900,
+      currentTransactions: 34,
+      itemsSoldDeltaPercent: 0.42,
+      salesDeltaPercent: 0.42,
+      transactionDeltaPercent: 0.48,
+      yesterdayAverageTransaction: 9765,
+      yesterdayItemsSold: 43,
+      yesterdaySales: 224600,
+      yesterdayTransactions: 23,
+    },
+    historyDays: 14,
+    isLimited: false,
+    // `share` is share of transactions, not of value — that is what the payment-mix
+    // panel renders beside each method's count.
+    paymentMix: [
+      { count: 14, label: "Mobile money", method: "mobile_money", share: 0.412, total: 142500 },
+      { count: 15, label: "Cash", method: "cash", share: 0.441, total: 121400 },
+      { count: 5, label: "Card", method: "card", share: 0.147, total: 55000 },
+    ],
+    topItems: [
+      { name: "Kente Scarf", productSku: "FM5W-8QJ-4K7", quantity: 4, totalSales: 140000 },
+      { name: "Bolga Woven Basket", productSku: "FM5W-6BX-5W1", quantity: 3, totalSales: 66000 },
+      { name: "Batik Tote Bag", productSku: "FM5W-5K4-9T2", quantity: 3, totalSales: 54000 },
+      { name: "Hibiscus Soy Candle", productSku: "FM5W-2MP-7F4", quantity: 5, totalSales: 60000 },
+      { name: "Raw Shea Butter 250g", productSku: "FM5W-7K2-3Q9", quantity: 9, totalSales: 54000 },
+    ],
+    trend,
+    usableHistoryDays: 14,
+  },
+  totalItemsSold: 61,
+  totalSales: 318900,
+  totalTransactions: 34,
+};
+
+/**
+ * A busy Saturday, mid-afternoon: one register trading, a discount approval waiting on
+ * a manager, and a low-stock nudge. The day is the strongest of the week and not yet
+ * closed.
+ */
+export const busySaturdayFixture: DailyOperationsViewContentProps = {
+  cachedWeekAnalyticsFetchedAt: at(15, 18),
+  cachedWeekMetrics: weekMetrics,
+  cachedWeekStorePulse: {
+    averageTransaction: 8674,
+    totalItemsSold: 248,
+    totalSales: 1211400,
+    totalTransactions: 126,
+  },
+  canViewAutomationStatuses: true,
+  currency: "GHS",
+  hasDetailSnapshot: true,
+  hasFinancialDetailsAccess: true,
+  hasFullAdminAccess: true,
+  isAuthenticated: true,
+  isLoadingAccess: false,
+  isLoadingSnapshot: false,
+  orgUrlSlug: ORG_URL_SLUG,
+  storePulseWindow: "today",
+  storeUrlSlug: STORE_URL_SLUG,
+  timelinePreviewSnapshot: {
+    operatingDate: OPERATING_DATE,
+    timeline: timeline.slice(0, 5),
+    timelineHasMore: true,
+  },
+  // Supplied so the "Show more" affordance opens a populated sheet rather than the
+  // "Timeline detail is not loaded yet" empty state.
+  timelineSnapshot: {
+    operatingDate: OPERATING_DATE,
+    timeline,
+  },
+  snapshot: {
+    attentionItems: [
+      {
+        id: "att-approval",
+        label: "Discount approval waiting",
+        message: "Sale #1183 needs a manager decision before the drawer closes.",
+        owner: "operations_queue",
+        params: linkParams,
+        severity: "warning",
+        source: { id: "apr-3391", label: "Discount approval", type: "approval" },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+      },
+      {
+        id: "att-stock",
+        label: "Kente Scarf running low",
+        message: "2 units left after today's sales.",
+        owner: "operations_queue",
+        params: linkParams,
+        severity: "info",
+        source: { id: "sku-kente", label: "Kente Scarf", type: "product" },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/products/demo-kente-scarf",
+      },
+    ],
+    closeSummary: {
+      carriedOverCashTotal: 50000,
+      carriedOverRegisterCount: 1,
+      currentDayCashTotal: 121400,
+      currentDayCashTransactionCount: 15,
+      expenseTotal: 8500,
+      expenseTransactionCount: 2,
+      netCashVariance: 0,
+      paymentTotals: [
+        { amount: 121400, method: "cash", transactionCount: 15 },
+        { amount: 142500, method: "mobile_money", transactionCount: 14 },
+        { amount: 55000, method: "card", transactionCount: 5 },
+      ],
+      registerVarianceCount: 0,
+      salesTotal: 318900,
+      transactionCount: 34,
+    },
+    currency: "GHS",
+    endAt: DAY_END,
+    lanes: [
+      {
+        count: 0,
+        description: "Opening checks cleared at 9:45 AM.",
+        key: "opening",
+        label: "Opening",
+        status: "ready",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/opening",
+      },
+      {
+        count: 1,
+        countLabel: "1 waiting",
+        description: "A discount needs a manager decision.",
+        key: "approvals",
+        label: "Store requests",
+        status: "needs_attention",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+      },
+      {
+        count: 1,
+        countLabel: "1 open",
+        description: "Register 01 is still trading.",
+        key: "registers",
+        label: "Cash controls",
+        status: "needs_attention",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls",
+      },
+      {
+        count: 0,
+        description: "Available once the drawer is counted.",
+        key: "close",
+        label: "EOD review",
+        status: "unknown",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+      },
+    ],
+    lifecycle: {
+      description: "Register 01 is trading. Close opens once the drawer is counted.",
+      label: "Store day open",
+      status: "operating",
+    },
+    operatingDate: OPERATING_DATE,
+    primaryAction: {
+      label: "Review store requests",
+      to: "/$orgUrlSlug/store/$storeUrlSlug/operations/approvals",
+    },
+    startAt: DAY_START,
+    storeId: STORE_ID,
+    storePulse,
+    timeline,
+    timelineHasMore: true,
+    weekMetrics,
+  },
+};
+
+export const dailyOperationsFixtures = {
+  "busy-saturday": {
+    clock: BUSY_SATURDAY_CLOCK,
+    props: busySaturdayFixture,
+  },
+} as const;
+
+export type DailyOperationsFixtureName = keyof typeof dailyOperationsFixtures;

--- a/packages/athena-webapp/src/stories/operations/devFixtureActivation.ts
+++ b/packages/athena-webapp/src/stories/operations/devFixtureActivation.ts
@@ -1,0 +1,83 @@
+/**
+ * Development-only activation for the operations screenshot fixtures.
+ *
+ * Fixture data is pulled in through a **dynamic** import behind an `import.meta.env.DEV`
+ * check. A static import was tried first and did not work: Vite replaces the flag with
+ * `false`, but Rollup still retained the fixture object, and the authored copy shipped in
+ * the production bundle. The dynamic form keeps it out — verified by grepping `dist/`.
+ *
+ * If you add a fixture module, re-run that check. These render authored operational and
+ * financial numbers inside the real app chrome, which is misleading if mistaken for a
+ * live store.
+ */
+
+import { useEffect, useState } from "react";
+
+import type { DailyOperationsViewContentProps } from "@/components/operations/DailyOperationsView";
+import { setOperatingClockOverride } from "@/lib/operations/operatingDate";
+
+type DailyOperationsFixtureState = {
+  /** True while a named fixture is still loading; render nothing rather than querying. */
+  isResolving: boolean;
+  fixture?: DailyOperationsViewContentProps;
+};
+
+const INERT: DailyOperationsFixtureState = { isResolving: false };
+
+/**
+ * Resolves a `?fixture=` search value to a Daily Operations prop bag, pinning the
+ * operating clock to the fixture's day so it renders as the current one.
+ *
+ * Stays inert in production, for an absent value, or for an unknown name — the workspace
+ * then loads normally from Convex. Any previous clock pin is cleared, so navigating away
+ * from a fixture restores the real date.
+ *
+ * While a named fixture is loading, `isResolving` is true so the caller can hold the
+ * render. Without that hold the workspace would briefly take the Convex path and issue
+ * the very queries a fixture exists to avoid.
+ */
+export function useDailyOperationsFixture(
+  name?: string,
+): DailyOperationsFixtureState {
+  const isRequested = Boolean(import.meta.env.DEV && name);
+  const [state, setState] = useState<DailyOperationsFixtureState>(() =>
+    isRequested ? { isResolving: true } : INERT,
+  );
+
+  useEffect(() => {
+    if (!import.meta.env.DEV || !name) {
+      setOperatingClockOverride(null);
+      setState(INERT);
+      return;
+    }
+
+    let cancelled = false;
+    setState({ isResolving: true });
+
+    void import("./dailyOperationsFixtures").then(
+      ({ dailyOperationsFixtures }) => {
+        if (cancelled) return;
+
+        const entry =
+          dailyOperationsFixtures[
+            name as keyof typeof dailyOperationsFixtures
+          ];
+
+        if (!entry) {
+          setOperatingClockOverride(null);
+          setState(INERT);
+          return;
+        }
+
+        setOperatingClockOverride(entry.clock);
+        setState({ fixture: entry.props, isResolving: false });
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  return state;
+}

--- a/packages/athena-webapp/src/stories/operations/devFixtureActivation.ts
+++ b/packages/athena-webapp/src/stories/operations/devFixtureActivation.ts
@@ -1,10 +1,11 @@
 /**
  * Development-only activation for the operations screenshot fixtures.
  *
- * Fixture data is pulled in through a **dynamic** import behind an `import.meta.env.DEV`
+ * Fixture data is pulled in through **dynamic** imports behind an `import.meta.env.DEV`
  * check. A static import was tried first and did not work: Vite replaces the flag with
- * `false`, but Rollup still retained the fixture object, and the authored copy shipped in
- * the production bundle. The dynamic form keeps it out — verified by grepping `dist/`.
+ * `false`, but Rollup still retained the fixture objects, and the authored copy shipped in
+ * the production bundle. The dynamic form keeps them out — verified by grepping `dist/`.
+ * The import specifiers below are string literals so Vite can still analyse them.
  *
  * If you add a fixture module, re-run that check. These render authored operational and
  * financial numbers inside the real app chrome, which is misleading if mistaken for a
@@ -13,34 +14,40 @@
 
 import { useEffect, useState } from "react";
 
+import type { DailyCloseViewContentProps } from "@/components/operations/DailyCloseView";
+import type { DailyOpeningViewContentProps } from "@/components/operations/DailyOpeningView";
 import type { DailyOperationsViewContentProps } from "@/components/operations/DailyOperationsView";
 import { setOperatingClockOverride } from "@/lib/operations/operatingDate";
 
-type DailyOperationsFixtureState = {
+type FixtureEntry<TProps> = { clock: Date; props: TProps };
+type FixtureRegistry<TProps> = Record<string, FixtureEntry<TProps>>;
+
+type FixtureState<TProps> = {
   /** True while a named fixture is still loading; render nothing rather than querying. */
   isResolving: boolean;
-  fixture?: DailyOperationsViewContentProps;
+  fixture?: TProps;
 };
 
-const INERT: DailyOperationsFixtureState = { isResolving: false };
+const INERT: FixtureState<never> = { isResolving: false };
 
 /**
- * Resolves a `?fixture=` search value to a Daily Operations prop bag, pinning the
- * operating clock to the fixture's day so it renders as the current one.
+ * Resolves a `?fixture=` search value to a workspace prop bag, pinning the operating clock
+ * to the fixture's day so it renders as the current one.
  *
  * Stays inert in production, for an absent value, or for an unknown name — the workspace
  * then loads normally from Convex. Any previous clock pin is cleared, so navigating away
- * from a fixture restores the real date.
+ * from a fixture restores the real date. While a named fixture is loading, `isResolving`
+ * is true so the caller can hold the render; otherwise the workspace would briefly take
+ * the Convex path and issue the very queries a fixture exists to avoid.
  *
- * While a named fixture is loading, `isResolving` is true so the caller can hold the
- * render. Without that hold the workspace would briefly take the Convex path and issue
- * the very queries a fixture exists to avoid.
+ * `load` must return a registry via a dynamic `import()` with a literal specifier.
  */
-export function useDailyOperationsFixture(
-  name?: string,
-): DailyOperationsFixtureState {
+function useWorkspaceFixture<TProps>(
+  name: string | undefined,
+  load: () => Promise<FixtureRegistry<TProps>>,
+): FixtureState<TProps> {
   const isRequested = Boolean(import.meta.env.DEV && name);
-  const [state, setState] = useState<DailyOperationsFixtureState>(() =>
+  const [state, setState] = useState<FixtureState<TProps>>(() =>
     isRequested ? { isResolving: true } : INERT,
   );
 
@@ -54,30 +61,45 @@ export function useDailyOperationsFixture(
     let cancelled = false;
     setState({ isResolving: true });
 
-    void import("./dailyOperationsFixtures").then(
-      ({ dailyOperationsFixtures }) => {
-        if (cancelled) return;
+    void load().then((registry) => {
+      if (cancelled) return;
 
-        const entry =
-          dailyOperationsFixtures[
-            name as keyof typeof dailyOperationsFixtures
-          ];
+      const entry = registry[name];
 
-        if (!entry) {
-          setOperatingClockOverride(null);
-          setState(INERT);
-          return;
-        }
+      if (!entry) {
+        setOperatingClockOverride(null);
+        setState(INERT);
+        return;
+      }
 
-        setOperatingClockOverride(entry.clock);
-        setState({ fixture: entry.props, isResolving: false });
-      },
-    );
+      setOperatingClockOverride(entry.clock);
+      setState({ fixture: entry.props, isResolving: false });
+    });
 
     return () => {
       cancelled = true;
     };
+    // `load` is a stable module-literal thunk per call site; keying on `name` is enough.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name]);
 
   return state;
+}
+
+export function useDailyOperationsFixture(name?: string) {
+  return useWorkspaceFixture<DailyOperationsViewContentProps>(name, () =>
+    import("./dailyOperationsFixtures").then((m) => m.dailyOperationsFixtures),
+  );
+}
+
+export function useDailyOpeningFixture(name?: string) {
+  return useWorkspaceFixture<DailyOpeningViewContentProps>(name, () =>
+    import("./openingHandoffFixtures").then((m) => m.openingHandoffFixtures),
+  );
+}
+
+export function useDailyCloseFixture(name?: string) {
+  return useWorkspaceFixture<DailyCloseViewContentProps>(name, () =>
+    import("./eodReviewFixtures").then((m) => m.eodReviewFixtures),
+  );
 }

--- a/packages/athena-webapp/src/stories/operations/eodReviewFixtures.ts
+++ b/packages/athena-webapp/src/stories/operations/eodReviewFixtures.ts
@@ -1,0 +1,206 @@
+/**
+ * Screenshot fixtures for the EOD Review workspace (daily close).
+ *
+ * Authored prop bags rendered directly by `DailyCloseView`'s `fixture` prop — no Convex
+ * query runs. The evening bookend to the Opening Handoff and Daily Operations fixtures:
+ * same Saturday, same store, the day's takings ready to reconcile and close.
+ *
+ * Item titles and messages are reproduced from the server helpers in
+ * `convex/operations/dailyClose.ts`. The day's totals come from the shared context so
+ * Daily Operations and EOD Review agree on what Saturday earned.
+ *
+ * Money is in minor units (pesewas).
+ */
+
+import type {
+  DailyCloseItem,
+  DailyCloseViewContentProps,
+} from "@/components/operations/DailyCloseView";
+
+import {
+  DAY_END,
+  DAY_START,
+  LINK_PARAMS,
+  OPERATING_DATE,
+  ORG_URL_SLUG,
+  REGISTER_DISPLAY_LABEL,
+  SATURDAY_TOTALS,
+  STORE_ID,
+  STORE_URL_SLUG,
+} from "./operationsFixtureContext";
+
+/** Evening, after the register is counted and the day is ready to review. */
+export const READY_TO_CLOSE_CLOCK = new Date(2026, 6, 18, 20, 30);
+
+/** Cash expected in the drawer: opening float plus the day's cash takings. */
+const EXPECTED_CASH = SATURDAY_TOTALS.openingFloat + SATURDAY_TOTALS.cashTotal;
+/** A GH₵5 short — a small, realistic variance to surface without blocking close. */
+const CASH_VARIANCE = -500;
+const CASH_DEPOSITED = 120000;
+
+/**
+ * Ready items reproduce server copy from `dailyClose.ts`: closed register sessions and
+ * completed sales are each surfaced as an included item. A couple of representative sales
+ * stand in for the day's 34.
+ */
+const readyItems: DailyCloseItem[] = [
+  {
+    category: "register_session",
+    id: "register_session:session-9931:closed",
+    key: "register_session:session-9931:closed",
+    message: "Closed register session is included in the end of day review.",
+    severity: "ready",
+    statusLabel: "Closed",
+    subject: {
+      id: "session-9931",
+      label: REGISTER_DISPLAY_LABEL,
+      type: "register_session",
+    },
+    title: "Register session closed",
+  },
+  {
+    category: "completed_sale",
+    id: "pos_transaction:txn-1184:completed",
+    key: "pos_transaction:txn-1184:completed",
+    link: {
+      label: "View transaction",
+      params: LINK_PARAMS,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/txn-1184",
+    },
+    message: "Completed sale is included in the end of day review.",
+    severity: "ready",
+    subject: { id: "txn-1184", label: "#1184", type: "pos_transaction" },
+    title: "Completed sale",
+  },
+  {
+    category: "completed_sale",
+    id: "pos_transaction:txn-1179:completed",
+    key: "pos_transaction:txn-1179:completed",
+    link: {
+      label: "View transaction",
+      params: LINK_PARAMS,
+      to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/txn-1179",
+    },
+    message: "Completed sale is included in the end of day review.",
+    severity: "ready",
+    subject: { id: "txn-1179", label: "#1179", type: "pos_transaction" },
+    title: "Completed sale",
+  },
+];
+
+/**
+ * The Kente scarf carried into tomorrow's opening — the same thread the Daily Operations
+ * timeline flagged and the Opening Handoff fixture acknowledges.
+ */
+const carryForwardItems: DailyCloseItem[] = [
+  {
+    category: "inventory",
+    description:
+      "4 left after today's sales — restock before tomorrow's opening.",
+    id: "carry_forward:kente",
+    key: "carry_forward:kente",
+    severity: "carry_forward",
+    statusLabel: "Carried to Opening",
+    subject: {
+      id: "work-kente-restock",
+      label: "Restock Kente Scarf",
+      type: "operational_work_item",
+    },
+    title: "Restock Kente Scarf before tomorrow's opening",
+  },
+];
+
+/**
+ * A Saturday ready to close: register counted with a small approved variance, sales
+ * reconciled, one item carried into tomorrow's opening. No blockers, so the Complete
+ * action is available.
+ */
+export const readyToCloseFixture: DailyCloseViewContentProps = {
+  canViewSummaryComparisons: true,
+  currency: "GHS",
+  hasFinancialDetailsAccess: true,
+  hasFullAdminAccess: true,
+  isAuthenticated: true,
+  isCompleting: false,
+  isLoadingAccess: false,
+  isLoadingSnapshot: false,
+  latestSelectableOperatingDate: READY_TO_CLOSE_CLOCK,
+  onComplete: async () => ({ data: undefined, kind: "ok" }),
+  // A no-op keeps the operating-date trigger enabled without a destination to navigate to.
+  onOperatingDateChange: () => {},
+  orgUrlSlug: ORG_URL_SLUG,
+  storeId: STORE_ID,
+  storeUrlSlug: STORE_URL_SLUG,
+  snapshot: {
+    blockers: [],
+    carryForwardItems,
+    endAt: DAY_END,
+    operatingDate: OPERATING_DATE,
+    readiness: {
+      blockerCount: 0,
+      carryForwardCount: 1,
+      readyCount: readyItems.length,
+      reviewCount: 0,
+      status: "ready",
+    },
+    readyItems,
+    reviewItems: [],
+    startAt: DAY_START,
+    // Friday 2026-07-17, matching the Daily Operations week fixture, so the tiles show a
+    // day-over-day comparison instead of "No activity yesterday".
+    priorDaySummary: {
+      currentDayCashTotal: 81900,
+      currentDayCashTransactionCount: 10,
+      paymentTotals: [
+        { amount: 81900, method: "cash", transactionCount: 10 },
+        { amount: 98700, method: "mobile_money", transactionCount: 9 },
+        { amount: 44000, method: "card", transactionCount: 4 },
+      ],
+      registerCount: 1,
+      salesTotal: 224600,
+      totalSales: 224600,
+      transactionCount: 23,
+    },
+    summary: {
+      cashDeposited: CASH_DEPOSITED,
+      cashExpected: EXPECTED_CASH,
+      closedRegisterSessionCount: 1,
+      currentDayCashTotal: SATURDAY_TOTALS.cashTotal,
+      currentDayCashTransactionCount: SATURDAY_TOTALS.cashTransactionCount,
+      expectedCashTotal: EXPECTED_CASH,
+      netCashVariance: CASH_VARIANCE,
+      paymentTotals: [
+        {
+          amount: SATURDAY_TOTALS.cashTotal,
+          method: "cash",
+          transactionCount: SATURDAY_TOTALS.cashTransactionCount,
+        },
+        {
+          amount: SATURDAY_TOTALS.mobileMoneyTotal,
+          method: "mobile_money",
+          transactionCount: SATURDAY_TOTALS.mobileMoneyTransactionCount,
+        },
+        {
+          amount: SATURDAY_TOTALS.cardTotal,
+          method: "card",
+          transactionCount: SATURDAY_TOTALS.cardTransactionCount,
+        },
+      ],
+      registerCount: 1,
+      registerVarianceCount: 1,
+      salesTotal: SATURDAY_TOTALS.salesTotal,
+      totalSales: SATURDAY_TOTALS.salesTotal,
+      transactionCount: SATURDAY_TOTALS.transactionCount,
+      varianceTotal: CASH_VARIANCE,
+    },
+  },
+};
+
+export const eodReviewFixtures = {
+  "ready-to-close": {
+    clock: READY_TO_CLOSE_CLOCK,
+    props: readyToCloseFixture,
+  },
+} as const;
+
+export type EodReviewFixtureName = keyof typeof eodReviewFixtures;

--- a/packages/athena-webapp/src/stories/operations/eodReviewFixtures.ts
+++ b/packages/athena-webapp/src/stories/operations/eodReviewFixtures.ts
@@ -20,6 +20,7 @@ import type {
 import {
   DAY_END,
   DAY_START,
+  KENTE_CARRY_FORWARD,
   LINK_PARAMS,
   OPERATING_DATE,
   ORG_URL_SLUG,
@@ -88,25 +89,45 @@ const readyItems: DailyCloseItem[] = [
   },
 ];
 
+/** When the Kente inventory review became actionable — mid-afternoon, when the sale that
+ * dropped its stock synced (the Daily Operations timeline flags it at 2:03 PM). */
+const KENTE_OPEN_SINCE = new Date(2026, 6, 18, 14, 3).getTime();
+
 /**
  * The Kente scarf carried into tomorrow's opening — the same thread the Daily Operations
  * timeline flagged and the Opening Handoff fixture acknowledges.
+ *
+ * A synced-sale inventory review with a product SKU projects as a single-member logical
+ * work group, so this follows the group branch of `logicalGroupAsCarryForwardItem` in
+ * convex/operations/dailyClose.ts: `subject.type` is `logical_operational_work_group`,
+ * `category` is "open_work", and the metadata carries `oldestActionableAt`. EOD Review
+ * renders that as "Open since" and shows only priority / open-since / work type — no
+ * status, no link, no description, no `statusLabel`.
  */
 const carryForwardItems: DailyCloseItem[] = [
   {
-    category: "inventory",
-    description:
-      "4 left after today's sales — restock before tomorrow's opening.",
-    id: "carry_forward:kente",
-    key: "carry_forward:kente",
-    severity: "carry_forward",
-    statusLabel: "Carried to Opening",
-    subject: {
-      id: "work-kente-restock",
-      label: "Restock Kente Scarf",
-      type: "operational_work_item",
+    category: "open_work",
+    id: `logical_operational_work:${KENTE_CARRY_FORWARD.groupKey}:carry_forward`,
+    key: `logical_operational_work:${KENTE_CARRY_FORWARD.groupKey}:carry_forward`,
+    message:
+      "Open operational work will carry forward after the end of day review.",
+    // memberCount / sourceCount are group-internal; the workspace filters them out of the
+    // row (they are not operator-facing). Kept here as real snapshot data.
+    metadata: {
+      memberCount: 1,
+      oldestActionableAt: KENTE_OPEN_SINCE,
+      priority: KENTE_CARRY_FORWARD.priority,
+      sourceCount: 1,
+      status: KENTE_CARRY_FORWARD.status,
+      type: KENTE_CARRY_FORWARD.workItemType,
     },
-    title: "Restock Kente Scarf before tomorrow's opening",
+    severity: "carry_forward",
+    subject: {
+      id: KENTE_CARRY_FORWARD.groupKey,
+      label: KENTE_CARRY_FORWARD.title,
+      type: "logical_operational_work_group",
+    },
+    title: KENTE_CARRY_FORWARD.title,
   },
 ];
 

--- a/packages/athena-webapp/src/stories/operations/openingHandoffFixtures.ts
+++ b/packages/athena-webapp/src/stories/operations/openingHandoffFixtures.ts
@@ -22,6 +22,7 @@ import {
   DAY_END,
   DAY_START,
   DEMO_STAFF,
+  KENTE_CARRY_FORWARD,
   LINK_PARAMS,
   momentAt,
   OPERATING_DATE,
@@ -65,31 +66,48 @@ const priorCloseReadyItem: DailyOpeningItem = {
   title: "Prior EOD Review completed",
 };
 
+/** When the Kente inventory review became actionable — flagged at the prior day's close,
+ * so it reads as carried into this morning's opening. */
+const KENTE_OPEN_SINCE = new Date(2026, 6, 17, 19, 15).getTime();
+
 /**
- * The Kente scarf carry-forward that EOD Review handed to opening — the same thread the
+ * The Kente scarf carry-forward from the prior close — the same low-stock thread the
  * Daily Operations timeline and EOD Review fixtures reference.
- * Copy follows `carryForwardItem` in convex/operations/dailyOpening.ts (title is the work
- * item's own title).
+ *
+ * A synced-sale inventory review with a product SKU projects as a single-member logical
+ * work group, so this follows the group branch of `legacyLogicalCarryForwardItem` in
+ * convex/operations/dailyOpening.ts: `subject.type` is `logical_operational_work_group`,
+ * the message speaks of a "work group", and the metadata carries `oldestActionableAt`.
+ * The builder sets no `statusLabel` or `description`.
  */
 const kenteCarryForwardItem: DailyOpeningItem = {
   category: "carry_forward",
-  id: "carry_forward:0",
-  key: "carry_forward:0",
+  id: "carry_forward_group:0",
+  key: "carry_forward_group:0",
   link: {
     label: "View open work",
     params: LINK_PARAMS,
     to: "/$orgUrlSlug/store/$storeUrlSlug/operations/open-work",
   },
   message:
-    "This unresolved carry-forward item remains open and must be acknowledged for Opening.",
-  metadata: { priority: "medium", status: "open" },
+    "This unresolved prior-close work group must be acknowledged for Opening.",
+  // memberCount / sourceCount are group-internal; the workspace filters them out of the
+  // row (they are not operator-facing). Kept here as real snapshot data.
+  metadata: {
+    memberCount: 1,
+    oldestActionableAt: KENTE_OPEN_SINCE,
+    priority: KENTE_CARRY_FORWARD.priority,
+    sourceCount: 1,
+    status: KENTE_CARRY_FORWARD.status,
+    type: KENTE_CARRY_FORWARD.workItemType,
+  },
   severity: "carry_forward",
   subject: {
-    id: "work-kente-restock",
-    label: "Restock Kente Scarf",
-    type: "operational_work_item",
+    id: KENTE_CARRY_FORWARD.groupKey,
+    label: KENTE_CARRY_FORWARD.title,
+    type: "logical_operational_work_group",
   },
-  title: "Restock Kente Scarf before tomorrow's opening",
+  title: KENTE_CARRY_FORWARD.title,
 };
 
 /**

--- a/packages/athena-webapp/src/stories/operations/openingHandoffFixtures.ts
+++ b/packages/athena-webapp/src/stories/operations/openingHandoffFixtures.ts
@@ -1,0 +1,163 @@
+/**
+ * Screenshot fixtures for the Opening Handoff workspace.
+ *
+ * Authored prop bags rendered directly by `DailyOpeningView`'s `fixture` prop — no Convex
+ * query runs. Part of one continuous story with the Daily Operations and EOD Review
+ * fixtures; see `operationsFixtureContext.ts` and the plan at
+ * `docs/plans/2026-07-19-001-feat-operations-screenshot-fixtures-plan.md`.
+ *
+ * Item titles and messages are reproduced from the server helpers in
+ * `convex/operations/dailyOpening.ts` rather than invented, so the workspace reads like
+ * real output.
+ *
+ * Money is in minor units (pesewas).
+ */
+
+import type {
+  DailyOpeningItem,
+  DailyOpeningViewContentProps,
+} from "@/components/operations/DailyOpeningView";
+
+import {
+  DAY_END,
+  DAY_START,
+  DEMO_STAFF,
+  LINK_PARAMS,
+  momentAt,
+  OPERATING_DATE,
+  ORG_URL_SLUG,
+  STORE_ID,
+  STORE_URL_SLUG,
+} from "./operationsFixtureContext";
+
+/** Just after 9:45 AM, when Athena opened the day in the companion stories. */
+export const OPENED_BY_ATHENA_CLOCK = new Date(2026, 6, 18, 9, 50);
+
+const PRIOR_OPERATING_DATE = "2026-07-17";
+const OPENED_AT = momentAt(9, 45);
+const PRIOR_CLOSED_AT = new Date(2026, 6, 17, 20, 40).getTime();
+
+/**
+ * The prior day's completed close, surfaced as a cleared readiness item.
+ * Copy follows `priorCloseReadyItem` in convex/operations/dailyOpening.ts.
+ */
+const priorCloseReadyItem: DailyOpeningItem = {
+  category: "prior_close",
+  id: "daily_close:prior:completed",
+  key: "daily_close:prior:completed",
+  link: {
+    label: "View EOD Review",
+    params: LINK_PARAMS,
+    search: { operatingDate: PRIOR_OPERATING_DATE },
+    to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close",
+  },
+  message: "The prior store day has a completed end of day review.",
+  metadata: {
+    completedAt: PRIOR_CLOSED_AT,
+    operatingDate: PRIOR_OPERATING_DATE,
+  },
+  severity: "ready",
+  subject: {
+    id: "daily_close:prior",
+    label: `EOD Review ${PRIOR_OPERATING_DATE}`,
+    type: "daily_close",
+  },
+  title: "Prior EOD Review completed",
+};
+
+/**
+ * The Kente scarf carry-forward that EOD Review handed to opening — the same thread the
+ * Daily Operations timeline and EOD Review fixtures reference.
+ * Copy follows `carryForwardItem` in convex/operations/dailyOpening.ts (title is the work
+ * item's own title).
+ */
+const kenteCarryForwardItem: DailyOpeningItem = {
+  category: "carry_forward",
+  id: "carry_forward:0",
+  key: "carry_forward:0",
+  link: {
+    label: "View open work",
+    params: LINK_PARAMS,
+    to: "/$orgUrlSlug/store/$storeUrlSlug/operations/open-work",
+  },
+  message:
+    "This unresolved carry-forward item remains open and must be acknowledged for Opening.",
+  metadata: { priority: "medium", status: "open" },
+  severity: "carry_forward",
+  subject: {
+    id: "work-kente-restock",
+    label: "Restock Kente Scarf",
+    type: "operational_work_item",
+  },
+  title: "Restock Kente Scarf before tomorrow's opening",
+};
+
+/**
+ * Opening Handoff already started automatically by Athena. The presence of
+ * `startedOpening` is what puts the workspace in its "started" state; `actorType:
+ * "automation"` with a null staff name renders the attribution as "Athena".
+ */
+export const openedByAthenaFixture: DailyOpeningViewContentProps = {
+  currency: "GHS",
+  hasFullAdminAccess: true,
+  isAuthenticated: true,
+  isLoadingAccess: false,
+  isLoadingSnapshot: false,
+  isStarting: false,
+  onStartDay: async () => ({ data: undefined, kind: "ok" }),
+  orgUrlSlug: ORG_URL_SLUG,
+  storeId: STORE_ID,
+  storeUrlSlug: STORE_URL_SLUG,
+  snapshot: {
+    automationStatus: {
+      bucket: "action_taken",
+      id: "auto-opening-0718",
+      occurredAt: OPENED_AT,
+      outcome: "applied",
+      reviewEvidence: [kenteCarryForwardItem],
+    },
+    blockers: [],
+    carryForwardItems: [kenteCarryForwardItem],
+    endAt: DAY_END,
+    operatingDate: OPERATING_DATE,
+    priorClose: {
+      completedAt: PRIOR_CLOSED_AT,
+      completedByStaffName: DEMO_STAFF.manager,
+      notes: null,
+      operatingDate: PRIOR_OPERATING_DATE,
+    },
+    readiness: {
+      blockerCount: 0,
+      carryForwardCount: 1,
+      readyCount: 1,
+      reviewCount: 0,
+      status: "ready",
+    },
+    readyItems: [priorCloseReadyItem],
+    reviewItems: [],
+    startAt: DAY_START,
+    startedOpening: {
+      actorType: "automation",
+      notes: "Opened automatically by Athena.",
+      reviewEvidence: [kenteCarryForwardItem],
+      startedAt: OPENED_AT,
+      startedByStaffName: null,
+    },
+    status: "started",
+    summary: {
+      blockerCount: 0,
+      carryForwardCount: 1,
+      readyCount: 1,
+      reviewCount: 0,
+    },
+  },
+};
+
+export const openingHandoffFixtures = {
+  "opened-by-athena": {
+    clock: OPENED_BY_ATHENA_CLOCK,
+    props: openedByAthenaFixture,
+  },
+} as const;
+
+export type OpeningHandoffFixtureName = keyof typeof openingHandoffFixtures;

--- a/packages/athena-webapp/src/stories/operations/operationsFixtureContext.ts
+++ b/packages/athena-webapp/src/stories/operations/operationsFixtureContext.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared context for the operations screenshot fixtures (Daily Operations, Opening
+ * Handoff, EOD Review).
+ *
+ * The three fixtures tell one continuous story about the same store day, so identity,
+ * routing, dates, staff and the day's headline totals live here rather than being
+ * re-authored (and drifting) in each file. Everything is pinned to the shared demo store
+ * so a capture taken against `/demo` reads coherently with the real app chrome.
+ *
+ * Money is in minor units (pesewas), matching the rest of the app.
+ */
+
+import type { Id } from "~/convex/_generated/dataModel";
+
+/** Saturday. The trading week runs Sunday 2026-07-12 → Saturday 2026-07-18. */
+export const OPERATING_DATE = "2026-07-18";
+
+export const STORE_ID = "demo-store-osu-atelier" as Id<"store">;
+
+// The shared demo store's actual route params, so links resolve against the session a
+// capture is taken in.
+export const ORG_URL_SLUG = "demo";
+export const STORE_URL_SLUG = "central";
+
+export const LINK_PARAMS = {
+  orgUrlSlug: ORG_URL_SLUG,
+  storeUrlSlug: STORE_URL_SLUG,
+} as const;
+
+export const DAY_START = new Date(2026, 6, 18, 0, 0).getTime();
+export const DAY_END = new Date(2026, 6, 19, 0, 0).getTime();
+
+/** Minutes past local midnight on the operating day → epoch millis. */
+export function momentAt(hour: number, minute: number) {
+  return new Date(2026, 6, 18, hour, minute).getTime();
+}
+
+/**
+ * Staff from the shared demo store's story (shared/sharedDemoStory.ts): Efua Tetteh
+ * cashiers, Kwabena Osei manages.
+ */
+export const DEMO_STAFF = {
+  cashier: "Efua Tetteh",
+  manager: "Kwabena Osei",
+} as const;
+
+/**
+ * Register sessions display as `{terminalName} / Register {registerNumber}` — see
+ * `formatTerminalRegisterLinkLabel` in convex/operations/dailyOperations.ts. Values are
+ * the shared demo store's terminal name and register number.
+ */
+export const REGISTER_DISPLAY_LABEL = "Studio Front Register / Register 01";
+
+/**
+ * The operating day's headline totals, shared so Daily Operations and EOD Review agree on
+ * what Saturday earned. Cash + card + mobile money sum to `salesTotal`; the transaction
+ * counts sum to `transactionCount`.
+ */
+export const SATURDAY_TOTALS = {
+  cardTotal: 55000,
+  cardTransactionCount: 5,
+  cashTotal: 121400,
+  cashTransactionCount: 15,
+  itemsSold: 61,
+  mobileMoneyTotal: 142500,
+  mobileMoneyTransactionCount: 14,
+  openingFloat: 50000,
+  salesTotal: 318900,
+  transactionCount: 34,
+} as const;

--- a/packages/athena-webapp/src/stories/operations/operationsFixtureContext.ts
+++ b/packages/athena-webapp/src/stories/operations/operationsFixtureContext.ts
@@ -52,6 +52,30 @@ export const DEMO_STAFF = {
 export const REGISTER_DISPLAY_LABEL = "Studio Front Register / Register 01";
 
 /**
+ * The carry-forward work item threaded through the Daily Operations stock nudge, the EOD
+ * Review close, and the next Opening Handoff.
+ *
+ * A carry-forward row's title is the underlying operational work item's own `title` — for
+ * an inventory follow-up the real template is `Review inventory for {product}` (see
+ * `projectLocalEvents.ts`); there is no "restock"/"reorder" title in the product. The
+ * work item type is likewise the real `synced_sale_inventory_review`.
+ *
+ * Because a synced-sale inventory review carries a product SKU, the product projects it as
+ * a single-member *logical work group* rather than a bare work item (see the branch at
+ * `dailyClose.ts` / `dailyOpening.ts` guarding on `synced_sale_inventory_review` +
+ * `productSkuId`). That is why `subject.type` is `logical_operational_work_group` and the
+ * metadata carries `oldestActionableAt` — EOD Review renders that as "Open since" and drops
+ * status.
+ */
+export const KENTE_CARRY_FORWARD = {
+  groupKey: "synced_sale_inventory_review:kente-scarf",
+  priority: "normal",
+  status: "open",
+  title: "Review inventory for Kente Scarf",
+  workItemType: "synced_sale_inventory_review",
+} as const;
+
+/**
  * The operating day's headline totals, shared so Daily Operations and EOD Review agree on
  * what Saturday earned. Cash + card + mobile money sum to `salesTotal`; the transaction
  * counts sum to `transactionCount`.


### PR DESCRIPTION
## Summary
- Adds a dev-only fixture seam (centralized operating-date clock + dynamic-import-gated fixture activation) so Daily Operations, Opening Handoff, and EOD Review can be screenshotted against fully-authored data instead of live Convex state; inert in production builds.
- Fixes four unrelated bugs found while driving the fixtures through real POS/demo chrome: an Expense register infinite render loop, expense transactions not syncing in the shared-demo experience, a drawer-not-saved gate flash after opening a replacement drawer, and a register-closed-locally gate flash during closeout (plus a visual redesign of that gate).
- Adds the delivery-gate-required landed-change report and solution note (the latter capturing the "instrument before you theorize" lesson from three separate wrong first diagnoses on this branch).

## Test plan
- [x] `tsc --noEmit` (typecheck) passes
- [x] `bun run lint:frontend:changed` passes
- [x] Unit tests pass: `registerUiState.test.ts`, `operatingDate.test.ts`, `useExpenseRegisterViewModel.test.ts`, `DailyOpeningView.test.tsx`, `DailyOperationsView.test.tsx`, `DailyCloseView.test.tsx` (234 tests total)
- [x] Each bug fix verified against the live demo/POS flow via direct browser instrumentation, re-confirmed after rebasing onto origin/main
- [x] `bun run delivery:documentation-check` and `bun run harness:inferential-review` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)