### PR TITLE
feat(landing): interactive POS hub with manager/staff pulse views

### DIFF
--- a/docs/reports/2026-07-22-pos-hub-landing-interactive-pulse-report.html
+++ b/docs/reports/2026-07-22-pos-hub-landing-interactive-pulse-report.html
@@ -170,7 +170,7 @@
   footer { margin-top: 3rem; padding-top: 1.25rem; border-top: 1px solid var(--border); font-size: 0.8rem; color: var(--text-muted); }
 </style>
 </head>
-<body data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="1684292bf43b3a665593532121c315280754bbe7592a62b658e159a9849a8330">
+<body data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="7a06ee03911d066800400c200f57df751b3d3f04a196de648b38ea8bdd4cd9a4">
 <main>
 
 <header class="report-head">

--- a/docs/reports/2026-07-22-pos-hub-landing-interactive-pulse-report.html
+++ b/docs/reports/2026-07-22-pos-hub-landing-interactive-pulse-report.html
@@ -170,7 +170,7 @@
   footer { margin-top: 3rem; padding-top: 1.25rem; border-top: 1px solid var(--border); font-size: 0.8rem; color: var(--text-muted); }
 </style>
 </head>
-<body data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="1e201d589c2b81c805054403237fabc8a5792f26c7e5992714d14f1d4d7824bb">
+<body data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="1684292bf43b3a665593532121c315280754bbe7592a62b658e159a9849a8330">
 <main>
 
 <header class="report-head">
@@ -178,15 +178,15 @@
   <p class="muted">Delivery candidate — <a href="https://github.com/kwam1na/athena/pull/691" style="color:var(--accent)">PR #691</a>, branch <code>worktree-pos-hub-landing-scene</code></p>
   <div class="pills">
     <span class="pill"><span class="dot warn"></span>Status: <b>delivery candidate (open, not merged)</b></span>
-    <span class="pill"><span class="dot warn"></span>Base alignment: <b>pending rebase — 1 commit behind origin/main</b></span>
-    <span class="pill"><span class="dot bad"></span>CI: <b>2 checks failing, 2 in progress (see Validation)</b></span>
+    <span class="pill"><span class="dot good"></span>Base alignment: <b>rebased onto origin/main (4269f857); not yet re-verified in CI</b></span>
+    <span class="pill"><span class="dot bad"></span>CI: <b>harness-contract-preflight failure still open as of last check (see Validation)</b></span>
     <span class="pill"><span class="dot warn"></span>Deploy: <b>not applicable — no merge yet</b></span>
   </div>
 </header>
 
 <h2>What is being delivered</h2>
 <p>
-  PR #691 (head <code>c81e30a9</code>, base <code>6568ee37</code>) adds an
+  PR #691 (head <code>bacb1140</code> after rebase, base <code>4269f857</code>) adds an
   interactive Point of Sale exhibit to the marketing landing page's POS
   section. Previously that section only linked to a pair of static
   pending/synced screenshots. This delivery adds a live, role-scoped hub:
@@ -290,12 +290,12 @@
   steady across six rapid consecutive toggles in both directions (no drift).
 </div>
 <div class="callout bad">
-  <strong>CI, as of this report (PR #691, head <code>c81e30a9</code>):</strong> Two
-  checks are currently failing and not yet resolved by this delivery:
+  <strong>CI, most recent run seen (PR #691, pre-rebase head <code>c81e30a9</code>):</strong>
+  Two checks were failing and not yet resolved by this delivery:
   <ul style="margin:0.5rem 0 0;">
     <li><code>Harness and Architecture Validation</code> — was failing on the
       missing landed-change report this file exists to satisfy. Not yet
-      re-verified against CI after this file was added.</li>
+      re-verified against CI.</li>
     <li><code>Harness Implementation Tests</code> — one pre-existing suite
       assertion, <code>runHarnessContractPreflight &gt; passes through every
       default adapter on the current consistent tree</code>
@@ -308,11 +308,13 @@
   </ul>
   Two further checks (<code>Athena and Storefront Webapp Validation</code>,
   <code>Athena POS E2E against Production Backend</code>) were still
-  <code>IN_PROGRESS</code> at last check. The PR's <code>mergeStateStatus</code>
-  is <code>BEHIND</code> — one commit landed on <code>origin/main</code>
-  (<code>4269f857</code>, an unrelated graphify/graph-artifact + email-template
-  update) after this branch was cut. A rebase onto current <code>origin/main</code>
-  is expected and has not been performed as of this report.
+  <code>IN_PROGRESS</code> at last check. <strong>Since that run,</strong> the
+  branch has been rebased onto <code>origin/main</code> at <code>4269f857</code>
+  (the one commit it was behind — an unrelated graphify/graph-artifact +
+  email-template update) and the deliverable diff fingerprint in this report
+  and the linked solution note were regenerated to match. CI has not yet run
+  against the rebased head, so none of the statuses above are re-confirmed as
+  of this report.
 </div>
 
 <h2>What intentionally did not change</h2>
@@ -397,8 +399,8 @@
 
 <footer>
   Generated directly from session tool output for PR #691
-  (<code>c81e30a9</code> on <code>worktree-pos-hub-landing-scene</code>,
-  base <code>6568ee37</code>). Subagent dispatch skipped per explicit
+  (<code>bacb1140</code> on <code>worktree-pos-hub-landing-scene</code>,
+  base <code>4269f857</code> after rebase). Subagent dispatch skipped per explicit
   operator instruction. This report reflects a delivery-candidate, unmerged
   state — see the CI callout above before treating it as final.
 </footer>

--- a/docs/reports/2026-07-22-pos-hub-landing-interactive-pulse-report.html
+++ b/docs/reports/2026-07-22-pos-hub-landing-interactive-pulse-report.html
@@ -1,0 +1,478 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Landed Change Report — Interactive POS Hub on the Landing Page</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #0b0d10;
+    --surface: #14171b;
+    --surface-raised: #1b1f24;
+    --border: #2a2f36;
+    --text: #e8eaed;
+    --text-muted: #9aa2ab;
+    --accent: #7c9cff;
+    --good: #4fd18b;
+    --warn: #e8b84f;
+    --bad: #ef6a6a;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f7f8fa;
+      --surface: #ffffff;
+      --surface-raised: #f0f2f5;
+      --border: #dfe3e8;
+      --text: #1b1f24;
+      --text-muted: #5b6470;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    line-height: 1.55;
+  }
+  main {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 5rem;
+  }
+  header.report-head {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 1.5rem;
+    margin-bottom: 2rem;
+  }
+  h1 { font-size: 1.7rem; margin: 0 0 0.5rem; letter-spacing: -0.01em; }
+  h2 {
+    font-size: 1.15rem;
+    margin: 2.5rem 0 0.9rem;
+    padding-top: 0.25rem;
+    border-top: 1px solid var(--border);
+  }
+  h2:first-of-type { border-top: none; padding-top: 0; }
+  h3 { font-size: 1rem; margin: 1.25rem 0 0.5rem; }
+  p { margin: 0 0 0.9rem; color: var(--text); }
+  .muted { color: var(--text-muted); }
+  code, .mono { font-family: var(--mono); font-size: 0.88em; }
+  code {
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.05em 0.35em;
+  }
+  .pills { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; }
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border: 1px solid var(--border);
+    background: var(--surface-raised);
+    border-radius: 999px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.82rem;
+    color: var(--text-muted);
+  }
+  .pill b { color: var(--text); font-weight: 600; }
+  .dot { width: 0.5rem; height: 0.5rem; border-radius: 50%; flex: none; }
+  .dot.good { background: var(--good); }
+  .dot.warn { background: var(--warn); }
+  .dot.bad { background: var(--bad); }
+  ul, ol { padding-left: 1.3rem; margin: 0 0 0.9rem; }
+  li { margin-bottom: 0.4rem; }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    margin: 0.5rem 0 1.25rem;
+  }
+  th, td {
+    text-align: left;
+    padding: 0.55rem 0.7rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  th { color: var(--text-muted); font-weight: 600; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  td.mono { white-space: nowrap; }
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.1rem 1.3rem;
+    margin-bottom: 1rem;
+  }
+  .callout {
+    border-left: 3px solid var(--warn);
+    background: var(--surface-raised);
+    border-radius: 0 8px 8px 0;
+    padding: 0.85rem 1rem;
+    margin: 0 0 1.25rem;
+    font-size: 0.92rem;
+  }
+  .callout.bad { border-left-color: var(--bad); }
+  .callout strong { color: var(--text); }
+  .grid-two {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+  @media (max-width: 640px) { .grid-two { grid-template-columns: 1fr; } }
+  #changeQuiz fieldset {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.1rem;
+    margin: 0 0 1rem;
+  }
+  #changeQuiz legend { font-size: 0.92rem; padding: 0 0.4rem; }
+  #changeQuiz label {
+    display: block;
+    padding: 0.4rem 0.2rem;
+    cursor: pointer;
+    border-radius: 6px;
+  }
+  #changeQuiz label:hover { background: var(--surface-raised); }
+  #changeQuiz input[type="radio"] { margin-right: 0.5rem; }
+  .quiz-explain {
+    display: none;
+    font-size: 0.85rem;
+    margin-top: 0.5rem;
+    padding: 0.5rem 0.7rem;
+    border-radius: 6px;
+    background: var(--surface-raised);
+    color: var(--text-muted);
+  }
+  .quiz-explain.show { display: block; }
+  .quiz-explain.correct { color: var(--good); }
+  .quiz-explain.incorrect { color: var(--bad); }
+  #quizActions { display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; }
+  button#gradeQuiz, button#resetQuiz {
+    font: inherit;
+    font-size: 0.9rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--surface-raised);
+    color: var(--text);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+  }
+  button#gradeQuiz { background: var(--accent); color: #0b0d10; border-color: var(--accent); font-weight: 600; }
+  button#gradeQuiz:hover { background: #6a8bff; }
+  button#resetQuiz:hover { background: var(--border); }
+  #quizResult { font-size: 0.92rem; font-weight: 600; }
+  #quizResult.pass { color: var(--good); }
+  #quizResult.fail { color: var(--bad); }
+  footer { margin-top: 3rem; padding-top: 1.25rem; border-top: 1px solid var(--border); font-size: 0.8rem; color: var(--text-muted); }
+</style>
+</head>
+<body data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="1e201d589c2b81c805054403237fabc8a5792f26c7e5992714d14f1d4d7824bb">
+<main>
+
+<header class="report-head">
+  <h1>Interactive POS Hub on the Landing Page</h1>
+  <p class="muted">Delivery candidate — <a href="https://github.com/kwam1na/athena/pull/691" style="color:var(--accent)">PR #691</a>, branch <code>worktree-pos-hub-landing-scene</code></p>
+  <div class="pills">
+    <span class="pill"><span class="dot warn"></span>Status: <b>delivery candidate (open, not merged)</b></span>
+    <span class="pill"><span class="dot warn"></span>Base alignment: <b>pending rebase — 1 commit behind origin/main</b></span>
+    <span class="pill"><span class="dot bad"></span>CI: <b>2 checks failing, 2 in progress (see Validation)</b></span>
+    <span class="pill"><span class="dot warn"></span>Deploy: <b>not applicable — no merge yet</b></span>
+  </div>
+</header>
+
+<h2>What is being delivered</h2>
+<p>
+  PR #691 (head <code>c81e30a9</code>, base <code>6568ee37</code>) adds an
+  interactive Point of Sale exhibit to the marketing landing page's POS
+  section. Previously that section only linked to a pair of static
+  pending/synced screenshots. This delivery adds a live, role-scoped hub:
+  a minimal toggle switches between what a <strong>store manager</strong>
+  sees (every launcher tile, plus a real store-pulse chart with working
+  <em>Today / This week / This month / All time</em> tabs) and what
+  <strong>staff</strong> see (their own launcher tiles plus a bare
+  transaction count — no financials).
+</p>
+
+<h2>Why it mattered</h2>
+<p>
+  The landing page's other workspace exhibits (Daily Operations, Opening
+  Handoff, Cash Controls, the sync bridge) already render real product
+  components fed by fixture data — the established pattern is documented in
+  <code>docs/solutions/design-patterns/athena-landing-story-real-component-exhibits-2026-07-17.md</code>.
+  The POS section was the odd one out, showing only two static screenshots
+  with no way to demonstrate the actual point of the feature: that Athena's
+  POS hub shows a materially different, authority-scoped view depending on
+  who is logged in. This delivery closes that gap and, unlike the other
+  exhibits, makes one control genuinely interactive rather than a frozen
+  screenshot.
+</p>
+
+<h2>The mental model</h2>
+<p>
+  One presentational component, three call sites. <code>PointOfSaleView.tsx</code>
+  was split so the POS hub's actual UI (launcher grid + store-pulse) lives in
+  a chrome-free <code>PosHubBody</code> component. That single component now
+  renders in three different contexts without being forked:
+</p>
+<table>
+  <thead><tr><th>Call site</th><th>Data source</th><th>Purpose</th></tr></thead>
+  <tbody>
+    <tr><td>Live app route (<code>pos/index.tsx</code>)</td><td>Convex queries</td><td>The real, authenticated POS hub a store uses day-to-day</td></tr>
+    <tr><td>Dev-only <code>?fixture=</code> route</td><td><code>posHubFixtures.ts</code></td><td>Deterministic screenshots for other marketing assets</td></tr>
+    <tr><td>Landing page exhibit (<code>PosHubRoleSwitcher.tsx</code>)</td><td><code>posHubFixtures.ts</code></td><td>The new interactive, role-toggling exhibit itself</td></tr>
+  </tbody>
+</table>
+<p>
+  The pulse's four time windows (Today / This week / This month / All time)
+  are each backed by fully authored, story-reconciled fixture data — not
+  just one snapshot — because the tabs are real and clickable; whichever
+  window a visitor clicks has to show correct numbers, not a placeholder.
+</p>
+
+<h2>Before vs after</h2>
+<div class="grid-two">
+  <div class="card">
+    <h3>Before</h3>
+    <p class="muted">
+      The POS section showed two static screenshots (pending-sync /
+      synced-sale) with no representation of the hub itself, and no
+      distinction between what an owner vs. staff member sees.
+    </p>
+  </div>
+  <div class="card">
+    <h3>After</h3>
+    <p class="muted">
+      A live exhibit with a role toggle; the manager's store-pulse tabs are
+      real and re-render authored data on click; staff view collapses to a
+      bare transaction count, matching the real product's authority gating
+      (<code>hasFinancialDetailsAccess</code>).
+    </p>
+  </div>
+</div>
+
+<h2>Layer-by-layer mechanics</h2>
+<table>
+  <thead><tr><th>File</th><th>Why it matters</th></tr></thead>
+  <tbody>
+    <tr><td class="mono">components/pos/PointOfSaleView.tsx</td><td>Split into <code>PosHubBody</code> (chrome-free content), <code>PointOfSaleViewContent</code> (app-chrome wrapper), and <code>buildPosFeatures</code> (shared launcher-tile logic) so the live route, the fixture route, and the landing exhibit can't drift apart.</td></tr>
+    <tr><td class="mono">stories/operations/posHubFixtures.ts</td><td>Authored data for all four pulse windows plus the manager/staff feature sets, reconciled against the shared demo store's story day (Wed 2026-07-15) — including comparison deltas pre-rounded to whole percents to match how <code>operationsMetricFormatting.tsx</code> renders them live, and today's top-items order matching Daily Operations exactly.</td></tr>
+    <tr><td class="mono">components/landing/story/PosHubRoleSwitcher.tsx</td><td>The new exhibit: role toggle, scroll-position pin across the swap, a click-triggered <code>animejs</code> fade, and scoped <code>pointer-events: none</code> on the decorative launcher tiles only (the pulse tabs stay live).</td></tr>
+    <tr><td class="mono">routes/-index-route-view.tsx</td><td>Wires the exhibit into the POS section's act, with copy/eyebrow/title refined to describe the toggle, and a canvas-to-white background transition so the exhibit blends into the following section.</td></tr>
+    <tr><td class="mono">routes/.../pos/index.tsx</td><td><code>?fixture=</code> search-param wiring for the dev-only screenshot route, unchanged in spirit from the existing operations-fixture pattern.</td></tr>
+  </tbody>
+</table>
+
+<h2>Failure boundaries</h2>
+<ul>
+  <li><strong>Scroll anchoring on a height-swapping toggle.</strong> The manager and staff views differ by hundreds/thousands of pixels; toggling let the browser silently reposition the viewport, intermittently, because the anchor node depends on scroll position. Scoping <code>overflow-anchor: none</code> to just the toggling subtree was not enough — anchoring could still pick a node in a section below it that also moved. Fixed by setting <code>overflow-anchor: none</code> on the whole landing <code>&lt;main&gt;</code> (safe: every other exhibit reserves explicit space) plus a belt-and-braces scroll-position pin in a <code>useLayoutEffect</code>.</li>
+  <li><strong>Animation-callback deadlock.</strong> An earlier version gated the role swap on an <code>animejs</code> <code>onComplete</code> callback; if that callback didn't fire, a guard flag stuck <code>true</code> and the toggle stopped responding entirely. Fixed by swapping state synchronously on click and treating the fade as a fire-and-forget entrance effect, not a gate.</li>
+  <li><strong>Decorative vs. live controls in one exhibit.</strong> Unlike every other landing exhibit (fully inert), this one is partially interactive — the launcher tiles must not navigate, but the pulse tabs must. Handled with a scoped CSS selector (<code>pointer-events: none</code> only on <code>[data-testid=athena-pos-hub-ready]</code>) rather than a blanket <code>inert</code> wrapper.</li>
+</ul>
+
+<h2>Validation</h2>
+<div class="callout">
+  <strong>Local, before push:</strong> <code>tsc --noEmit</code> clean (0 errors).
+  33 tests passing across the touched surface, run via <code>vitest</code>:
+  <code>landing.test.tsx</code> (3), <code>PointOfSaleView.test.tsx</code> (11),
+  <code>POSSalesPulseView.test.tsx</code> (12), <code>demoDay.test.ts</code> (5),
+  <code>terminals.route.test.tsx</code> (2). Manually verified in a live dev-server
+  browser preview: the role toggle swaps synchronously and re-renders the
+  correct pulse; clicking each of the four window tabs re-renders real chart
+  data (confirmed against exact expected numbers, e.g. All time → GH₵367,000
+  from the May 12 store-open date); dark mode renders automatically through
+  the existing theme system with no extra wiring; the decorative launcher
+  tiles have <code>pointer-events: none</code> (confirmed via computed
+  style) while the pulse tabs remain clickable; scroll position held exactly
+  steady across six rapid consecutive toggles in both directions (no drift).
+</div>
+<div class="callout bad">
+  <strong>CI, as of this report (PR #691, head <code>c81e30a9</code>):</strong> Two
+  checks are currently failing and not yet resolved by this delivery:
+  <ul style="margin:0.5rem 0 0;">
+    <li><code>Harness and Architecture Validation</code> — was failing on the
+      missing landed-change report this file exists to satisfy. Not yet
+      re-verified against CI after this file was added.</li>
+    <li><code>Harness Implementation Tests</code> — one pre-existing suite
+      assertion, <code>runHarnessContractPreflight &gt; passes through every
+      default adapter on the current consistent tree</code>
+      (<code>scripts/harness-contract-preflight.test.ts:214</code>), fails with
+      <code>exitCode</code> 1 instead of the expected 0. Root cause not yet
+      diagnosed at the time of this report — the specific findings that
+      caused the nonzero exit were not printed to the CI log and have not
+      been reproduced locally. <strong>This is an open item, not something
+      this delivery has fixed.</strong></li>
+  </ul>
+  Two further checks (<code>Athena and Storefront Webapp Validation</code>,
+  <code>Athena POS E2E against Production Backend</code>) were still
+  <code>IN_PROGRESS</code> at last check. The PR's <code>mergeStateStatus</code>
+  is <code>BEHIND</code> — one commit landed on <code>origin/main</code>
+  (<code>4269f857</code>, an unrelated graphify/graph-artifact + email-template
+  update) after this branch was cut. A rebase onto current <code>origin/main</code>
+  is expected and has not been performed as of this report.
+</div>
+
+<h2>What intentionally did not change</h2>
+<ul>
+  <li>The live, authenticated POS hub route (<code>/pos</code>) behaves identically for real stores — only the presentational layer was extracted, not the data-fetching logic in <code>PointOfSaleViewLive</code>.</li>
+  <li>The dev-only screenshot fixtures for other marketing assets (pending/synced sale shots) are untouched.</li>
+  <li>No Convex schema, query, or mutation changed.</li>
+</ul>
+
+<h2>Next-time guidance</h2>
+<ul>
+  <li>When a marketing exhibit needs to demonstrate role- or state-dependent behavior, prefer making the specific control interactive (with authored fixture data for every reachable state) over adding another static screenshot — but scope interactivity narrowly (see Failure Boundaries) rather than making the whole exhibit live.</li>
+  <li>A toggle between two states with a large height difference needs the page-level <code>overflow-anchor: none</code> treatment, not just a scoped one — verify by rapid-toggling near a section boundary, not just at rest.</li>
+  <li>Never gate a state transition on an animation library callback; animate as a side effect of the state change, not a precondition for it.</li>
+  <li>When authoring comparison-delta fixture numbers alongside a real formatter that rounds, pre-round the fixture to match — decimals read as a bug against the live UI's whole-percent display.</li>
+</ul>
+
+<h2>Subagent Evidence</h2>
+<p>
+  This report was written directly by the delivering agent from the same
+  conversation that implemented the change, without dispatching the
+  session-context, delivered-diff, or reviewer subagents the
+  <code>ce-landed-change-report</code> skill normally requires. That was an
+  explicit operator instruction to keep this report lightweight, not a
+  platform limitation — subagent dispatch was available and simply skipped.
+  All claims above are grounded directly in this session's own tool output
+  (tsc/vitest runs, live browser DOM/computed-style checks, and GitHub CLI
+  calls against PR #691 and its CI run), not subagent synthesis. No prior-session
+  history was independently gathered; the "before" state described above is
+  based on the diff against the PR's base commit only.
+</p>
+
+<h2>Quiz: Pass Required</h2>
+<p class="muted">Answer all 5 questions, then grade. Pass threshold: 4/5.</p>
+<form id="changeQuiz">
+  <fieldset data-correct="b">
+    <legend>1. Why was PosHubBody split out of PointOfSaleView?</legend>
+    <label><input type="radio" name="q1" value="a" /> To remove the launcher tiles from the app entirely</label>
+    <label><input type="radio" name="q1" value="b" /> So the same presentational content can render live from Convex, from dev fixtures, and embedded on the landing page without duplicating it</label>
+    <label><input type="radio" name="q1" value="c" /> To move the store-pulse chart into a separate Convex query</label>
+    <div class="quiz-explain" data-for="q1"></div>
+  </fieldset>
+
+  <fieldset data-correct="c">
+    <legend>2. What does a staff (non-financial-access) user see in the landing exhibit's pulse?</legend>
+    <label><input type="radio" name="q2" value="a" /> The same four window tabs as a manager, but grayed out</label>
+    <label><input type="radio" name="q2" value="b" /> Nothing — the pulse section is hidden entirely for staff</label>
+    <label><input type="radio" name="q2" value="c" /> A bare transaction count for today only, with no financial figures and no window tabs</label>
+    <div class="quiz-explain" data-for="q2"></div>
+  </fieldset>
+
+  <fieldset data-correct="a">
+    <legend>3. Why did the fixtures need real authored data for all four pulse windows, not just one?</legend>
+    <label><input type="radio" name="q3" value="a" /> Because the window tabs are genuinely clickable in the exhibit, so whichever one a visitor clicks has to render correct data</label>
+    <label><input type="radio" name="q3" value="b" /> Because Convex requires all four windows to be pre-computed at build time</label>
+    <label><input type="radio" name="q3" value="c" /> It didn't — only the default window (This week) needed real data</label>
+    <div class="quiz-explain" data-for="q3"></div>
+  </fieldset>
+
+  <fieldset data-correct="b">
+    <legend>4. Why wasn't scoping overflow-anchor:none to just the toggle's own subtree enough to fix the scroll jump?</legend>
+    <label><input type="radio" name="q4" value="a" /> overflow-anchor doesn't work in any browser and had to be replaced entirely</label>
+    <label><input type="radio" name="q4" value="b" /> The browser could still anchor to a node in a section below the toggle, which also moved when the toggle's height changed</label>
+    <label><input type="radio" name="q4" value="c" /> The bug was actually caused by the animejs fade, not scroll anchoring</label>
+    <div class="quiz-explain" data-for="q4"></div>
+  </fieldset>
+
+  <fieldset data-correct="c">
+    <legend>5. What is still outstanding before PR #691 can merge, per this report?</legend>
+    <label><input type="radio" name="q5" value="a" /> Nothing — all CI checks were passing at the time of this report</label>
+    <label><input type="radio" name="q5" value="b" /> Only a rebase onto origin/main; all tests already pass</label>
+    <label><input type="radio" name="q5" value="c" /> A rebase onto origin/main, and an unresolved harness-contract-preflight test failure whose root cause has not yet been diagnosed</label>
+    <div class="quiz-explain" data-for="q5"></div>
+  </fieldset>
+
+  <div id="quizActions">
+    <button type="button" id="gradeQuiz">Grade quiz</button>
+    <button type="button" id="resetQuiz">Reset</button>
+    <span id="quizResult" role="status"></span>
+  </div>
+</form>
+
+<footer>
+  Generated directly from session tool output for PR #691
+  (<code>c81e30a9</code> on <code>worktree-pos-hub-landing-scene</code>,
+  base <code>6568ee37</code>). Subagent dispatch skipped per explicit
+  operator instruction. This report reflects a delivery-candidate, unmerged
+  state — see the CI callout above before treating it as final.
+</footer>
+
+</main>
+
+<script>
+(function () {
+  var answers = {
+    q1: "b", q2: "c", q3: "a", q4: "b", q5: "c"
+  };
+  var explanations = {
+    q1: {
+      correct: "Right — one presentational component now backs the live route, the dev-fixture screenshot route, and the landing exhibit, so they can't silently diverge.",
+      wrong: "Not quite — the split's purpose is reuse across three render contexts (live/fixture/landing), not removing tiles or moving query logic."
+    },
+    q2: {
+      correct: "Right — hasFinancialDetailsAccess=false collapses the pulse to a bare today-only transaction count, matching the real product's authority gating.",
+      wrong: "Not quite — staff genuinely see a live count (not hidden or grayed-out tabs); there are no window tabs at all for staff."
+    },
+    q3: {
+      correct: "Right — because the tabs are real and clickable in this exhibit (unlike a static screenshot), every reachable state needs correct data.",
+      wrong: "Not quite — the tabs are genuinely interactive in the browser, which is exactly why every window needed authored data."
+    },
+    q4: {
+      correct: "Right — anchoring could pick a node in an unrelated section below the toggle that also shifted, so the fix had to cover the whole page, not just the toggle's subtree.",
+      wrong: "Not quite — overflow-anchor works as designed; the issue was scope (subtree vs. page), and the animejs fade was a separate, later fix for a different bug (animation-callback deadlock)."
+    },
+    q5: {
+      correct: "Right — per this report's Validation section, both a rebase and an undiagnosed harness-contract-preflight failure are open at delivery-candidate time.",
+      wrong: "Not quite — the report explicitly states two CI checks were failing and one root cause was not yet diagnosed; nothing here claims a clean CI state."
+    }
+  };
+
+  var grade = document.getElementById("gradeQuiz");
+  var reset = document.getElementById("resetQuiz");
+  var result = document.getElementById("quizResult");
+  var form = document.getElementById("changeQuiz");
+
+  grade.addEventListener("click", function () {
+    var correctCount = 0;
+    var total = Object.keys(answers).length;
+
+    Object.keys(answers).forEach(function (name) {
+      var selected = form.querySelector('input[name="' + name + '"]:checked');
+      var explainEl = form.querySelector('.quiz-explain[data-for="' + name + '"]');
+      var isCorrect = !!selected && selected.value === answers[name];
+
+      if (isCorrect) correctCount += 1;
+
+      explainEl.textContent = isCorrect
+        ? explanations[name].correct
+        : explanations[name].wrong + (selected ? "" : " (No answer selected.)");
+      explainEl.classList.remove("correct", "incorrect");
+      explainEl.classList.add("show", isCorrect ? "correct" : "incorrect");
+    });
+
+    var passed = correctCount >= 4;
+    result.textContent = correctCount + " / " + total + (passed ? " — Passed" : " — Not passed (need 4/5)");
+    result.classList.remove("pass", "fail");
+    result.classList.add(passed ? "pass" : "fail");
+  });
+
+  reset.addEventListener("click", function () {
+    form.reset();
+    form.querySelectorAll(".quiz-explain").forEach(function (el) {
+      el.classList.remove("show", "correct", "incorrect");
+      el.textContent = "";
+    });
+    result.textContent = "";
+    result.classList.remove("pass", "fail");
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/docs/solutions/design-patterns/athena-landing-story-real-component-exhibits-2026-07-17.md
+++ b/docs/solutions/design-patterns/athena-landing-story-real-component-exhibits-2026-07-17.md
@@ -15,7 +15,7 @@ applies_when:
   - Making one exhibit on an otherwise-inert marketing page genuinely interactive
 tags: [landing-page, demo-store, marketing, exhibits, animation, design-pattern, pos]
 related_components: [athena-webapp, landing, sharedDemo, cash-controls, daily-operations, pos]
-delivery_diff_fingerprint: 1e201d589c2b81c805054403237fabc8a5792f26c7e5992714d14f1d4d7824bb
+delivery_diff_fingerprint: 1684292bf43b3a665593532121c315280754bbe7592a62b658e159a9849a8330
 ---
 
 # Landing Story Told With Real Product Components As Exhibits

--- a/docs/solutions/design-patterns/athena-landing-story-real-component-exhibits-2026-07-17.md
+++ b/docs/solutions/design-patterns/athena-landing-story-real-component-exhibits-2026-07-17.md
@@ -15,7 +15,7 @@ applies_when:
   - Making one exhibit on an otherwise-inert marketing page genuinely interactive
 tags: [landing-page, demo-store, marketing, exhibits, animation, design-pattern, pos]
 related_components: [athena-webapp, landing, sharedDemo, cash-controls, daily-operations, pos]
-delivery_diff_fingerprint: 1684292bf43b3a665593532121c315280754bbe7592a62b658e159a9849a8330
+delivery_diff_fingerprint: 7a06ee03911d066800400c200f57df751b3d3f04a196de648b38ea8bdd4cd9a4
 ---
 
 # Landing Story Told With Real Product Components As Exhibits

--- a/docs/solutions/design-patterns/athena-landing-story-real-component-exhibits-2026-07-17.md
+++ b/docs/solutions/design-patterns/athena-landing-story-real-component-exhibits-2026-07-17.md
@@ -1,7 +1,7 @@
 ---
 title: Landing Story Told With Real Product Components As Exhibits
 date: 2026-07-17
-last_updated: 2026-07-17
+last_updated: 2026-07-22
 category: design-patterns
 module: Athena marketing landing page and shared demo store
 problem_type: design_pattern
@@ -12,9 +12,10 @@ applies_when:
   - Building marketing or onboarding surfaces that should mirror the real product UI
   - Rendering authenticated workspace components on a public, unauthenticated page
   - Keeping demo/marketing copy in sync with the store the demo actually opens
-tags: [landing-page, demo-store, marketing, exhibits, animation, design-pattern]
-related_components: [athena-webapp, landing, sharedDemo, cash-controls, daily-operations]
-delivery_diff_fingerprint: e00852a3b480254e67eb6d3da244cb8a9717f73eec823963f017c7c6690f2f25
+  - Making one exhibit on an otherwise-inert marketing page genuinely interactive
+tags: [landing-page, demo-store, marketing, exhibits, animation, design-pattern, pos]
+related_components: [athena-webapp, landing, sharedDemo, cash-controls, daily-operations, pos]
+delivery_diff_fingerprint: 1e201d589c2b81c805054403237fabc8a5792f26c7e5992714d14f1d4d7824bb
 ---
 
 # Landing Story Told With Real Product Components As Exhibits
@@ -100,3 +101,59 @@ shared module the demo provisioner also reads.
 - Treat removing a marketing link (e.g. "Sign in", "Request a walkthrough") as a
   page-copy change, and update the corresponding `landing.test.tsx` assertions;
   the routes themselves stay intact.
+
+## Addendum (2026-07-22): a partially-interactive exhibit
+
+The POS section's hub act (`PosHubRoleSwitcher.tsx`) extends the pattern one
+step further: the exhibit is not fully inert. It renders `PosHubBody` (the POS
+hub split out from `PointOfSaleView` without the app's `View` chrome) live,
+scoped to two roles (manager/staff) with a role toggle, and — unlike every
+other exhibit on the page — its store-pulse window tabs (Today / This week /
+This month / All time) are genuinely clickable and re-render real charts from
+authored fixture data (`stories/operations/posHubFixtures.ts`).
+
+- **Selective inertness, not blanket `inert`.** Only the launcher-tile grid is
+  disabled (`pointer-events-none` scoped to `[data-testid=athena-pos-hub-ready]`
+  via a CSS descendant selector) — the store-pulse tabs stay interactive on
+  purpose. This is a deliberate exception to the "mark the whole subtree inert"
+  rule above: decide inertness per-control, not per-exhibit, when a scoped
+  interaction is the point of the exhibit.
+- **Author fixture data for every mode the live control can reach.** Because the
+  tabs are real, all four pulse windows need authored, story-reconciled data
+  (metrics, trend, top items, payment mix, vs-prior comparison) — not just the
+  one window a static shot would have captured. Round comparison deltas to
+  whole percents in the fixture (`Math.round((current−prior)/prior·100)`),
+  matching how `operationsMetricFormatting.tsx`'s `getDeltaPercent` computes
+  them live; authoring decimals here reads as a bug on the page. Keep
+  cross-surface numbers literally aligned — e.g. the POS hub's "Today" top
+  items must list in the same order as Daily Operations' for the same day, not
+  just match on total.
+- **A height-swapping toggle fights scroll anchoring.** Toggling between two
+  states whose rendered height differs by hundreds/thousands of px lets the
+  browser's scroll anchoring silently reposition the viewport — intermittently,
+  because the anchor node it picks depends on current scroll position, and it
+  is **not enough** to set `overflow-anchor: none` on the toggling subtree
+  alone: anchoring can pick a node in an unrelated section below the toggle
+  that also happens to move. Set `overflow-anchor: none` on the containing
+  page-level element (safe when every other exhibit reserves explicit
+  width/height). Belt-and-braces: record the toggle's `getBoundingClientRect().top`
+  before the state change and correct any drift with `window.scrollBy` in a
+  `useLayoutEffect` (runs pre-paint).
+- **Drive a click-triggered fade from state, not from an animation callback.**
+  Swap the state **synchronously** on click; treat the `animejs` fade
+  (`opacity: {from: 0}`) as a fire-and-forget entrance effect in the
+  `useLayoutEffect` that follows the state change. Do not gate the state swap
+  on an animation's `onComplete` — if that callback doesn't fire (easy to get
+  wrong when mocking `animejs` in tests, or under real browser jank), a guard
+  flag can get stuck `true` and the control stops responding to any further
+  clicks.
+- **Scale a live exhibit with `zoom`, not `transform: scale`.** `zoom` reflows
+  layout height at the scaled size, so the exhibit's footprint in the page
+  shrinks along with its rendered size (needed for a live grid + chart, which
+  `transform: scale` would leave taking full untransformed space).
+- Testing an interactive exhibit: assert the real behavior
+  (`userEvent.click` on a tab, then check the chart's own description text
+  changes) rather than an `alt` text swap — there is no captured image to key
+  off anymore. Mock `animejs`'s `animate` via `importActual` (override only
+  `animate`, keep the real `createTimeline`/`onScroll`/`stagger` other scenes
+  depend on) so a click-driven fade resolves synchronously under jsdom.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2682 files · ~0 words
+- 2684 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10869 nodes · 13190 edges · 2608 communities detected
+- 10876 nodes · 13196 edges · 2610 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2618,6 +2618,8 @@
 - [[_COMMUNITY_Community 2605|Community 2605]]
 - [[_COMMUNITY_Community 2606|Community 2606]]
 - [[_COMMUNITY_Community 2607|Community 2607]]
+- [[_COMMUNITY_Community 2608|Community 2608]]
+- [[_COMMUNITY_Community 2609|Community 2609]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -4123,71 +4125,71 @@ Nodes (0):
 
 ### Community 369 - "Community 369"
 Cohesion: 0.29
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 370 - "Community 370"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 371 - "Community 371"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.48
 Nodes (6): collectDeliverableDiffFingerprint(), gitEnv(), isDeliverableFingerprintPath(), normalizeRepoPath(), runGit(), sortUniquePaths()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.43
 Nodes (4): createPackage(), installFixturePackages(), writeFixtureManifests(), writeJson()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.47
 Nodes (3): canonical(), isValidBody(), text()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.4
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 384 - "Community 384"
-Cohesion: 0.6
-Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
 ### Community 385 - "Community 385"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.6
+Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.33
@@ -4198,144 +4200,144 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 388 - "Community 388"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 389 - "Community 389"
 Cohesion: 0.6
 Nodes (4): cleanEventText(), cleanOptionalEventText(), sanitizeClientEventMetadata(), truncate()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 390 - "Community 390"
+### Community 391 - "Community 391"
 Cohesion: 0.4
 Nodes (2): mergeProjectionHealthState(), upsertProjectionHealthWithCtx()
 
-### Community 391 - "Community 391"
+### Community 392 - "Community 392"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 392 - "Community 392"
+### Community 393 - "Community 393"
 Cohesion: 0.67
 Nodes (5): comparisonFor(), localDate(), resolveReportPeriod(), shiftDate(), weekday()
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.6
 Nodes (4): advanceSkuAttributionAppliedWithCtx(), allocateSkuAttributionSequenceWithCtx(), currentSkuAttributionCursorWithCtx(), markSkuAttributionAppliedWithCtx()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.4
 Nodes (2): localDate(), resolveStoreTimeAuthority()
 
-### Community 395 - "Community 395"
+### Community 396 - "Community 396"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 396 - "Community 396"
+### Community 397 - "Community 397"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 397 - "Community 397"
+### Community 398 - "Community 398"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 398 - "Community 398"
+### Community 399 - "Community 399"
 Cohesion: 0.53
 Nodes (4): buildOnlineOrderReportedReturns(), buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 399 - "Community 399"
+### Community 400 - "Community 400"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 400 - "Community 400"
+### Community 401 - "Community 401"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 401 - "Community 401"
+### Community 402 - "Community 402"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.47
 Nodes (3): canUploadPosLocalSyncLocalEventType(), getPosLocalSyncEventContractForLocalEventType(), getPosLocalSyncEventTypeForLocalEventType()
 
-### Community 404 - "Community 404"
+### Community 405 - "Community 405"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 405 - "Community 405"
+### Community 406 - "Community 406"
 Cohesion: 0.4
 Nodes (2): sharedDemoPickupOrderAmount(), sharedDemoProductBySku()
 
-### Community 406 - "Community 406"
+### Community 407 - "Community 407"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 407 - "Community 407"
+### Community 408 - "Community 408"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 410 - "Community 410"
+### Community 411 - "Community 411"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 411 - "Community 411"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 412 - "Community 412"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 413 - "Community 413"
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
+
+### Community 414 - "Community 414"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 415 - "Community 415"
+### Community 416 - "Community 416"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 416 - "Community 416"
+### Community 417 - "Community 417"
 Cohesion: 0.4
 Nodes (2): makeQueueSnapshot(), makeWorkItem()
 
-### Community 417 - "Community 417"
+### Community 418 - "Community 418"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 418 - "Community 418"
+### Community 419 - "Community 419"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 419 - "Community 419"
+### Community 420 - "Community 420"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 0.47
 Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
 
-### Community 421 - "Community 421"
+### Community 422 - "Community 422"
 Cohesion: 0.4
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 422 - "Community 422"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 423 - "Community 423"
 Cohesion: 0.33
@@ -4346,192 +4348,192 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 425 - "Community 425"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 426 - "Community 426"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 427 - "Community 427"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 428 - "Community 428"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 429 - "Community 429"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 431 - "Community 431"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 432 - "Community 432"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 434 - "Community 434"
 Cohesion: 0.4
 Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
-### Community 433 - "Community 433"
+### Community 435 - "Community 435"
 Cohesion: 0.4
 Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
-### Community 434 - "Community 434"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 435 - "Community 435"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 436 - "Community 436"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 437 - "Community 437"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 438 - "Community 438"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 437 - "Community 437"
+### Community 439 - "Community 439"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 438 - "Community 438"
+### Community 440 - "Community 440"
 Cohesion: 0.33
 Nodes (1): MemoryCache
 
-### Community 439 - "Community 439"
+### Community 441 - "Community 441"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 440 - "Community 440"
+### Community 442 - "Community 442"
 Cohesion: 0.47
 Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
-### Community 441 - "Community 441"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 442 - "Community 442"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
 ### Community 443 - "Community 443"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 444 - "Community 444"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.6
+Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 447 - "Community 447"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 448 - "Community 448"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 450 - "Community 450"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 451 - "Community 451"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 452 - "Community 452"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 453 - "Community 453"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 454 - "Community 454"
 Cohesion: 0.47
-Nodes (3): assertDeliveryDocumentationCheck(), findingsFrom(), isPolicyFailure()
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
 ### Community 455 - "Community 455"
+Cohesion: 0.53
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+
+### Community 456 - "Community 456"
+Cohesion: 0.47
+Nodes (3): assertDeliveryDocumentationCheck(), findingsFrom(), isPolicyFailure()
+
+### Community 457 - "Community 457"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 456 - "Community 456"
+### Community 458 - "Community 458"
 Cohesion: 0.53
 Nodes (5): commitFixtureRepo(), createFixtureRepo(), gitFixtureEnv(), runFixtureCommand(), write()
 
-### Community 457 - "Community 457"
+### Community 459 - "Community 459"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 458 - "Community 458"
+### Community 460 - "Community 460"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 459 - "Community 459"
+### Community 461 - "Community 461"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
-
-### Community 460 - "Community 460"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 461 - "Community 461"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 463 - "Community 463"
+Cohesion: 0.6
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
+
+### Community 464 - "Community 464"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 464 - "Community 464"
+### Community 465 - "Community 465"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 466 - "Community 466"
 Cohesion: 0.6
 Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
 
-### Community 465 - "Community 465"
+### Community 467 - "Community 467"
 Cohesion: 0.6
 Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
-### Community 466 - "Community 466"
+### Community 468 - "Community 468"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 467 - "Community 467"
+### Community 469 - "Community 469"
 Cohesion: 0.5
 Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
-### Community 468 - "Community 468"
+### Community 470 - "Community 470"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 469 - "Community 469"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 470 - "Community 470"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 471 - "Community 471"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 472 - "Community 472"
 Cohesion: 0.4
@@ -4539,163 +4541,163 @@ Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.6
-Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 474 - "Community 474"
-Cohesion: 0.7
-Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 475 - "Community 475"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 476 - "Community 476"
+### Community 475 - "Community 475"
 Cohesion: 0.6
-Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
+
+### Community 476 - "Community 476"
+Cohesion: 0.7
+Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 478 - "Community 478"
+Cohesion: 0.6
+Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
+
+### Community 479 - "Community 479"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 480 - "Community 480"
 Cohesion: 0.7
 Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
-### Community 479 - "Community 479"
+### Community 481 - "Community 481"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 480 - "Community 480"
+### Community 482 - "Community 482"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 481 - "Community 481"
+### Community 483 - "Community 483"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 482 - "Community 482"
+### Community 484 - "Community 484"
 Cohesion: 0.6
 Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
-### Community 483 - "Community 483"
+### Community 485 - "Community 485"
 Cohesion: 0.6
 Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
-
-### Community 484 - "Community 484"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 485 - "Community 485"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 486 - "Community 486"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 487 - "Community 487"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 488 - "Community 488"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 489 - "Community 489"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 488 - "Community 488"
+### Community 490 - "Community 490"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 489 - "Community 489"
+### Community 491 - "Community 491"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 490 - "Community 490"
-Cohesion: 0.7
-Nodes (4): canonicalReportingBusinessEventKey(), canonicalReportingFactIdentity(), canonicalReportingFactKey(), requiredIdentityPart()
-
-### Community 491 - "Community 491"
-Cohesion: 0.6
-Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
 
 ### Community 492 - "Community 492"
 Cohesion: 0.7
-Nodes (4): backfillAuthorizationEnvelopeHash(), backfillAuthorizationMatches(), fnv1a(), normalizeEnvelope()
+Nodes (4): canonicalReportingBusinessEventKey(), canonicalReportingFactIdentity(), canonicalReportingFactKey(), requiredIdentityPart()
 
 ### Community 493 - "Community 493"
+Cohesion: 0.6
+Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
+
+### Community 494 - "Community 494"
+Cohesion: 0.7
+Nodes (4): backfillAuthorizationEnvelopeHash(), backfillAuthorizationMatches(), fnv1a(), normalizeEnvelope()
+
+### Community 495 - "Community 495"
 Cohesion: 0.5
 Nodes (2): fnv1a(), sourceDerivedPosCensusHash()
 
-### Community 494 - "Community 494"
+### Community 496 - "Community 496"
 Cohesion: 0.6
 Nodes (3): indexRows(), reconcilePosSourceFacts(), sum()
 
-### Community 495 - "Community 495"
+### Community 497 - "Community 497"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 496 - "Community 496"
+### Community 498 - "Community 498"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 497 - "Community 497"
+### Community 499 - "Community 499"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 498 - "Community 498"
+### Community 500 - "Community 500"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 499 - "Community 499"
+### Community 501 - "Community 501"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 500 - "Community 500"
+### Community 502 - "Community 502"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 501 - "Community 501"
+### Community 503 - "Community 503"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 502 - "Community 502"
+### Community 504 - "Community 504"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 503 - "Community 503"
+### Community 505 - "Community 505"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
 
-### Community 504 - "Community 504"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 505 - "Community 505"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 506 - "Community 506"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 507 - "Community 507"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 509 - "Community 509"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 510 - "Community 510"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 511 - "Community 511"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 512 - "Community 512"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.4
@@ -4706,108 +4708,108 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 515 - "Community 515"
-Cohesion: 0.7
-Nodes (4): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), routeTemplateMatches()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 517 - "Community 517"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), routeTemplateMatches()
 
 ### Community 518 - "Community 518"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 519 - "Community 519"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 520 - "Community 520"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 521 - "Community 521"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 522 - "Community 522"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 522 - "Community 522"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
-
 ### Community 523 - "Community 523"
-Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 524 - "Community 524"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 525 - "Community 525"
+Cohesion: 0.5
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
+
+### Community 526 - "Community 526"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 527 - "Community 527"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 526 - "Community 526"
+### Community 528 - "Community 528"
 Cohesion: 0.6
 Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
 
-### Community 527 - "Community 527"
+### Community 529 - "Community 529"
 Cohesion: 0.4
 Nodes (1): MockImage
-
-### Community 528 - "Community 528"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 529 - "Community 529"
-Cohesion: 0.5
-Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
 ### Community 530 - "Community 530"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 531 - "Community 531"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Cohesion: 0.5
+Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
 ### Community 532 - "Community 532"
-Cohesion: 0.8
-Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 533 - "Community 533"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 534 - "Community 534"
-Cohesion: 0.6
-Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+Cohesion: 0.8
+Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
 ### Community 535 - "Community 535"
 Cohesion: 0.6
-Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 536 - "Community 536"
+Cohesion: 0.6
+Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 537 - "Community 537"
+Cohesion: 0.6
+Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
+
+### Community 538 - "Community 538"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 537 - "Community 537"
+### Community 539 - "Community 539"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
-### Community 538 - "Community 538"
+### Community 540 - "Community 540"
 Cohesion: 0.5
 Nodes (2): buildAdminSkuSearchOption(), compactJoin()
-
-### Community 539 - "Community 539"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 540 - "Community 540"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 541 - "Community 541"
 Cohesion: 0.4
@@ -4815,15 +4817,15 @@ Nodes (0):
 
 ### Community 542 - "Community 542"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 543 - "Community 543"
-Cohesion: 0.5
-Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 544 - "Community 544"
-Cohesion: 0.7
-Nodes (4): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), useWorkspaceFixture()
+Cohesion: 0.5
+Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
 ### Community 545 - "Community 545"
 Cohesion: 0.4
@@ -8031,11 +8033,11 @@ Nodes (0):
 
 ### Community 1346 - "Community 1346"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1347 - "Community 1347"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1348 - "Community 1348"
 Cohesion: 1.0
@@ -13077,6 +13079,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2608 - "Community 2608"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 2609 - "Community 2609"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **2 isolated node(s):** `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -13508,79 +13518,81 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1187`** (2 nodes): `LandingWorkspaceShot()`, `LandingWorkspaceShot.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
+- **Thin community `Community 1188`** (2 nodes): `PosHubRoleSwitcher.tsx`, `PosHubRoleSwitcher()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
+- **Thin community `Community 1189`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
+- **Thin community `Community 1190`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `useLandingTheme.ts`, `useLandingTheme()`
+- **Thin community `Community 1191`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 1192`** (2 nodes): `useLandingTheme.ts`, `useLandingTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 1193`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 1194`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 1195`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 1196`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 1197`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 1198`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 1199`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 1200`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
+- **Thin community `Community 1201`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 1202`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 1203`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 1204`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 1205`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 1206`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 1207`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 1208`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
+- **Thin community `Community 1209`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 1210`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 1211`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 1212`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 1213`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 1214`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 1215`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 1216`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 1217`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 1218`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 1219`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 1220`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 1221`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 1222`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 1223`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 1224`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1225`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -13616,2771 +13628,2773 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 1226`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
+- **Thin community `Community 1227`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 1228`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 1229`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 1230`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 1231`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 1232`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 1233`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 1234`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
+- **Thin community `Community 1235`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 1236`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 1237`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 1238`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 1239`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 1240`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 1241`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 1242`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 1243`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 1244`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 1245`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 1246`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 1247`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 1248`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 1249`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 1250`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 1251`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 1252`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 1253`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 1254`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
+- **Thin community `Community 1255`** (2 nodes): `CustomRangeStatus()`, `CustomRangeStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
+- **Thin community `Community 1256`** (2 nodes): `ReportPeriodControl.tsx`, `ReportPeriodControl()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
+- **Thin community `Community 1257`** (2 nodes): `ReportStatusBand.tsx`, `ReportStatusBand()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
+- **Thin community `Community 1258`** (2 nodes): `ReportsOverviewView.tsx`, `ReportsOverviewView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
+- **Thin community `Community 1259`** (2 nodes): `ReportsSkuEvidenceList.tsx`, `destinationLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
+- **Thin community `Community 1260`** (2 nodes): `reportDestinations.ts`, `getReportDestinationPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 1261`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1262`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1263`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1264`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
+- **Thin community `Community 1265`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1266`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
+- **Thin community `Community 1267`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
+- **Thin community `Community 1268`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
+- **Thin community `Community 1269`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
+- **Thin community `Community 1270`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
+- **Thin community `Community 1271`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
+- **Thin community `Community 1272`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
+- **Thin community `Community 1273`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
+- **Thin community `Community 1274`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
+- **Thin community `Community 1275`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
+- **Thin community `Community 1276`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 1277`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 1278`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 1279`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 1280`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 1281`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 1282`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 1283`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 1284`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 1285`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 1286`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 1287`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 1288`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 1289`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 1290`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 1291`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 1292`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 1293`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 1294`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 1295`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 1296`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1297`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1298`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1299`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
+- **Thin community `Community 1300`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1301`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1302`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1303`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1304`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1305`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1306`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1307`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1308`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1309`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1310`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1311`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1312`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1313`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1314`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1315`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1316`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
+- **Thin community `Community 1317`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1318`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1319`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1320`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1321`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1322`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1323`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1324`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1325`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1326`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1327`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1328`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1329`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1330`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1331`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1332`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1333`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1334`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1335`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1336`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1337`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1338`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1339`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1340`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1341`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1342`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1343`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1344`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1345`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1346`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1347`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1348`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1349`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1350`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1351`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1352`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1353`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1354`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
+- **Thin community `Community 1355`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1356`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1357`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1358`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1359`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1360`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1361`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1362`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
+- **Thin community `Community 1363`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
+- **Thin community `Community 1364`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
+- **Thin community `Community 1365`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
+- **Thin community `Community 1366`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
+- **Thin community `Community 1367`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
+- **Thin community `Community 1368`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
+- **Thin community `Community 1369`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
+- **Thin community `Community 1370`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
+- **Thin community `Community 1371`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1372`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1373`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
+- **Thin community `Community 1374`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1375`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1376`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
+- **Thin community `Community 1377`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1378`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1379`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1380`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1381`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
+- **Thin community `Community 1382`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
+- **Thin community `Community 1383`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1384`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1385`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1386`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1387`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1388`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1389`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1390`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1391`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1392`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1393`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1394`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1395`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
+- **Thin community `Community 1396`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
+- **Thin community `Community 1397`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `-public-layout.tsx`, `onScroll()`
+- **Thin community `Community 1398`** (2 nodes): `-public-layout.tsx`, `onScroll()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `-walkthrough-page.tsx`, `WalkthroughPage()`
+- **Thin community `Community 1399`** (2 nodes): `-walkthrough-page.tsx`, `WalkthroughPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1400`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1401`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1402`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1403`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1404`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1405`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1406`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1407`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
+- **Thin community `Community 1408`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1409`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1410`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1411`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1412`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
+- **Thin community `Community 1413`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1414`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1415`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1416`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1417`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
+- **Thin community `Community 1418`** (2 nodes): `ReportsOverviewRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
+- **Thin community `Community 1419`** (2 nodes): `ReportsInventoryRoute()`, `inventory.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
+- **Thin community `Community 1420`** (2 nodes): `$productSkuId.tsx`, `ReportsItemDetailRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1421`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
+- **Thin community `Community 1422`** (2 nodes): `reports.tsx`, `getNextReportPeriodSearch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1423`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
+- **Thin community `Community 1424`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1425`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1426`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1427`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1428`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1429`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1430`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1431`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1432`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1433`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1434`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1435`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1436`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1437`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (2 nodes): `wedAt()`, `dailyOperationsFixtures.ts`
+- **Thin community `Community 1438`** (2 nodes): `wedAt()`, `dailyOperationsFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (2 nodes): `wedAt()`, `openingHandoffFixtures.ts`
+- **Thin community `Community 1439`** (2 nodes): `wedAt()`, `openingHandoffFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (2 nodes): `momentAt()`, `operationsFixtureContext.ts`
+- **Thin community `Community 1440`** (2 nodes): `momentAt()`, `operationsFixtureContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1441`** (2 nodes): `posHubFixtures.ts`, `buildTrend()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1442`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1443`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1444`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1445`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1446`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1447`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1448`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1449`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1450`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1451`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1452`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1453`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1454`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1455`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1456`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1457`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1458`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1459`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1460`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1461`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1462`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1463`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1464`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1465`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1466`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1467`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1468`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1469`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1470`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1471`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1472`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1473`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1474`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1475`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1476`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1477`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1478`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1479`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1480`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1481`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1482`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1483`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1484`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1485`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1486`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1487`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1488`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1489`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1490`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1491`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1492`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1493`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1494`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1495`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1496`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1497`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1498`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1499`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1500`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1501`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1502`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1503`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1504`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1505`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1506`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1507`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1508`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1509`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1510`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1511`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1512`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1513`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1514`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1515`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1516`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1517`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1518`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1519`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1520`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1521`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1522`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1523`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1524`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1525`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1526`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1527`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1528`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1529`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1530`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1531`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1532`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1533`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1534`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1535`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1536`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1537`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1538`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1539`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1540`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1541`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1542`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1543`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1544`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1545`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1546`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1547`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1548`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1549`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1550`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1551`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1552`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1553`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1554`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1555`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1556`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1557`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1558`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1559`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1560`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1561`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1562`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1563`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1564`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1565`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
+- **Thin community `Community 1566`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1567`** (2 nodes): `createTempRoot()`, `harness-delivery-run-ledger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
+- **Thin community `Community 1568`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1569`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1570`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `api.js`
+- **Thin community `Community 1571`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1572`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1573`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `server.js`
+- **Thin community `Community 1574`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `app.ts`
+- **Thin community `Community 1575`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1577`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `SharedDemoTicket.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1579`** (1 nodes): `SharedDemoTicket.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `auth.ts`
+- **Thin community `Community 1581`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1582`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1583`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1584`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `countries.ts`
+- **Thin community `Community 1585`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `email.ts`
+- **Thin community `Community 1586`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1587`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `payment.ts`
+- **Thin community `Community 1588`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `eventDefinitions.test.ts`
+- **Thin community `Community 1589`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `types.ts`
+- **Thin community `Community 1590`** (1 nodes): `eventDefinitions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1591`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1592`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `crons.ts`
+- **Thin community `Community 1593`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `internal.ts`
+- **Thin community `Community 1595`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1597`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1600`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1601`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
+- **Thin community `Community 1602`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1603`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1604`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `NewOrderAdmin.test.tsx`
+- **Thin community `Community 1605`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `OrderEmail.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `NewOrderAdmin.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1607`** (1 nodes): `OrderEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1608`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `env.ts`
+- **Thin community `Community 1611`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1612`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `auth.ts`
+- **Thin community `Community 1613`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `bannerMessage.test.ts`
+- **Thin community `Community 1614`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `colors.ts`
+- **Thin community `Community 1615`** (1 nodes): `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `index.ts`
+- **Thin community `Community 1616`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1617`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `landingFunnelEvents.ts`
+- **Thin community `Community 1618`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1619`** (1 nodes): `landingFunnelEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `products.ts`
+- **Thin community `Community 1620`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `stores.ts`
+- **Thin community `Community 1622`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `bag.ts`
+- **Thin community `Community 1625`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `guest.ts`
+- **Thin community `Community 1626`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 1627`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `index.ts`
+- **Thin community `Community 1628`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `me.ts`
+- **Thin community `Community 1629`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `offers.ts`
+- **Thin community `Community 1630`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1631`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1632`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1633`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1634`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1635`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1636`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1637`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1638`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1639`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `user.ts`
+- **Thin community `Community 1640`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1641`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `index.ts`
+- **Thin community `Community 1642`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1643`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `http.ts`
+- **Thin community `Community 1644`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `access.ts`
+- **Thin community `Community 1645`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `actions.test.ts`
+- **Thin community `Community 1646`** (1 nodes): `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `insights.test.ts`
+- **Thin community `Community 1647`** (1 nodes): `actions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `lifecycle.test.ts`
+- **Thin community `Community 1648`** (1 nodes): `insights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `index.ts`
+- **Thin community `Community 1649`** (1 nodes): `lifecycle.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `providerFoundation.test.ts`
+- **Thin community `Community 1650`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `types.ts`
+- **Thin community `Community 1651`** (1 nodes): `providerFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `athenaUser.test.ts`
+- **Thin community `Community 1652`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1653`** (1 nodes): `athenaUser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `categories.ts`
+- **Thin community `Community 1654`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `colors.ts`
+- **Thin community `Community 1655`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1656`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `inviteCode.test.ts`
+- **Thin community `Community 1657`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1658`** (1 nodes): `inviteCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `organizationMembers.test.ts`
+- **Thin community `Community 1659`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1660`** (1 nodes): `organizationMembers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1661`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `pos.ts`
+- **Thin community `Community 1662`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1663`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1664`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `productSku.test.ts`
+- **Thin community `Community 1665`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `productSku.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1668`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1669`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `stores.test.ts`
+- **Thin community `Community 1670`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1671`** (1 nodes): `stores.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1672`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1673`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `storeMemberAccess.test.ts`
+- **Thin community `Community 1674`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1675`** (1 nodes): `storeMemberAccess.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1676`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `landingFunnelEvents.test.ts`
+- **Thin community `Community 1677`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `landingFunnelRetention.test.ts`
+- **Thin community `Community 1678`** (1 nodes): `landingFunnelEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `walkthroughConfig.test.ts`
+- **Thin community `Community 1679`** (1 nodes): `landingFunnelRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `walkthroughRequestRetention.test.ts`
+- **Thin community `Community 1680`** (1 nodes): `walkthroughConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `walkthroughRequests.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `walkthroughRequestRetention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1682`** (1 nodes): `walkthroughRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1683`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1684`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1685`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `types.ts`
+- **Thin community `Community 1686`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
+- **Thin community `Community 1687`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1688`** (1 nodes): `approvalRequests.sharedDemo.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `adjustmentReports.test.ts`
+- **Thin community `Community 1689`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `approval.test.ts`
+- **Thin community `Community 1690`** (1 nodes): `adjustmentReports.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `automationPolicy.test.ts`
+- **Thin community `Community 1691`** (1 nodes): `approval.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `eventBuilders.test.ts`
+- **Thin community `Community 1692`** (1 nodes): `automationPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
+- **Thin community `Community 1693`** (1 nodes): `eventBuilders.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `registerSessionCloseoutGate.test.ts`
+- **Thin community `Community 1694`** (1 nodes): `registerSessionAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1695`** (1 nodes): `registerSessionCloseoutGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `appLoginEmailAllowlist.test.ts`
+- **Thin community `Community 1696`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `registerLifecycleAuthority.test.ts`
+- **Thin community `Community 1697`** (1 nodes): `appLoginEmailAllowlist.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1698`** (1 nodes): `registerLifecycleAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1699`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1700`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `dto.ts`
+- **Thin community `Community 1701`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1702`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1703`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1704`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
+- **Thin community `Community 1705`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
+- **Thin community `Community 1706`** (1 nodes): `registerMappingAuthorityRevision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `types.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `facts.ts`
+- **Thin community `Community 1707`** (1 nodes): `registerSessionCloseoutHolds.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1708`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `types.ts`
+- **Thin community `Community 1709`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `terminalHealthAlerts.test.ts`
+- **Thin community `Community 1710`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `terminalSyncEvidence.ts`
+- **Thin community `Community 1711`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `types.ts`
+- **Thin community `Community 1712`** (1 nodes): `terminalHealthAlerts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
+- **Thin community `Community 1713`** (1 nodes): `terminalSyncEvidence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
+- **Thin community `Community 1714`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `transactionRepository.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `registerLifecycleAuthorityRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `register.ts`
+- **Thin community `Community 1716`** (1 nodes): `registerLifecycleAuthorityStatusRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1717`** (1 nodes): `transactionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1718`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1719`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `activation.test.ts`
+- **Thin community `Community 1720`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `attentionRules.test.ts`
+- **Thin community `Community 1721`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `commerceRecognition.test.ts`
+- **Thin community `Community 1722`** (1 nodes): `activation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `customRangeRequests.test.ts`
+- **Thin community `Community 1723`** (1 nodes): `attentionRules.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `export.test.ts`
+- **Thin community `Community 1724`** (1 nodes): `commerceRecognition.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `factFingerprint.test.ts`
+- **Thin community `Community 1725`** (1 nodes): `customRangeRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `factIdentity.test.ts`
+- **Thin community `Community 1726`** (1 nodes): `export.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1727`** (1 nodes): `factFingerprint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `integrity.test.ts`
+- **Thin community `Community 1728`** (1 nodes): `factIdentity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `corrections.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `corrections.ts`
+- **Thin community `Community 1730`** (1 nodes): `integrity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `deficitResolutionWork.test.ts`
+- **Thin community `Community 1731`** (1 nodes): `corrections.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `types.ts`
+- **Thin community `Community 1732`** (1 nodes): `corrections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `authorizedPosBackfill.test.ts`
+- **Thin community `Community 1733`** (1 nodes): `deficitResolutionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `backfillAuthorization.test.ts`
+- **Thin community `Community 1734`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `cutover.test.ts`
+- **Thin community `Community 1735`** (1 nodes): `authorizedPosBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `inventoryRebuild.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `backfillAuthorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `legacyCompatibility.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `cutover.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `posCensusBackfill.test.ts`
+- **Thin community `Community 1738`** (1 nodes): `inventoryRebuild.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `posSourceReconciliationGate.test.ts`
+- **Thin community `Community 1739`** (1 nodes): `legacyCompatibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `processing.test.ts`
+- **Thin community `Community 1740`** (1 nodes): `posCensusBackfill.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `runLedger.test.ts`
+- **Thin community `Community 1741`** (1 nodes): `posSourceReconciliationGate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `metricContracts.test.ts`
+- **Thin community `Community 1742`** (1 nodes): `processing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `periods.test.ts`
+- **Thin community `Community 1743`** (1 nodes): `runLedger.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `projectionWork.test.ts`
+- **Thin community `Community 1744`** (1 nodes): `metricContracts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `attention.test.ts`
+- **Thin community `Community 1745`** (1 nodes): `periods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `currentInventory.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `projectionWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `customRange.test.ts`
+- **Thin community `Community 1747`** (1 nodes): `attention.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `daily.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `currentInventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `dailyCloseTrust.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `customRange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `factContributions.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `daily.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `inventory.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `dailyCloseTrust.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `processor.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `factContributions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `reconciliation.test.ts`
+- **Thin community `Community 1753`** (1 nodes): `inventory.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `skuDay.test.ts`
+- **Thin community `Community 1754`** (1 nodes): `processor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `skuInsights.test.ts`
+- **Thin community `Community 1755`** (1 nodes): `reconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `storeIntraday.test.ts`
+- **Thin community `Community 1756`** (1 nodes): `skuDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1757`** (1 nodes): `skuInsights.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `destinations.test.ts`
+- **Thin community `Community 1758`** (1 nodes): `storeIntraday.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `items.ts`
+- **Thin community `Community 1759`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `reportingReadModels.test.ts`
+- **Thin community `Community 1760`** (1 nodes): `destinations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `skuAttributionSequence.test.ts`
+- **Thin community `Community 1761`** (1 nodes): `items.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `types.ts`
+- **Thin community `Community 1762`** (1 nodes): `reportingReadModels.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `sourceAdapters.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `skuAttributionSequence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `storeTimeAuthority.test.ts`
+- **Thin community `Community 1764`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `schema.ts`
+- **Thin community `Community 1765`** (1 nodes): `sourceAdapters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `automation.ts`
+- **Thin community `Community 1766`** (1 nodes): `storeTimeAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `contextTracking.ts`
+- **Thin community `Community 1767`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1768`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `index.ts`
+- **Thin community `Community 1769`** (1 nodes): `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1770`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `intelligence.ts`
+- **Thin community `Community 1771`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1772`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1773`** (1 nodes): `intelligence.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1774`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1775`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `catalogSummary.ts`
+- **Thin community `Community 1776`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `category.ts`
+- **Thin community `Community 1777`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `color.ts`
+- **Thin community `Community 1778`** (1 nodes): `catalogSummary.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1779`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1780`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `index.ts`
+- **Thin community `Community 1781`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1782`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1783`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1784`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1785`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `organization.ts`
+- **Thin community `Community 1786`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1787`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `posRegisterCatalogRevision.ts`
+- **Thin community `Community 1788`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `product.ts`
+- **Thin community `Community 1789`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `productSkuSearch.ts`
+- **Thin community `Community 1790`** (1 nodes): `posRegisterCatalogRevision.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1791`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1792`** (1 nodes): `productSkuSearch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `store.ts`
+- **Thin community `Community 1793`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `storeSchedule.ts`
+- **Thin community `Community 1794`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `storeTimezone.ts`
+- **Thin community `Community 1795`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1796`** (1 nodes): `storeSchedule.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `landingFunnelEvent.ts`
+- **Thin community `Community 1797`** (1 nodes): `storeTimezone.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `walkthroughRequest.ts`
+- **Thin community `Community 1798`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `index.ts`
+- **Thin community `Community 1799`** (1 nodes): `landingFunnelEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1800`** (1 nodes): `walkthroughRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1801`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1802`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1803`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1804`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1805`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1806`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `index.ts`
+- **Thin community `Community 1807`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1808`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1809`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1810`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1811`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `oversizedOperationalWorkRepair.ts`
+- **Thin community `Community 1812`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1813`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1814`** (1 nodes): `oversizedOperationalWorkRepair.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1815`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1816`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1817`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1818`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1819`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `customer.ts`
+- **Thin community `Community 1820`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1821`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1822`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1823`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1824`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `index.ts`
+- **Thin community `Community 1825`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `posAmountMigrationRun.ts`
+- **Thin community `Community 1826`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `posClientEvent.ts`
+- **Thin community `Community 1827`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `posLifecycleJournal.ts`
+- **Thin community `Community 1828`** (1 nodes): `posAmountMigrationRun.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1829`** (1 nodes): `posClientEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1830`** (1 nodes): `posLifecycleJournal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1831`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1832`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1833`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1834`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
+- **Thin community `Community 1835`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1836`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
+- **Thin community `Community 1837`** (1 nodes): `posPendingCheckoutLookupAlias.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `posRegisterMappingAuthority.ts`
+- **Thin community `Community 1838`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `posRegisterSessionActivity.ts`
+- **Thin community `Community 1839`** (1 nodes): `posRegisterAuthorityReplicationStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
+- **Thin community `Community 1840`** (1 nodes): `posRegisterMappingAuthority.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1841`** (1 nodes): `posRegisterSessionActivity.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1842`** (1 nodes): `posRegisterSessionActivityCheckpoint.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1843`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1844`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1845`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1846`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1847`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1848`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1849`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1850`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1851`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1852`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `index.ts`
+- **Thin community `Community 1853`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1854`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1855`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `facts.ts`
+- **Thin community `Community 1856`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `index.ts`
+- **Thin community `Community 1857`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `inventoryValuation.ts`
+- **Thin community `Community 1858`** (1 nodes): `facts.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `maintenance.ts`
+- **Thin community `Community 1859`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1860`** (1 nodes): `projections.ts`
+- **Thin community `Community 1860`** (1 nodes): `inventoryValuation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1861`** (1 nodes): `index.ts`
+- **Thin community `Community 1861`** (1 nodes): `maintenance.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1862`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1862`** (1 nodes): `projections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1863`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1863`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1864`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1864`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1865`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1865`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1866`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1866`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1867`** (1 nodes): `sharedDemo.ts`
+- **Thin community `Community 1867`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1868`** (1 nodes): `staffMessages.ts`
+- **Thin community `Community 1868`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1869`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1869`** (1 nodes): `sharedDemo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1870`** (1 nodes): `index.ts`
+- **Thin community `Community 1870`** (1 nodes): `staffMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1871`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1871`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1872`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1872`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1873`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1873`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1874`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1874`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1875`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1875`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1876`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1876`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1877`** (1 nodes): `bag.ts`
+- **Thin community `Community 1877`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1878`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1878`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1879`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1879`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1880`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1880`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1881`** (1 nodes): `guest.ts`
+- **Thin community `Community 1881`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1882`** (1 nodes): `index.ts`
+- **Thin community `Community 1882`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1883`** (1 nodes): `offer.ts`
+- **Thin community `Community 1883`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1884`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1884`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1885`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1885`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1886`** (1 nodes): `review.ts`
+- **Thin community `Community 1886`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1887`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1887`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1888`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1888`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1889`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1889`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1890`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1890`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1891`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1891`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1892`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1892`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1893`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1893`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1894`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1894`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1895`** (1 nodes): `authBoundary.test.ts`
+- **Thin community `Community 1895`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1896`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1896`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1897`** (1 nodes): `domainRestore.test.ts`
+- **Thin community `Community 1897`** (1 nodes): `authBoundary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1898`** (1 nodes): `foundation.test.ts`
+- **Thin community `Community 1898`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1899`** (1 nodes): `openingBaseline.test.ts`
+- **Thin community `Community 1899`** (1 nodes): `domainRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1900`** (1 nodes): `policy.test.ts`
+- **Thin community `Community 1900`** (1 nodes): `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1901`** (1 nodes): `provision.test.ts`
+- **Thin community `Community 1901`** (1 nodes): `openingBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1902`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1902`** (1 nodes): `policy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1903`** (1 nodes): `registerBaseline.test.ts`
+- **Thin community `Community 1903`** (1 nodes): `provision.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1904`** (1 nodes): `reporting.test.ts`
+- **Thin community `Community 1904`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1905`** (1 nodes): `scheduledRestore.test.ts`
+- **Thin community `Community 1905`** (1 nodes): `registerBaseline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1906`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
+- **Thin community `Community 1906`** (1 nodes): `reporting.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1907`** (1 nodes): `bag.ts`
+- **Thin community `Community 1907`** (1 nodes): `scheduledRestore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1908`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1908`** (1 nodes): `serviceEffectBoundaryCoverage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1909`** (1 nodes): `customer.ts`
+- **Thin community `Community 1909`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1910`** (1 nodes): `guest.ts`
+- **Thin community `Community 1910`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1911`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1911`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1912`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1912`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1913`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1913`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1914`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1914`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1915`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1915`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1916`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1916`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1917`** (1 nodes): `userStoreActivity.test.ts`
+- **Thin community `Community 1917`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1918`** (1 nodes): `users.ts`
+- **Thin community `Community 1918`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1919`** (1 nodes): `payment.ts`
+- **Thin community `Community 1919`** (1 nodes): `userStoreActivity.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1920`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1920`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1921`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1921`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1922`** (1 nodes): `purchaseOrder.test.ts`
+- **Thin community `Community 1922`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1923`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1923`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1924`** (1 nodes): `serviceCase.test.ts`
+- **Thin community `Community 1924`** (1 nodes): `purchaseOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1925`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1925`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1926`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1926`** (1 nodes): `serviceCase.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1927`** (1 nodes): `index.ts`
+- **Thin community `Community 1927`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1928`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1928`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1929`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1929`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1930`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1930`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1931`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1931`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1932`** (1 nodes): `auth.ts`
+- **Thin community `Community 1932`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1933`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1933`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1934`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1934`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1935`** (1 nodes): `homepageRanking.test.ts`
+- **Thin community `Community 1935`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1936`** (1 nodes): `contextBundleTypes.ts`
+- **Thin community `Community 1936`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1937`** (1 nodes): `contextEventTypes.ts`
+- **Thin community `Community 1937`** (1 nodes): `homepageRanking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1938`** (1 nodes): `contextTracking.test.ts`
+- **Thin community `Community 1938`** (1 nodes): `contextBundleTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1939`** (1 nodes): `contextTypes.ts`
+- **Thin community `Community 1939`** (1 nodes): `contextEventTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1940`** (1 nodes): `index.ts`
+- **Thin community `Community 1940`** (1 nodes): `contextTracking.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1941`** (1 nodes): `providerTypes.ts`
+- **Thin community `Community 1941`** (1 nodes): `contextTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1942`** (1 nodes): `terminalRuntimeMaterial.test.ts`
+- **Thin community `Community 1942`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1943`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
+- **Thin community `Community 1943`** (1 nodes): `providerTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1944`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
+- **Thin community `Community 1944`** (1 nodes): `terminalRuntimeMaterial.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1945`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1945`** (1 nodes): `posRegisterSessionActivityContract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1946`** (1 nodes): `reportingContract.ts`
+- **Thin community `Community 1946`** (1 nodes): `registerSessionLifecyclePolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1947`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1947`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1948`** (1 nodes): `storefrontVisibility.test.ts`
+- **Thin community `Community 1948`** (1 nodes): `reportingContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1949`** (1 nodes): `appRouter.ts`
+- **Thin community `Community 1949`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1950`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1950`** (1 nodes): `storefrontVisibility.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1951`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1951`** (1 nodes): `appRouter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1952`** (1 nodes): `Navbar.test.tsx`
+- **Thin community `Community 1952`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1953`** (1 nodes): `Navbar.tsx`
+- **Thin community `Community 1953`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1954`** (1 nodes): `OrganizationView.test.tsx`
+- **Thin community `Community 1954`** (1 nodes): `Navbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1955`** (1 nodes): `ProtectedRoute.test.tsx`
+- **Thin community `Community 1955`** (1 nodes): `Navbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1956`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1956`** (1 nodes): `OrganizationView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1957`** (1 nodes): `StoreView.test.tsx`
+- **Thin community `Community 1957`** (1 nodes): `ProtectedRoute.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1958`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1958`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1959`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1959`** (1 nodes): `StoreView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1960`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1960`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1961`** (1 nodes): `AttributesTable.test.ts`
+- **Thin community `Community 1961`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1962`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1962`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1963`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1963`** (1 nodes): `AttributesTable.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1964`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1964`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1965`** (1 nodes): `ProductCategorization.test.ts`
+- **Thin community `Community 1965`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1966`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1966`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1967`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1967`** (1 nodes): `ProductCategorization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1968`** (1 nodes): `CopyImagesView.test.tsx`
+- **Thin community `Community 1968`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1969`** (1 nodes): `constants.ts`
+- **Thin community `Community 1969`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1970`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1970`** (1 nodes): `CopyImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1971`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1971`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1972`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1972`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1973`** (1 nodes): `types.ts`
+- **Thin community `Community 1973`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1974`** (1 nodes): `AnalyticsView.test.tsx`
+- **Thin community `Community 1974`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1975`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1975`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1976`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1976`** (1 nodes): `AnalyticsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1977`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1977`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1978`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1978`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1979`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1979`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1980`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1980`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1981`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1981`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1982`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1982`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1983`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1983`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1984`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1984`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1985`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1985`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1986`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1986`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1987`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1987`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1988`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1988`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1989`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1989`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1990`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1990`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1991`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1991`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1992`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1992`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1993`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1993`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1994`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1994`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1995`** (1 nodes): `constants.ts`
+- **Thin community `Community 1995`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1996`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1996`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1997`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1997`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1998`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1998`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1999`** (1 nodes): `data.ts`
+- **Thin community `Community 1999`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2000`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2000`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2001`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2001`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2002`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2002`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2003`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2003`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2004`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2004`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2005`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2005`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2006`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2006`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2007`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2007`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2008`** (1 nodes): `AppSettingsView.test.tsx`
+- **Thin community `Community 2008`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2009`** (1 nodes): `app-sidebar.test.tsx`
+- **Thin community `Community 2009`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2010`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 2010`** (1 nodes): `AppSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2011`** (1 nodes): `constants.ts`
+- **Thin community `Community 2011`** (1 nodes): `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2012`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2012`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2013`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2013`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2014`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2014`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2015`** (1 nodes): `data.ts`
+- **Thin community `Community 2015`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2016`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 2016`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2017`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2017`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2018`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 2018`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2019`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 2019`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2020`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2020`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2021`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2021`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2022`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2022`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2023`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2023`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2024`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2024`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2025`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2025`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2026`** (1 nodes): `constants.ts`
+- **Thin community `Community 2026`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2027`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2027`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2028`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2028`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2029`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2029`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2030`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2030`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2031`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 2031`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2032`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 2032`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2033`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 2033`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2034`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 2034`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2035`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 2035`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2036`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 2036`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2037`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 2037`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2038`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 2038`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2039`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2039`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2040`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2040`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2041`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2041`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2042`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 2042`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2043`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 2043`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2044`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 2044`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2045`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 2045`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2046`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 2046`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2047`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 2047`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2048`** (1 nodes): `Home.test.tsx`
+- **Thin community `Community 2048`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2049`** (1 nodes): `HomepagePlacementProductImage.test.ts`
+- **Thin community `Community 2049`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2050`** (1 nodes): `ShopLookImageUploader.test.tsx`
+- **Thin community `Community 2050`** (1 nodes): `Home.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2051`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2051`** (1 nodes): `HomepagePlacementProductImage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2052`** (1 nodes): `demoDay.test.ts`
+- **Thin community `Community 2052`** (1 nodes): `ShopLookImageUploader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2053`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 2053`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2054`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 2054`** (1 nodes): `demoDay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2055`** (1 nodes): `OperationsSummaryMetric.test.tsx`
+- **Thin community `Community 2055`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2056`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 2056`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2057`** (1 nodes): `openWorkInventoryReport.test.ts`
+- **Thin community `Community 2057`** (1 nodes): `OperationsSummaryMetric.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2058`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 2058`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2059`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
+- **Thin community `Community 2059`** (1 nodes): `openWorkInventoryReport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2060`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 2060`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2061`** (1 nodes): `CustomerDetailsView.test.tsx`
+- **Thin community `Community 2061`** (1 nodes): `skuActivityUntrustedSalesAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2062`** (1 nodes): `CustomerDetailsView.tsx`
+- **Thin community `Community 2062`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2063`** (1 nodes): `OrderDetailsView.test.tsx`
+- **Thin community `Community 2063`** (1 nodes): `CustomerDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2064`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 2064`** (1 nodes): `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2065`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 2065`** (1 nodes): `OrderDetailsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2066`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 2066`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2067`** (1 nodes): `OrdersView.test.tsx`
+- **Thin community `Community 2067`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2068`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 2068`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2069`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 2069`** (1 nodes): `OrdersView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2070`** (1 nodes): `constants.ts`
+- **Thin community `Community 2070`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2071`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2071`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2072`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2072`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2073`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2073`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2074`** (1 nodes): `data.ts`
+- **Thin community `Community 2074`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2075`** (1 nodes): `orderColumns.test.tsx`
+- **Thin community `Community 2075`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2076`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 2076`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2077`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2077`** (1 nodes): `orderColumns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2078`** (1 nodes): `constants.ts`
+- **Thin community `Community 2078`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2079`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2079`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2080`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2080`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2081`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2081`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2082`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2082`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2083`** (1 nodes): `data.ts`
+- **Thin community `Community 2083`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2084`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 2084`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2085`** (1 nodes): `constants.ts`
+- **Thin community `Community 2085`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2086`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2086`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2087`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2087`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2088`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2088`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2089`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2089`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2090`** (1 nodes): `data.ts`
+- **Thin community `Community 2090`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2091`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 2091`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2092`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 2092`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2093`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 2093`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2094`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 2094`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2095`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 2095`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2096`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 2096`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2097`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 2097`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2098`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 2098`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2099`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 2099`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2100`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 2100`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2101`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 2101`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2102`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 2102`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2103`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 2103`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2104`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 2104`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2105`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 2105`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2106`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 2106`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2107`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 2107`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2108`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 2108`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2109`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 2109`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2110`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 2110`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2111`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 2111`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2112`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 2112`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2113`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 2113`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2114`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 2114`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2115`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 2115`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2116`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 2116`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2117`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 2117`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2118`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 2118`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2119`** (1 nodes): `types.ts`
+- **Thin community `Community 2119`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2120`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 2120`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2121`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 2121`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2122`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 2122`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2123`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 2123`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2124`** (1 nodes): `ImagesView.test.tsx`
+- **Thin community `Community 2124`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2125`** (1 nodes): `ProductDetailView.test.tsx`
+- **Thin community `Community 2125`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2126`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 2126`** (1 nodes): `ImagesView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2127`** (1 nodes): `productStockPresentation.test.ts`
+- **Thin community `Community 2127`** (1 nodes): `ProductDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2128`** (1 nodes): `ArchivedProducts.test.tsx`
+- **Thin community `Community 2128`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2129`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 2129`** (1 nodes): `productStockPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2130`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 2130`** (1 nodes): `ArchivedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2131`** (1 nodes): `ProductsListView.test.tsx`
+- **Thin community `Community 2131`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2132`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 2132`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2133`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 2133`** (1 nodes): `ProductsListView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2134`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 2134`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2135`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 2135`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2136`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 2136`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2137`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2137`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2138`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2138`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2139`** (1 nodes): `data-table-toolbar.test.tsx`
+- **Thin community `Community 2139`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2140`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2140`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2141`** (1 nodes): `data-table.test.tsx`
+- **Thin community `Community 2141`** (1 nodes): `data-table-toolbar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2142`** (1 nodes): `data.ts`
+- **Thin community `Community 2142`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2143`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 2143`** (1 nodes): `data-table.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2144`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 2144`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2145`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 2145`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2146`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 2146`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2147`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 2147`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2148`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 2148`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2149`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2149`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2150`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2150`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2151`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2151`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2152`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2152`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2153`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2153`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2154`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2154`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2155`** (1 nodes): `constants.ts`
+- **Thin community `Community 2155`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2156`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2156`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2157`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2157`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2158`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2158`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2159`** (1 nodes): `data.ts`
+- **Thin community `Community 2159`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2160`** (1 nodes): `types.ts`
+- **Thin community `Community 2160`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2161`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 2161`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2162`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 2162`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2163`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 2163`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2164`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 2164`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2165`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 2165`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2166`** (1 nodes): `index.ts`
+- **Thin community `Community 2166`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2167`** (1 nodes): `CustomRangeStatus.test.tsx`
+- **Thin community `Community 2167`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2168`** (1 nodes): `InventoryMovementSummary.tsx`
+- **Thin community `Community 2168`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2169`** (1 nodes): `ReportAttentionList.tsx`
+- **Thin community `Community 2169`** (1 nodes): `CustomRangeStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2170`** (1 nodes): `ReportPeriodControl.test.tsx`
+- **Thin community `Community 2170`** (1 nodes): `InventoryMovementSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2171`** (1 nodes): `ReportsInventoryView.test.tsx`
+- **Thin community `Community 2171`** (1 nodes): `ReportAttentionList.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2172`** (1 nodes): `ReportsInventoryView.tsx`
+- **Thin community `Community 2172`** (1 nodes): `ReportPeriodControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2173`** (1 nodes): `ReportsItemsView.test.tsx`
+- **Thin community `Community 2173`** (1 nodes): `ReportsInventoryView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2174`** (1 nodes): `ReportsItemsView.tsx`
+- **Thin community `Community 2174`** (1 nodes): `ReportsInventoryView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2175`** (1 nodes): `ReportsLayout.test.tsx`
+- **Thin community `Community 2175`** (1 nodes): `ReportsItemsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2176`** (1 nodes): `ReportsOverviewView.test.tsx`
+- **Thin community `Community 2176`** (1 nodes): `ReportsItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2177`** (1 nodes): `ReportsSkuDetailView.test.tsx`
+- **Thin community `Community 2177`** (1 nodes): `ReportsLayout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2178`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
+- **Thin community `Community 2178`** (1 nodes): `ReportsOverviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2179`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
+- **Thin community `Community 2179`** (1 nodes): `ReportsSkuDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2180`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
+- **Thin community `Community 2180`** (1 nodes): `ReportsSkuEvidenceList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2181`** (1 nodes): `ReportsWorkspaceControls.tsx`
+- **Thin community `Community 2181`** (1 nodes): `ReportsWorkspace.integration.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2182`** (1 nodes): `RevenueContribution.tsx`
+- **Thin community `Community 2182`** (1 nodes): `ReportsWorkspaceControls.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2183`** (1 nodes): `reportPresentation.test.ts`
+- **Thin community `Community 2183`** (1 nodes): `ReportsWorkspaceControls.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2184`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 2184`** (1 nodes): `RevenueContribution.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2185`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 2185`** (1 nodes): `reportPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2186`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 2186`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2187`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 2187`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2188`** (1 nodes): `SharedDemoExperience.test.tsx`
+- **Thin community `Community 2188`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2189`** (1 nodes): `SharedDemoOwnerHome.tsx`
+- **Thin community `Community 2189`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2190`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
+- **Thin community `Community 2190`** (1 nodes): `SharedDemoExperience.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2191`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
+- **Thin community `Community 2191`** (1 nodes): `SharedDemoOwnerHome.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2192`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
+- **Thin community `Community 2192`** (1 nodes): `SharedDemoRestoreOverlay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2193`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
+- **Thin community `Community 2193`** (1 nodes): `sharedDemoLocalBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2194`** (1 nodes): `index.tsx`
+- **Thin community `Community 2194`** (1 nodes): `sharedDemoRestoreOverlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2195`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 2195`** (1 nodes): `sharedDemoRestoreOverlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2196`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 2196`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2197`** (1 nodes): `NotFound.test.tsx`
+- **Thin community `Community 2197`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2198`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 2198`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2199`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 2199`** (1 nodes): `NotFound.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2200`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 2200`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2201`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 2201`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2202`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 2202`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2203`** (1 nodes): `StoreHoursView.test.tsx`
+- **Thin community `Community 2203`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2204`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 2204`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2205`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
+- **Thin community `Community 2205`** (1 nodes): `StoreHoursView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2206`** (1 nodes): `index.tsx`
+- **Thin community `Community 2206`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2207`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 2207`** (1 nodes): `useStoreScheduleUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2208`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2208`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2209`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 2209`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2210`** (1 nodes): `button.tsx`
+- **Thin community `Community 2210`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2211`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 2211`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2212`** (1 nodes): `card.tsx`
+- **Thin community `Community 2212`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2213`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2213`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2214`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 2214`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2215`** (1 nodes): `command.tsx`
+- **Thin community `Community 2215`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2216`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2216`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2217`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2217`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2218`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2218`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2219`** (1 nodes): `form.tsx`
+- **Thin community `Community 2219`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2220`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2220`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2221`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2221`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2222`** (1 nodes): `input.tsx`
+- **Thin community `Community 2222`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2223`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2223`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2224`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 2224`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2225`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2225`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2226`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 2226`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2227`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2227`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2228`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2228`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2229`** (1 nodes): `select.tsx`
+- **Thin community `Community 2229`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2230`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2230`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2231`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2231`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2232`** (1 nodes): `switch.tsx`
+- **Thin community `Community 2232`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2233`** (1 nodes): `table.tsx`
+- **Thin community `Community 2233`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2234`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2234`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2235`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2235`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2236`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2236`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2237`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2237`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2238`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2238`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2239`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 2239`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2240`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 2240`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2241`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2241`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2242`** (1 nodes): `constants.ts`
+- **Thin community `Community 2242`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2243`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2243`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2244`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2244`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2245`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2245`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2246`** (1 nodes): `data.ts`
+- **Thin community `Community 2246`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2247`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 2247`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2248`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 2248`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2249`** (1 nodes): `columns.tsx`
+- **Thin community `Community 2249`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2250`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 2250`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2251`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 2251`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2252`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 2252`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2253`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 2253`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2254`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 2254`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2255`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 2255`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2256`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 2256`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2257`** (1 nodes): `index.ts`
+- **Thin community `Community 2257`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2258`** (1 nodes): `config.test.ts`
+- **Thin community `Community 2258`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2259`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 2259`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2260`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 2260`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2261`** (1 nodes): `use-pagination-persistence.test.ts`
+- **Thin community `Community 2261`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2262`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2262`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2263`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 2263`** (1 nodes): `use-pagination-persistence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2264`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 2264`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2265`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 2265`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2266`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 2266`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2267`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2267`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2268`** (1 nodes): `usePOSProducts.test.ts`
+- **Thin community `Community 2268`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2269`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 2269`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2270`** (1 nodes): `useSharedDemoContext.test.ts`
+- **Thin community `Community 2270`** (1 nodes): `usePOSProducts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2271`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 2271`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2272`** (1 nodes): `AppMessagesContext.ts`
+- **Thin community `Community 2272`** (1 nodes): `useSharedDemoContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2273`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
+- **Thin community `Community 2273`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2274`** (1 nodes): `index.ts`
+- **Thin community `Community 2274`** (1 nodes): `AppMessagesContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2275`** (1 nodes): `appUpdateActions.ts`
+- **Thin community `Community 2275`** (1 nodes): `appMessageCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2276`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2277`** (1 nodes): `updateCommunicationPreferenceContext.ts`
+- **Thin community `Community 2277`** (1 nodes): `appUpdateActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2278`** (1 nodes): `updateCoordinator.test.ts`
+- **Thin community `Community 2278`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2279`** (1 nodes): `aws.ts`
+- **Thin community `Community 2279`** (1 nodes): `updateCommunicationPreferenceContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2280`** (1 nodes): `constants.ts`
+- **Thin community `Community 2280`** (1 nodes): `updateCoordinator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2281`** (1 nodes): `countries.ts`
+- **Thin community `Community 2281`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2282`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 2282`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2283`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 2283`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2284`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 2284`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2285`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 2285`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2286`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2286`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2287`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2287`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2288`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 2288`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2289`** (1 nodes): `landingFunnelClient.test.ts`
+- **Thin community `Community 2289`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2290`** (1 nodes): `walkthroughPrivacy.ts`
+- **Thin community `Community 2290`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2291`** (1 nodes): `walkthroughRequestClient.test.ts`
+- **Thin community `Community 2291`** (1 nodes): `landingFunnelClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2292`** (1 nodes): `appEntryRoutes.test.ts`
+- **Thin community `Community 2292`** (1 nodes): `walkthroughPrivacy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2293`** (1 nodes): `storeEntryRoute.test.ts`
+- **Thin community `Community 2293`** (1 nodes): `walkthroughRequestClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2294`** (1 nodes): `operatingDate.test.ts`
+- **Thin community `Community 2294`** (1 nodes): `appEntryRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2295`** (1 nodes): `dto.ts`
+- **Thin community `Community 2295`** (1 nodes): `storeEntryRoute.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2296`** (1 nodes): `ports.ts`
+- **Thin community `Community 2296`** (1 nodes): `operatingDate.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2297`** (1 nodes): `posLocalStorePort.ts`
+- **Thin community `Community 2297`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2298`** (1 nodes): `results.test.ts`
+- **Thin community `Community 2298`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2299`** (1 nodes): `constants.ts`
+- **Thin community `Community 2299`** (1 nodes): `posLocalStorePort.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2300`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 2300`** (1 nodes): `results.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2301`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 2301`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2302`** (1 nodes): `index.ts`
+- **Thin community `Community 2302`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2303`** (1 nodes): `session.test.ts`
+- **Thin community `Community 2303`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2304`** (1 nodes): `types.ts`
+- **Thin community `Community 2304`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2305`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 2305`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2306`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 2306`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2307`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
+- **Thin community `Community 2307`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2308`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 2308`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2309`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
+- **Thin community `Community 2309`** (1 nodes): `registerLifecycleAuthorityGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2310`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
+- **Thin community `Community 2310`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2311`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 2311`** (1 nodes): `drawerAuthorityReconciliation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2312`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 2312`** (1 nodes): `indexedDbPosLocalStorageEngine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2313`** (1 nodes): `posLocalLedgerPolicy.test.ts`
+- **Thin community `Community 2313`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2314`** (1 nodes): `posLocalStorageHealth.test.ts`
+- **Thin community `Community 2314`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2315`** (1 nodes): `posLocalStorageRuntime.test.ts`
+- **Thin community `Community 2315`** (1 nodes): `posLocalLedgerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2316`** (1 nodes): `posLocalStoreInitialization.test.ts`
+- **Thin community `Community 2316`** (1 nodes): `posLocalStorageHealth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2317`** (1 nodes): `posLocalStoreMaintenance.test.ts`
+- **Thin community `Community 2317`** (1 nodes): `posLocalStorageRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2318`** (1 nodes): `posLocalStoreMigrations.test.ts`
+- **Thin community `Community 2318`** (1 nodes): `posLocalStoreInitialization.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2319`** (1 nodes): `posLocalStoreSnapshot.test.ts`
+- **Thin community `Community 2319`** (1 nodes): `posLocalStoreMaintenance.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2320`** (1 nodes): `registerCatalogPinRuntime.test.ts`
+- **Thin community `Community 2320`** (1 nodes): `posLocalStoreMigrations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2321`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
+- **Thin community `Community 2321`** (1 nodes): `posLocalStoreSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2322`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
+- **Thin community `Community 2322`** (1 nodes): `registerCatalogPinRuntime.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2323`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 2323`** (1 nodes): `registerLifecycleAuthorityRollout.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2324`** (1 nodes): `runtimeCounters.test.ts`
+- **Thin community `Community 2324`** (1 nodes): `registerSessionAuthorityBootstrap.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2325`** (1 nodes): `telemetryBuffer.test.ts`
+- **Thin community `Community 2325`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2326`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 2326`** (1 nodes): `runtimeCounters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2327`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 2327`** (1 nodes): `telemetryBuffer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2328`** (1 nodes): `registerCashierPresence.test.ts`
+- **Thin community `Community 2328`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2329`** (1 nodes): `registerCheckoutProjection.test.ts`
+- **Thin community `Community 2329`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2330`** (1 nodes): `registerUiState.test.ts`
+- **Thin community `Community 2330`** (1 nodes): `registerCashierPresence.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2331`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
+- **Thin community `Community 2331`** (1 nodes): `registerCheckoutProjection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2332`** (1 nodes): `registerSessionCode.test.ts`
+- **Thin community `Community 2332`** (1 nodes): `registerUiState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2333`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 2333`** (1 nodes): `useRegisterCheckoutDraftState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2334`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2334`** (1 nodes): `registerSessionCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2335`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 2335`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2336`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 2336`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2337`** (1 nodes): `index.ts`
+- **Thin community `Community 2337`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2338`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 2338`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2339`** (1 nodes): `category.ts`
+- **Thin community `Community 2339`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2340`** (1 nodes): `product.ts`
+- **Thin community `Community 2340`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2341`** (1 nodes): `store.ts`
+- **Thin community `Community 2341`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2342`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2342`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2343`** (1 nodes): `user.ts`
+- **Thin community `Community 2343`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2344`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 2344`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2345`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 2345`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2346`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 2346`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2347`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 2347`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2348`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2348`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2349`** (1 nodes): `main.tsx`
+- **Thin community `Community 2349`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2350`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 2350`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2351`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 2351`** (1 nodes): `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2352`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 2352`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2353`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 2353`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2354`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2354`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2355`** (1 nodes): `-app-entry-route.tsx`
+- **Thin community `Community 2355`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2356`** (1 nodes): `-privacy-page.tsx`
+- **Thin community `Community 2356`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2357`** (1 nodes): `-root-page-search.ts`
+- **Thin community `Community 2357`** (1 nodes): `-app-entry-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2358`** (1 nodes): `-shared-demo-entry.tsx`
+- **Thin community `Community 2358`** (1 nodes): `-privacy-page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2359`** (1 nodes): `__root.test.ts`
+- **Thin community `Community 2359`** (1 nodes): `-root-page-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2360`** (1 nodes): `index.tsx`
+- **Thin community `Community 2360`** (1 nodes): `-shared-demo-entry.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2361`** (1 nodes): `index.tsx`
+- **Thin community `Community 2361`** (1 nodes): `__root.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2362`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2363`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 2363`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2364`** (1 nodes): `app-settings.tsx`
+- **Thin community `Community 2364`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2365`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 2365`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2366`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 2366`** (1 nodes): `app-settings.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2367`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 2367`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2368`** (1 nodes): `index.tsx`
+- **Thin community `Community 2368`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2369`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 2369`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2370`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 2370`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2371`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 2371`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2372`** (1 nodes): `home.tsx`
+- **Thin community `Community 2372`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2373`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 2373`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2374`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 2374`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2375`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 2375`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2376`** (1 nodes): `review.tsx`
+- **Thin community `Community 2376`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2377`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2377`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2378`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2378`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2379`** (1 nodes): `index.tsx`
+- **Thin community `Community 2379`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2380`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2380`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2381`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2381`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2382`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `index.tsx`
+- **Thin community `Community 2383`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2384`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2385`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2386`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2387`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2388`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2389`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2390`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2391`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2392`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2393`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2394`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2395`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2396`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2397`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2398`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `index.tsx`
+- **Thin community `Community 2399`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2400`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `new.tsx`
+- **Thin community `Community 2401`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `new.tsx`
+- **Thin community `Community 2402`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2403`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2404`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `index.tsx`
+- **Thin community `Community 2405`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `new.tsx`
+- **Thin community `Community 2406`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `items.tsx`
+- **Thin community `Community 2407`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `search.test.ts`
+- **Thin community `Community 2408`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `storefront.tsx`
+- **Thin community `Community 2409`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `index.tsx`
+- **Thin community `Community 2410`** (1 nodes): `search.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2411`** (1 nodes): `storefront.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2412`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2412`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2413`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2414`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `index.tsx`
+- **Thin community `Community 2415`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2416`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2417`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2418`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `index.tsx`
+- **Thin community `Community 2419`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2420`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2421`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `_authed.tsx`
+- **Thin community `Community 2422`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2423`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `app.tsx`
+- **Thin community `Community 2424`** (1 nodes): `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2425`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `demo.tsx`
+- **Thin community `Community 2426`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2427`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `index.tsx`
+- **Thin community `Community 2428`** (1 nodes): `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2429`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2430`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2431`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2431`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2432`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2433`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2434`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2435`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2436`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `walkthrough.tsx`
+- **Thin community `Community 2437`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2438`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2439`** (1 nodes): `walkthrough.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2440`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2441`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2442`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2443`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2444`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2445`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2446`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2447`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2448`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2449`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2450`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2451`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2452`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2453`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `eodReviewFixtures.ts`
+- **Thin community `Community 2454`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2455`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2456`** (1 nodes): `eodReviewFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `setup.ts`
+- **Thin community `Community 2457`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `vite-env.d.ts`
+- **Thin community `Community 2458`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2459`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `types.ts`
+- **Thin community `Community 2460`** (1 nodes): `vite-env.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2461`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2462`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2463`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2464`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2465`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2466`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2467`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `types.ts`
+- **Thin community `Community 2468`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2469`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2470`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2471`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2472`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2473`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2474`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2475`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2476`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `schema.ts`
+- **Thin community `Community 2477`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2478`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2479`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2480`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2481`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2482`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2483`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2484`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2485`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2486`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `types.ts`
+- **Thin community `Community 2487`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2488`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2489`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2490`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2491`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2492`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2493`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2494`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `constants.ts`
+- **Thin community `Community 2495`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2496`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `About.tsx`
+- **Thin community `Community 2497`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2498`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2499`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2500`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2501`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2502`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2503`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2504`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2505`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2506`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2507`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `types.ts`
+- **Thin community `Community 2508`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2509`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2510`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2511`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2512`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2513`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2514`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2515`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2516`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2517`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2518`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2519`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `button.tsx`
+- **Thin community `Community 2520`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `card.tsx`
+- **Thin community `Community 2521`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2522`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `command.tsx`
+- **Thin community `Community 2523`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2524`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2525`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2526`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `form.tsx`
+- **Thin community `Community 2527`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2528`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2528`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2529`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2530`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2531`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `input.tsx`
+- **Thin community `Community 2532`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `label.tsx`
+- **Thin community `Community 2533`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2534`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2535`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2536`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2537`** (1 nodes): `index.ts`
+- **Thin community `Community 2537`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `types.ts`
+- **Thin community `Community 2538`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2539`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2540`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2541`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2542`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2543`** (1 nodes): `select.tsx`
+- **Thin community `Community 2543`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2544`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2544`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2545`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2545`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `table.tsx`
+- **Thin community `Community 2546`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2547`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2548`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2549`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2550`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2551`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `config.ts`
+- **Thin community `Community 2552`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2553`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2554`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2555`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2556`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2557`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `constants.ts`
+- **Thin community `Community 2558`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `countries.ts`
+- **Thin community `Community 2559`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2560`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2561`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2562`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2563`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `index.ts`
+- **Thin community `Community 2564`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2565`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `store.ts`
+- **Thin community `Community 2566`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `bag.ts`
+- **Thin community `Community 2567`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2568`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `category.ts`
+- **Thin community `Community 2569`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `organization.ts`
+- **Thin community `Community 2570`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `product.ts`
+- **Thin community `Community 2571`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `store.ts`
+- **Thin community `Community 2572`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2573`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2574`** (1 nodes): `user.ts`
+- **Thin community `Community 2574`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `states.ts`
+- **Thin community `Community 2575`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2576`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2576`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2577`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2578`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2579`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2580`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2581`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2582`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2583`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `index.tsx`
+- **Thin community `Community 2584`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2585`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2586`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2587`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2588`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2589`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2589`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2590`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2591`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `index.tsx`
+- **Thin community `Community 2592`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2593`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2594`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2595`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2596`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2596`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2597`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2597`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2598`** (1 nodes): `index.js`
+- **Thin community `Community 2598`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2599`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2599`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2600`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2600`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2601`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2601`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2602`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2602`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2603`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2603`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2604`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2604`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2605`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2605`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2606`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2606`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2607`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2607`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2608`** (1 nodes): `harness-repo-validation.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2609`** (1 nodes): `operational-work-repair.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2682
-- Graph nodes: 10869
-- Graph edges: 13190
-- Communities: 2608
+- Code files discovered: 2684
+- Graph nodes: 10876
+- Graph edges: 13196
+- Communities: 2610
 
 ## Graph Hotspots
 - `dailyClose.ts` (92 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 122 file(s); key children: -app-entry-route.tsx, -authed-layout.tsx, -authenticated-layout.tsx, -demo-presentation.ts, -index-route-view.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 743 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 744 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 35 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/src/components/landing/story/PosHubRoleSwitcher.tsx
+++ b/packages/athena-webapp/src/components/landing/story/PosHubRoleSwitcher.tsx
@@ -1,0 +1,154 @@
+import { animate } from "animejs";
+import { useReducedMotion } from "framer-motion";
+import { useLayoutEffect, useRef, useState } from "react";
+
+import { PosHubBody } from "@/components/pos/PointOfSaleView";
+import type { POSStorePulseWindow } from "@/components/pos/sales-pulse/POSSalesPulseView";
+import {
+  POS_HUB_NOW,
+  posHubCurrencyFormatter,
+  posHubManagerFeatures,
+  posHubManagerPulseByWindow,
+  posHubScheduleSummary,
+  posHubStaffFeatures,
+  posHubStaffSummary,
+} from "@/stories/operations/posHubFixtures";
+
+type Role = "manager" | "staff";
+
+const ROLES: Array<{ caption: string; id: Role; label: string }> = [
+  {
+    caption: "The owner's view: every launcher, and the whole pulse — live.",
+    id: "manager",
+    label: "Store manager",
+  },
+  {
+    caption: "A cashier's view: the tools to sell, and today's count — no store financials.",
+    id: "staff",
+    label: "Staff",
+  },
+];
+
+// The POS hub, filtered to a role — rendered live from authored fixture data, so
+// the manager's store-pulse tabs (today / this week / this month / all time) are
+// genuinely interactive. Staff see the launchers they can act on and a bare
+// transaction count. A minimal toggle swaps between the two.
+export function PosHubRoleSwitcher() {
+  const [role, setRole] = useState<Role>("manager");
+  const [pulseWindow, setPulseWindow] =
+    useState<POSStorePulseWindow>("this_week");
+  const active = ROLES.find((entry) => entry.id === role) ?? ROLES[0];
+  const reduceMotion = useReducedMotion();
+
+  const rootRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  // The manager and staff hubs differ a lot in height, so swapping them lets the
+  // browser's scroll anchoring nudge the viewport. Record where the control sits
+  // before the swap and correct any drift before paint so it stays put.
+  const anchorTopRef = useRef<number | null>(null);
+  const didMountRef = useRef(false);
+
+  const selectRole = (next: Role) => {
+    if (next === role) return;
+    // Swap synchronously; the fade below is a fire-and-forget entrance.
+    anchorTopRef.current = rootRef.current?.getBoundingClientRect().top ?? null;
+    setRole(next);
+  };
+
+  useLayoutEffect(() => {
+    const anchorTop = anchorTopRef.current;
+    anchorTopRef.current = null;
+    if (anchorTop != null && rootRef.current) {
+      const drift = rootRef.current.getBoundingClientRect().top - anchorTop;
+      if (drift !== 0) window.scrollBy(0, drift);
+    }
+
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    if (reduceMotion || !bodyRef.current) return;
+    animate(bodyRef.current, {
+      duration: 280,
+      ease: "outQuad",
+      opacity: { from: 0 },
+    });
+    // Only fade on a role change, not on pulse-window changes within a role.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [role]);
+
+  const body =
+    role === "manager" ? (
+      <PosHubBody
+        currencyFormatter={posHubCurrencyFormatter}
+        hasFullAdminAccess
+        nowOverride={POS_HUB_NOW}
+        onPulseWindowChange={setPulseWindow}
+        posFeatures={posHubManagerFeatures}
+        pulseWindow={pulseWindow}
+        scheduleSummary={posHubScheduleSummary}
+        todaySummary={posHubManagerPulseByWindow[pulseWindow]}
+      />
+    ) : (
+      <PosHubBody
+        currencyFormatter={posHubCurrencyFormatter}
+        hasFullAdminAccess={false}
+        nowOverride={POS_HUB_NOW}
+        onPulseWindowChange={() => {}}
+        posFeatures={posHubStaffFeatures}
+        pulseWindow="today"
+        scheduleSummary={posHubScheduleSummary}
+        todaySummary={posHubStaffSummary}
+      />
+    );
+
+  return (
+    <div
+      className="w-full space-y-layout-2xl [overflow-anchor:none]"
+      data-testid="pos-hub-exhibit"
+      ref={rootRef}
+    >
+      <div className="flex flex-wrap items-center gap-x-layout-lg gap-y-layout-sm">
+        <div
+          aria-label="POS hub role"
+          className="inline-flex rounded-full border border-border bg-surface p-1 shadow-surface"
+          role="group"
+        >
+          {ROLES.map((entry) => {
+            const isActive = entry.id === role;
+
+            return (
+              <button
+                aria-pressed={isActive}
+                className={`rounded-full px-layout-md py-2 text-sm font-medium transition-colors ${
+                  isActive
+                    ? "bg-primary-soft text-primary shadow-surface"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+                key={entry.id}
+                onClick={() => selectRole(entry.id)}
+                type="button"
+              >
+                {entry.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-sm leading-6 text-muted-foreground">
+          {active.caption}
+        </p>
+      </div>
+
+      {/* Live hub exhibit, scaled down to sit as a product shot in the column
+          (zoom reflows height, unlike transform). The launcher tiles are
+          decorative here, so their real in-app links are disabled — the store
+          pulse below stays interactive. */}
+      <div
+        className="will-change-[opacity] [zoom:0.8] [&_[data-testid=athena-pos-hub-ready]]:pointer-events-none"
+        ref={bodyRef}
+      >
+        {body}
+      </div>
+    </div>
+  );
+}

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -33,6 +33,7 @@ import { usePrewarmRegisterCatalogOfflineSnapshots } from "@/lib/pos/infrastruct
 import type { Id } from "~/convex/_generated/dataModel";
 import {
   POSStorePulseSection,
+  type POSStorePulseSummary,
   type POSStorePulseWindow,
 } from "./sales-pulse/POSSalesPulseView";
 
@@ -155,12 +156,17 @@ function useMinuteNow() {
 }
 
 function StoreLocalTime({
+  nowOverride,
   scheduleSummary,
 }: {
+  nowOverride?: Date;
   scheduleSummary: StoreScheduleSummaryResult | undefined;
 }) {
   const shouldReduceMotion = useReducedMotion();
-  const now = useMinuteNow();
+  const tickingNow = useMinuteNow();
+  // Screenshot fixtures pin the clock so the captured header is deterministic;
+  // the live page always uses the ticking wall clock.
+  const now = nowOverride ?? tickingNow;
   const timezone =
     scheduleSummary?.context?.timezone ?? scheduleSummary?.schedule?.timezone;
   const formattedTime = useMemo(
@@ -206,7 +212,109 @@ function StoreLocalTime({
   );
 }
 
-export default function PointOfSaleView() {
+/**
+ * Builds the POS hub's launcher tiles. Shared by the live wrapper and the
+ * screenshot fixtures so the authored hub can't drift from the real one.
+ */
+export function buildPosFeatures({
+  canAccessPOS,
+  hasFinancialDetailsAccess,
+  liveLinkParams,
+  posLinkParams,
+  setupRequired,
+}: {
+  canAccessPOS: boolean;
+  hasFinancialDetailsAccess: boolean;
+  liveLinkParams: { orgUrlSlug: string; storeUrlSlug: string } | null;
+  posLinkParams: { orgUrlSlug: string; storeUrlSlug: string } | null;
+  setupRequired: boolean;
+}): PosFeatureConfig[] {
+  return [
+    {
+      title: "POS",
+      description: setupRequired
+        ? "Connect this terminal before starting sales"
+        : "Transact in-store sales",
+      icon: ScanBarcode,
+      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/register",
+      params: posLinkParams,
+      color: "bg-blue-500",
+      available: true,
+      enabled: Boolean(posLinkParams),
+      badge: setupRequired ? "Setup required" : undefined,
+    },
+    {
+      title: "Expense Products",
+      description: "Track products expensed",
+      icon: HandCoins,
+      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense",
+      params: liveLinkParams,
+      color: "bg-rose-500",
+      available: Boolean(liveLinkParams),
+      enabled: Boolean(liveLinkParams),
+    },
+    {
+      title: "Product Lookup",
+      description: "Search and scan products for quick reference",
+      icon: Search,
+      href: "/$orgUrlSlug/store/$storeUrlSlug/products",
+      params: liveLinkParams,
+      color: "bg-green-500",
+      available: hasFinancialDetailsAccess && Boolean(liveLinkParams),
+    },
+
+    {
+      title: "Transactions",
+      description: "View completed transaction history",
+      icon: Receipt,
+      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
+      params: liveLinkParams,
+      color: "bg-orange-500",
+      available: Boolean(liveLinkParams),
+    },
+    {
+      title: "Expense Reports",
+      description: "View expense reports",
+      icon: Receipt,
+      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports",
+      params: liveLinkParams,
+      color: "bg-yellow-500",
+      available: Boolean(liveLinkParams),
+    },
+    {
+      title: "Terminal Health",
+      description:
+        "Review checkout station sync, staff authority, and support signals",
+      icon: MonitorCheck,
+      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/terminals",
+      params: liveLinkParams,
+      color: "bg-emerald-600",
+      available:
+        canAccessPOS && hasFinancialDetailsAccess && Boolean(liveLinkParams),
+    },
+    {
+      title: "Customers",
+      description: "Manage customer information and purchase history",
+      icon: Users,
+      href: null,
+      params: null,
+      color: "bg-pink-500",
+      available: false,
+    },
+    {
+      title: "POS Settings",
+      description: "Configure terminal settings",
+      icon: Settings,
+      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/settings",
+      params: liveLinkParams,
+      color: "bg-gray-500",
+      available:
+        canAccessPOS && hasFinancialDetailsAccess && Boolean(liveLinkParams),
+    },
+  ];
+}
+
+function PointOfSaleViewLive() {
   const { activeStore } = useGetActiveStore();
   const { activeOrganization } = useGetActiveOrganization();
   const [storePulseWindow, setStorePulseWindow] =
@@ -267,98 +375,77 @@ export default function PointOfSaleView() {
   const setupRequired =
     localEntryContext.status !== "loading" &&
     localEntryContext.status !== "ready";
-  const posFeatures = [
-    {
-      title: "POS",
-      description: setupRequired
-        ? "Connect this terminal before starting sales"
-        : "Transact in-store sales",
-      icon: ScanBarcode,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/register" as const,
-      params: posLinkParams,
-      color: "bg-blue-500",
-      available: true,
-      enabled: Boolean(posLinkParams),
-      badge: setupRequired ? "Setup required" : undefined,
-    },
-    {
-      title: "Expense Products",
-      description: "Track products expensed",
-      icon: HandCoins,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense" as const,
-      params: liveLinkParams,
-      color: "bg-rose-500",
-      available: Boolean(liveLinkParams),
-      enabled: Boolean(liveLinkParams),
-    },
-    {
-      title: "Product Lookup",
-      description: "Search and scan products for quick reference",
-      icon: Search,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/products" as const,
-      params: liveLinkParams,
-      color: "bg-green-500",
-      available: hasFinancialDetailsAccess && Boolean(liveLinkParams),
-    },
-
-    {
-      title: "Transactions",
-      description: "View completed transaction history",
-      icon: Receipt,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions" as const,
-      params: liveLinkParams,
-      color: "bg-orange-500",
-      available: Boolean(liveLinkParams),
-    },
-    {
-      title: "Expense Reports",
-      description: "View expense reports",
-      icon: Receipt,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports" as const,
-      params: liveLinkParams,
-      color: "bg-yellow-500",
-      available: Boolean(liveLinkParams),
-    },
-    {
-      title: "Terminal Health",
-      description:
-        "Review checkout station sync, staff authority, and support signals",
-      icon: MonitorCheck,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/terminals" as const,
-      params: liveLinkParams,
-      color: "bg-emerald-600",
-      available:
-        canAccessPOS() && hasFinancialDetailsAccess && Boolean(liveLinkParams),
-    },
-    {
-      title: "Customers",
-      description: "Manage customer information and purchase history",
-      icon: Users,
-      href: null,
-      params: null,
-      color: "bg-pink-500",
-      available: false,
-    },
-    {
-      title: "POS Settings",
-      description: "Configure terminal settings",
-      icon: Settings,
-      href: "/$orgUrlSlug/store/$storeUrlSlug/pos/settings" as const,
-      params: liveLinkParams,
-      color: "bg-gray-500",
-      available:
-        canAccessPOS() && hasFinancialDetailsAccess && Boolean(liveLinkParams),
-    },
-  ];
+  const posFeatures = buildPosFeatures({
+    canAccessPOS: canAccessPOS(),
+    hasFinancialDetailsAccess,
+    liveLinkParams,
+    posLinkParams,
+    setupRequired,
+  });
 
   return (
-    <View hideBorder hideHeaderBottomBorder>
-      <FadeIn className="container mx-auto py-layout-xl">
+    <PointOfSaleViewContent
+      currencyFormatter={currencyFormatter}
+      hasFullAdminAccess={hasFullAdminAccess}
+      onPulseWindowChange={setStorePulseWindow}
+      posFeatures={posFeatures}
+      pulseWindow={visibleStorePulseWindow}
+      scheduleSummary={storeScheduleSummary}
+      todaySummary={todaySummary}
+    />
+  );
+}
+
+export type PosFeatureConfig = {
+  available: boolean;
+  badge?: string;
+  color: string;
+  description: string;
+  enabled?: boolean;
+  href: string | null;
+  icon: ComponentType<{ className?: string }>;
+  params: { orgUrlSlug: string; storeUrlSlug: string } | null;
+  title: string;
+};
+
+export type PointOfSaleViewContentProps = {
+  currencyFormatter: Intl.NumberFormat;
+  hasFullAdminAccess: boolean;
+  /** Pin the header's store clock; screenshot fixtures only. */
+  nowOverride?: Date;
+  onPulseWindowChange: (pulseWindow: POSStorePulseWindow) => void;
+  posFeatures: PosFeatureConfig[];
+  pulseWindow: POSStorePulseWindow;
+  scheduleSummary: StoreScheduleSummaryResult | undefined;
+  todaySummary: POSStorePulseSummary | undefined;
+};
+
+/**
+ * The POS hub's inner content — the feature launchers and the store-pulse
+ * summary — without the {@link View} chrome. Split out so it can be embedded
+ * on its own (e.g. the marketing landing renders a live, interactive pulse
+ * from this) without View's mount-time `window.scrollTo`.
+ */
+export function PosHubBody({
+  currencyFormatter,
+  hasFullAdminAccess,
+  nowOverride,
+  onPulseWindowChange,
+  posFeatures,
+  pulseWindow,
+  scheduleSummary,
+  todaySummary,
+}: PointOfSaleViewContentProps) {
+  return (
+    <>
         <PageWorkspace>
           <PageLevelHeader
             title="Point of Sale"
             description={
-              <StoreLocalTime scheduleSummary={storeScheduleSummary} />
+              <StoreLocalTime
+                nowOverride={nowOverride}
+                scheduleSummary={scheduleSummary}
+              />
             }
           />
 
@@ -452,12 +539,39 @@ export default function PointOfSaleView() {
           <POSStorePulseSection
             currencyFormatter={currencyFormatter}
             hasFullAdminAccess={hasFullAdminAccess}
-            onPulseWindowChange={setStorePulseWindow}
-            pulseWindow={visibleStorePulseWindow}
+            onPulseWindowChange={onPulseWindowChange}
+            pulseWindow={pulseWindow}
             todaySummary={todaySummary}
           />
         </PageWorkspace>
+    </>
+  );
+}
+
+/**
+ * Presentational POS hub inside the app's {@link View} chrome. Rendered live
+ * from Convex by {@link PointOfSaleViewLive}, or from authored screenshot
+ * fixtures via the `fixture` prop on the default export.
+ */
+export function PointOfSaleViewContent(props: PointOfSaleViewContentProps) {
+  return (
+    <View hideBorder hideHeaderBottomBorder>
+      <FadeIn className="container mx-auto py-layout-xl">
+        <PosHubBody {...props} />
       </FadeIn>
     </View>
+  );
+}
+
+export default function PointOfSaleView({
+  fixture,
+}: {
+  /** Authored screenshot fixture; dev-only, bypasses all live queries. */
+  fixture?: PointOfSaleViewContentProps;
+} = {}) {
+  return fixture ? (
+    <PointOfSaleViewContent {...fixture} />
+  ) : (
+    <PointOfSaleViewLive />
   );
 }

--- a/packages/athena-webapp/src/routes/-index-route-view.tsx
+++ b/packages/athena-webapp/src/routes/-index-route-view.tsx
@@ -23,6 +23,7 @@ import {
   WholeLoopFigure,
 } from "@/components/landing/story/ControlLoopFigures";
 import { LandingWorkspaceShot } from "@/components/landing/story/LandingWorkspaceShot";
+import { PosHubRoleSwitcher } from "@/components/landing/story/PosHubRoleSwitcher";
 import { RegisterSessionScene } from "@/components/landing/story/RegisterSessionScene";
 import { SyncBridgeScene } from "@/components/landing/story/SyncBridgeScene";
 import { AutomationBeat } from "@/components/landing/story/SceneChrome";
@@ -453,7 +454,12 @@ export function Index() {
   return (
     <PublicLayout trackFunnelCtas hideSecondaryNav showThemeToggle>
       <LandingGrain />
-      <main>
+      {/* Every exhibit on this page reserves its space (explicit width/height),
+          so browser scroll anchoring has nothing to protect against — but it
+          does misfire on the POS hub role switcher, whose two shots differ by
+          ~2400px: with an anchor node picked from a section below the act, the
+          swap yanks the viewport. Exclude the whole page from anchor selection. */}
+      <main className="[overflow-anchor:none]">
         <HeroSection />
 
         <ControlLoopSection />
@@ -500,10 +506,29 @@ export function Index() {
         </StoryAct>
 
         <StoryAct
-          background="bg-background"
+          background="bg-app-canvas"
           layout="stacked"
           stackedGap="space-y-layout-3xl"
           workspace="Point of Sale"
+          title="One register, two views."
+          copy="Everything the counter needs, in one hub. Staff see their tools; you see the whole pulse — today to all time."
+          automation="Every synced sale updates the pulse on its own; nothing to refresh, nothing to tally."
+          texture={
+            // The hub shot's own canvas backdrop sits flush on the canvas
+            // section so it reads as the page, not a card; the section's foot
+            // then melts into white so the next act's background flows in.
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-gradient-to-b from-transparent to-background" />
+          }
+        >
+          <PosHubRoleSwitcher />
+        </StoryAct>
+
+        <StoryAct
+          hideTopBorder
+          background="bg-background"
+          layout="stacked"
+          stackedGap="space-y-layout-3xl"
+          workspace="Device-first"
           title="The network drops. Sales don't."
           copy="Every sale lands on the device first, instantly. Lose the connection and the counter keeps moving: the sale is held safe, then syncs itself the moment the network returns."
           automation="No manual sync, no re-entry, nothing to remember."

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx
@@ -1,9 +1,28 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+
 import PointOfSaleView from "~/src/components/pos/PointOfSaleView";
 import { PosClientTelemetryHost } from "~/src/components/pos/PosClientTelemetryHost";
 import { NotFoundView } from "~/src/components/states/not-found/NotFoundView";
+import { usePosHubFixture } from "~/src/stories/operations/devFixtureActivation";
+
+const pointOfSaleSearchSchema = z.object({
+  // Development-only screenshot fixture; inert in production builds.
+  fixture: z.string().optional(),
+});
 
 function PointOfSaleRoute() {
+  const { fixture: fixtureName } = Route.useSearch();
+  const { fixture, isResolving } = usePosHubFixture(fixtureName);
+
+  // Hold the render while a fixture loads, so the hub never briefly takes the
+  // Convex path and issues the queries the fixture exists to avoid.
+  if (isResolving) return null;
+
+  // In fixture mode the authored hub stands alone — no live telemetry side
+  // effects behind the screenshot.
+  if (fixture) return <PointOfSaleView fixture={fixture} />;
+
   return (
     <>
       <PosClientTelemetryHost />
@@ -29,4 +48,5 @@ export const Route = createFileRoute(
   component: PointOfSaleRoute,
 
   notFoundComponent: PointOfSaleNotFoundRoute,
+  validateSearch: pointOfSaleSearchSchema,
 });

--- a/packages/athena-webapp/src/routes/landing.test.tsx
+++ b/packages/athena-webapp/src/routes/landing.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -12,6 +12,24 @@ const mocked = vi.hoisted(() => ({
 vi.mock("@/lib/marketing/landingFunnelClient", () => ({
   emitLandingFunnelEvent: mocked.emitLandingFunnelEvent,
 }));
+
+// Keep the real anime.js (the scenes build timelines with it), but resolve the
+// POS hub role switcher's click-driven fade synchronously so the swap is
+// deterministic under test — anime's rAF loop never settles in jsdom.
+vi.mock("animejs", async (importActual) => {
+  const actual = await importActual<typeof import("animejs")>();
+  return {
+    ...actual,
+    animate: (
+      _targets: unknown,
+      params?: { onComplete?: () => void; onUpdate?: () => void },
+    ) => {
+      params?.onUpdate?.();
+      params?.onComplete?.();
+      return { pause() {}, revert() {} };
+    },
+  };
+});
 
 // The POS cart exhibit resolves the store currency through this hook; on the
 // public landing page there is no active store and it falls back to GHS.
@@ -167,6 +185,13 @@ describe("landing route", () => {
     expect(
       screen.getByAltText(/daily operations workspace:/i),
     ).toBeInTheDocument();
+    // The POS hub is a live exhibit (not a shot); its manager pulse defaults to
+    // the this-week window.
+    expect(
+      within(screen.getByTestId("pos-hub-exhibit")).getByText(
+        "This week's completed POS sales.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByAltText(/pending sync/i)).toBeInTheDocument();
     expect(screen.getByAltText(/'synced'/i)).toBeInTheDocument();
     expect(screen.getByAltText(/eod review workspace/i)).toBeInTheDocument();
@@ -191,5 +216,27 @@ describe("landing route", () => {
     expect(
       screen.getByText(/every decision stayed with the owner/i),
     ).toBeInTheDocument();
+  });
+
+  it("filters the manager pulse and toggles to the staff view", async () => {
+    const user = userEvent.setup();
+    render(<Index />);
+    const hub = within(screen.getByTestId("pos-hub-exhibit"));
+
+    // Manager (default): the financial pulse, on the this-week window, with the
+    // real window tabs.
+    expect(hub.getByText("This week's completed POS sales.")).toBeInTheDocument();
+    expect(hub.getByRole("tab", { name: "This month" })).toBeInTheDocument();
+
+    // The tabs actually filter the live pulse.
+    await user.click(hub.getByRole("tab", { name: "Today" }));
+    expect(hub.getByText("Today's completed POS sales.")).toBeInTheDocument();
+
+    // Staff: launchers plus a bare count — no financial pulse, no window tabs.
+    await user.click(hub.getByRole("button", { name: "Staff" }));
+    expect(
+      hub.queryByRole("tab", { name: "This month" }),
+    ).not.toBeInTheDocument();
+    expect(hub.queryByText(/completed POS sales\./)).not.toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/stories/operations/devFixtureActivation.ts
+++ b/packages/athena-webapp/src/stories/operations/devFixtureActivation.ts
@@ -17,6 +17,7 @@ import { useEffect, useState } from "react";
 import type { DailyCloseViewContentProps } from "@/components/operations/DailyCloseView";
 import type { DailyOpeningViewContentProps } from "@/components/operations/DailyOpeningView";
 import type { DailyOperationsViewContentProps } from "@/components/operations/DailyOperationsView";
+import type { PointOfSaleViewContentProps } from "@/components/pos/PointOfSaleView";
 import { setOperatingClockOverride } from "@/lib/operations/operatingDate";
 
 type FixtureEntry<TProps> = { clock: Date; props: TProps };
@@ -101,5 +102,11 @@ export function useDailyOpeningFixture(name?: string) {
 export function useDailyCloseFixture(name?: string) {
   return useWorkspaceFixture<DailyCloseViewContentProps>(name, () =>
     import("./eodReviewFixtures").then((m) => m.eodReviewFixtures),
+  );
+}
+
+export function usePosHubFixture(name?: string) {
+  return useWorkspaceFixture<PointOfSaleViewContentProps>(name, () =>
+    import("./posHubFixtures").then((m) => m.posHubFixtures),
   );
 }

--- a/packages/athena-webapp/src/stories/operations/posHubFixtures.ts
+++ b/packages/athena-webapp/src/stories/operations/posHubFixtures.ts
@@ -1,0 +1,348 @@
+/**
+ * Authored POS-hub data for the shared demo store (Osu Studio, GHS), pinned to
+ * the story Wednesday (2026-07-15).
+ *
+ * The marketing landing renders a **live, interactive** manager pulse from this:
+ * the real store-pulse tabs swap `posHubManagerPulseByWindow[window]` so Today /
+ * This week / This month / All time each show their own metrics, trend, top
+ * items and payment mix. Staff (no financial-details access) only ever see a
+ * transaction count for today. Everything reconciles to the story day — today is
+ * GH₵6,700 / 28 sales / 51 items; the week-to-date is GH₵23,500 / 97 / 180 (the
+ * canon `cachedWeekStorePulse`).
+ *
+ * Also feeds the dev-only `?fixture=` screenshot route via `usePosHubFixture`.
+ */
+
+import {
+  buildPosFeatures,
+  type PointOfSaleViewContentProps,
+} from "@/components/pos/PointOfSaleView";
+import type {
+  POSStorePulseSummary,
+  POSStorePulseWindow,
+} from "@/components/pos/sales-pulse/POSSalesPulseView";
+import { currencyFormatter } from "@/lib/utils";
+
+import { LINK_PARAMS } from "./operationsFixtureContext";
+
+const WED_OPERATING_DATE = "2026-07-15";
+
+// Mid-afternoon on the story Wednesday, after the traced 3:14 PM sale. Accra
+// keeps GMT year-round, so a UTC instant renders as the same wall-clock time on
+// any machine.
+export const POS_HUB_NOW = new Date(Date.UTC(2026, 6, 15, 15, 20));
+
+// Osu Studio trades in Ghana cedis; match the live formatter exactly (GH₵).
+export const posHubCurrencyFormatter = currencyFormatter("GHS");
+
+export const posHubScheduleSummary = {
+  context: {
+    nextWindow: { localDate: "2026-07-16", localStartLabel: "09:00" },
+    timezone: "Africa/Accra",
+  },
+  schedule: { timezone: "Africa/Accra" },
+};
+
+export const posHubManagerFeatures = buildPosFeatures({
+  canAccessPOS: true,
+  hasFinancialDetailsAccess: true,
+  liveLinkParams: LINK_PARAMS,
+  posLinkParams: LINK_PARAMS,
+  setupRequired: false,
+});
+
+export const posHubStaffFeatures = buildPosFeatures({
+  canAccessPOS: true,
+  hasFinancialDetailsAccess: false,
+  liveLinkParams: LINK_PARAMS,
+  posLinkParams: LINK_PARAMS,
+  setupRequired: false,
+});
+
+type TrendSeed = {
+  date: string;
+  itemsSold: number;
+  label: string;
+  salesTotal: number;
+  transactionCount: number;
+};
+
+function buildTrend(seeds: TrendSeed[]) {
+  return seeds.map((day) => ({
+    averageTransaction: Math.round(day.salesTotal / day.transactionCount),
+    date: day.date,
+    hasKnownItemCount: true,
+    label: day.label,
+    totalItemsSold: day.itemsSold,
+    totalSales: day.salesTotal,
+    transactionCount: day.transactionCount,
+  }));
+}
+
+// The Today window plots just yesterday → today, matching the live product; the
+// axis labels those two points "Yesterday"/"Today".
+const todayTrend = buildTrend([
+  { date: "2026-07-14", label: "Jul 14", salesTotal: 560000, transactionCount: 23, itemsSold: 43 },
+  { date: WED_OPERATING_DATE, label: "Jul 15", salesTotal: 670000, transactionCount: 28, itemsSold: 51 },
+]);
+
+// Sunday → the story Wednesday: the elapsed days of the trading week.
+const weekTrend = buildTrend([
+  { date: "2026-07-12", label: "Jul 12", salesTotal: 640000, transactionCount: 26, itemsSold: 49 },
+  { date: "2026-07-13", label: "Jul 13", salesTotal: 480000, transactionCount: 20, itemsSold: 37 },
+  { date: "2026-07-14", label: "Jul 14", salesTotal: 560000, transactionCount: 23, itemsSold: 43 },
+  { date: WED_OPERATING_DATE, label: "Jul 15", salesTotal: 670000, transactionCount: 28, itemsSold: 51 },
+]);
+
+// Jul 1 → the story Wednesday: month-to-date daily points (sum = 86,890 / 361 / 685).
+const monthTrend = buildTrend([
+  { date: "2026-07-01", label: "Jul 1", salesTotal: 540000, transactionCount: 22, itemsSold: 41 },
+  { date: "2026-07-02", label: "Jul 2", salesTotal: 495000, transactionCount: 21, itemsSold: 40 },
+  { date: "2026-07-03", label: "Jul 3", salesTotal: 528000, transactionCount: 22, itemsSold: 43 },
+  { date: "2026-07-04", label: "Jul 4", salesTotal: 612000, transactionCount: 26, itemsSold: 49 },
+  { date: "2026-07-05", label: "Jul 5", salesTotal: 549000, transactionCount: 23, itemsSold: 44 },
+  { date: "2026-07-06", label: "Jul 6", salesTotal: 438000, transactionCount: 18, itemsSold: 35 },
+  { date: "2026-07-07", label: "Jul 7", salesTotal: 501000, transactionCount: 21, itemsSold: 40 },
+  { date: "2026-07-08", label: "Jul 8", salesTotal: 606000, transactionCount: 25, itemsSold: 48 },
+  { date: "2026-07-09", label: "Jul 9", salesTotal: 573000, transactionCount: 24, itemsSold: 46 },
+  { date: "2026-07-10", label: "Jul 10", salesTotal: 702000, transactionCount: 29, itemsSold: 56 },
+  { date: "2026-07-11", label: "Jul 11", salesTotal: 795000, transactionCount: 33, itemsSold: 63 },
+  { date: "2026-07-12", label: "Jul 12", salesTotal: 640000, transactionCount: 26, itemsSold: 49 },
+  { date: "2026-07-13", label: "Jul 13", salesTotal: 480000, transactionCount: 20, itemsSold: 37 },
+  { date: "2026-07-14", label: "Jul 14", salesTotal: 560000, transactionCount: 23, itemsSold: 43 },
+  { date: WED_OPERATING_DATE, label: "Jul 15", salesTotal: 670000, transactionCount: 28, itemsSold: 51 },
+]);
+
+// Since the store opened (May 12 → the story week), weekly points
+// (sum = 367,000 / 1,530 / 2,879).
+const allTimeTrend = buildTrend([
+  { date: "2026-05-12", label: "May 12", salesTotal: 3600000, transactionCount: 150, itemsSold: 280 },
+  { date: "2026-05-19", label: "May 19", salesTotal: 3900000, transactionCount: 163, itemsSold: 305 },
+  { date: "2026-05-26", label: "May 26", salesTotal: 4050000, transactionCount: 169, itemsSold: 318 },
+  { date: "2026-06-02", label: "Jun 2", salesTotal: 4200000, transactionCount: 175, itemsSold: 330 },
+  { date: "2026-06-09", label: "Jun 9", salesTotal: 3950000, transactionCount: 165, itemsSold: 310 },
+  { date: "2026-06-16", label: "Jun 16", salesTotal: 4300000, transactionCount: 179, itemsSold: 338 },
+  { date: "2026-06-23", label: "Jun 23", salesTotal: 4450000, transactionCount: 185, itemsSold: 350 },
+  { date: "2026-06-30", label: "Jun 30", salesTotal: 4100000, transactionCount: 171, itemsSold: 322 },
+  { date: "2026-07-07", label: "Jul 7", salesTotal: 4150000, transactionCount: 173, itemsSold: 326 },
+]);
+
+const todaySummary: POSStorePulseSummary = {
+  averageTransaction: 23929,
+  date: WED_OPERATING_DATE,
+  operatorSnapshot: {
+    busiestHour: { hour: 12, label: "12 – 1 PM", totalSales: 148000, transactionCount: 7 },
+    comparison: {
+      // Deltas are pre-rounded to whole percents, matching how Daily Operations
+      // renders them (getDeltaPercent → Math.round).
+      averageTransactionDeltaPercent: -2,
+      currentAverageTransaction: 23929,
+      currentItemsSold: 51,
+      currentSales: 670000,
+      currentTransactions: 28,
+      itemsSoldDeltaPercent: 19,
+      salesDeltaPercent: 20,
+      transactionDeltaPercent: 22,
+      yesterdayAverageTransaction: 24348,
+      yesterdayItemsSold: 43,
+      yesterdaySales: 560000,
+      yesterdayTransactions: 23,
+    },
+    historyDays: 14,
+    isLimited: false,
+    paymentMix: [
+      { count: 15, label: "Mobile money", method: "mobile_money", share: 0.536, total: 330000 },
+      { count: 8, label: "Cash", method: "cash", share: 0.286, total: 190000 },
+      { count: 5, label: "Card", method: "card", share: 0.178, total: 150000 },
+    ],
+    // Order matches Daily Operations' today top-items exactly (Batik above
+    // Hibiscus), so the two surfaces agree for the story day.
+    topItems: [
+      { name: "Kente Scarf", productSku: "FM5W-8QJ-4K7", quantity: 4, totalSales: 140000 },
+      { name: "Bolga Woven Basket", productSku: "FM5W-6BX-5W1", quantity: 5, totalSales: 110000 },
+      { name: "Batik Tote Bag", productSku: "FM5W-5K4-9T2", quantity: 4, totalSales: 72000 },
+      { name: "Hibiscus Soy Candle", productSku: "FM5W-2MP-7F4", quantity: 7, totalSales: 84000 },
+      { name: "Raw Shea Butter 250g", productSku: "FM5W-7K2-3Q9", quantity: 11, totalSales: 66000 },
+    ],
+    trend: todayTrend,
+    usableHistoryDays: 14,
+  },
+  totalItemsSold: 51,
+  totalSales: 670000,
+  totalTransactions: 28,
+};
+
+const weekSummary: POSStorePulseSummary = {
+  averageTransaction: 24227,
+  date: WED_OPERATING_DATE,
+  operatorSnapshot: {
+    busiestHour: { hour: 12, label: "12 – 1 PM", totalSales: 512000, transactionCount: 23 },
+    comparison: {
+      averageTransactionDeltaPercent: 1,
+      currentAverageTransaction: 24227,
+      currentItemsSold: 180,
+      currentSales: 2350000,
+      currentTransactions: 97,
+      itemsSoldDeltaPercent: 8,
+      salesDeltaPercent: 12,
+      transactionDeltaPercent: 11,
+      yesterdayAverageTransaction: 24069,
+      yesterdayItemsSold: 167,
+      yesterdaySales: 2094000,
+      yesterdayTransactions: 87,
+    },
+    historyDays: 14,
+    isLimited: false,
+    paymentMix: [
+      { count: 52, label: "Mobile money", method: "mobile_money", share: 0.536, total: 1255000 },
+      { count: 28, label: "Cash", method: "cash", share: 0.289, total: 665000 },
+      { count: 17, label: "Card", method: "card", share: 0.175, total: 430000 },
+    ],
+    topItems: [
+      { name: "Kente Scarf", productSku: "FM5W-8QJ-4K7", quantity: 14, totalSales: 490000 },
+      { name: "Bolga Woven Basket", productSku: "FM5W-6BX-5W1", quantity: 17, totalSales: 374000 },
+      { name: "Hibiscus Soy Candle", productSku: "FM5W-2MP-7F4", quantity: 24, totalSales: 288000 },
+      { name: "Batik Tote Bag", productSku: "FM5W-5K4-9T2", quantity: 14, totalSales: 252000 },
+      { name: "Raw Shea Butter 250g", productSku: "FM5W-7K2-3Q9", quantity: 38, totalSales: 228000 },
+    ],
+    trend: weekTrend,
+    usableHistoryDays: 14,
+  },
+  totalItemsSold: 180,
+  totalSales: 2350000,
+  totalTransactions: 97,
+};
+
+const monthSummary: POSStorePulseSummary = {
+  averageTransaction: 24070,
+  date: WED_OPERATING_DATE,
+  operatorSnapshot: {
+    busiestHour: { hour: 13, label: "1 – 2 PM", totalSales: 1180000, transactionCount: 52 },
+    comparison: {
+      averageTransactionDeltaPercent: 1,
+      currentAverageTransaction: 24070,
+      currentItemsSold: 685,
+      currentSales: 8689000,
+      currentTransactions: 361,
+      itemsSoldDeltaPercent: 10,
+      salesDeltaPercent: 10,
+      transactionDeltaPercent: 9,
+      yesterdayAverageTransaction: 23939,
+      yesterdayItemsSold: 620,
+      yesterdaySales: 7900000,
+      yesterdayTransactions: 330,
+    },
+    historyDays: 15,
+    isLimited: false,
+    paymentMix: [
+      { count: 193, label: "Mobile money", method: "mobile_money", share: 0.535, total: 4650000 },
+      { count: 103, label: "Cash", method: "cash", share: 0.285, total: 2480000 },
+      { count: 65, label: "Card", method: "card", share: 0.180, total: 1559000 },
+    ],
+    topItems: [
+      { name: "Kente Scarf", productSku: "FM5W-8QJ-4K7", quantity: 52, totalSales: 1820000 },
+      { name: "Bolga Woven Basket", productSku: "FM5W-6BX-5W1", quantity: 63, totalSales: 1386000 },
+      { name: "Hibiscus Soy Candle", productSku: "FM5W-2MP-7F4", quantity: 89, totalSales: 1068000 },
+      { name: "Batik Tote Bag", productSku: "FM5W-5K4-9T2", quantity: 51, totalSales: 918000 },
+      { name: "Raw Shea Butter 250g", productSku: "FM5W-7K2-3Q9", quantity: 141, totalSales: 846000 },
+    ],
+    trend: monthTrend,
+    usableHistoryDays: 15,
+  },
+  totalItemsSold: 685,
+  totalSales: 8689000,
+  totalTransactions: 361,
+};
+
+const allTimeSummary: POSStorePulseSummary = {
+  averageTransaction: 23987,
+  date: WED_OPERATING_DATE,
+  operatorSnapshot: {
+    // All-time has no prior period, so the pulse hides comparisons; this object
+    // is required by the type but never rendered for the all-time window.
+    busiestHour: { hour: 13, label: "1 – 2 PM", totalSales: 4900000, transactionCount: 218 },
+    comparison: {
+      averageTransactionDeltaPercent: 0,
+      currentAverageTransaction: 23987,
+      currentItemsSold: 2879,
+      currentSales: 36700000,
+      currentTransactions: 1530,
+      itemsSoldDeltaPercent: 0,
+      salesDeltaPercent: 0,
+      transactionDeltaPercent: 0,
+      yesterdayAverageTransaction: 0,
+      yesterdayItemsSold: 0,
+      yesterdaySales: 0,
+      yesterdayTransactions: 0,
+    },
+    historyDays: 64,
+    isLimited: false,
+    paymentMix: [
+      { count: 819, label: "Mobile money", method: "mobile_money", share: 0.535, total: 19650000 },
+      { count: 436, label: "Cash", method: "cash", share: 0.285, total: 10450000 },
+      { count: 275, label: "Card", method: "card", share: 0.180, total: 6600000 },
+    ],
+    topItems: [
+      { name: "Kente Scarf", productSku: "FM5W-8QJ-4K7", quantity: 220, totalSales: 7700000 },
+      { name: "Bolga Woven Basket", productSku: "FM5W-6BX-5W1", quantity: 266, totalSales: 5852000 },
+      { name: "Hibiscus Soy Candle", productSku: "FM5W-2MP-7F4", quantity: 376, totalSales: 4512000 },
+      { name: "Batik Tote Bag", productSku: "FM5W-5K4-9T2", quantity: 216, totalSales: 3888000 },
+      { name: "Raw Shea Butter 250g", productSku: "FM5W-7K2-3Q9", quantity: 597, totalSales: 3582000 },
+    ],
+    trend: allTimeTrend,
+    usableHistoryDays: 64,
+  },
+  totalItemsSold: 2879,
+  totalSales: 36700000,
+  totalTransactions: 1530,
+};
+
+export const posHubManagerPulseByWindow: Record<
+  POSStorePulseWindow,
+  POSStorePulseSummary
+> = {
+  all_time: allTimeSummary,
+  this_month: monthSummary,
+  this_week: weekSummary,
+  today: todaySummary,
+};
+
+// Staff can't change the window; their pulse always reads today, and only the
+// transaction count is exposed.
+export const posHubStaffSummary = todaySummary;
+
+// --- Dev-only screenshot registry (`?fixture=` route via usePosHubFixture) ---
+
+type PosHubFixtureEntry = { clock: Date; props: PointOfSaleViewContentProps };
+
+const sharedProps = {
+  currencyFormatter: posHubCurrencyFormatter,
+  nowOverride: POS_HUB_NOW,
+  onPulseWindowChange: () => {},
+  scheduleSummary: posHubScheduleSummary,
+};
+
+export const posHubFixtures: Record<string, PosHubFixtureEntry> = {
+  "wednesday-hub-manager": {
+    clock: POS_HUB_NOW,
+    props: {
+      ...sharedProps,
+      hasFullAdminAccess: true,
+      posFeatures: posHubManagerFeatures,
+      pulseWindow: "this_week",
+      todaySummary: weekSummary,
+    },
+  },
+  "wednesday-hub-staff": {
+    clock: POS_HUB_NOW,
+    props: {
+      ...sharedProps,
+      hasFullAdminAccess: false,
+      posFeatures: posHubStaffFeatures,
+      pulseWindow: "today",
+      todaySummary: todaySummary,
+    },
+  },
+};
+
+export type PosHubFixtureName = keyof typeof posHubFixtures;


### PR DESCRIPTION
## Summary
- Adds a live, role-scoped Point of Sale hub to the landing page's POS section: a minimal toggle switches between what a **store manager** sees (every launcher, plus a real store-pulse with working Today / This week / This month / All time tabs) and what **staff** see (their launchers plus a bare transaction count, no financials).
- Splits `PointOfSaleView` into a presentational `PosHubBody` / `PointOfSaleViewContent` so the same component renders live from Convex, from dev-only screenshot fixtures (`?fixture=`), or embedded directly on the landing page.
- Authors all four pulse windows (`posHubFixtures.ts`) against the shared demo store's story day (Wednesday 2026-07-15) so the numbers reconcile with Daily Operations — including whole-percent comparison deltas and top-items ordering matching Daily Ops for the same day.
- Refined the act's copy/eyebrow/title and fixed a scroll-anchoring jump + an animation-callback deadlock risk in the role toggle.
- Updated `docs/solutions/design-patterns/athena-landing-story-real-component-exhibits-2026-07-17.md` with an addendum on building a partially-interactive exhibit, plus its `delivery_diff_fingerprint`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Focused vitest suites pass: `landing.test.tsx`, `PointOfSaleView.test.tsx`, `POSSalesPulseView.test.tsx`, `demoDay.test.ts`, `terminals.route.test.tsx` (33 tests)
- [x] Manually verified in the dev-server browser preview: role toggle, live pulse tab filtering (Today/This week/This month/All time), dark mode, no console errors from decorative tiles