### PR TITLE
Refuse over-cap fold reads instead of silently truncating

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 10829 nodes · 13205 edges · 2582 communities detected
+- 10831 nodes · 13207 edges · 2582 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3152,168 +3152,168 @@ Cohesion: 0.15
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
 ### Community 133 - "Community 133"
+Cohesion: 0.22
+Nodes (11): computePendingRanges(), DayCapExceeded, expireRangeResults(), foldAndReplaceDay(), loadAcceptedClose(), markDayDirty(), parseStoreAllowlist(), readStoreAllowlist() (+3 more)
+
+### Community 134 - "Community 134"
 Cohesion: 0.3
 Nodes (14): applyBaselineDocumentsWithCtx(), applyRestoreLeaseWithCtx(), assertSharedDemoWriteEpoch(), baselineMatches(), beginRestore(), beginRestoreLeaseWithCtx(), completeRestore(), completeRestoreLeaseWithCtx() (+6 more)
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.28
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getStatusesToOrdered() (+5 more)
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.25
 Nodes (13): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), assertReceivingReplayMatches(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems() (+5 more)
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.28
 Nodes (14): buildActorRefs(), buildReturnExchangeTraceEvent(), buildReturnExchangeTraceRecord(), buildTraceEvent(), buildTraceRecord(), compactDetails(), recordOnlineOrderReturnExchangeTraceBestEffort(), recordOnlineOrderTraceBestEffort() (+6 more)
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.2
 Nodes (9): canReuseCloudRegisterSessionForLocalOpen(), canSupersedeReviewedRegisterSessionForLocalOpen(), drawerAuthorityMatchesActiveRegisterSession(), getSaleBlockingDrawerAuthority(), isDrawerAuthoritySaleBlocking(), isRegisterSessionConflictBlocking(), isRegisterSessionReplacementBlocking(), isRegisterSessionSaleUsable() (+1 more)
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.18
 Nodes (6): buildTrustedInventoryFinalizationPayload(), buildTrustedInventoryMoneyPayload(), getTrustedInventoryReviewValidationMessage(), isNonNegativeInteger(), parseVariantDisplayMoney(), resolveTrustedInventoryReviewState()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.14
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.17
 Nodes (6): formatOperatingDateFilterLabel(), formatPaymentMethod(), getEmptyTransactionTitle(), getNextTransactionPageSearch(), getNextTransactionPaymentFilterSearch(), getNextTransactionTimeFilterSearch()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.17
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.15
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.22
 Nodes (10): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), canProjectRegisterOpenForTerminalCloudRepair(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), getRepairOpenRegisterCloseoutReviewState(), getRepairRegisterSessionCloseoutBoundaryAt(), isDuplicateRegisterOpenConflict() (+2 more)
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.16
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.26
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.19
 Nodes (6): formatOperatingDate(), formatOptionalMoney(), formatReportMoney(), formatReportProfit(), reportDaySettlementPresentation(), reportOldestUnreconciledPresentation()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.23
 Nodes (11): buildDayTransactions(), buildItems(), buildPaymentProductMixes(), buildTransaction(), createSharedDemoTransactionFixtures(), findProductMix(), formatOperatingDate(), getSharedDemoTransactionFixture() (+3 more)
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.24
 Nodes (8): canonicalizeWalkthroughPayload(), normalizeWalkthroughEmail(), normalizeWalkthroughText(), readPublicErrorCode(), resolveWalkthroughRequestUrl(), stripControlCharacters(), submitWalkthroughRequest(), WalkthroughSubmissionIdentity
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.16
 Nodes (3): getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.28
 Nodes (11): defineCashControlsRead(), defineDailyCloseRead(), defineDailyOperationsRead(), defineInventoryCatalogRead(), defineInventoryCostOverlayRead(), defineOnlineOrdersRead(), defineOperationalWorkRead(), defineOrganizationRead() (+3 more)
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.21
 Nodes (6): buildOperationalWorkItem(), createOperationalWorkItemWithCtx(), metadataArrayCount(), metadataNumber(), projectOperationalWorkItemForQueue(), sanitizeOperationalWorkItemDetails()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
-
-### Community 163 - "Community 163"
-Cohesion: 0.27
-Nodes (10): computePendingRanges(), expireRangeResults(), foldAndReplaceDay(), loadAcceptedClose(), markDayDirty(), parseStoreAllowlist(), readStoreAllowlist(), selectAcceptedClose() (+2 more)
 
 ### Community 164 - "Community 164"
 Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
 
 ### Community 165 - "Community 165"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 166 - "Community 166"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 167 - "Community 167"
+### Community 166 - "Community 166"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 168 - "Community 168"
+### Community 167 - "Community 167"
 Cohesion: 0.31
 Nodes (12): captureRegisterCatalogRuntimePin(), chooseRegisterCatalogRuntimeOwnerId(), clearRegisterCatalogRuntimeActionGuard(), clearRegisterCatalogRuntimeSelection(), getRegisterCatalogRuntimeOwnerId(), hasRegisterCatalogRuntimeActionGuard(), keyForScope(), maintainOwnerClaim() (+4 more)
 
-### Community 169 - "Community 169"
+### Community 168 - "Community 168"
 Cohesion: 0.32
 Nodes (11): clearPosClientTelemetryBuffer(), enqueuePosClientEvent(), mintClientEventId(), normalizePosTelemetryError(), peekPosClientEventBatch(), posClientTelemetryBufferSize(), readBuffer(), removePosClientEvents() (+3 more)
 
-### Community 170 - "Community 170"
+### Community 169 - "Community 169"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 171 - "Community 171"
+### Community 170 - "Community 170"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 172 - "Community 172"
+### Community 171 - "Community 171"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 173 - "Community 173"
+### Community 172 - "Community 172"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
+
+### Community 173 - "Community 173"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 174 - "Community 174"
 Cohesion: 0.28
@@ -3709,15 +3709,15 @@ Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 273 - "Community 273"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 274 - "Community 274"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.22
@@ -4340,104 +4340,104 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 430 - "Community 430"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 432 - "Community 432"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 433 - "Community 433"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 433 - "Community 433"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 435 - "Community 435"
-Cohesion: 0.4
-Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 436 - "Community 436"
 Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 437 - "Community 437"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 440 - "Community 440"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 441 - "Community 441"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 442 - "Community 442"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 440 - "Community 440"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 441 - "Community 441"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 442 - "Community 442"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
 ### Community 443 - "Community 443"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 444 - "Community 444"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 446 - "Community 446"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 447 - "Community 447"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 448 - "Community 448"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 449 - "Community 449"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 450 - "Community 450"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 451 - "Community 451"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 452 - "Community 452"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 453 - "Community 453"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 453 - "Community 453"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 454 - "Community 454"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 455 - "Community 455"
 Cohesion: 0.53
@@ -5028,40 +5028,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 602 - "Community 602"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (1): buildCtx()
 
 ### Community 603 - "Community 603"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 604 - "Community 604"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 605 - "Community 605"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 606 - "Community 606"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 606 - "Community 606"
+### Community 607 - "Community 607"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 607 - "Community 607"
+### Community 608 - "Community 608"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 608 - "Community 608"
+### Community 609 - "Community 609"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 609 - "Community 609"
-Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 610 - "Community 610"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 611 - "Community 611"
 Cohesion: 0.5
@@ -5073,7 +5073,7 @@ Nodes (0):
 
 ### Community 613 - "Community 613"
 Cohesion: 0.5
-Nodes (1): buildCtx()
+Nodes (0):
 
 ### Community 614 - "Community 614"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -67559,7 +67559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L44",
+      "source_location": "L45",
       "target": "sweeper_test_allow",
       "weight": 1
     },
@@ -67571,7 +67571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L66",
+      "source_location": "L67",
       "target": "sweeper_test_close",
       "weight": 1
     },
@@ -67583,7 +67583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L177",
+      "source_location": "L178",
       "target": "sweeper_test_insertsalefact",
       "weight": 1
     },
@@ -67595,7 +67595,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L216",
+      "source_location": "L217",
       "target": "sweeper_test_mark",
       "weight": 1
     },
@@ -67607,7 +67607,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L235",
+      "source_location": "L236",
       "target": "sweeper_test_marksof",
       "weight": 1
     },
@@ -67619,7 +67619,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L123",
+      "source_location": "L124",
       "target": "sweeper_test_seedstore",
       "weight": 1
     },
@@ -67631,7 +67631,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L233",
+      "source_location": "L234",
       "target": "sweeper_test_sweep",
       "weight": 1
     },
@@ -67643,8 +67643,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L359",
+      "source_location": "L400",
       "target": "sweeper_computependingranges",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_reports_sweeper_ts",
+      "_tgt": "sweeper_daycapexceeded",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_sweeper_ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L76",
+      "target": "sweeper_daycapexceeded",
       "weight": 1
     },
     {
@@ -67655,7 +67667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L390",
+      "source_location": "L431",
       "target": "sweeper_expirerangeresults",
       "weight": 1
     },
@@ -67667,7 +67679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L342",
+      "source_location": "L383",
       "target": "sweeper_findopenoperatingdate",
       "weight": 1
     },
@@ -67679,7 +67691,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L190",
+      "source_location": "L215",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -67691,7 +67703,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L164",
+      "source_location": "L189",
       "target": "sweeper_loadacceptedclose",
       "weight": 1
     },
@@ -67703,7 +67715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L309",
+      "source_location": "L350",
       "target": "sweeper_markdaydirty",
       "weight": 1
     },
@@ -67715,7 +67727,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L74",
+      "source_location": "L99",
       "target": "sweeper_parsestoreallowlist",
       "weight": 1
     },
@@ -67727,7 +67739,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L84",
+      "source_location": "L109",
       "target": "sweeper_readstoreallowlist",
       "weight": 1
     },
@@ -67739,7 +67751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L130",
+      "source_location": "L155",
       "target": "sweeper_selectacceptedclose",
       "weight": 1
     },
@@ -67751,7 +67763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L407",
+      "source_location": "L448",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -67763,7 +67775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L146",
+      "source_location": "L171",
       "target": "sweeper_tocloseref",
       "weight": 1
     },
@@ -67775,7 +67787,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_sweeper_ts",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L92",
+      "source_location": "L117",
       "target": "sweeper_tofoldfact",
       "weight": 1
     },
@@ -149656,6 +149668,18 @@
       "weight": 1
     },
     {
+      "_src": "sweeper_daycapexceeded",
+      "_tgt": "sweeper_daycapexceeded_constructor",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "method",
+      "source": "sweeper_daycapexceeded",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L77",
+      "target": "sweeper_daycapexceeded_constructor",
+      "weight": 1
+    },
+    {
       "_src": "sweeper_foldandreplaceday",
       "_tgt": "sweeper_loadacceptedclose",
       "confidence": "EXTRACTED",
@@ -149663,7 +149687,7 @@
       "relation": "calls",
       "source": "sweeper_loadacceptedclose",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L215",
+      "source_location": "L262",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -149675,7 +149699,7 @@
       "relation": "calls",
       "source": "sweeper_tocloseref",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L216",
+      "source_location": "L263",
       "target": "sweeper_foldandreplaceday",
       "weight": 1
     },
@@ -149687,7 +149711,7 @@
       "relation": "calls",
       "source": "sweeper_selectacceptedclose",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L176",
+      "source_location": "L201",
       "target": "sweeper_loadacceptedclose",
       "weight": 1
     },
@@ -149699,7 +149723,7 @@
       "relation": "calls",
       "source": "sweeper_parsestoreallowlist",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L85",
+      "source_location": "L110",
       "target": "sweeper_readstoreallowlist",
       "weight": 1
     },
@@ -149711,7 +149735,7 @@
       "relation": "calls",
       "source": "sweeper_computependingranges",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L470",
+      "source_location": "L528",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -149723,7 +149747,7 @@
       "relation": "calls",
       "source": "sweeper_expirerangeresults",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L474",
+      "source_location": "L532",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -149735,7 +149759,7 @@
       "relation": "calls",
       "source": "sweeper_foldandreplaceday",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L450",
+      "source_location": "L497",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -149747,7 +149771,7 @@
       "relation": "calls",
       "source": "sweeper_markdaydirty",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L458",
+      "source_location": "L516",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -149759,7 +149783,7 @@
       "relation": "calls",
       "source": "sweeper_readstoreallowlist",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L409",
+      "source_location": "L450",
       "target": "sweeper_sweepwithctx",
       "weight": 1
     },
@@ -172716,137 +172740,137 @@
     {
       "community": 133,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_restore_ts",
-      "label": "restore.ts",
-      "norm_label": "restore.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "id": "packages_athena_webapp_convex_reports_sweeper_ts",
+      "label": "sweeper.ts",
+      "norm_label": "sweeper.ts",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
       "source_location": "L1"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_applybaselinedocumentswithctx",
-      "label": "applyBaselineDocumentsWithCtx()",
-      "norm_label": "applybaselinedocumentswithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L123"
+      "id": "sweeper_computependingranges",
+      "label": "computePendingRanges()",
+      "norm_label": "computependingranges()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L400"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_applyrestoreleasewithctx",
-      "label": "applyRestoreLeaseWithCtx()",
-      "norm_label": "applyrestoreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L278"
+      "id": "sweeper_daycapexceeded",
+      "label": "DayCapExceeded",
+      "norm_label": "daycapexceeded",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L76"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_assertshareddemowriteepoch",
-      "label": "assertSharedDemoWriteEpoch()",
-      "norm_label": "assertshareddemowriteepoch()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L78"
+      "id": "sweeper_daycapexceeded_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L77"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_baselinematches",
-      "label": "baselineMatches()",
-      "norm_label": "baselinematches()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L88"
+      "id": "sweeper_expirerangeresults",
+      "label": "expireRangeResults()",
+      "norm_label": "expirerangeresults()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L431"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_beginrestore",
-      "label": "beginRestore()",
-      "norm_label": "beginrestore()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L57"
+      "id": "sweeper_findopenoperatingdate",
+      "label": "findOpenOperatingDate()",
+      "norm_label": "findopenoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L383"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_beginrestoreleasewithctx",
-      "label": "beginRestoreLeaseWithCtx()",
-      "norm_label": "beginrestoreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L212"
+      "id": "sweeper_foldandreplaceday",
+      "label": "foldAndReplaceDay()",
+      "norm_label": "foldandreplaceday()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L215"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_completerestore",
-      "label": "completeRestore()",
-      "norm_label": "completerestore()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "id": "sweeper_loadacceptedclose",
+      "label": "loadAcceptedClose()",
+      "norm_label": "loadacceptedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "sweeper_markdaydirty",
+      "label": "markDayDirty()",
+      "norm_label": "markdaydirty()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L350"
+    },
+    {
+      "community": 133,
+      "file_type": "code",
+      "id": "sweeper_parsestoreallowlist",
+      "label": "parseStoreAllowlist()",
+      "norm_label": "parsestoreallowlist()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
       "source_location": "L99"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_completerestoreleasewithctx",
-      "label": "completeRestoreLeaseWithCtx()",
-      "norm_label": "completerestoreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L336"
+      "id": "sweeper_readstoreallowlist",
+      "label": "readStoreAllowlist()",
+      "norm_label": "readstoreallowlist()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L109"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_failrestoreleasewithctx",
-      "label": "failRestoreLeaseWithCtx()",
-      "norm_label": "failrestoreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L380"
+      "id": "sweeper_selectacceptedclose",
+      "label": "selectAcceptedClose()",
+      "norm_label": "selectacceptedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L155"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_readrestorestatewithctx",
-      "label": "readRestoreStateWithCtx()",
-      "norm_label": "readrestorestatewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L176"
+      "id": "sweeper_sweepwithctx",
+      "label": "sweepWithCtx()",
+      "norm_label": "sweepwithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L448"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_requirecurrentshareddemobaseline",
-      "label": "requireCurrentSharedDemoBaseline()",
-      "norm_label": "requirecurrentshareddemobaseline()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L48"
+      "id": "sweeper_tocloseref",
+      "label": "toCloseRef()",
+      "norm_label": "tocloseref()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L171"
     },
     {
       "community": 133,
       "file_type": "code",
-      "id": "restore_requirematchingrestorelease",
-      "label": "requireMatchingRestoreLease()",
-      "norm_label": "requirematchingrestorelease()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L186"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "restore_requirereadyshareddemowritewithctx",
-      "label": "requireReadySharedDemoWriteWithCtx()",
-      "norm_label": "requirereadyshareddemowritewithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L459"
-    },
-    {
-      "community": 133,
-      "file_type": "code",
-      "id": "restore_schedulerestorecontinuation",
-      "label": "scheduleRestoreContinuation()",
-      "norm_label": "schedulerestorecontinuation()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
-      "source_location": "L201"
+      "id": "sweeper_tofoldfact",
+      "label": "toFoldFact()",
+      "norm_label": "tofoldfact()",
+      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "source_location": "L117"
     },
     {
       "community": 1330,
@@ -173031,137 +173055,137 @@
     {
       "community": 134,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
-      "label": "purchaseOrders.ts",
-      "norm_label": "purchaseorders.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "id": "packages_athena_webapp_convex_shareddemo_restore_ts",
+      "label": "restore.ts",
+      "norm_label": "restore.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
       "source_location": "L1"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_advancepurchaseordertoorderedcommandwithctx",
-      "label": "advancePurchaseOrderToOrderedCommandWithCtx()",
-      "norm_label": "advancepurchaseordertoorderedcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L670"
+      "id": "restore_applybaselinedocumentswithctx",
+      "label": "applyBaselineDocumentsWithCtx()",
+      "norm_label": "applybaselinedocumentswithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L123"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_advancepurchaseordertoorderedwithctx",
-      "label": "advancePurchaseOrderToOrderedWithCtx()",
-      "norm_label": "advancepurchaseordertoorderedwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L646"
+      "id": "restore_applyrestoreleasewithctx",
+      "label": "applyRestoreLeaseWithCtx()",
+      "norm_label": "applyrestoreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L278"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
-      "label": "assertValidPurchaseOrderStatusTransition()",
-      "norm_label": "assertvalidpurchaseorderstatustransition()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L155"
+      "id": "restore_assertshareddemowriteepoch",
+      "label": "assertSharedDemoWriteEpoch()",
+      "norm_label": "assertshareddemowriteepoch()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L78"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordercommitmentstatusdelta",
-      "label": "buildPurchaseOrderCommitmentStatusDelta()",
-      "norm_label": "buildpurchaseordercommitmentstatusdelta()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L100"
+      "id": "restore_baselinematches",
+      "label": "baselineMatches()",
+      "norm_label": "baselinematches()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L88"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_buildpurchaseordernumber",
-      "label": "buildPurchaseOrderNumber()",
-      "norm_label": "buildpurchaseordernumber()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L170"
+      "id": "restore_beginrestore",
+      "label": "beginRestore()",
+      "norm_label": "beginrestore()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L57"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_calculatepurchaseordertotals",
-      "label": "calculatePurchaseOrderTotals()",
-      "norm_label": "calculatepurchaseordertotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L124"
+      "id": "restore_beginrestoreleasewithctx",
+      "label": "beginRestoreLeaseWithCtx()",
+      "norm_label": "beginrestoreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L212"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_createpurchaseordercommandwithctx",
-      "label": "createPurchaseOrderCommandWithCtx()",
-      "norm_label": "createpurchaseordercommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L472"
+      "id": "restore_completerestore",
+      "label": "completeRestore()",
+      "norm_label": "completerestore()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L99"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_createpurchaseorderwithctx",
-      "label": "createPurchaseOrderWithCtx()",
-      "norm_label": "createpurchaseorderwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L337"
+      "id": "restore_completerestoreleasewithctx",
+      "label": "completeRestoreLeaseWithCtx()",
+      "norm_label": "completerestoreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L336"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_getstatusestoordered",
-      "label": "getStatusesToOrdered()",
-      "norm_label": "getstatusestoordered()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L630"
+      "id": "restore_failrestoreleasewithctx",
+      "label": "failRestoreLeaseWithCtx()",
+      "norm_label": "failrestoreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L380"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_mappurchaseordercommanderror",
-      "label": "mapPurchaseOrderCommandError()",
-      "norm_label": "mappurchaseordercommanderror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L192"
+      "id": "restore_readrestorestatewithctx",
+      "label": "readRestoreStateWithCtx()",
+      "norm_label": "readrestorestatewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L176"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_mappurchaseorderstatustoworkitemstatus",
-      "label": "mapPurchaseOrderStatusToWorkItemStatus()",
-      "norm_label": "mappurchaseorderstatustoworkitemstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L174"
+      "id": "restore_requirecurrentshareddemobaseline",
+      "label": "requireCurrentSharedDemoBaseline()",
+      "norm_label": "requirecurrentshareddemobaseline()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L48"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L119"
+      "id": "restore_requirematchingrestorelease",
+      "label": "requireMatchingRestoreLease()",
+      "norm_label": "requirematchingrestorelease()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L186"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_updatepurchaseorderstatuscommandwithctx",
-      "label": "updatePurchaseOrderStatusCommandWithCtx()",
-      "norm_label": "updatepurchaseorderstatuscommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L613"
+      "id": "restore_requirereadyshareddemowritewithctx",
+      "label": "requireReadySharedDemoWriteWithCtx()",
+      "norm_label": "requirereadyshareddemowritewithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L459"
     },
     {
       "community": 134,
       "file_type": "code",
-      "id": "purchaseorders_updatepurchaseorderstatuswithctx",
-      "label": "updatePurchaseOrderStatusWithCtx()",
-      "norm_label": "updatepurchaseorderstatuswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
-      "source_location": "L500"
+      "id": "restore_schedulerestorecontinuation",
+      "label": "scheduleRestoreContinuation()",
+      "norm_label": "schedulerestorecontinuation()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/restore.ts",
+      "source_location": "L201"
     },
     {
       "community": 1340,
@@ -173346,137 +173370,137 @@
     {
       "community": 135,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
-      "label": "receiving.ts",
-      "norm_label": "receiving.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "id": "packages_athena_webapp_convex_stockops_purchaseorders_ts",
+      "label": "purchaseOrders.ts",
+      "norm_label": "purchaseorders.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L1"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "receiving_assertdistinctreceivinglineitems",
-      "label": "assertDistinctReceivingLineItems()",
-      "norm_label": "assertdistinctreceivinglineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L153"
+      "id": "purchaseorders_advancepurchaseordertoorderedcommandwithctx",
+      "label": "advancePurchaseOrderToOrderedCommandWithCtx()",
+      "norm_label": "advancepurchaseordertoorderedcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L670"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "receiving_assertreceivablepurchaseorderstatus",
-      "label": "assertReceivablePurchaseOrderStatus()",
-      "norm_label": "assertreceivablepurchaseorderstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L129"
+      "id": "purchaseorders_advancepurchaseordertoorderedwithctx",
+      "label": "advancePurchaseOrderToOrderedWithCtx()",
+      "norm_label": "advancepurchaseordertoorderedwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L646"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "receiving_assertreceivinglinequantities",
-      "label": "assertReceivingLineQuantities()",
-      "norm_label": "assertreceivinglinequantities()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L139"
+      "id": "purchaseorders_assertvalidpurchaseorderstatustransition",
+      "label": "assertValidPurchaseOrderStatusTransition()",
+      "norm_label": "assertvalidpurchaseorderstatustransition()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L155"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "receiving_assertreceivingreplaymatches",
-      "label": "assertReceivingReplayMatches()",
-      "norm_label": "assertreceivingreplaymatches()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L68"
+      "id": "purchaseorders_buildpurchaseordercommitmentstatusdelta",
+      "label": "buildPurchaseOrderCommitmentStatusDelta()",
+      "norm_label": "buildpurchaseordercommitmentstatusdelta()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L100"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "receiving_buildreceivingbatchsourceid",
-      "label": "buildReceivingBatchSourceId()",
-      "norm_label": "buildreceivingbatchsourceid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L201"
+      "id": "purchaseorders_buildpurchaseordernumber",
+      "label": "buildPurchaseOrderNumber()",
+      "norm_label": "buildpurchaseordernumber()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L170"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "receiving_calculatepurchaseorderreceivingstatus",
-      "label": "calculatePurchaseOrderReceivingStatus()",
-      "norm_label": "calculatepurchaseorderreceivingstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "id": "purchaseorders_calculatepurchaseordertotals",
+      "label": "calculatePurchaseOrderTotals()",
+      "norm_label": "calculatepurchaseordertotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "purchaseorders_createpurchaseordercommandwithctx",
+      "label": "createPurchaseOrderCommandWithCtx()",
+      "norm_label": "createpurchaseordercommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "purchaseorders_createpurchaseorderwithctx",
+      "label": "createPurchaseOrderWithCtx()",
+      "norm_label": "createpurchaseorderwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L337"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "purchaseorders_getstatusestoordered",
+      "label": "getStatusesToOrdered()",
+      "norm_label": "getstatusestoordered()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L630"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "purchaseorders_mappurchaseordercommanderror",
+      "label": "mapPurchaseOrderCommandError()",
+      "norm_label": "mappurchaseordercommanderror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L192"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "purchaseorders_mappurchaseorderstatustoworkitemstatus",
+      "label": "mapPurchaseOrderStatusToWorkItemStatus()",
+      "norm_label": "mappurchaseorderstatustoworkitemstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 135,
+      "file_type": "code",
+      "id": "purchaseorders_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
       "source_location": "L119"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "receiving_calculatereceivingbatchtotals",
-      "label": "calculateReceivingBatchTotals()",
-      "norm_label": "calculatereceivingbatchtotals()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L98"
+      "id": "purchaseorders_updatepurchaseorderstatuscommandwithctx",
+      "label": "updatePurchaseOrderStatusCommandWithCtx()",
+      "norm_label": "updatepurchaseorderstatuscommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L613"
     },
     {
       "community": 135,
       "file_type": "code",
-      "id": "receiving_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L208"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "receiving_mapreceivepurchaseorderbatcherror",
-      "label": "mapReceivePurchaseOrderBatchError()",
-      "norm_label": "mapreceivepurchaseorderbatcherror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L539"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "receiving_normalizeconfirmedreceiptcost",
-      "label": "normalizeConfirmedReceiptCost()",
-      "norm_label": "normalizeconfirmedreceiptcost()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "receiving_receivepurchaseorderbatchcommandwithctx",
-      "label": "receivePurchaseOrderBatchCommandWithCtx()",
-      "norm_label": "receivepurchaseorderbatchcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L589"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "receiving_receivepurchaseorderbatchwithctx",
-      "label": "receivePurchaseOrderBatchWithCtx()",
-      "norm_label": "receivepurchaseorderbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "receiving_summarizereceivingskudeltas",
-      "label": "summarizeReceivingSkuDeltas()",
-      "norm_label": "summarizereceivingskudeltas()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 135,
-      "file_type": "code",
-      "id": "receiving_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
-      "source_location": "L40"
+      "id": "purchaseorders_updatepurchaseorderstatuswithctx",
+      "label": "updatePurchaseOrderStatusWithCtx()",
+      "norm_label": "updatepurchaseorderstatuswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/purchaseOrders.ts",
+      "source_location": "L500"
     },
     {
       "community": 1350,
@@ -173661,137 +173685,137 @@
     {
       "community": 136,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
-      "label": "paymentHelpers.ts",
-      "norm_label": "paymenthelpers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "id": "packages_athena_webapp_convex_stockops_receiving_ts",
+      "label": "receiving.ts",
+      "norm_label": "receiving.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
       "source_location": "L1"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_buildserverpricedcheckoutproducts",
-      "label": "buildServerPricedCheckoutProducts()",
-      "norm_label": "buildserverpricedcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L43"
+      "id": "receiving_assertdistinctreceivinglineitems",
+      "label": "assertDistinctReceivingLineItems()",
+      "norm_label": "assertdistinctreceivinglineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L153"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_calculateitemssubtotal",
-      "label": "calculateItemsSubtotal()",
-      "norm_label": "calculateitemssubtotal()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L35"
+      "id": "receiving_assertreceivablepurchaseorderstatus",
+      "label": "assertReceivablePurchaseOrderStatus()",
+      "norm_label": "assertreceivablepurchaseorderstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L129"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_calculateorderamount",
-      "label": "calculateOrderAmount()",
-      "norm_label": "calculateorderamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L266"
+      "id": "receiving_assertreceivinglinequantities",
+      "label": "assertReceivingLineQuantities()",
+      "norm_label": "assertreceivinglinequantities()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L139"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_calculaterewardpoints",
-      "label": "calculateRewardPoints()",
-      "norm_label": "calculaterewardpoints()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L286"
+      "id": "receiving_assertreceivingreplaymatches",
+      "label": "assertReceivingReplayMatches()",
+      "norm_label": "assertreceivingreplaymatches()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L68"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_derivedeliveryoptionfromaddress",
-      "label": "deriveDeliveryOptionFromAddress()",
-      "norm_label": "derivedeliveryoptionfromaddress()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L92"
+      "id": "receiving_buildreceivingbatchsourceid",
+      "label": "buildReceivingBatchSourceId()",
+      "norm_label": "buildreceivingbatchsourceid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L201"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_extractorderitems",
-      "label": "extractOrderItems()",
-      "norm_label": "extractorderitems()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L249"
+      "id": "receiving_calculatepurchaseorderreceivingstatus",
+      "label": "calculatePurchaseOrderReceivingStatus()",
+      "norm_label": "calculatepurchaseorderreceivingstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L119"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_generatepodreference",
-      "label": "generatePODReference()",
-      "norm_label": "generatepodreference()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L240"
+      "id": "receiving_calculatereceivingbatchtotals",
+      "label": "calculateReceivingBatchTotals()",
+      "norm_label": "calculatereceivingbatchtotals()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L98"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_getorderdiscountvalue",
-      "label": "getOrderDiscountValue()",
-      "norm_label": "getorderdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L308"
+      "id": "receiving_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L208"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_getremainingrefundablebalance",
-      "label": "getRemainingRefundableBalance()",
-      "norm_label": "getremainingrefundablebalance()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L207"
+      "id": "receiving_mapreceivepurchaseorderbatcherror",
+      "label": "mapReceivePurchaseOrderBatchError()",
+      "norm_label": "mapreceivepurchaseorderbatcherror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L539"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_isdeliveryfeewaived",
-      "label": "isDeliveryFeeWaived()",
-      "norm_label": "isdeliveryfeewaived()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L110"
+      "id": "receiving_normalizeconfirmedreceiptcost",
+      "label": "normalizeConfirmedReceiptCost()",
+      "norm_label": "normalizeconfirmedreceiptcost()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L45"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_normalizedeliveryoption",
-      "label": "normalizeDeliveryOption()",
-      "norm_label": "normalizedeliveryoption()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L80"
+      "id": "receiving_receivepurchaseorderbatchcommandwithctx",
+      "label": "receivePurchaseOrderBatchCommandWithCtx()",
+      "norm_label": "receivepurchaseorderbatchcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L589"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_resolverefundamount",
-      "label": "resolveRefundAmount()",
-      "norm_label": "resolverefundamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L218"
+      "id": "receiving_receivepurchaseorderbatchwithctx",
+      "label": "receivePurchaseOrderBatchWithCtx()",
+      "norm_label": "receivepurchaseorderbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L239"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_resolveserverdeliveryfee",
-      "label": "resolveServerDeliveryFee()",
-      "norm_label": "resolveserverdeliveryfee()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L151"
+      "id": "receiving_summarizereceivingskudeltas",
+      "label": "summarizeReceivingSkuDeltas()",
+      "norm_label": "summarizereceivingskudeltas()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L169"
     },
     {
       "community": 136,
       "file_type": "code",
-      "id": "paymenthelpers_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
-      "source_location": "L294"
+      "id": "receiving_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/receiving.ts",
+      "source_location": "L40"
     },
     {
       "community": 1360,
@@ -173976,137 +174000,137 @@
     {
       "community": 137,
       "file_type": "code",
-      "id": "onlineordertracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_buildreturnexchangetraceevent",
-      "label": "buildReturnExchangeTraceEvent()",
-      "norm_label": "buildreturnexchangetraceevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_buildreturnexchangetracerecord",
-      "label": "buildReturnExchangeTraceRecord()",
-      "norm_label": "buildreturnexchangetracerecord()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L283"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L149"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_compactdetails",
-      "label": "compactDetails()",
-      "norm_label": "compactdetails()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_recordonlineorderreturnexchangetracebesteffort",
-      "label": "recordOnlineOrderReturnExchangeTraceBestEffort()",
-      "norm_label": "recordonlineorderreturnexchangetracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L396"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_recordonlineordertracebesteffort",
-      "label": "recordOnlineOrderTraceBestEffort()",
-      "norm_label": "recordonlineordertracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L352"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_resolvestoreorganizationid",
-      "label": "resolveStoreOrganizationId()",
-      "norm_label": "resolvestoreorganizationid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_returnexchangemessage",
-      "label": "returnExchangeMessage()",
-      "norm_label": "returnexchangemessage()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L260"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_returnexchangestep",
-      "label": "returnExchangeStep()",
-      "norm_label": "returnexchangestep()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L344"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_statusmessage",
-      "label": "statusMessage()",
-      "norm_label": "statusmessage()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "onlineordertracing_statusstep",
-      "label": "statusStep()",
-      "norm_label": "statusstep()",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 137,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_onlineordertracing_ts",
-      "label": "onlineOrderTracing.ts",
-      "norm_label": "onlineordertracing.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "id": "packages_athena_webapp_convex_storefront_helpers_paymenthelpers_ts",
+      "label": "paymentHelpers.ts",
+      "norm_label": "paymenthelpers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_buildserverpricedcheckoutproducts",
+      "label": "buildServerPricedCheckoutProducts()",
+      "norm_label": "buildserverpricedcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateitemssubtotal",
+      "label": "calculateItemsSubtotal()",
+      "norm_label": "calculateitemssubtotal()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_calculateorderamount",
+      "label": "calculateOrderAmount()",
+      "norm_label": "calculateorderamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_calculaterewardpoints",
+      "label": "calculateRewardPoints()",
+      "norm_label": "calculaterewardpoints()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_derivedeliveryoptionfromaddress",
+      "label": "deriveDeliveryOptionFromAddress()",
+      "norm_label": "derivedeliveryoptionfromaddress()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_extractorderitems",
+      "label": "extractOrderItems()",
+      "norm_label": "extractorderitems()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_generatepodreference",
+      "label": "generatePODReference()",
+      "norm_label": "generatepodreference()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L240"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_getorderdiscountvalue",
+      "label": "getOrderDiscountValue()",
+      "norm_label": "getorderdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L308"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_getremainingrefundablebalance",
+      "label": "getRemainingRefundableBalance()",
+      "norm_label": "getremainingrefundablebalance()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_isdeliveryfeewaived",
+      "label": "isDeliveryFeeWaived()",
+      "norm_label": "isdeliveryfeewaived()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_normalizedeliveryoption",
+      "label": "normalizeDeliveryOption()",
+      "norm_label": "normalizedeliveryoption()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_resolverefundamount",
+      "label": "resolveRefundAmount()",
+      "norm_label": "resolverefundamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_resolveserverdeliveryfee",
+      "label": "resolveServerDeliveryFee()",
+      "norm_label": "resolveserverdeliveryfee()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 137,
+      "file_type": "code",
+      "id": "paymenthelpers_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/convex/storeFront/helpers/paymentHelpers.ts",
+      "source_location": "L294"
     },
     {
       "community": 1370,
@@ -174291,137 +174315,137 @@
     {
       "community": 138,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionlifecyclepolicy_ts",
-      "label": "registerSessionLifecyclePolicy.ts",
-      "norm_label": "registersessionlifecyclepolicy.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L1"
+      "id": "onlineordertracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L90"
     },
     {
       "community": 138,
       "file_type": "code",
-      "id": "registersessionlifecyclepolicy_caninspectruntimeclouddrawerauthority",
-      "label": "canInspectRuntimeCloudDrawerAuthority()",
-      "norm_label": "caninspectruntimeclouddrawerauthority()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_canopenreplacementdrawerforlocalblock",
-      "label": "canOpenReplacementDrawerForLocalBlock()",
-      "norm_label": "canopenreplacementdrawerforlocalblock()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_canreusecloudregistersessionforlocalopen",
-      "label": "canReuseCloudRegisterSessionForLocalOpen()",
-      "norm_label": "canreusecloudregistersessionforlocalopen()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L163"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_cansupersedereviewedregistersessionforlocalopen",
-      "label": "canSupersedeReviewedRegisterSessionForLocalOpen()",
-      "norm_label": "cansupersedereviewedregistersessionforlocalopen()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_drawerauthoritymatchesactiveregistersession",
-      "label": "drawerAuthorityMatchesActiveRegisterSession()",
-      "norm_label": "drawerauthoritymatchesactiveregistersession()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L298"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_getregistersessionvoidapplicationstatus",
-      "label": "getRegisterSessionVoidApplicationStatus()",
-      "norm_label": "getregistersessionvoidapplicationstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_getsaleblockingdrawerauthority",
-      "label": "getSaleBlockingDrawerAuthority()",
-      "norm_label": "getsaleblockingdrawerauthority()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isdrawerauthoritysaleblocking",
-      "label": "isDrawerAuthoritySaleBlocking()",
-      "norm_label": "isdrawerauthoritysaleblocking()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L156"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isnonblockingregisterlifecyclereviewevent",
-      "label": "isNonBlockingRegisterLifecycleReviewEvent()",
-      "norm_label": "isnonblockingregisterlifecyclereviewevent()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isregistercloseoutreviewconflict",
-      "label": "isRegisterCloseoutReviewConflict()",
-      "norm_label": "isregistercloseoutreviewconflict()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isregistersessionconflictblocking",
-      "label": "isRegisterSessionConflictBlocking()",
-      "norm_label": "isregistersessionconflictblocking()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isregistersessionreplacementblocking",
-      "label": "isRegisterSessionReplacementBlocking()",
-      "norm_label": "isregistersessionreplacementblocking()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isregistersessionsaleusable",
-      "label": "isRegisterSessionSaleUsable()",
-      "norm_label": "isregistersessionsaleusable()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 138,
-      "file_type": "code",
-      "id": "registersessionlifecyclepolicy_isscopedregistersession",
-      "label": "isScopedRegisterSession()",
-      "norm_label": "isscopedregistersession()",
-      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "id": "onlineordertracing_buildreturnexchangetraceevent",
+      "label": "buildReturnExchangeTraceEvent()",
+      "norm_label": "buildreturnexchangetraceevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
       "source_location": "L287"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_buildreturnexchangetracerecord",
+      "label": "buildReturnExchangeTraceRecord()",
+      "norm_label": "buildreturnexchangetracerecord()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L283"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L149"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_compactdetails",
+      "label": "compactDetails()",
+      "norm_label": "compactdetails()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_recordonlineorderreturnexchangetracebesteffort",
+      "label": "recordOnlineOrderReturnExchangeTraceBestEffort()",
+      "norm_label": "recordonlineorderreturnexchangetracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L396"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_recordonlineordertracebesteffort",
+      "label": "recordOnlineOrderTraceBestEffort()",
+      "norm_label": "recordonlineordertracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L352"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_resolvestoreorganizationid",
+      "label": "resolveStoreOrganizationId()",
+      "norm_label": "resolvestoreorganizationid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_returnexchangemessage",
+      "label": "returnExchangeMessage()",
+      "norm_label": "returnexchangemessage()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_returnexchangestep",
+      "label": "returnExchangeStep()",
+      "norm_label": "returnexchangestep()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L344"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_statusmessage",
+      "label": "statusMessage()",
+      "norm_label": "statusmessage()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "onlineordertracing_statusstep",
+      "label": "statusStep()",
+      "norm_label": "statusstep()",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 138,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_onlineordertracing_ts",
+      "label": "onlineOrderTracing.ts",
+      "norm_label": "onlineordertracing.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/onlineOrderTracing.ts",
+      "source_location": "L1"
     },
     {
       "community": 1380,
@@ -174606,137 +174630,137 @@
     {
       "community": 139,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productstockinput_ts",
-      "label": "ProductStockInput.ts",
-      "norm_label": "productstockinput.ts",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "id": "packages_athena_webapp_shared_registersessionlifecyclepolicy_ts",
+      "label": "registerSessionLifecyclePolicy.ts",
+      "norm_label": "registersessionlifecyclepolicy.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
       "source_location": "L1"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_buildtrustedinventoryfinalizationpayload",
-      "label": "buildTrustedInventoryFinalizationPayload()",
-      "norm_label": "buildtrustedinventoryfinalizationpayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L527"
+      "id": "registersessionlifecyclepolicy_caninspectruntimeclouddrawerauthority",
+      "label": "canInspectRuntimeCloudDrawerAuthority()",
+      "norm_label": "caninspectruntimeclouddrawerauthority()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L258"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_buildtrustedinventorymoneypayload",
-      "label": "buildTrustedInventoryMoneyPayload()",
-      "norm_label": "buildtrustedinventorymoneypayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L507"
+      "id": "registersessionlifecyclepolicy_canopenreplacementdrawerforlocalblock",
+      "label": "canOpenReplacementDrawerForLocalBlock()",
+      "norm_label": "canopenreplacementdrawerforlocalblock()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L233"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_gettrustedinventoryreviewvalidationmessage",
-      "label": "getTrustedInventoryReviewValidationMessage()",
-      "norm_label": "gettrustedinventoryreviewvalidationmessage()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L317"
+      "id": "registersessionlifecyclepolicy_canreusecloudregistersessionforlocalopen",
+      "label": "canReuseCloudRegisterSessionForLocalOpen()",
+      "norm_label": "canreusecloudregistersessionforlocalopen()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L163"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_isnonnegativeinteger",
-      "label": "isNonNegativeInteger()",
-      "norm_label": "isnonnegativeinteger()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L308"
+      "id": "registersessionlifecyclepolicy_cansupersedereviewedregistersessionforlocalopen",
+      "label": "canSupersedeReviewedRegisterSessionForLocalOpen()",
+      "norm_label": "cansupersedereviewedregistersessionforlocalopen()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L194"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_parsevariantdisplaymoney",
-      "label": "parseVariantDisplayMoney()",
-      "norm_label": "parsevariantdisplaymoney()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L499"
+      "id": "registersessionlifecyclepolicy_drawerauthoritymatchesactiveregistersession",
+      "label": "drawerAuthorityMatchesActiveRegisterSession()",
+      "norm_label": "drawerauthoritymatchesactiveregistersession()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L298"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_parsevariantinputvalue",
-      "label": "parseVariantInputValue()",
-      "norm_label": "parsevariantinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L21"
+      "id": "registersessionlifecyclepolicy_getregistersessionvoidapplicationstatus",
+      "label": "getRegisterSessionVoidApplicationStatus()",
+      "norm_label": "getregistersessionvoidapplicationstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L79"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_resolvependingcheckoutskulinkpricestate",
-      "label": "resolvePendingCheckoutSkuLinkPriceState()",
-      "norm_label": "resolvependingcheckoutskulinkpricestate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L171"
+      "id": "registersessionlifecyclepolicy_getsaleblockingdrawerauthority",
+      "label": "getSaleBlockingDrawerAuthority()",
+      "norm_label": "getsaleblockingdrawerauthority()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L128"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_resolvestockinputupdate",
-      "label": "resolveStockInputUpdate()",
-      "norm_label": "resolvestockinputupdate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L43"
+      "id": "registersessionlifecyclepolicy_isdrawerauthoritysaleblocking",
+      "label": "isDrawerAuthoritySaleBlocking()",
+      "norm_label": "isdrawerauthoritysaleblocking()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L156"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventorycommanderror",
-      "label": "resolveTrustedInventoryCommandError()",
-      "norm_label": "resolvetrustedinventorycommanderror()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L84"
+      "id": "registersessionlifecyclepolicy_isnonblockingregisterlifecyclereviewevent",
+      "label": "isNonBlockingRegisterLifecycleReviewEvent()",
+      "norm_label": "isnonblockingregisterlifecyclereviewevent()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L51"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventoryfinalizationpricingpolicy",
-      "label": "resolveTrustedInventoryFinalizationPricingPolicy()",
-      "norm_label": "resolvetrustedinventoryfinalizationpricingpolicy()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L151"
+      "id": "registersessionlifecyclepolicy_isregistercloseoutreviewconflict",
+      "label": "isRegisterCloseoutReviewConflict()",
+      "norm_label": "isregistercloseoutreviewconflict()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L268"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventoryrefreshreviewstate",
-      "label": "resolveTrustedInventoryRefreshReviewState()",
-      "norm_label": "resolvetrustedinventoryrefreshreviewstate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L130"
+      "id": "registersessionlifecyclepolicy_isregistersessionconflictblocking",
+      "label": "isRegisterSessionConflictBlocking()",
+      "norm_label": "isregistersessionconflictblocking()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L109"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventoryreviewclickaction",
-      "label": "resolveTrustedInventoryReviewClickAction()",
-      "norm_label": "resolvetrustedinventoryreviewclickaction()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "id": "registersessionlifecyclepolicy_isregistersessionreplacementblocking",
+      "label": "isRegisterSessionReplacementBlocking()",
+      "norm_label": "isregistersessionreplacementblocking()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 139,
+      "file_type": "code",
+      "id": "registersessionlifecyclepolicy_isregistersessionsaleusable",
+      "label": "isRegisterSessionSaleUsable()",
+      "norm_label": "isregistersessionsaleusable()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
       "source_location": "L62"
     },
     {
       "community": 139,
       "file_type": "code",
-      "id": "productstockinput_resolvetrustedinventoryreviewstate",
-      "label": "resolveTrustedInventoryReviewState()",
-      "norm_label": "resolvetrustedinventoryreviewstate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L344"
-    },
-    {
-      "community": 139,
-      "file_type": "code",
-      "id": "productstockinput_resolvevariantnumericinputvalue",
-      "label": "resolveVariantNumericInputValue()",
-      "norm_label": "resolvevariantnumericinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
-      "source_location": "L52"
+      "id": "registersessionlifecyclepolicy_isscopedregistersession",
+      "label": "isScopedRegisterSession()",
+      "norm_label": "isscopedregistersession()",
+      "source_file": "packages/athena-webapp/shared/registerSessionLifecyclePolicy.ts",
+      "source_location": "L287"
     },
     {
       "community": 1390,
@@ -175317,137 +175341,137 @@
     {
       "community": 140,
       "file_type": "code",
-      "id": "inventoryimportview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1292"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_handleapplybulkreviewdecision",
-      "label": "handleApplyBulkReviewDecision()",
-      "norm_label": "handleapplybulkreviewdecision()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1126"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_handleenterreviewmode",
-      "label": "handleEnterReviewMode()",
-      "norm_label": "handleenterreviewmode()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1092"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_handlefilechange",
-      "label": "handleFileChange()",
-      "norm_label": "handlefilechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L833"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_handleloadlatestreviewversion",
-      "label": "handleLoadLatestReviewVersion()",
-      "norm_label": "handleloadlatestreviewversion()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1063"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_handleoverlaypagechange",
-      "label": "handleOverlayPageChange()",
-      "norm_label": "handleoverlaypagechange()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L1119"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_handlesavereviewversion",
-      "label": "handleSaveReviewVersion()",
-      "norm_label": "handlesavereviewversion()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L967"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_handlestagereviewrowsforpos",
-      "label": "handleStageReviewRowsForPos()",
-      "norm_label": "handlestagereviewrowsforpos()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L971"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_parseinventoryoverlayfilter",
-      "label": "parseInventoryOverlayFilter()",
-      "norm_label": "parseinventoryoverlayfilter()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L207"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_parseinventoryoverlaypage",
-      "label": "parseInventoryOverlayPage()",
-      "norm_label": "parseinventoryoverlaypage()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L220"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_parseinventoryoverlayquery",
-      "label": "parseInventoryOverlayQuery()",
-      "norm_label": "parseinventoryoverlayquery()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_readinventoryimportroutedraft",
-      "label": "readInventoryImportRouteDraft()",
-      "norm_label": "readinventoryimportroutedraft()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L244"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_saveinventoryimportroutedraft",
-      "label": "saveInventoryImportRouteDraft()",
-      "norm_label": "saveinventoryimportroutedraft()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L235"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "inventoryimportview_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
-      "source_location": "L2943"
-    },
-    {
-      "community": 140,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_operations_inventoryimportview_tsx",
-      "label": "InventoryImportView.tsx",
-      "norm_label": "inventoryimportview.tsx",
-      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "id": "packages_athena_webapp_src_components_add_product_productstockinput_ts",
+      "label": "ProductStockInput.ts",
+      "norm_label": "productstockinput.ts",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_buildtrustedinventoryfinalizationpayload",
+      "label": "buildTrustedInventoryFinalizationPayload()",
+      "norm_label": "buildtrustedinventoryfinalizationpayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L527"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_buildtrustedinventorymoneypayload",
+      "label": "buildTrustedInventoryMoneyPayload()",
+      "norm_label": "buildtrustedinventorymoneypayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L507"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_gettrustedinventoryreviewvalidationmessage",
+      "label": "getTrustedInventoryReviewValidationMessage()",
+      "norm_label": "gettrustedinventoryreviewvalidationmessage()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L317"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_isnonnegativeinteger",
+      "label": "isNonNegativeInteger()",
+      "norm_label": "isnonnegativeinteger()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L308"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_parsevariantdisplaymoney",
+      "label": "parseVariantDisplayMoney()",
+      "norm_label": "parsevariantdisplaymoney()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L499"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_parsevariantinputvalue",
+      "label": "parseVariantInputValue()",
+      "norm_label": "parsevariantinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_resolvependingcheckoutskulinkpricestate",
+      "label": "resolvePendingCheckoutSkuLinkPriceState()",
+      "norm_label": "resolvependingcheckoutskulinkpricestate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_resolvestockinputupdate",
+      "label": "resolveStockInputUpdate()",
+      "norm_label": "resolvestockinputupdate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventorycommanderror",
+      "label": "resolveTrustedInventoryCommandError()",
+      "norm_label": "resolvetrustedinventorycommanderror()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventoryfinalizationpricingpolicy",
+      "label": "resolveTrustedInventoryFinalizationPricingPolicy()",
+      "norm_label": "resolvetrustedinventoryfinalizationpricingpolicy()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventoryrefreshreviewstate",
+      "label": "resolveTrustedInventoryRefreshReviewState()",
+      "norm_label": "resolvetrustedinventoryrefreshreviewstate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventoryreviewclickaction",
+      "label": "resolveTrustedInventoryReviewClickAction()",
+      "norm_label": "resolvetrustedinventoryreviewclickaction()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_resolvetrustedinventoryreviewstate",
+      "label": "resolveTrustedInventoryReviewState()",
+      "norm_label": "resolvetrustedinventoryreviewstate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L344"
+    },
+    {
+      "community": 140,
+      "file_type": "code",
+      "id": "productstockinput_resolvevariantnumericinputvalue",
+      "label": "resolveVariantNumericInputValue()",
+      "norm_label": "resolvevariantnumericinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductStockInput.ts",
+      "source_location": "L52"
     },
     {
       "community": 1400,
@@ -175632,137 +175656,137 @@
     {
       "community": 141,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
-      "label": "TransactionsView.tsx",
-      "norm_label": "transactionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L1"
+      "id": "inventoryimportview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1292"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "transactionsview_formatoperatingdatefilterlabel",
-      "label": "formatOperatingDateFilterLabel()",
-      "norm_label": "formatoperatingdatefilterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L109"
+      "id": "inventoryimportview_handleapplybulkreviewdecision",
+      "label": "handleApplyBulkReviewDecision()",
+      "norm_label": "handleapplybulkreviewdecision()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1126"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "transactionsview_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L38"
+      "id": "inventoryimportview_handleenterreviewmode",
+      "label": "handleEnterReviewMode()",
+      "norm_label": "handleenterreviewmode()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1092"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "transactionsview_formatregisterfilterlabel",
-      "label": "formatRegisterFilterLabel()",
-      "norm_label": "formatregisterfilterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L43"
+      "id": "inventoryimportview_handlefilechange",
+      "label": "handleFileChange()",
+      "norm_label": "handlefilechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L833"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "transactionsview_getcompletedtransactionlimitforpage",
-      "label": "getCompletedTransactionLimitForPage()",
-      "norm_label": "getcompletedtransactionlimitforpage()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L123"
+      "id": "inventoryimportview_handleloadlatestreviewversion",
+      "label": "handleLoadLatestReviewVersion()",
+      "norm_label": "handleloadlatestreviewversion()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1063"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "transactionsview_getemptytransactiontitle",
-      "label": "getEmptyTransactionTitle()",
-      "norm_label": "getemptytransactiontitle()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "id": "inventoryimportview_handleoverlaypagechange",
+      "label": "handleOverlayPageChange()",
+      "norm_label": "handleoverlaypagechange()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1119"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventoryimportview_handlesavereviewversion",
+      "label": "handleSaveReviewVersion()",
+      "norm_label": "handlesavereviewversion()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L967"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventoryimportview_handlestagereviewrowsforpos",
+      "label": "handleStageReviewRowsForPos()",
+      "norm_label": "handlestagereviewrowsforpos()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L971"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventoryimportview_parseinventoryoverlayfilter",
+      "label": "parseInventoryOverlayFilter()",
+      "norm_label": "parseinventoryoverlayfilter()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L207"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventoryimportview_parseinventoryoverlaypage",
+      "label": "parseInventoryOverlayPage()",
+      "norm_label": "parseinventoryoverlaypage()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L220"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventoryimportview_parseinventoryoverlayquery",
+      "label": "parseInventoryOverlayQuery()",
+      "norm_label": "parseinventoryoverlayquery()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L216"
+    },
+    {
+      "community": 141,
+      "file_type": "code",
+      "id": "inventoryimportview_readinventoryimportroutedraft",
+      "label": "readInventoryImportRouteDraft()",
+      "norm_label": "readinventoryimportroutedraft()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
       "source_location": "L244"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "transactionsview_getnexttransactionpagesearch",
-      "label": "getNextTransactionPageSearch()",
-      "norm_label": "getnexttransactionpagesearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L133"
+      "id": "inventoryimportview_saveinventoryimportroutedraft",
+      "label": "saveInventoryImportRouteDraft()",
+      "norm_label": "saveinventoryimportroutedraft()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L235"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "transactionsview_getnexttransactionpaymentfiltersearch",
-      "label": "getNextTransactionPaymentFilterSearch()",
-      "norm_label": "getnexttransactionpaymentfiltersearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L187"
+      "id": "inventoryimportview_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L2943"
     },
     {
       "community": 141,
       "file_type": "code",
-      "id": "transactionsview_getnexttransactiontimefiltersearch",
-      "label": "getNextTransactionTimeFilterSearch()",
-      "norm_label": "getnexttransactiontimefiltersearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L177"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "transactionsview_getpageindexfromsearch",
-      "label": "getPageIndexFromSearch()",
-      "norm_label": "getpageindexfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "transactionsview_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L221"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "transactionsview_getstartofoperatingdate",
-      "label": "getStartOfOperatingDate()",
-      "norm_label": "getstartofoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L100"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "transactionsview_gettransactiontimefilter",
-      "label": "getTransactionTimeFilter()",
-      "norm_label": "gettransactiontimefilter()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L149"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "transactionsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L94"
-    },
-    {
-      "community": 141,
-      "file_type": "code",
-      "id": "transactionsview_transactionmobilecard",
-      "label": "TransactionMobileCard()",
-      "norm_label": "transactionmobilecard()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
-      "source_location": "L285"
+      "id": "packages_athena_webapp_src_components_operations_inventoryimportview_tsx",
+      "label": "InventoryImportView.tsx",
+      "norm_label": "inventoryimportview.tsx",
+      "source_file": "packages/athena-webapp/src/components/operations/InventoryImportView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1410,
@@ -175947,137 +175971,137 @@
     {
       "community": 142,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
-      "label": "QuickAddProductDialog.tsx",
-      "norm_label": "quickaddproductdialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactionsview_tsx",
+      "label": "TransactionsView.tsx",
+      "norm_label": "transactionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_addquickaddextravariant",
-      "label": "addQuickAddExtraVariant()",
-      "norm_label": "addquickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L453"
+      "id": "transactionsview_formatoperatingdatefilterlabel",
+      "label": "formatOperatingDateFilterLabel()",
+      "norm_label": "formatoperatingdatefilterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L109"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_buildquickaddexistingskuoptionfromsearchresult",
-      "label": "buildQuickAddExistingSkuOptionFromSearchResult()",
-      "norm_label": "buildquickaddexistingskuoptionfromsearchresult()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L169"
+      "id": "transactionsview_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L38"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L824"
+      "id": "transactionsview_formatregisterfilterlabel",
+      "label": "formatRegisterFilterLabel()",
+      "norm_label": "formatregisterfilterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L43"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_formatquickadddialogerror",
-      "label": "formatQuickAddDialogError()",
-      "norm_label": "formatquickadddialogerror()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L118"
+      "id": "transactionsview_getcompletedtransactionlimitforpage",
+      "label": "getCompletedTransactionLimitForPage()",
+      "norm_label": "getcompletedtransactionlimitforpage()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L123"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_getexistingskumetadata",
-      "label": "getExistingSkuMetadata()",
-      "norm_label": "getexistingskumetadata()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L158"
+      "id": "transactionsview_getemptytransactiontitle",
+      "label": "getEmptyTransactionTitle()",
+      "norm_label": "getemptytransactiontitle()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L244"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_handleattachbarcode",
-      "label": "handleAttachBarcode()",
-      "norm_label": "handleattachbarcode()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L681"
+      "id": "transactionsview_getnexttransactionpagesearch",
+      "label": "getNextTransactionPageSearch()",
+      "norm_label": "getnexttransactionpagesearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L133"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_handlecancel",
-      "label": "handleCancel()",
-      "norm_label": "handlecancel()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L473"
+      "id": "transactionsview_getnexttransactionpaymentfiltersearch",
+      "label": "getNextTransactionPaymentFilterSearch()",
+      "norm_label": "getnexttransactionpaymentfiltersearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L187"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_handleopenchange",
-      "label": "handleOpenChange()",
-      "norm_label": "handleopenchange()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L466"
+      "id": "transactionsview_getnexttransactiontimefiltersearch",
+      "label": "getNextTransactionTimeFilterSearch()",
+      "norm_label": "getnexttransactiontimefiltersearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L177"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_handlequickaddmultiplevariantschange",
-      "label": "handleQuickAddMultipleVariantsChange()",
-      "norm_label": "handlequickaddmultiplevariantschange()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L435"
+      "id": "transactionsview_getpageindexfromsearch",
+      "label": "getPageIndexFromSearch()",
+      "norm_label": "getpageindexfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L117"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_handlequickaddsubmit",
-      "label": "handleQuickAddSubmit()",
-      "norm_label": "handlequickaddsubmit()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L487"
+      "id": "transactionsview_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L221"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_preventoutsidedismiss",
-      "label": "preventOutsideDismiss()",
-      "norm_label": "preventoutsidedismiss()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L478"
+      "id": "transactionsview_getstartofoperatingdate",
+      "label": "getStartOfOperatingDate()",
+      "norm_label": "getstartofoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L100"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_removequickaddextravariant",
-      "label": "removeQuickAddExtraVariant()",
-      "norm_label": "removequickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L460"
+      "id": "transactionsview_gettransactiontimefilter",
+      "label": "getTransactionTimeFilter()",
+      "norm_label": "gettransactiontimefilter()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L149"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_updatequickaddextravariant",
-      "label": "updateQuickAddExtraVariant()",
-      "norm_label": "updatequickaddextravariant()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L442"
+      "id": "transactionsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L94"
     },
     {
       "community": 142,
       "file_type": "code",
-      "id": "quickaddproductdialog_validatequickaddlookupcode",
-      "label": "validateQuickAddLookupCode()",
-      "norm_label": "validatequickaddlookupcode()",
-      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
-      "source_location": "L136"
+      "id": "transactionsview_transactionmobilecard",
+      "label": "TransactionMobileCard()",
+      "norm_label": "transactionmobilecard()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx",
+      "source_location": "L285"
     },
     {
       "community": 1420,
@@ -176262,128 +176286,137 @@
     {
       "community": 143,
       "file_type": "code",
-      "id": "dailyclose_test_compareindexedvalue",
-      "label": "compareIndexedValue()",
-      "norm_label": "compareindexedvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_completeddailycloserow",
-      "label": "completedDailyCloseRow()",
-      "norm_label": "completeddailycloserow()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L464"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_completeddailyclosesnapshot",
-      "label": "completedDailyCloseSnapshot()",
-      "norm_label": "completeddailyclosesnapshot()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L410"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_createcommandargs",
-      "label": "createCommandArgs()",
-      "norm_label": "createcommandargs()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L5554"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_createdb",
-      "label": "createDb()",
-      "norm_label": "createdb()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_dailycloseapprovalproof",
-      "label": "dailyCloseApprovalProof()",
-      "norm_label": "dailycloseapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_dailyclosecarryforwardapprovalproof",
-      "label": "dailyCloseCarryForwardApprovalProof()",
-      "norm_label": "dailyclosecarryforwardapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L390"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_dailyclosereopenapprovalproof",
-      "label": "dailyCloseReopenApprovalProof()",
-      "norm_label": "dailyclosereopenapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L372"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_dailyclosesummary",
-      "label": "dailyCloseSummary()",
-      "norm_label": "dailyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L329"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_mockdailyclosesnapshotaccess",
-      "label": "mockDailyCloseSnapshotAccess()",
-      "norm_label": "mockdailyclosesnapshotaccess()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L497"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_openoperationalworkitems",
-      "label": "openOperationalWorkItems()",
-      "norm_label": "openoperationalworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "dailyclose_test_syncedreview",
-      "label": "syncedReview()",
-      "norm_label": "syncedreview()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L1914"
-    },
-    {
-      "community": 143,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
-      "label": "dailyClose.test.ts",
-      "norm_label": "dailyclose.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_tsx",
+      "label": "QuickAddProductDialog.tsx",
+      "norm_label": "quickaddproductdialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
       "source_location": "L1"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_addquickaddextravariant",
+      "label": "addQuickAddExtraVariant()",
+      "norm_label": "addquickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L453"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_buildquickaddexistingskuoptionfromsearchresult",
+      "label": "buildQuickAddExistingSkuOptionFromSearchResult()",
+      "norm_label": "buildquickaddexistingskuoptionfromsearchresult()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L169"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L824"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_formatquickadddialogerror",
+      "label": "formatQuickAddDialogError()",
+      "norm_label": "formatquickadddialogerror()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L118"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_getexistingskumetadata",
+      "label": "getExistingSkuMetadata()",
+      "norm_label": "getexistingskumetadata()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L158"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handleattachbarcode",
+      "label": "handleAttachBarcode()",
+      "norm_label": "handleattachbarcode()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L681"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handlecancel",
+      "label": "handleCancel()",
+      "norm_label": "handlecancel()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L473"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handleopenchange",
+      "label": "handleOpenChange()",
+      "norm_label": "handleopenchange()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L466"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handlequickaddmultiplevariantschange",
+      "label": "handleQuickAddMultipleVariantsChange()",
+      "norm_label": "handlequickaddmultiplevariantschange()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L435"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_handlequickaddsubmit",
+      "label": "handleQuickAddSubmit()",
+      "norm_label": "handlequickaddsubmit()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L487"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_preventoutsidedismiss",
+      "label": "preventOutsideDismiss()",
+      "norm_label": "preventoutsidedismiss()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L478"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_removequickaddextravariant",
+      "label": "removeQuickAddExtraVariant()",
+      "norm_label": "removequickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L460"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_updatequickaddextravariant",
+      "label": "updateQuickAddExtraVariant()",
+      "norm_label": "updatequickaddextravariant()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L442"
+    },
+    {
+      "community": 143,
+      "file_type": "code",
+      "id": "quickaddproductdialog_validatequickaddlookupcode",
+      "label": "validateQuickAddLookupCode()",
+      "norm_label": "validatequickaddlookupcode()",
+      "source_file": "packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx",
+      "source_location": "L136"
     },
     {
       "community": 1430,
@@ -176568,128 +176601,128 @@
     {
       "community": 144,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
-      "label": "staffProfiles.ts",
-      "norm_label": "staffprofiles.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "id": "dailyclose_test_compareindexedvalue",
+      "label": "compareIndexedValue()",
+      "norm_label": "compareindexedvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_completeddailycloserow",
+      "label": "completedDailyCloseRow()",
+      "norm_label": "completeddailycloserow()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L464"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_completeddailyclosesnapshot",
+      "label": "completedDailyCloseSnapshot()",
+      "norm_label": "completeddailyclosesnapshot()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L410"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_createcommandargs",
+      "label": "createCommandArgs()",
+      "norm_label": "createcommandargs()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L5554"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_createdb",
+      "label": "createDb()",
+      "norm_label": "createdb()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_dailycloseapprovalproof",
+      "label": "dailyCloseApprovalProof()",
+      "norm_label": "dailycloseapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_dailyclosecarryforwardapprovalproof",
+      "label": "dailyCloseCarryForwardApprovalProof()",
+      "norm_label": "dailyclosecarryforwardapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L390"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_dailyclosereopenapprovalproof",
+      "label": "dailyCloseReopenApprovalProof()",
+      "norm_label": "dailyclosereopenapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L372"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_dailyclosesummary",
+      "label": "dailyCloseSummary()",
+      "norm_label": "dailyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L329"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_mockdailyclosesnapshotaccess",
+      "label": "mockDailyCloseSnapshotAccess()",
+      "norm_label": "mockdailyclosesnapshotaccess()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L497"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_openoperationalworkitems",
+      "label": "openOperationalWorkItems()",
+      "norm_label": "openoperationalworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "dailyclose_test_syncedreview",
+      "label": "syncedReview()",
+      "norm_label": "syncedreview()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
+      "source_location": "L1914"
+    },
+    {
+      "community": 144,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
+      "label": "dailyClose.test.ts",
+      "norm_label": "dailyclose.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_assertroleconfiguration",
-      "label": "assertRoleConfiguration()",
-      "norm_label": "assertroleconfiguration()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_buildroleassignmentdrafts",
-      "label": "buildRoleAssignmentDrafts()",
-      "norm_label": "buildroleassignmentdrafts()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_buildstafffullname",
-      "label": "buildStaffFullName()",
-      "norm_label": "buildstafffullname()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_buildstaffprofileresult",
-      "label": "buildStaffProfileResult()",
-      "norm_label": "buildstaffprofileresult()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_createstaffprofilewithctx",
-      "label": "createStaffProfileWithCtx()",
-      "norm_label": "createstaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L305"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_ensurelinkeduseravailable",
-      "label": "ensureLinkedUserAvailable()",
-      "norm_label": "ensurelinkeduseravailable()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_getstaffprofilebyidwithctx",
-      "label": "getStaffProfileByIdWithCtx()",
-      "norm_label": "getstaffprofilebyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_liststaffprofileswithctx",
-      "label": "listStaffProfilesWithCtx()",
-      "norm_label": "liststaffprofileswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L254"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_normalizeoptionalstring",
-      "label": "normalizeOptionalString()",
-      "norm_label": "normalizeoptionalstring()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_normalizestaffprofilepatch",
-      "label": "normalizeStaffProfilePatch()",
-      "norm_label": "normalizestaffprofilepatch()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_requirenamesegment",
-      "label": "requireNameSegment()",
-      "norm_label": "requirenamesegment()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_syncstaffroleassignmentswithctx",
-      "label": "syncStaffRoleAssignmentsWithCtx()",
-      "norm_label": "syncstaffroleassignmentswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 144,
-      "file_type": "code",
-      "id": "staffprofiles_updatestaffprofilewithctx",
-      "label": "updateStaffProfileWithCtx()",
-      "norm_label": "updatestaffprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
-      "source_location": "L381"
     },
     {
       "community": 1440,
@@ -176874,128 +176907,128 @@
     {
       "community": 145,
       "file_type": "code",
-      "id": "cloudrepairpolicy_buildterminalcloudrepairpreconditionhash",
-      "label": "buildTerminalCloudRepairPreconditionHash()",
-      "norm_label": "buildterminalcloudrepairpreconditionhash()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L143"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_buildterminalcloudrepairpreview",
-      "label": "buildTerminalCloudRepairPreview()",
-      "norm_label": "buildterminalcloudrepairpreview()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_canprojectregisteropenforterminalcloudrepair",
-      "label": "canProjectRegisterOpenForTerminalCloudRepair()",
-      "norm_label": "canprojectregisteropenforterminalcloudrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_classifyterminalcloudrepairconflict",
-      "label": "classifyTerminalCloudRepairConflict()",
-      "norm_label": "classifyterminalcloudrepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_containsbusinessfacts",
-      "label": "containsBusinessFacts()",
-      "norm_label": "containsbusinessfacts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairconflictcloseoutreviewboundaryat",
-      "label": "getRepairConflictCloseoutReviewBoundaryAt()",
-      "norm_label": "getrepairconflictcloseoutreviewboundaryat()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairopenregistercloseoutreviewstate",
-      "label": "getRepairOpenRegisterCloseoutReviewState()",
-      "norm_label": "getrepairopenregistercloseoutreviewstate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L261"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_getrepairregistersessioncloseoutboundaryat",
-      "label": "getRepairRegisterSessionCloseoutBoundaryAt()",
-      "norm_label": "getrepairregistersessioncloseoutboundaryat()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L297"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_isduplicateregisteropenconflict",
-      "label": "isDuplicateRegisterOpenConflict()",
-      "norm_label": "isduplicateregisteropenconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L354"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_normalizerepairstring",
-      "label": "normalizeRepairString()",
-      "norm_label": "normalizerepairstring()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L395"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_repairfactmatchesregistersessioncloseoutreview",
-      "label": "repairFactMatchesRegisterSessionCloseoutReview()",
-      "norm_label": "repairfactmatchesregistersessioncloseoutreview()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L326"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_skipterminalcloudrepairconflict",
-      "label": "skipTerminalCloudRepairConflict()",
-      "norm_label": "skipterminalcloudrepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 145,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_ts",
-      "label": "cloudRepairPolicy.ts",
-      "norm_label": "cloudrepairpolicy.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "id": "packages_athena_webapp_convex_operations_staffprofiles_ts",
+      "label": "staffProfiles.ts",
+      "norm_label": "staffprofiles.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_assertroleconfiguration",
+      "label": "assertRoleConfiguration()",
+      "norm_label": "assertroleconfiguration()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_buildroleassignmentdrafts",
+      "label": "buildRoleAssignmentDrafts()",
+      "norm_label": "buildroleassignmentdrafts()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_buildstafffullname",
+      "label": "buildStaffFullName()",
+      "norm_label": "buildstafffullname()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_buildstaffprofileresult",
+      "label": "buildStaffProfileResult()",
+      "norm_label": "buildstaffprofileresult()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_createstaffprofilewithctx",
+      "label": "createStaffProfileWithCtx()",
+      "norm_label": "createstaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L305"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_ensurelinkeduseravailable",
+      "label": "ensureLinkedUserAvailable()",
+      "norm_label": "ensurelinkeduseravailable()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_getstaffprofilebyidwithctx",
+      "label": "getStaffProfileByIdWithCtx()",
+      "norm_label": "getstaffprofilebyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_liststaffprofileswithctx",
+      "label": "listStaffProfilesWithCtx()",
+      "norm_label": "liststaffprofileswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_normalizeoptionalstring",
+      "label": "normalizeOptionalString()",
+      "norm_label": "normalizeoptionalstring()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_normalizestaffprofilepatch",
+      "label": "normalizeStaffProfilePatch()",
+      "norm_label": "normalizestaffprofilepatch()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_requirenamesegment",
+      "label": "requireNameSegment()",
+      "norm_label": "requirenamesegment()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_syncstaffroleassignmentswithctx",
+      "label": "syncStaffRoleAssignmentsWithCtx()",
+      "norm_label": "syncstaffroleassignmentswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 145,
+      "file_type": "code",
+      "id": "staffprofiles_updatestaffprofilewithctx",
+      "label": "updateStaffProfileWithCtx()",
+      "norm_label": "updatestaffprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffProfiles.ts",
+      "source_location": "L381"
     },
     {
       "community": 1450,
@@ -177180,128 +177213,128 @@
     {
       "community": 146,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_tsx",
-      "label": "RegisterSessionsView.tsx",
-      "norm_label": "registersessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "id": "cloudrepairpolicy_buildterminalcloudrepairpreconditionhash",
+      "label": "buildTerminalCloudRepairPreconditionHash()",
+      "norm_label": "buildterminalcloudrepairpreconditionhash()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L143"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_buildterminalcloudrepairpreview",
+      "label": "buildTerminalCloudRepairPreview()",
+      "norm_label": "buildterminalcloudrepairpreview()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_canprojectregisteropenforterminalcloudrepair",
+      "label": "canProjectRegisterOpenForTerminalCloudRepair()",
+      "norm_label": "canprojectregisteropenforterminalcloudrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_classifyterminalcloudrepairconflict",
+      "label": "classifyTerminalCloudRepairConflict()",
+      "norm_label": "classifyterminalcloudrepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_containsbusinessfacts",
+      "label": "containsBusinessFacts()",
+      "norm_label": "containsbusinessfacts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairconflictcloseoutreviewboundaryat",
+      "label": "getRepairConflictCloseoutReviewBoundaryAt()",
+      "norm_label": "getrepairconflictcloseoutreviewboundaryat()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairopenregistercloseoutreviewstate",
+      "label": "getRepairOpenRegisterCloseoutReviewState()",
+      "norm_label": "getrepairopenregistercloseoutreviewstate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L261"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_getrepairregistersessioncloseoutboundaryat",
+      "label": "getRepairRegisterSessionCloseoutBoundaryAt()",
+      "norm_label": "getrepairregistersessioncloseoutboundaryat()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L297"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_isduplicateregisteropenconflict",
+      "label": "isDuplicateRegisterOpenConflict()",
+      "norm_label": "isduplicateregisteropenconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L354"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_normalizerepairstring",
+      "label": "normalizeRepairString()",
+      "norm_label": "normalizerepairstring()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L395"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_repairfactmatchesregistersessioncloseoutreview",
+      "label": "repairFactMatchesRegisterSessionCloseoutReview()",
+      "norm_label": "repairfactmatchesregistersessioncloseoutreview()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L326"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_skipterminalcloudrepairconflict",
+      "label": "skipTerminalCloudRepairConflict()",
+      "norm_label": "skipterminalcloudrepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 146,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_ts",
+      "label": "cloudRepairPolicy.ts",
+      "norm_label": "cloudrepairpolicy.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L40"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formatduration",
-      "label": "formatDuration()",
-      "norm_label": "formatduration()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L108"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formatfinanciallabel",
-      "label": "formatFinancialLabel()",
-      "norm_label": "formatfinanciallabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L50"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formattimelinedate",
-      "label": "formatTimelineDate()",
-      "norm_label": "formattimelinedate()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formattimelinelabel",
-      "label": "formatTimelineLabel()",
-      "norm_label": "formattimelinelabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L84"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formattimelinerange",
-      "label": "formatTimelineRange()",
-      "norm_label": "formattimelinerange()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L128"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formattimelinetime",
-      "label": "formatTimelineTime()",
-      "norm_label": "formattimelinetime()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_getstaffname",
-      "label": "getStaffName()",
-      "norm_label": "getstaffname()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L154"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_getvariancecaption",
-      "label": "getVarianceCaption()",
-      "norm_label": "getvariancecaption()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L146"
-    },
-    {
-      "community": 146,
-      "file_type": "code",
-      "id": "registersessionsview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L138"
     },
     {
       "community": 1460,
@@ -177486,128 +177519,128 @@
     {
       "community": 147,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
-      "label": "PaymentsAddedList.tsx",
-      "norm_label": "paymentsaddedlist.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_tsx",
+      "label": "RegisterSessionsView.tsx",
+      "norm_label": "registersessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_clearpaymentediting",
-      "label": "clearPaymentEditing()",
-      "norm_label": "clearpaymentediting()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L139"
+      "id": "registersessionsview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L40"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L384"
+      "id": "registersessionsview_formatduration",
+      "label": "formatDuration()",
+      "norm_label": "formatduration()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L108"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L52"
+      "id": "registersessionsview_formatfinanciallabel",
+      "label": "formatFinancialLabel()",
+      "norm_label": "formatfinanciallabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L50"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_getpaymentmethodlabel",
-      "label": "getPaymentMethodLabel()",
-      "norm_label": "getpaymentmethodlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L63"
+      "id": "registersessionsview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L62"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlecanceledit",
-      "label": "handleCancelEdit()",
-      "norm_label": "handlecanceledit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L180"
+      "id": "registersessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L73"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_handleclearpayments",
-      "label": "handleClearPayments()",
-      "norm_label": "handleclearpayments()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L198"
+      "id": "registersessionsview_formattimelinedate",
+      "label": "formatTimelineDate()",
+      "norm_label": "formattimelinedate()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L93"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_handleremovepayment",
-      "label": "handleRemovePayment()",
-      "norm_label": "handleremovepayment()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L204"
+      "id": "registersessionsview_formattimelinelabel",
+      "label": "formatTimelineLabel()",
+      "norm_label": "formattimelinelabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L84"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlesaveedit",
-      "label": "handleSaveEdit()",
-      "norm_label": "handlesaveedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L145"
+      "id": "registersessionsview_formattimelinerange",
+      "label": "formatTimelineRange()",
+      "norm_label": "formattimelinerange()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L128"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_handlestartedit",
-      "label": "handleStartEdit()",
-      "norm_label": "handlestartedit()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L132"
+      "id": "registersessionsview_formattimelinetime",
+      "label": "formatTimelineTime()",
+      "norm_label": "formattimelinetime()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L101"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L315"
+      "id": "registersessionsview_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L77"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_resetpaymentcollectioncontrols",
-      "label": "resetPaymentCollectionControls()",
-      "norm_label": "resetpaymentcollectioncontrols()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L193"
+      "id": "registersessionsview_getstaffname",
+      "label": "getStaffName()",
+      "norm_label": "getstaffname()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L154"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_setpaymentediting",
-      "label": "setPaymentEditing()",
-      "norm_label": "setpaymentediting()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L123"
+      "id": "registersessionsview_getvariancecaption",
+      "label": "getVarianceCaption()",
+      "norm_label": "getvariancecaption()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L146"
     },
     {
       "community": 147,
       "file_type": "code",
-      "id": "paymentsaddedlist_setpaymentsexpanded",
-      "label": "setPaymentsExpanded()",
-      "norm_label": "setpaymentsexpanded()",
-      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
-      "source_location": "L115"
+      "id": "registersessionsview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L138"
     },
     {
       "community": 1470,
@@ -177792,128 +177825,128 @@
     {
       "community": 148,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportformat_ts",
-      "label": "reportFormat.ts",
-      "norm_label": "reportformat.ts",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_tsx",
+      "label": "PaymentsAddedList.tsx",
+      "norm_label": "paymentsaddedlist.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L1"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatbasispoints",
-      "label": "formatBasisPoints()",
-      "norm_label": "formatbasispoints()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L96"
+      "id": "paymentsaddedlist_clearpaymentediting",
+      "label": "clearPaymentEditing()",
+      "norm_label": "clearpaymentediting()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L139"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatcompactreportmoney",
-      "label": "formatCompactReportMoney()",
-      "norm_label": "formatcompactreportmoney()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L74"
+      "id": "paymentsaddedlist_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L384"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L124"
+      "id": "paymentsaddedlist_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L52"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatoptionalmoney",
-      "label": "formatOptionalMoney()",
-      "norm_label": "formatoptionalmoney()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L56"
+      "id": "paymentsaddedlist_getpaymentmethodlabel",
+      "label": "getPaymentMethodLabel()",
+      "norm_label": "getpaymentmethodlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L63"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatreportmoney",
-      "label": "formatReportMoney()",
-      "norm_label": "formatreportmoney()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L14"
+      "id": "paymentsaddedlist_handlecanceledit",
+      "label": "handleCancelEdit()",
+      "norm_label": "handlecanceledit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L180"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatreportprofit",
-      "label": "formatReportProfit()",
-      "norm_label": "formatreportprofit()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L36"
+      "id": "paymentsaddedlist_handleclearpayments",
+      "label": "handleClearPayments()",
+      "norm_label": "handleclearpayments()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L198"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatskudisplayname",
-      "label": "formatSkuDisplayName()",
-      "norm_label": "formatskudisplayname()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L244"
+      "id": "paymentsaddedlist_handleremovepayment",
+      "label": "handleRemovePayment()",
+      "norm_label": "handleremovepayment()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L204"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatskusubtitle",
-      "label": "formatSkuSubtitle()",
-      "norm_label": "formatskusubtitle()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L226"
+      "id": "paymentsaddedlist_handlesaveedit",
+      "label": "handleSaveEdit()",
+      "norm_label": "handlesaveedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L145"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_formatunits",
-      "label": "formatUnits()",
-      "norm_label": "formatunits()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L64"
+      "id": "paymentsaddedlist_handlestartedit",
+      "label": "handleStartEdit()",
+      "norm_label": "handlestartedit()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L132"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_reportdaysettlementpresentation",
-      "label": "reportDaySettlementPresentation()",
-      "norm_label": "reportdaysettlementpresentation()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L148"
+      "id": "paymentsaddedlist_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L315"
     },
     {
       "community": 148,
       "file_type": "code",
-      "id": "reportformat_reportdaystatuspresentation",
-      "label": "reportDayStatusPresentation()",
-      "norm_label": "reportdaystatuspresentation()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "id": "paymentsaddedlist_resetpaymentcollectioncontrols",
+      "label": "resetPaymentCollectionControls()",
+      "norm_label": "resetpaymentcollectioncontrols()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L193"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "paymentsaddedlist_setpaymentediting",
+      "label": "setPaymentEditing()",
+      "norm_label": "setpaymentediting()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 148,
+      "file_type": "code",
+      "id": "paymentsaddedlist_setpaymentsexpanded",
+      "label": "setPaymentsExpanded()",
+      "norm_label": "setpaymentsexpanded()",
+      "source_file": "packages/athena-webapp/src/components/pos/PaymentsAddedList.tsx",
       "source_location": "L115"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "reportformat_reportoldestunreconciledpresentation",
-      "label": "reportOldestUnreconciledPresentation()",
-      "norm_label": "reportoldestunreconciledpresentation()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L266"
-    },
-    {
-      "community": 148,
-      "file_type": "code",
-      "id": "reportformat_reportprofithelper",
-      "label": "reportProfitHelper()",
-      "norm_label": "reportprofithelper()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
-      "source_location": "L45"
     },
     {
       "community": 1480,
@@ -178098,128 +178131,128 @@
     {
       "community": 149,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemotransactionsfixture_ts",
-      "label": "sharedDemoTransactionsFixture.ts",
-      "norm_label": "shareddemotransactionsfixture.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "id": "packages_athena_webapp_src_components_reports_reportformat_ts",
+      "label": "reportFormat.ts",
+      "norm_label": "reportformat.ts",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
       "source_location": "L1"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_builddaytransactions",
-      "label": "buildDayTransactions()",
-      "norm_label": "builddaytransactions()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L360"
+      "id": "reportformat_formatbasispoints",
+      "label": "formatBasisPoints()",
+      "norm_label": "formatbasispoints()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L96"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_builditems",
-      "label": "buildItems()",
-      "norm_label": "builditems()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L260"
+      "id": "reportformat_formatcompactreportmoney",
+      "label": "formatCompactReportMoney()",
+      "norm_label": "formatcompactreportmoney()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L74"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_buildpaymentproductmixes",
-      "label": "buildPaymentProductMixes()",
-      "norm_label": "buildpaymentproductmixes()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "shareddemotransactionsfixture_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L289"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "shareddemotransactionsfixture_createshareddemotransactionfixtures",
-      "label": "createSharedDemoTransactionFixtures()",
-      "norm_label": "createshareddemotransactionfixtures()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L414"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "shareddemotransactionsfixture_distributeproducts",
-      "label": "distributeProducts()",
-      "norm_label": "distributeproducts()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "shareddemotransactionsfixture_findproductmix",
-      "label": "findProductMix()",
-      "norm_label": "findproductmix()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 149,
-      "file_type": "code",
-      "id": "shareddemotransactionsfixture_formatoperatingdate",
+      "id": "reportformat_formatoperatingdate",
       "label": "formatOperatingDate()",
       "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L104"
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L124"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_getshareddemotransactionfixture",
-      "label": "getSharedDemoTransactionFixture()",
-      "norm_label": "getshareddemotransactionfixture()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L441"
+      "id": "reportformat_formatoptionalmoney",
+      "label": "formatOptionalMoney()",
+      "norm_label": "formatoptionalmoney()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L56"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_isshareddemotransactionfixtureid",
-      "label": "isSharedDemoTransactionFixtureId()",
-      "norm_label": "isshareddemotransactionfixtureid()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L437"
+      "id": "reportformat_formatreportmoney",
+      "label": "formatReportMoney()",
+      "norm_label": "formatreportmoney()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L14"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_operatingdatetimestamp",
-      "label": "operatingDateTimestamp()",
-      "norm_label": "operatingdatetimestamp()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L118"
+      "id": "reportformat_formatreportprofit",
+      "label": "formatReportProfit()",
+      "norm_label": "formatreportprofit()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L36"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_ordereditemcountcandidates",
-      "label": "orderedItemCountCandidates()",
-      "norm_label": "ordereditemcountcandidates()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L160"
+      "id": "reportformat_formatskudisplayname",
+      "label": "formatSkuDisplayName()",
+      "norm_label": "formatskudisplayname()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L244"
     },
     {
       "community": 149,
       "file_type": "code",
-      "id": "shareddemotransactionsfixture_shiftoperatingdate",
-      "label": "shiftOperatingDate()",
-      "norm_label": "shiftoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
-      "source_location": "L111"
+      "id": "reportformat_formatskusubtitle",
+      "label": "formatSkuSubtitle()",
+      "norm_label": "formatskusubtitle()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reportformat_formatunits",
+      "label": "formatUnits()",
+      "norm_label": "formatunits()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reportformat_reportdaysettlementpresentation",
+      "label": "reportDaySettlementPresentation()",
+      "norm_label": "reportdaysettlementpresentation()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reportformat_reportdaystatuspresentation",
+      "label": "reportDayStatusPresentation()",
+      "norm_label": "reportdaystatuspresentation()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reportformat_reportoldestunreconciledpresentation",
+      "label": "reportOldestUnreconciledPresentation()",
+      "norm_label": "reportoldestunreconciledpresentation()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 149,
+      "file_type": "code",
+      "id": "reportformat_reportprofithelper",
+      "label": "reportProfitHelper()",
+      "norm_label": "reportprofithelper()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportFormat.ts",
+      "source_location": "L45"
     },
     {
       "community": 1490,
@@ -178791,128 +178824,128 @@
     {
       "community": 150,
       "file_type": "code",
-      "id": "mtnmomoview_cleanundefinedfields",
-      "label": "cleanUndefinedFields()",
-      "norm_label": "cleanundefinedfields()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_clonereceivingaccount",
-      "label": "cloneReceivingAccount()",
-      "norm_label": "clonereceivingaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_createemptyreceivingaccount",
-      "label": "createEmptyReceivingAccount()",
-      "norm_label": "createemptyreceivingaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L35"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_getstatusbadgevariant",
-      "label": "getStatusBadgeVariant()",
-      "norm_label": "getstatusbadgevariant()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_handleaddaccount",
-      "label": "handleAddAccount()",
-      "norm_label": "handleaddaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L152"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_handlemakeprimary",
-      "label": "handleMakePrimary()",
-      "norm_label": "handlemakeprimary()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L159"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_handleremoveaccount",
-      "label": "handleRemoveAccount()",
-      "norm_label": "handleremoveaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L168"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L188"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_hasreceivingaccountdetails",
-      "label": "hasReceivingAccountDetails()",
-      "norm_label": "hasreceivingaccountdetails()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_normalizeprimaryaccounts",
-      "label": "normalizePrimaryAccounts()",
-      "norm_label": "normalizeprimaryaccounts()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_topatchreceivingaccounts",
-      "label": "toPatchReceivingAccounts()",
-      "norm_label": "topatchreceivingaccounts()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L93"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_trimtoundefined",
-      "label": "trimToUndefined()",
-      "norm_label": "trimtoundefined()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "mtnmomoview_updateaccount",
-      "label": "updateAccount()",
-      "norm_label": "updateaccount()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 150,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
-      "label": "MtnMomoView.tsx",
-      "norm_label": "mtnmomoview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemotransactionsfixture_ts",
+      "label": "sharedDemoTransactionsFixture.ts",
+      "norm_label": "shareddemotransactionsfixture.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_builddaytransactions",
+      "label": "buildDayTransactions()",
+      "norm_label": "builddaytransactions()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L360"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_builditems",
+      "label": "buildItems()",
+      "norm_label": "builditems()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L260"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_buildpaymentproductmixes",
+      "label": "buildPaymentProductMixes()",
+      "norm_label": "buildpaymentproductmixes()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_createshareddemotransactionfixtures",
+      "label": "createSharedDemoTransactionFixtures()",
+      "norm_label": "createshareddemotransactionfixtures()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L414"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_distributeproducts",
+      "label": "distributeProducts()",
+      "norm_label": "distributeproducts()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_findproductmix",
+      "label": "findProductMix()",
+      "norm_label": "findproductmix()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L104"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_getshareddemotransactionfixture",
+      "label": "getSharedDemoTransactionFixture()",
+      "norm_label": "getshareddemotransactionfixture()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L441"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_isshareddemotransactionfixtureid",
+      "label": "isSharedDemoTransactionFixtureId()",
+      "norm_label": "isshareddemotransactionfixtureid()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L437"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_operatingdatetimestamp",
+      "label": "operatingDateTimestamp()",
+      "norm_label": "operatingdatetimestamp()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_ordereditemcountcandidates",
+      "label": "orderedItemCountCandidates()",
+      "norm_label": "ordereditemcountcandidates()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 150,
+      "file_type": "code",
+      "id": "shareddemotransactionsfixture_shiftoperatingdate",
+      "label": "shiftOperatingDate()",
+      "norm_label": "shiftoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoTransactionsFixture.ts",
+      "source_location": "L111"
     },
     {
       "community": 1500,
@@ -179097,128 +179130,128 @@
     {
       "community": 151,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_ts",
-      "label": "walkthroughRequestClient.ts",
-      "norm_label": "walkthroughrequestclient.ts",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "walkthroughrequestclient_canonicalizewalkthroughpayload",
-      "label": "canonicalizeWalkthroughPayload()",
-      "norm_label": "canonicalizewalkthroughpayload()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 151,
-      "file_type": "code",
-      "id": "walkthroughrequestclient_generatesubmissionkey",
-      "label": "generateSubmissionKey()",
-      "norm_label": "generatesubmissionkey()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "id": "mtnmomoview_cleanundefinedfields",
+      "label": "cleanUndefinedFields()",
+      "norm_label": "cleanundefinedfields()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
       "source_location": "L52"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_normalizewalkthroughemail",
-      "label": "normalizeWalkthroughEmail()",
-      "norm_label": "normalizewalkthroughemail()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L41"
+      "id": "mtnmomoview_clonereceivingaccount",
+      "label": "cloneReceivingAccount()",
+      "norm_label": "clonereceivingaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L27"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_normalizewalkthroughtext",
-      "label": "normalizeWalkthroughText()",
-      "norm_label": "normalizewalkthroughtext()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L37"
+      "id": "mtnmomoview_createemptyreceivingaccount",
+      "label": "createEmptyReceivingAccount()",
+      "norm_label": "createemptyreceivingaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L35"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_readpublicerrorcode",
-      "label": "readPublicErrorCode()",
-      "norm_label": "readpublicerrorcode()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L160"
+      "id": "mtnmomoview_getstatusbadgevariant",
+      "label": "getStatusBadgeVariant()",
+      "norm_label": "getstatusbadgevariant()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_resolvewalkthroughrequesturl",
-      "label": "resolveWalkthroughRequestUrl()",
-      "norm_label": "resolvewalkthroughrequesturl()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L98"
+      "id": "mtnmomoview_handleaddaccount",
+      "label": "handleAddAccount()",
+      "norm_label": "handleaddaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L152"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_stripcontrolcharacters",
-      "label": "stripControlCharacters()",
-      "norm_label": "stripcontrolcharacters()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L45"
+      "id": "mtnmomoview_handlemakeprimary",
+      "label": "handleMakePrimary()",
+      "norm_label": "handlemakeprimary()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L159"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_submitwalkthroughrequest",
-      "label": "submitWalkthroughRequest()",
-      "norm_label": "submitwalkthroughrequest()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L106"
+      "id": "mtnmomoview_handleremoveaccount",
+      "label": "handleRemoveAccount()",
+      "norm_label": "handleremoveaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L168"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity",
-      "label": "WalkthroughSubmissionIdentity",
-      "norm_label": "walkthroughsubmissionidentity",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L65"
+      "id": "mtnmomoview_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L188"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_beginattempt",
-      "label": ".beginAttempt()",
-      "norm_label": ".beginattempt()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L85"
+      "id": "mtnmomoview_hasreceivingaccountdetails",
+      "label": "hasReceivingAccountDetails()",
+      "norm_label": "hasreceivingaccountdetails()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L64"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L70"
+      "id": "mtnmomoview_normalizeprimaryaccounts",
+      "label": "normalizePrimaryAccounts()",
+      "norm_label": "normalizeprimaryaccounts()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L77"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_notepayloadchange",
-      "label": ".notePayloadChange()",
-      "norm_label": ".notepayloadchange()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L74"
+      "id": "mtnmomoview_topatchreceivingaccounts",
+      "label": "toPatchReceivingAccounts()",
+      "norm_label": "topatchreceivingaccounts()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L93"
     },
     {
       "community": 151,
       "file_type": "code",
-      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_rotateforretry",
-      "label": ".rotateForRetry()",
-      "norm_label": ".rotateforretry()",
-      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
-      "source_location": "L91"
+      "id": "mtnmomoview_trimtoundefined",
+      "label": "trimToUndefined()",
+      "norm_label": "trimtoundefined()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "mtnmomoview_updateaccount",
+      "label": "updateAccount()",
+      "norm_label": "updateaccount()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 151,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_mtnmomoview_tsx",
+      "label": "MtnMomoView.tsx",
+      "norm_label": "mtnmomoview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MtnMomoView.tsx",
+      "source_location": "L1"
     },
     {
       "community": 1510,
@@ -179403,128 +179436,128 @@
     {
       "community": 152,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_validation_ts",
-      "label": "validation.ts",
-      "norm_label": "validation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "id": "packages_athena_webapp_src_lib_marketing_walkthroughrequestclient_ts",
+      "label": "walkthroughRequestClient.ts",
+      "norm_label": "walkthroughrequestclient.ts",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
       "source_location": "L1"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_cancompletetransaction",
-      "label": "canCompleteTransaction()",
-      "norm_label": "cancompletetransaction()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L404"
+      "id": "walkthroughrequestclient_canonicalizewalkthroughpayload",
+      "label": "canonicalizeWalkthroughPayload()",
+      "norm_label": "canonicalizewalkthroughpayload()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L25"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_isoverpaypaymentmethod",
-      "label": "isOverpayPaymentMethod()",
-      "norm_label": "isoverpaypaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L414"
+      "id": "walkthroughrequestclient_generatesubmissionkey",
+      "label": "generateSubmissionKey()",
+      "norm_label": "generatesubmissionkey()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L52"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_isvalidemail",
-      "label": "isValidEmail()",
-      "norm_label": "isvalidemail()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L246"
+      "id": "walkthroughrequestclient_normalizewalkthroughemail",
+      "label": "normalizeWalkthroughEmail()",
+      "norm_label": "normalizewalkthroughemail()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L41"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_isvalidphone",
-      "label": "isValidPhone()",
-      "norm_label": "isvalidphone()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L304"
+      "id": "walkthroughrequestclient_normalizewalkthroughtext",
+      "label": "normalizeWalkthroughText()",
+      "norm_label": "normalizewalkthroughtext()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L37"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validatebarcode",
-      "label": "validateBarcode()",
-      "norm_label": "validatebarcode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L187"
+      "id": "walkthroughrequestclient_readpublicerrorcode",
+      "label": "readPublicErrorCode()",
+      "norm_label": "readpublicerrorcode()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L160"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validatecart",
-      "label": "validateCart()",
-      "norm_label": "validatecart()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L23"
+      "id": "walkthroughrequestclient_resolvewalkthroughrequesturl",
+      "label": "resolveWalkthroughRequestUrl()",
+      "norm_label": "resolvewalkthroughrequesturl()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L98"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validatecustomer",
-      "label": "validateCustomer()",
-      "norm_label": "validatecustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L110"
+      "id": "walkthroughrequestclient_stripcontrolcharacters",
+      "label": "stripControlCharacters()",
+      "norm_label": "stripcontrolcharacters()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L45"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validatepayment",
-      "label": "validatePayment()",
-      "norm_label": "validatepayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L148"
+      "id": "walkthroughrequestclient_submitwalkthroughrequest",
+      "label": "submitWalkthroughRequest()",
+      "norm_label": "submitwalkthroughrequest()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L106"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validatepaymentamount",
-      "label": "validatePaymentAmount()",
-      "norm_label": "validatepaymentamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L317"
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity",
+      "label": "WalkthroughSubmissionIdentity",
+      "norm_label": "walkthroughsubmissionidentity",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L65"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validatepayments",
-      "label": "validatePayments()",
-      "norm_label": "validatepayments()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L359"
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_beginattempt",
+      "label": ".beginAttempt()",
+      "norm_label": ".beginattempt()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L85"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validateproduct",
-      "label": "validateProduct()",
-      "norm_label": "validateproduct()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
       "source_location": "L70"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validatequantity",
-      "label": "validateQuantity()",
-      "norm_label": "validatequantity()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L215"
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_notepayloadchange",
+      "label": ".notePayloadChange()",
+      "norm_label": ".notepayloadchange()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L74"
     },
     {
       "community": 152,
       "file_type": "code",
-      "id": "validation_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
-      "source_location": "L254"
+      "id": "walkthroughrequestclient_walkthroughsubmissionidentity_rotateforretry",
+      "label": ".rotateForRetry()",
+      "norm_label": ".rotateforretry()",
+      "source_file": "packages/athena-webapp/src/lib/marketing/walkthroughRequestClient.ts",
+      "source_location": "L91"
     },
     {
       "community": 1520,
@@ -179709,128 +179742,128 @@
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_buildparticipantidentity",
-      "label": "buildParticipantIdentity()",
-      "norm_label": "buildparticipantidentity()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L164"
+      "id": "packages_athena_webapp_src_lib_pos_validation_ts",
+      "label": "validation.ts",
+      "norm_label": "validation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L1"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_createlivekitremoteassistclient",
-      "label": "createLiveKitRemoteAssistClient()",
-      "norm_label": "createlivekitremoteassistclient()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L19"
+      "id": "validation_cancompletetransaction",
+      "label": "canCompleteTransaction()",
+      "norm_label": "cancompletetransaction()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L404"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_getdatapublishrouting",
-      "label": "getDataPublishRouting()",
-      "norm_label": "getdatapublishrouting()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L143"
+      "id": "validation_isoverpaypaymentmethod",
+      "label": "isOverpayPaymentMethod()",
+      "norm_label": "isoverpaypaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L414"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_getparticipantrole",
-      "label": "getParticipantRole()",
-      "norm_label": "getparticipantrole()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L211"
+      "id": "validation_isvalidemail",
+      "label": "isValidEmail()",
+      "norm_label": "isvalidemail()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L246"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_isallowedsender",
-      "label": "isAllowedSender()",
-      "norm_label": "isallowedsender()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L179"
+      "id": "validation_isvalidphone",
+      "label": "isValidPhone()",
+      "norm_label": "isvalidphone()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L304"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient",
-      "label": "LiveKitRemoteAssistClient",
-      "norm_label": "livekitremoteassistclient",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "id": "validation_validatebarcode",
+      "label": "validateBarcode()",
+      "norm_label": "validatebarcode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L187"
+    },
+    {
+      "community": 153,
+      "file_type": "code",
+      "id": "validation_validatecart",
+      "label": "validateCart()",
+      "norm_label": "validatecart()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
       "source_location": "L23"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_connect",
-      "label": ".connect()",
-      "norm_label": ".connect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L33"
+      "id": "validation_validatecustomer",
+      "label": "validateCustomer()",
+      "norm_label": "validatecustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L110"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L59"
+      "id": "validation_validatepayment",
+      "label": "validatePayment()",
+      "norm_label": "validatepayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L148"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_emitstate",
-      "label": ".emitState()",
-      "norm_label": ".emitstate()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L136"
+      "id": "validation_validatepaymentamount",
+      "label": "validatePaymentAmount()",
+      "norm_label": "validatepaymentamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L317"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_publish",
-      "label": ".publish()",
-      "norm_label": ".publish()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L71"
+      "id": "validation_validatepayments",
+      "label": "validatePayments()",
+      "norm_label": "validatepayments()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L359"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_subscribe",
-      "label": ".subscribe()",
-      "norm_label": ".subscribe()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L91"
+      "id": "validation_validateproduct",
+      "label": "validateProduct()",
+      "norm_label": "validateproduct()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L70"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_livekitremoteassistclient_subscribetoconnectionstate",
-      "label": ".subscribeToConnectionState()",
-      "norm_label": ".subscribetoconnectionstate()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L96"
+      "id": "validation_validatequantity",
+      "label": "validateQuantity()",
+      "norm_label": "validatequantity()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L215"
     },
     {
       "community": 153,
       "file_type": "code",
-      "id": "livekitremoteassistclient_parseparticipantrole",
-      "label": "parseParticipantRole()",
-      "norm_label": "parseparticipantrole()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 153,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_transport_livekitremoteassistclient_ts",
-      "label": "livekitRemoteAssistClient.ts",
-      "norm_label": "livekitremoteassistclient.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
-      "source_location": "L1"
+      "id": "validation_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/validation.ts",
+      "source_location": "L254"
     },
     {
       "community": 1530,
@@ -180015,127 +180048,127 @@
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_bestfuzzytokenscore",
-      "label": "bestFuzzyTokenScore()",
-      "norm_label": "bestfuzzytokenscore()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 154,
-      "file_type": "code",
-      "id": "fuzzysearch_compactsearchtext",
-      "label": "compactSearchText()",
-      "norm_label": "compactsearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "id": "livekitremoteassistclient_buildparticipantidentity",
+      "label": "buildParticipantIdentity()",
+      "norm_label": "buildparticipantidentity()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
       "source_location": "L164"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_createfuzzysearchentry",
-      "label": "createFuzzySearchEntry()",
-      "norm_label": "createfuzzysearchentry()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L9"
+      "id": "livekitremoteassistclient_createlivekitremoteassistclient",
+      "label": "createLiveKitRemoteAssistClient()",
+      "norm_label": "createlivekitremoteassistclient()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L19"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_isprobablysametoken",
-      "label": "isProbablySameToken()",
-      "norm_label": "isprobablysametoken()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L216"
+      "id": "livekitremoteassistclient_getdatapublishrouting",
+      "label": "getDataPublishRouting()",
+      "norm_label": "getdatapublishrouting()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L143"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_levenshteindistance",
-      "label": "levenshteinDistance()",
-      "norm_label": "levenshteindistance()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L224"
+      "id": "livekitremoteassistclient_getparticipantrole",
+      "label": "getParticipantRole()",
+      "norm_label": "getparticipantrole()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L211"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_normalizefuzzysearchtext",
-      "label": "normalizeFuzzySearchText()",
-      "norm_label": "normalizefuzzysearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L76"
+      "id": "livekitremoteassistclient_isallowedsender",
+      "label": "isAllowedSender()",
+      "norm_label": "isallowedsender()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L179"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_scorecompactfieldcontains",
-      "label": "scoreCompactFieldContains()",
-      "norm_label": "scorecompactfieldcontains()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L131"
+      "id": "livekitremoteassistclient_livekitremoteassistclient",
+      "label": "LiveKitRemoteAssistClient",
+      "norm_label": "livekitremoteassistclient",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L23"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_scorefieldcontains",
-      "label": "scoreFieldContains()",
-      "norm_label": "scorefieldcontains()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L127"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_connect",
+      "label": ".connect()",
+      "norm_label": ".connect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L33"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_scorefuzzysearchentry",
-      "label": "scoreFuzzySearchEntry()",
-      "norm_label": "scorefuzzysearchentry()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L56"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L59"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_scorefuzzytokenmatch",
-      "label": "scoreFuzzyTokenMatch()",
-      "norm_label": "scorefuzzytokenmatch()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L185"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_emitstate",
+      "label": ".emitState()",
+      "norm_label": ".emitstate()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L136"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_scorequerytokenforentry",
-      "label": "scoreQueryTokenForEntry()",
-      "norm_label": "scorequerytokenforentry()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L100"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_publish",
+      "label": ".publish()",
+      "norm_label": ".publish()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L71"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_searchfuzzyentries",
-      "label": "searchFuzzyEntries()",
-      "norm_label": "searchfuzzyentries()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L27"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_subscribe",
+      "label": ".subscribe()",
+      "norm_label": ".subscribe()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L91"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "fuzzysearch_tokenizefuzzysearchtext",
-      "label": "tokenizeFuzzySearchText()",
-      "norm_label": "tokenizefuzzysearchtext()",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
-      "source_location": "L86"
+      "id": "livekitremoteassistclient_livekitremoteassistclient_subscribetoconnectionstate",
+      "label": ".subscribeToConnectionState()",
+      "norm_label": ".subscribetoconnectionstate()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L96"
     },
     {
       "community": 154,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_search_fuzzysearch_ts",
-      "label": "fuzzySearch.ts",
-      "norm_label": "fuzzysearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "id": "livekitremoteassistclient_parseparticipantrole",
+      "label": "parseParticipantRole()",
+      "norm_label": "parseparticipantrole()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 154,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_transport_livekitremoteassistclient_ts",
+      "label": "livekitRemoteAssistClient.ts",
+      "norm_label": "livekitremoteassistclient.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/livekitRemoteAssistClient.ts",
       "source_location": "L1"
     },
     {
@@ -180321,127 +180354,127 @@
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_getbrowserpathname",
-      "label": "getBrowserPathname()",
-      "norm_label": "getbrowserpathname()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L133"
+      "id": "fuzzysearch_bestfuzzytokenscore",
+      "label": "bestFuzzyTokenScore()",
+      "norm_label": "bestfuzzytokenscore()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L168"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_getbrowserpathwithsearch",
-      "label": "getBrowserPathWithSearch()",
-      "norm_label": "getbrowserpathwithsearch()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L137"
+      "id": "fuzzysearch_compactsearchtext",
+      "label": "compactSearchText()",
+      "norm_label": "compactsearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L164"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_getloginhref",
-      "label": "getLoginHref()",
-      "norm_label": "getloginhref()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L156"
+      "id": "fuzzysearch_createfuzzysearchentry",
+      "label": "createFuzzySearchEntry()",
+      "norm_label": "createfuzzysearchentry()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L9"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_getposhubrouteparams",
-      "label": "getPosHubRouteParams()",
-      "norm_label": "getposhubrouteparams()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L98"
+      "id": "fuzzysearch_isprobablysametoken",
+      "label": "isProbablySameToken()",
+      "norm_label": "isprobablysametoken()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L216"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_getredirectpathwithsearch",
-      "label": "getRedirectPathWithSearch()",
-      "norm_label": "getredirectpathwithsearch()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L145"
+      "id": "fuzzysearch_levenshteindistance",
+      "label": "levenshteinDistance()",
+      "norm_label": "levenshteindistance()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L224"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_getrouteparamsforpattern",
-      "label": "getRouteParamsForPattern()",
-      "norm_label": "getrouteparamsforpattern()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L106"
+      "id": "fuzzysearch_normalizefuzzysearchtext",
+      "label": "normalizeFuzzySearchText()",
+      "norm_label": "normalizefuzzysearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L76"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_getstoreworkspacerouteparams",
-      "label": "getStoreWorkspaceRouteParams()",
-      "norm_label": "getstoreworkspacerouteparams()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L102"
+      "id": "fuzzysearch_scorecompactfieldcontains",
+      "label": "scoreCompactFieldContains()",
+      "norm_label": "scorecompactfieldcontains()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L131"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_handlesignout",
-      "label": "handleSignOut()",
-      "norm_label": "handlesignout()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L441"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "authed_layout_hasstoredlocalsession",
-      "label": "hasStoredLocalSession()",
-      "norm_label": "hasstoredlocalsession()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L169"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "authed_layout_isbrowseroffline",
-      "label": "isBrowserOffline()",
-      "norm_label": "isbrowseroffline()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L184"
-    },
-    {
-      "community": 155,
-      "file_type": "code",
-      "id": "authed_layout_isposterminalfullscreenpath",
-      "label": "isPosTerminalFullscreenPath()",
-      "norm_label": "isposterminalfullscreenpath()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "id": "fuzzysearch_scorefieldcontains",
+      "label": "scoreFieldContains()",
+      "norm_label": "scorefieldcontains()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
       "source_location": "L127"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_isunknownrouterpath",
-      "label": "isUnknownRouterPath()",
-      "norm_label": "isunknownrouterpath()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L165"
+      "id": "fuzzysearch_scorefuzzysearchentry",
+      "label": "scoreFuzzySearchEntry()",
+      "norm_label": "scorefuzzysearchentry()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L56"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "authed_layout_usebrowserofflinestatus",
-      "label": "useBrowserOfflineStatus()",
-      "norm_label": "usebrowserofflinestatus()",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
-      "source_location": "L188"
+      "id": "fuzzysearch_scorefuzzytokenmatch",
+      "label": "scoreFuzzyTokenMatch()",
+      "norm_label": "scorefuzzytokenmatch()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L185"
     },
     {
       "community": 155,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_layout_tsx",
-      "label": "-authed-layout.tsx",
-      "norm_label": "-authed-layout.tsx",
-      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "id": "fuzzysearch_scorequerytokenforentry",
+      "label": "scoreQueryTokenForEntry()",
+      "norm_label": "scorequerytokenforentry()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "fuzzysearch_searchfuzzyentries",
+      "label": "searchFuzzyEntries()",
+      "norm_label": "searchfuzzyentries()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "fuzzysearch_tokenizefuzzysearchtext",
+      "label": "tokenizeFuzzySearchText()",
+      "norm_label": "tokenizefuzzysearchtext()",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 155,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_search_fuzzysearch_ts",
+      "label": "fuzzySearch.ts",
+      "norm_label": "fuzzysearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/search/fuzzySearch.ts",
       "source_location": "L1"
     },
     {
@@ -180627,127 +180660,127 @@
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_deleteheadbranch",
-      "label": "deleteHeadBranch()",
-      "norm_label": "deleteheadbranch()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L207"
+      "id": "authed_layout_getbrowserpathname",
+      "label": "getBrowserPathname()",
+      "norm_label": "getbrowserpathname()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L133"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_enablepullrequestautomerge",
-      "label": "enablePullRequestAutoMerge()",
-      "norm_label": "enablepullrequestautomerge()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L225"
+      "id": "authed_layout_getbrowserpathwithsearch",
+      "label": "getBrowserPathWithSearch()",
+      "norm_label": "getbrowserpathwithsearch()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L137"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_encodegitrefpath",
-      "label": "encodeGitRefPath()",
-      "norm_label": "encodegitrefpath()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L268"
+      "id": "authed_layout_getloginhref",
+      "label": "getLoginHref()",
+      "norm_label": "getloginhref()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L156"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_ghjson",
-      "label": "ghJson()",
-      "norm_label": "ghjson()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L272"
+      "id": "authed_layout_getposhubrouteparams",
+      "label": "getPosHubRouteParams()",
+      "norm_label": "getposhubrouteparams()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L98"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_helprequested",
-      "label": "HelpRequested",
-      "norm_label": "helprequested",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L318"
+      "id": "authed_layout_getredirectpathwithsearch",
+      "label": "getRedirectPathWithSearch()",
+      "norm_label": "getredirectpathwithsearch()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L145"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_mergepullrequest",
-      "label": "mergePullRequest()",
-      "norm_label": "mergepullrequest()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L65"
+      "id": "authed_layout_getrouteparamsforpattern",
+      "label": "getRouteParamsForPattern()",
+      "norm_label": "getrouteparamsforpattern()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L106"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_parseargs",
-      "label": "parseArgs()",
-      "norm_label": "parseargs()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L115"
+      "id": "authed_layout_getstoreworkspacerouteparams",
+      "label": "getStoreWorkspaceRouteParams()",
+      "norm_label": "getstoreworkspacerouteparams()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L102"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_parsemergemethod",
-      "label": "parseMergeMethod()",
-      "norm_label": "parsemergemethod()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L328"
+      "id": "authed_layout_handlesignout",
+      "label": "handleSignOut()",
+      "norm_label": "handlesignout()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L441"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_requirevalue",
-      "label": "requireValue()",
-      "norm_label": "requirevalue()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L320"
+      "id": "authed_layout_hasstoredlocalsession",
+      "label": "hasStoredLocalSession()",
+      "norm_label": "hasstoredlocalsession()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L169"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_resolvecurrentrepo",
-      "label": "resolveCurrentRepo()",
-      "norm_label": "resolvecurrentrepo()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L177"
+      "id": "authed_layout_isbrowseroffline",
+      "label": "isBrowserOffline()",
+      "norm_label": "isbrowseroffline()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L184"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_runprocess",
-      "label": "runProcess()",
-      "norm_label": "runprocess()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L294"
+      "id": "authed_layout_isposterminalfullscreenpath",
+      "label": "isPosTerminalFullscreenPath()",
+      "norm_label": "isposterminalfullscreenpath()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L127"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_shoulddeleteheadbranch",
-      "label": "shouldDeleteHeadBranch()",
-      "norm_label": "shoulddeleteheadbranch()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L264"
+      "id": "authed_layout_isunknownrouterpath",
+      "label": "isUnknownRouterPath()",
+      "norm_label": "isunknownrouterpath()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L165"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "github_pr_merge_viewpullrequest",
-      "label": "viewPullRequest()",
-      "norm_label": "viewpullrequest()",
-      "source_file": "scripts/github-pr-merge.ts",
-      "source_location": "L186"
+      "id": "authed_layout_usebrowserofflinestatus",
+      "label": "useBrowserOfflineStatus()",
+      "norm_label": "usebrowserofflinestatus()",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
+      "source_location": "L188"
     },
     {
       "community": 156,
       "file_type": "code",
-      "id": "scripts_github_pr_merge_ts",
-      "label": "github-pr-merge.ts",
-      "norm_label": "github-pr-merge.ts",
-      "source_file": "scripts/github-pr-merge.ts",
+      "id": "packages_athena_webapp_src_routes_authed_layout_tsx",
+      "label": "-authed-layout.tsx",
+      "norm_label": "-authed-layout.tsx",
+      "source_file": "packages/athena-webapp/src/routes/-authed-layout.tsx",
       "source_location": "L1"
     },
     {
@@ -180915,118 +180948,127 @@
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
-      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
-      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L321"
+      "id": "github_pr_merge_deleteheadbranch",
+      "label": "deleteHeadBranch()",
+      "norm_label": "deleteheadbranch()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L207"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_buildbackfillrow",
-      "label": "buildBackfillRow()",
-      "norm_label": "buildbackfillrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L185"
+      "id": "github_pr_merge_enablepullrequestautomerge",
+      "label": "enablePullRequestAutoMerge()",
+      "norm_label": "enablepullrequestautomerge()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L225"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_buildcandidateweeklywindows",
-      "label": "buildCandidateWeeklyWindows()",
-      "norm_label": "buildcandidateweeklywindows()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L161"
+      "id": "github_pr_merge_encodegitrefpath",
+      "label": "encodeGitRefPath()",
+      "norm_label": "encodegitrefpath()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L268"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_compatibilitymetadata",
-      "label": "compatibilityMetadata()",
-      "norm_label": "compatibilitymetadata()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L133"
+      "id": "github_pr_merge_ghjson",
+      "label": "ghJson()",
+      "norm_label": "ghjson()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L272"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_compatibilityonlyrow",
-      "label": "compatibilityOnlyRow()",
-      "norm_label": "compatibilityonlyrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L172"
+      "id": "github_pr_merge_helprequested",
+      "label": "HelpRequested",
+      "norm_label": "helprequested",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L318"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_findexistingscheduletoskip",
-      "label": "findExistingScheduleToSkip()",
-      "norm_label": "findexistingscheduletoskip()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L114"
+      "id": "github_pr_merge_mergepullrequest",
+      "label": "mergePullRequest()",
+      "norm_label": "mergepullrequest()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L65"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_firstpolicy",
-      "label": "firstPolicy()",
-      "norm_label": "firstpolicy()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L75"
+      "id": "github_pr_merge_parseargs",
+      "label": "parseArgs()",
+      "norm_label": "parseargs()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L115"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_isvalidminute",
-      "label": "isValidMinute()",
-      "norm_label": "isvalidminute()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L66"
+      "id": "github_pr_merge_parsemergemethod",
+      "label": "parseMergeMethod()",
+      "norm_label": "parsemergemethod()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L328"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_listpoliciesforstoreaction",
-      "label": "listPoliciesForStoreAction()",
-      "norm_label": "listpoliciesforstoreaction()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L81"
+      "id": "github_pr_merge_requirevalue",
+      "label": "requireValue()",
+      "norm_label": "requirevalue()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L320"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_listschedulesforstorebystatus",
-      "label": "listSchedulesForStoreByStatus()",
-      "norm_label": "listschedulesforstorebystatus()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L99"
+      "id": "github_pr_merge_resolvecurrentrepo",
+      "label": "resolveCurrentRepo()",
+      "norm_label": "resolvecurrentrepo()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L177"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L58"
+      "id": "github_pr_merge_runprocess",
+      "label": "runProcess()",
+      "norm_label": "runprocess()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L294"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "backfillstoreschedules_trustedtimezoneforstore",
-      "label": "trustedTimezoneForStore()",
-      "norm_label": "trustedtimezoneforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L126"
+      "id": "github_pr_merge_shoulddeleteheadbranch",
+      "label": "shouldDeleteHeadBranch()",
+      "norm_label": "shoulddeleteheadbranch()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L264"
     },
     {
       "community": 157,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
-      "label": "backfillStoreSchedules.ts",
-      "norm_label": "backfillstoreschedules.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "id": "github_pr_merge_viewpullrequest",
+      "label": "viewPullRequest()",
+      "norm_label": "viewpullrequest()",
+      "source_file": "scripts/github-pr-merge.ts",
+      "source_location": "L186"
+    },
+    {
+      "community": 157,
+      "file_type": "code",
+      "id": "scripts_github_pr_merge_ts",
+      "label": "github-pr-merge.ts",
+      "norm_label": "github-pr-merge.ts",
+      "source_file": "scripts/github-pr-merge.ts",
       "source_location": "L1"
     },
     {
@@ -181122,119 +181164,119 @@
     {
       "community": 158,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
-      "label": "readDefinitions.ts",
-      "norm_label": "readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
+      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
+      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L321"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_buildbackfillrow",
+      "label": "buildBackfillRow()",
+      "norm_label": "buildbackfillrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L185"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_buildcandidateweeklywindows",
+      "label": "buildCandidateWeeklyWindows()",
+      "norm_label": "buildcandidateweeklywindows()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_compatibilitymetadata",
+      "label": "compatibilityMetadata()",
+      "norm_label": "compatibilitymetadata()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_compatibilityonlyrow",
+      "label": "compatibilityOnlyRow()",
+      "norm_label": "compatibilityonlyrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_findexistingscheduletoskip",
+      "label": "findExistingScheduleToSkip()",
+      "norm_label": "findexistingscheduletoskip()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_firstpolicy",
+      "label": "firstPolicy()",
+      "norm_label": "firstpolicy()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_isvalidminute",
+      "label": "isValidMinute()",
+      "norm_label": "isvalidminute()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listpoliciesforstoreaction",
+      "label": "listPoliciesForStoreAction()",
+      "norm_label": "listpoliciesforstoreaction()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listschedulesforstorebystatus",
+      "label": "listSchedulesForStoreByStatus()",
+      "norm_label": "listschedulesforstorebystatus()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "backfillstoreschedules_trustedtimezoneforstore",
+      "label": "trustedTimezoneForStore()",
+      "norm_label": "trustedtimezoneforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 158,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
+      "label": "backfillStoreSchedules.ts",
+      "norm_label": "backfillstoreschedules.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_definecashcontrolsread",
-      "label": "defineCashControlsRead()",
-      "norm_label": "definecashcontrolsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_definedailycloseread",
-      "label": "defineDailyCloseRead()",
-      "norm_label": "definedailycloseread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_definedailyoperationsread",
-      "label": "defineDailyOperationsRead()",
-      "norm_label": "definedailyoperationsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycatalogread",
-      "label": "defineInventoryCatalogRead()",
-      "norm_label": "defineinventorycatalogread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycostoverlayread",
-      "label": "defineInventoryCostOverlayRead()",
-      "norm_label": "defineinventorycostoverlayread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_defineonlineordersread",
-      "label": "defineOnlineOrdersRead()",
-      "norm_label": "defineonlineordersread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_defineoperationalworkread",
-      "label": "defineOperationalWorkRead()",
-      "norm_label": "defineoperationalworkread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_defineorganizationread",
-      "label": "defineOrganizationRead()",
-      "norm_label": "defineorganizationread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_defineposread",
-      "label": "definePosRead()",
-      "norm_label": "defineposread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_definereadoperation",
-      "label": "defineReadOperation()",
-      "norm_label": "definereadoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_definestockadjustmentsread",
-      "label": "defineStockAdjustmentsRead()",
-      "norm_label": "definestockadjustmentsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 158,
-      "file_type": "code",
-      "id": "readdefinitions_validatereadoperationdefinition",
-      "label": "validateReadOperationDefinition()",
-      "norm_label": "validatereadoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L753"
     },
     {
       "community": 1580,
@@ -181329,119 +181371,119 @@
     {
       "community": 159,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L956"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1109"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildmapping",
-      "label": "buildMapping()",
-      "norm_label": "buildmapping()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1213"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildproductsku",
-      "label": "buildProductSku()",
-      "norm_label": "buildproductsku()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1130"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1169"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstaffprofile",
-      "label": "buildStaffProfile()",
-      "norm_label": "buildstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1065"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstore",
-      "label": "buildStore()",
-      "norm_label": "buildstore()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1052"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1149"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1189"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildworkitem",
-      "label": "buildWorkItem()",
-      "norm_label": "buildworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1079"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_defaultargs",
-      "label": "defaultArgs()",
-      "norm_label": "defaultargs()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L909"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "openworkinventoryreviews_test_expectrejectedcontext",
-      "label": "expectRejectedContext()",
-      "norm_label": "expectrejectedcontext()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L891"
-    },
-    {
-      "community": 159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
-      "label": "openWorkInventoryReviews.test.ts",
-      "norm_label": "openworkinventoryreviews.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
+      "label": "readDefinitions.ts",
+      "norm_label": "readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_definecashcontrolsread",
+      "label": "defineCashControlsRead()",
+      "norm_label": "definecashcontrolsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_definedailycloseread",
+      "label": "defineDailyCloseRead()",
+      "norm_label": "definedailycloseread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_definedailyoperationsread",
+      "label": "defineDailyOperationsRead()",
+      "norm_label": "definedailyoperationsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycatalogread",
+      "label": "defineInventoryCatalogRead()",
+      "norm_label": "defineinventorycatalogread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycostoverlayread",
+      "label": "defineInventoryCostOverlayRead()",
+      "norm_label": "defineinventorycostoverlayread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_defineonlineordersread",
+      "label": "defineOnlineOrdersRead()",
+      "norm_label": "defineonlineordersread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_defineoperationalworkread",
+      "label": "defineOperationalWorkRead()",
+      "norm_label": "defineoperationalworkread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_defineorganizationread",
+      "label": "defineOrganizationRead()",
+      "norm_label": "defineorganizationread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_defineposread",
+      "label": "definePosRead()",
+      "norm_label": "defineposread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_definereadoperation",
+      "label": "defineReadOperation()",
+      "norm_label": "definereadoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_definestockadjustmentsread",
+      "label": "defineStockAdjustmentsRead()",
+      "norm_label": "definestockadjustmentsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 159,
+      "file_type": "code",
+      "id": "readdefinitions_validatereadoperationdefinition",
+      "label": "validateReadOperationDefinition()",
+      "norm_label": "validatereadoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L753"
     },
     {
       "community": 1590,
@@ -181923,118 +181965,118 @@
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_approvalrequesttransactionid",
-      "label": "approvalRequestTransactionId()",
-      "norm_label": "approvalrequesttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L400"
+      "id": "openworkinventoryreviews_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L956"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_authorizeoperationalworksummaryread",
-      "label": "authorizeOperationalWorkSummaryRead()",
-      "norm_label": "authorizeoperationalworksummaryread()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L62"
+      "id": "openworkinventoryreviews_test_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1109"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_buildoperationalworkitem",
-      "label": "buildOperationalWorkItem()",
-      "norm_label": "buildoperationalworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L487"
+      "id": "openworkinventoryreviews_test_buildmapping",
+      "label": "buildMapping()",
+      "norm_label": "buildmapping()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1213"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_createoperationalworkitemwithctx",
-      "label": "createOperationalWorkItemWithCtx()",
-      "norm_label": "createoperationalworkitemwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L514"
+      "id": "openworkinventoryreviews_test_buildproductsku",
+      "label": "buildProductSku()",
+      "norm_label": "buildproductsku()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1130"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_filterarchivedpendingcheckoutworkitems",
-      "label": "filterArchivedPendingCheckoutWorkItems()",
-      "norm_label": "filterarchivedpendingcheckoutworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L86"
+      "id": "openworkinventoryreviews_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1169"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_formatregistersyncreviewtitle",
-      "label": "formatRegisterSyncReviewTitle()",
-      "norm_label": "formatregistersyncreviewtitle()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L481"
+      "id": "openworkinventoryreviews_test_buildstaffprofile",
+      "label": "buildStaffProfile()",
+      "norm_label": "buildstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1065"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_metadataarraycount",
-      "label": "metadataArrayCount()",
-      "norm_label": "metadataarraycount()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L133"
+      "id": "openworkinventoryreviews_test_buildstore",
+      "label": "buildStore()",
+      "norm_label": "buildstore()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1052"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_metadatanumber",
-      "label": "metadataNumber()",
-      "norm_label": "metadatanumber()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L125"
+      "id": "openworkinventoryreviews_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1149"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_projectoperationalworkitemforqueue",
-      "label": "projectOperationalWorkItemForQueue()",
-      "norm_label": "projectoperationalworkitemforqueue()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L370"
+      "id": "openworkinventoryreviews_test_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1189"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_sanitizeapprovalrequestmetadata",
-      "label": "sanitizeApprovalRequestMetadata()",
-      "norm_label": "sanitizeapprovalrequestmetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L425"
+      "id": "openworkinventoryreviews_test_buildworkitem",
+      "label": "buildWorkItem()",
+      "norm_label": "buildworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1079"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_sanitizeoperationalworkitemdetails",
-      "label": "sanitizeOperationalWorkItemDetails()",
-      "norm_label": "sanitizeoperationalworkitemdetails()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L293"
+      "id": "openworkinventoryreviews_test_defaultargs",
+      "label": "defaultArgs()",
+      "norm_label": "defaultargs()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L909"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
-      "label": "updateOperationalWorkItemStatusWithCtx()",
-      "norm_label": "updateoperationalworkitemstatuswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L549"
+      "id": "openworkinventoryreviews_test_expectrejectedcontext",
+      "label": "expectRejectedContext()",
+      "norm_label": "expectrejectedcontext()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L891"
     },
     {
       "community": 160,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
-      "label": "operationalWorkItems.ts",
-      "norm_label": "operationalworkitems.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
+      "label": "openWorkInventoryReviews.test.ts",
+      "norm_label": "openworkinventoryreviews.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
       "source_location": "L1"
     },
     {
@@ -182130,118 +182172,118 @@
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
+      "id": "operationalworkitems_approvalrequesttransactionid",
+      "label": "approvalRequestTransactionId()",
+      "norm_label": "approvalrequesttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L400"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
+      "id": "operationalworkitems_authorizeoperationalworksummaryread",
+      "label": "authorizeOperationalWorkSummaryRead()",
+      "norm_label": "authorizeoperationalworksummaryread()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L62"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "id": "operationalworkitems_buildoperationalworkitem",
+      "label": "buildOperationalWorkItem()",
+      "norm_label": "buildoperationalworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L487"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L348"
+      "id": "operationalworkitems_createoperationalworkitemwithctx",
+      "label": "createOperationalWorkItemWithCtx()",
+      "norm_label": "createoperationalworkitemwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L514"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
+      "id": "operationalworkitems_filterarchivedpendingcheckoutworkitems",
+      "label": "filterArchivedPendingCheckoutWorkItems()",
+      "norm_label": "filterarchivedpendingcheckoutworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L86"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
+      "id": "operationalworkitems_formatregistersyncreviewtitle",
+      "label": "formatRegisterSyncReviewTitle()",
+      "norm_label": "formatregistersyncreviewtitle()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L481"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L478"
+      "id": "operationalworkitems_metadataarraycount",
+      "label": "metadataArrayCount()",
+      "norm_label": "metadataarraycount()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L133"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
+      "id": "operationalworkitems_metadatanumber",
+      "label": "metadataNumber()",
+      "norm_label": "metadatanumber()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L125"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L384"
+      "id": "operationalworkitems_projectoperationalworkitemforqueue",
+      "label": "projectOperationalWorkItemForQueue()",
+      "norm_label": "projectoperationalworkitemforqueue()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L370"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
+      "id": "operationalworkitems_sanitizeapprovalrequestmetadata",
+      "label": "sanitizeApprovalRequestMetadata()",
+      "norm_label": "sanitizeapprovalrequestmetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L425"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
+      "id": "operationalworkitems_sanitizeoperationalworkitemdetails",
+      "label": "sanitizeOperationalWorkItemDetails()",
+      "norm_label": "sanitizeoperationalworkitemdetails()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L293"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
+      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
+      "label": "updateOperationalWorkItemStatusWithCtx()",
+      "norm_label": "updateoperationalworkitemstatuswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L549"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
+      "label": "operationalWorkItems.ts",
+      "norm_label": "operationalworkitems.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
       "source_location": "L1"
     },
     {
@@ -182337,118 +182379,118 @@
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L97"
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
-      "label": "findActiveProvisionalImportSkuForStoreSku()",
-      "norm_label": "findactiveprovisionalimportskuforstoresku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L120"
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubybarcode",
-      "label": "findStoreSkuByBarcode()",
-      "norm_label": "findstoreskubybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L62"
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubysku",
-      "label": "findStoreSkuBySku()",
-      "norm_label": "findstoreskubysku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L77"
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L348"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_getcategorybyid",
-      "label": "getCategoryById()",
-      "norm_label": "getcategorybyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L29"
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_getcolorbyid",
-      "label": "getColorById()",
-      "norm_label": "getcolorbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L40"
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L71"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_getproductbyid",
-      "label": "getProductById()",
-      "norm_label": "getproductbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L25"
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L478"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L11"
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_listmatchingstoreskus",
-      "label": "listMatchingStoreSkus()",
-      "norm_label": "listmatchingstoreskus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L140"
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L384"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L51"
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L90"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_normalizelookupcode",
-      "label": "normalizeLookupCode()",
-      "norm_label": "normalizelookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L92"
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "catalogrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L15"
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
     },
     {
       "community": 162,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
-      "label": "catalogRepository.ts",
-      "norm_label": "catalogrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
     },
     {
@@ -182544,119 +182586,119 @@
     {
       "community": 163,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_sweeper_ts",
-      "label": "sweeper.ts",
-      "norm_label": "sweeper.ts",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L1"
+      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L97"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_computependingranges",
-      "label": "computePendingRanges()",
-      "norm_label": "computependingranges()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L359"
+      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
+      "label": "findActiveProvisionalImportSkuForStoreSku()",
+      "norm_label": "findactiveprovisionalimportskuforstoresku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L120"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_expirerangeresults",
-      "label": "expireRangeResults()",
-      "norm_label": "expirerangeresults()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L390"
+      "id": "catalogrepository_findstoreskubybarcode",
+      "label": "findStoreSkuByBarcode()",
+      "norm_label": "findstoreskubybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L62"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_findopenoperatingdate",
-      "label": "findOpenOperatingDate()",
-      "norm_label": "findopenoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L342"
+      "id": "catalogrepository_findstoreskubysku",
+      "label": "findStoreSkuBySku()",
+      "norm_label": "findstoreskubysku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L77"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_foldandreplaceday",
-      "label": "foldAndReplaceDay()",
-      "norm_label": "foldandreplaceday()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L190"
+      "id": "catalogrepository_getcategorybyid",
+      "label": "getCategoryById()",
+      "norm_label": "getcategorybyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L29"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_loadacceptedclose",
-      "label": "loadAcceptedClose()",
-      "norm_label": "loadacceptedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L164"
+      "id": "catalogrepository_getcolorbyid",
+      "label": "getColorById()",
+      "norm_label": "getcolorbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L40"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_markdaydirty",
-      "label": "markDayDirty()",
-      "norm_label": "markdaydirty()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L309"
+      "id": "catalogrepository_getproductbyid",
+      "label": "getProductById()",
+      "norm_label": "getproductbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L25"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_parsestoreallowlist",
-      "label": "parseStoreAllowlist()",
-      "norm_label": "parsestoreallowlist()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L74"
+      "id": "catalogrepository_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L11"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_readstoreallowlist",
-      "label": "readStoreAllowlist()",
-      "norm_label": "readstoreallowlist()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L84"
+      "id": "catalogrepository_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L140"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_selectacceptedclose",
-      "label": "selectAcceptedClose()",
-      "norm_label": "selectacceptedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L130"
+      "id": "catalogrepository_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L51"
     },
     {
       "community": 163,
       "file_type": "code",
-      "id": "sweeper_sweepwithctx",
-      "label": "sweepWithCtx()",
-      "norm_label": "sweepwithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "sweeper_tocloseref",
-      "label": "toCloseRef()",
-      "norm_label": "tocloseref()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "sweeper_tofoldfact",
-      "label": "toFoldFact()",
-      "norm_label": "tofoldfact()",
-      "source_file": "packages/athena-webapp/convex/reports/sweeper.ts",
+      "id": "catalogrepository_normalizelookupcode",
+      "label": "normalizeLookupCode()",
+      "norm_label": "normalizelookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
       "source_location": "L92"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "catalogrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
+      "label": "catalogRepository.ts",
+      "norm_label": "catalogrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L1"
     },
     {
       "community": 1630,
@@ -182958,119 +183000,119 @@
     {
       "community": 165,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
+      "label": "POSSessionsView.tsx",
+      "norm_label": "possessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_formatexpiry",
+      "label": "formatExpiry()",
+      "norm_label": "formatexpiry()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L190"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_formatholddetails",
+      "label": "formatHoldDetails()",
+      "norm_label": "formatholddetails()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L216"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "possessionsview_formatregisterlabel",
+      "label": "formatRegisterLabel()",
+      "norm_label": "formatregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L147"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
+      "id": "possessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L122"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "possessionsview_getcartcount",
+      "label": "getCartCount()",
+      "norm_label": "getcartcount()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L180"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_getcustomerlabel",
+      "label": "getCustomerLabel()",
+      "norm_label": "getcustomerlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L176"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "possessionsview_getoperatorlabel",
+      "label": "getOperatorLabel()",
+      "norm_label": "getoperatorlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L138"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
+      "id": "possessionsview_getregisterlabel",
+      "label": "getRegisterLabel()",
+      "norm_label": "getregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L157"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
+      "id": "possessionsview_getsessioncode",
+      "label": "getSessionCode()",
+      "norm_label": "getsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L131"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "possessionsview_getsessions",
+      "label": "getSessions()",
+      "norm_label": "getsessions()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "possessionsview_getstatusbadgeclass",
+      "label": "getStatusBadgeClass()",
+      "norm_label": "getstatusbadgeclass()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L250"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "possessionsview_possessionsheader",
+      "label": "POSSessionsHeader()",
+      "norm_label": "possessionsheader()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L261"
     },
     {
       "community": 1650,
@@ -183165,119 +183207,119 @@
     {
       "community": 166,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
-      "label": "POSSessionsView.tsx",
-      "norm_label": "possessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "id": "localposreadiness_blocked",
+      "label": "blocked()",
+      "norm_label": "blocked()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L638"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposreadiness",
+      "label": "evaluateLocalPosReadiness()",
+      "norm_label": "evaluatelocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
+      "label": "evaluateLocalPosServiceCatalogReadiness()",
+      "norm_label": "evaluatelocalposservicecatalogreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_formatreadinessstatekey",
+      "label": "formatReadinessStateKey()",
+      "norm_label": "formatreadinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L591"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_hassettledlocalcloseout",
+      "label": "hasSettledLocalCloseout()",
+      "norm_label": "hassettledlocalcloseout()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessmatchesinput",
+      "label": "localReadinessMatchesInput()",
+      "norm_label": "localreadinessmatchesinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L287"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessrecordfromsnapshots",
+      "label": "localReadinessRecordFromSnapshots()",
+      "norm_label": "localreadinessrecordfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekey",
+      "label": "readinessStateKey()",
+      "norm_label": "readinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L610"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekeysequal",
+      "label": "readinessStateKeysEqual()",
+      "norm_label": "readinessstatekeysequal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L624"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_readlocalposreadiness",
+      "label": "readLocalPosReadiness()",
+      "norm_label": "readlocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
+      "label": "refreshLocalPosReadinessFromSnapshots()",
+      "norm_label": "refreshlocalposreadinessfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "localposreadiness_uselocalposreadiness",
+      "label": "useLocalPosReadiness()",
+      "norm_label": "uselocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 166,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
+      "label": "localPosReadiness.ts",
+      "norm_label": "localposreadiness.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_formatexpiry",
-      "label": "formatExpiry()",
-      "norm_label": "formatexpiry()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L190"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_formatholddetails",
-      "label": "formatHoldDetails()",
-      "norm_label": "formatholddetails()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_formatregisterlabel",
-      "label": "formatRegisterLabel()",
-      "norm_label": "formatregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_getcartcount",
-      "label": "getCartCount()",
-      "norm_label": "getcartcount()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L180"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_getcustomerlabel",
-      "label": "getCustomerLabel()",
-      "norm_label": "getcustomerlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L176"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_getoperatorlabel",
-      "label": "getOperatorLabel()",
-      "norm_label": "getoperatorlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_getregisterlabel",
-      "label": "getRegisterLabel()",
-      "norm_label": "getregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L157"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_getsessioncode",
-      "label": "getSessionCode()",
-      "norm_label": "getsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_getsessions",
-      "label": "getSessions()",
-      "norm_label": "getsessions()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_getstatusbadgeclass",
-      "label": "getStatusBadgeClass()",
-      "norm_label": "getstatusbadgeclass()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 166,
-      "file_type": "code",
-      "id": "possessionsview_possessionsheader",
-      "label": "POSSessionsHeader()",
-      "norm_label": "possessionsheader()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L261"
     },
     {
       "community": 1660,
@@ -183372,119 +183414,119 @@
     {
       "community": 167,
       "file_type": "code",
-      "id": "localposreadiness_blocked",
-      "label": "blocked()",
-      "norm_label": "blocked()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L638"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposreadiness",
-      "label": "evaluateLocalPosReadiness()",
-      "norm_label": "evaluatelocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
-      "label": "evaluateLocalPosServiceCatalogReadiness()",
-      "norm_label": "evaluatelocalposservicecatalogreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_formatreadinessstatekey",
-      "label": "formatReadinessStateKey()",
-      "norm_label": "formatreadinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L591"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_hassettledlocalcloseout",
-      "label": "hasSettledLocalCloseout()",
-      "norm_label": "hassettledlocalcloseout()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessmatchesinput",
-      "label": "localReadinessMatchesInput()",
-      "norm_label": "localreadinessmatchesinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessrecordfromsnapshots",
-      "label": "localReadinessRecordFromSnapshots()",
-      "norm_label": "localreadinessrecordfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekey",
-      "label": "readinessStateKey()",
-      "norm_label": "readinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L610"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekeysequal",
-      "label": "readinessStateKeysEqual()",
-      "norm_label": "readinessstatekeysequal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L624"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_readlocalposreadiness",
-      "label": "readLocalPosReadiness()",
-      "norm_label": "readlocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
-      "label": "refreshLocalPosReadinessFromSnapshots()",
-      "norm_label": "refreshlocalposreadinessfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "localposreadiness_uselocalposreadiness",
-      "label": "useLocalPosReadiness()",
-      "norm_label": "uselocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 167,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
-      "label": "localPosReadiness.ts",
-      "norm_label": "localposreadiness.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
+      "label": "registerCatalogPinRuntime.ts",
+      "norm_label": "registercatalogpinruntime.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
+      "label": "captureRegisterCatalogRuntimePin()",
+      "norm_label": "captureregistercatalogruntimepin()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
+      "label": "chooseRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "chooseregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
+      "label": "clearRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "clearregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
+      "label": "clearRegisterCatalogRuntimeSelection()",
+      "norm_label": "clearregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
+      "label": "getRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "getregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
+      "label": "hasRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "hasregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_keyforscope",
+      "label": "keyForScope()",
+      "norm_label": "keyforscope()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_maintainownerclaim",
+      "label": "maintainOwnerClaim()",
+      "norm_label": "maintainownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_ownerclaimkey",
+      "label": "ownerClaimKey()",
+      "norm_label": "ownerclaimkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_readownerclaim",
+      "label": "readOwnerClaim()",
+      "norm_label": "readownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
+      "label": "setRegisterCatalogRuntimeSelection()",
+      "norm_label": "setregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 167,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_writeownerclaim",
+      "label": "writeOwnerClaim()",
+      "norm_label": "writeownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L71"
     },
     {
       "community": 1670,
@@ -183579,119 +183621,119 @@
     {
       "community": 168,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
-      "label": "registerCatalogPinRuntime.ts",
-      "norm_label": "registercatalogpinruntime.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
+      "label": "telemetryBuffer.ts",
+      "norm_label": "telemetrybuffer.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
       "source_location": "L1"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
-      "label": "captureRegisterCatalogRuntimePin()",
-      "norm_label": "captureregistercatalogruntimepin()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L138"
+      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
+      "label": "clearPosClientTelemetryBuffer()",
+      "norm_label": "clearposclienttelemetrybuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L212"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
-      "label": "chooseRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "chooseregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L31"
+      "id": "telemetrybuffer_enqueueposclientevent",
+      "label": "enqueuePosClientEvent()",
+      "norm_label": "enqueueposclientevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L167"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
-      "label": "clearRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "clearregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L171"
+      "id": "telemetrybuffer_isbufferedevent",
+      "label": "isBufferedEvent()",
+      "norm_label": "isbufferedevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L100"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
-      "label": "clearRegisterCatalogRuntimeSelection()",
-      "norm_label": "clearregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L132"
+      "id": "telemetrybuffer_mintclienteventid",
+      "label": "mintClientEventId()",
+      "norm_label": "mintclienteventid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L63"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
-      "label": "getRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "getregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L177"
+      "id": "telemetrybuffer_normalizepostelemetryerror",
+      "label": "normalizePosTelemetryError()",
+      "norm_label": "normalizepostelemetryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L116"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
-      "label": "hasRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "hasregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L165"
+      "id": "telemetrybuffer_peekposclienteventbatch",
+      "label": "peekPosClientEventBatch()",
+      "norm_label": "peekposclienteventbatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L194"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_keyforscope",
-      "label": "keyForScope()",
-      "norm_label": "keyforscope()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L122"
+      "id": "telemetrybuffer_posclienttelemetrybuffersize",
+      "label": "posClientTelemetryBufferSize()",
+      "norm_label": "posclienttelemetrybuffersize()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L208"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_maintainownerclaim",
-      "label": "maintainOwnerClaim()",
-      "norm_label": "maintainownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L87"
+      "id": "telemetrybuffer_readbuffer",
+      "label": "readBuffer()",
+      "norm_label": "readbuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L74"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_ownerclaimkey",
-      "label": "ownerClaimKey()",
-      "norm_label": "ownerclaimkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L47"
+      "id": "telemetrybuffer_removeposclientevents",
+      "label": "removePosClientEvents()",
+      "norm_label": "removeposclientevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L200"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_readownerclaim",
-      "label": "readOwnerClaim()",
-      "norm_label": "readownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L51"
+      "id": "telemetrybuffer_sanitizemetadata",
+      "label": "sanitizeMetadata()",
+      "norm_label": "sanitizemetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L145"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
-      "label": "setRegisterCatalogRuntimeSelection()",
-      "norm_label": "setregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L126"
+      "id": "telemetrybuffer_truncate",
+      "label": "truncate()",
+      "norm_label": "truncate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L59"
     },
     {
       "community": 168,
       "file_type": "code",
-      "id": "registercatalogpinruntime_writeownerclaim",
-      "label": "writeOwnerClaim()",
-      "norm_label": "writeownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L71"
+      "id": "telemetrybuffer_writebuffer",
+      "label": "writeBuffer()",
+      "norm_label": "writebuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L90"
     },
     {
       "community": 1680,
@@ -183786,119 +183828,119 @@
     {
       "community": 169,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
-      "label": "telemetryBuffer.ts",
-      "norm_label": "telemetrybuffer.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
+      "label": "registerCheckoutProjection.ts",
+      "norm_label": "registercheckoutprojection.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
       "source_location": "L1"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
-      "label": "clearPosClientTelemetryBuffer()",
-      "norm_label": "clearposclienttelemetrybuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L212"
+      "id": "registercheckoutprojection_buildcompletedsalepayload",
+      "label": "buildCompletedSalePayload()",
+      "norm_label": "buildcompletedsalepayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L121"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_enqueueposclientevent",
-      "label": "enqueuePosClientEvent()",
-      "norm_label": "enqueueposclientevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L167"
+      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
+      "label": "buildServiceCheckoutBlockMessage()",
+      "norm_label": "buildservicecheckoutblockmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L16"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_isbufferedevent",
-      "label": "isBufferedEvent()",
-      "norm_label": "isbufferedevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L100"
+      "id": "registercheckoutprojection_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L78"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_mintclienteventid",
-      "label": "mintClientEventId()",
-      "norm_label": "mintclienteventid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L63"
+      "id": "registercheckoutprojection_completedcustomerinfo",
+      "label": "completedCustomerInfo()",
+      "norm_label": "completedcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L290"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_normalizepostelemetryerror",
-      "label": "normalizePosTelemetryError()",
-      "norm_label": "normalizepostelemetryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L116"
+      "id": "registercheckoutprojection_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L50"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_peekposclienteventbatch",
-      "label": "peekPosClientEventBatch()",
-      "norm_label": "peekposclienteventbatch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L194"
+      "id": "registercheckoutprojection_ispospaymentmethod",
+      "label": "isPosPaymentMethod()",
+      "norm_label": "ispospaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L98"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_posclienttelemetrybuffersize",
-      "label": "posClientTelemetryBufferSize()",
-      "norm_label": "posclienttelemetrybuffersize()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L208"
+      "id": "registercheckoutprojection_maplocalpaymenttopayment",
+      "label": "mapLocalPaymentToPayment()",
+      "norm_label": "maplocalpaymenttopayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L102"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_readbuffer",
-      "label": "readBuffer()",
-      "norm_label": "readbuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L74"
+      "id": "registercheckoutprojection_maplocalservicelinetostate",
+      "label": "mapLocalServiceLineToState()",
+      "norm_label": "maplocalservicelinetostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L197"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_removeposclientevents",
-      "label": "removePosClientEvents()",
-      "norm_label": "removeposclientevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L200"
+      "id": "registercheckoutprojection_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L65"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_sanitizemetadata",
-      "label": "sanitizeMetadata()",
-      "norm_label": "sanitizemetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L145"
+      "id": "registercheckoutprojection_matchingservicelinedraft",
+      "label": "matchingServiceLineDraft()",
+      "norm_label": "matchingservicelinedraft()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L223"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_truncate",
-      "label": "truncate()",
-      "norm_label": "truncate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L59"
+      "id": "registercheckoutprojection_servicelinestatetocartline",
+      "label": "serviceLineStateToCartLine()",
+      "norm_label": "servicelinestatetocartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L272"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "telemetrybuffer_writebuffer",
-      "label": "writeBuffer()",
-      "norm_label": "writebuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L90"
+      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
+      "label": "serviceLineStateToLocalPayload()",
+      "norm_label": "servicelinestatetolocalpayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L254"
     },
     {
       "community": 1690,
@@ -184362,119 +184404,119 @@
     {
       "community": 170,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
-      "label": "registerCheckoutProjection.ts",
-      "norm_label": "registercheckoutprojection.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
+      "label": "registerDrawerPresentation.ts",
+      "norm_label": "registerdrawerpresentation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
       "source_location": "L1"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildcompletedsalepayload",
-      "label": "buildCompletedSalePayload()",
-      "norm_label": "buildcompletedsalepayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L121"
+      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
+      "label": "buildOpenDrawerFailureMessage()",
+      "norm_label": "buildopendrawerfailuremessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L189"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
-      "label": "buildServiceCheckoutBlockMessage()",
-      "norm_label": "buildservicecheckoutblockmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L16"
+      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
+      "label": "findRegisterCloseoutReviewItem()",
+      "norm_label": "findregistercloseoutreviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L171"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "registercheckoutprojection_completedcustomerinfo",
-      "label": "completedCustomerInfo()",
-      "norm_label": "completedcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "registercheckoutprojection_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "registercheckoutprojection_ispospaymentmethod",
-      "label": "isPosPaymentMethod()",
-      "norm_label": "ispospaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
+      "label": "formatCloseoutCloudRegisterSessionCode()",
+      "norm_label": "formatcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
       "source_location": "L98"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalpaymenttopayment",
-      "label": "mapLocalPaymentToPayment()",
-      "norm_label": "maplocalpaymenttopayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L102"
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
+      "label": "getCloseoutCloudRegisterSessionCode()",
+      "norm_label": "getcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L68"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalservicelinetostate",
-      "label": "mapLocalServiceLineToState()",
-      "norm_label": "maplocalservicelinetostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L197"
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
+      "label": "getCloseoutCloudRegisterSessionId()",
+      "norm_label": "getcloseoutcloudregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L50"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L65"
+      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
+      "label": "getCloseoutLocalRegisterSessionId()",
+      "norm_label": "getcloseoutlocalregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L29"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_matchingservicelinedraft",
-      "label": "matchingServiceLineDraft()",
-      "norm_label": "matchingservicelinedraft()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L223"
+      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
+      "label": "getLatestLocalRegisterLifecycleEvent()",
+      "norm_label": "getlatestlocalregisterlifecycleevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L207"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetocartline",
-      "label": "serviceLineStateToCartLine()",
-      "norm_label": "servicelinestatetocartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L272"
+      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
+      "label": "getPendingLocalCashVoidApprovals()",
+      "norm_label": "getpendinglocalcashvoidapprovals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L270"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
-      "label": "serviceLineStateToLocalPayload()",
-      "norm_label": "servicelinestatetolocalpayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L254"
+      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
+      "label": "getPendingLocalCloseoutRegisterSession()",
+      "norm_label": "getpendinglocalcloseoutregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L234"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
+      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
+      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_readlocalsyncstatus",
+      "label": "readLocalSyncStatus()",
+      "norm_label": "readlocalsyncstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_stringfield",
+      "label": "stringField()",
+      "norm_label": "stringfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L334"
     },
     {
       "community": 1700,
@@ -184569,119 +184611,119 @@
     {
       "community": 171,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
-      "label": "registerDrawerPresentation.ts",
-      "norm_label": "registerdrawerpresentation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
-      "label": "buildOpenDrawerFailureMessage()",
-      "norm_label": "buildopendrawerfailuremessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
-      "label": "findRegisterCloseoutReviewItem()",
-      "norm_label": "findregistercloseoutreviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
-      "label": "formatCloseoutCloudRegisterSessionCode()",
-      "norm_label": "formatcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
-      "label": "getCloseoutCloudRegisterSessionCode()",
-      "norm_label": "getcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 171,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
-      "label": "getCloseoutCloudRegisterSessionId()",
-      "norm_label": "getcloseoutcloudregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "id": "localpinverifier_base64tobytes",
+      "label": "base64ToBytes()",
+      "norm_label": "base64tobytes()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
       "source_location": "L50"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
-      "label": "getCloseoutLocalRegisterSessionId()",
-      "norm_label": "getcloseoutlocalregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L29"
+      "id": "localpinverifier_bytestobase64",
+      "label": "bytesToBase64()",
+      "norm_label": "bytestobase64()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L38"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
-      "label": "getLatestLocalRegisterLifecycleEvent()",
-      "norm_label": "getlatestlocalregisterlifecycleevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L207"
+      "id": "localpinverifier_createlocalpinverifier",
+      "label": "createLocalPinVerifier()",
+      "norm_label": "createlocalpinverifier()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L131"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
-      "label": "getPendingLocalCashVoidApprovals()",
-      "norm_label": "getpendinglocalcashvoidapprovals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L270"
+      "id": "localpinverifier_cryptorefdecrypt",
+      "label": "cryptoRefDecrypt()",
+      "norm_label": "cryptorefdecrypt()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L268"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
-      "label": "getPendingLocalCloseoutRegisterSession()",
-      "norm_label": "getpendinglocalcloseoutregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L234"
+      "id": "localpinverifier_derivepinhash",
+      "label": "derivePinHash()",
+      "norm_label": "derivepinhash()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L76"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
-      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
-      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L114"
+      "id": "localpinverifier_derivewrappingkey",
+      "label": "deriveWrappingKey()",
+      "norm_label": "derivewrappingkey()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L103"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "registerdrawerpresentation_readlocalsyncstatus",
-      "label": "readLocalSyncStatus()",
-      "norm_label": "readlocalsyncstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L146"
+      "id": "localpinverifier_getcrypto",
+      "label": "getCrypto()",
+      "norm_label": "getcrypto()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L30"
     },
     {
       "community": 171,
       "file_type": "code",
-      "id": "registerdrawerpresentation_stringfield",
-      "label": "stringField()",
-      "norm_label": "stringfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L334"
+      "id": "localpinverifier_islocalpinverifiermetadata",
+      "label": "isLocalPinVerifierMetadata()",
+      "norm_label": "islocalpinverifiermetadata()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L281"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "localpinverifier_timingsafeequal",
+      "label": "timingSafeEqual()",
+      "norm_label": "timingsafeequal()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "localpinverifier_unwraplocalstaffprooftoken",
+      "label": "unwrapLocalStaffProofToken()",
+      "norm_label": "unwraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "localpinverifier_verifylocalpin",
+      "label": "verifyLocalPin()",
+      "norm_label": "verifylocalpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "localpinverifier_wraplocalstaffprooftoken",
+      "label": "wrapLocalStaffProofToken()",
+      "norm_label": "wraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 171,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
+      "label": "localPinVerifier.ts",
+      "norm_label": "localpinverifier.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L1"
     },
     {
       "community": 1710,
@@ -184776,119 +184818,119 @@
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_base64tobytes",
-      "label": "base64ToBytes()",
-      "norm_label": "base64tobytes()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L50"
+      "id": "packages_storefront_webapp_src_api_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L1"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_bytestobase64",
-      "label": "bytesToBase64()",
-      "norm_label": "bytestobase64()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L38"
+      "id": "reviews_createreview",
+      "label": "createReview()",
+      "norm_label": "createreview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L13"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_createlocalpinverifier",
-      "label": "createLocalPinVerifier()",
-      "norm_label": "createlocalpinverifier()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L131"
+      "id": "reviews_deletereview",
+      "label": "deleteReview()",
+      "norm_label": "deletereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L69"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_cryptorefdecrypt",
-      "label": "cryptoRefDecrypt()",
-      "norm_label": "cryptorefdecrypt()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L268"
+      "id": "reviews_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L4"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_derivepinhash",
-      "label": "derivePinHash()",
-      "norm_label": "derivepinhash()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L76"
+      "id": "reviews_getreviewbyorderitem",
+      "label": "getReviewByOrderItem()",
+      "norm_label": "getreviewbyorderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L32"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_derivewrappingkey",
-      "label": "deriveWrappingKey()",
-      "norm_label": "derivewrappingkey()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L103"
+      "id": "reviews_getreviewsbyproductid",
+      "label": "getReviewsByProductId()",
+      "norm_label": "getreviewsbyproductid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L132"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_getcrypto",
-      "label": "getCrypto()",
-      "norm_label": "getcrypto()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L30"
+      "id": "reviews_getreviewsbyproductskuid",
+      "label": "getReviewsByProductSkuId()",
+      "norm_label": "getreviewsbyproductskuid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L83"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_islocalpinverifiermetadata",
-      "label": "isLocalPinVerifierMetadata()",
-      "norm_label": "islocalpinverifiermetadata()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L281"
+      "id": "reviews_getuserreviews",
+      "label": "getUserReviews()",
+      "norm_label": "getuserreviews()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L99"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_timingsafeequal",
-      "label": "timingSafeEqual()",
-      "norm_label": "timingsafeequal()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L63"
+      "id": "reviews_getuserreviewsforproduct",
+      "label": "getUserReviewsForProduct()",
+      "norm_label": "getuserreviewsforproduct()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L113"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_unwraplocalstaffprooftoken",
-      "label": "unwrapLocalStaffProofToken()",
-      "norm_label": "unwraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L221"
+      "id": "reviews_hasreviewfororderitem",
+      "label": "hasReviewForOrderItem()",
+      "norm_label": "hasreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L164"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "localpinverifier_verifylocalpin",
-      "label": "verifyLocalPin()",
-      "norm_label": "verifylocalpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 172,
-      "file_type": "code",
-      "id": "localpinverifier_wraplocalstaffprooftoken",
-      "label": "wrapLocalStaffProofToken()",
-      "norm_label": "wraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "id": "reviews_hasuserreviewfororderitem",
+      "label": "hasUserReviewForOrderItem()",
+      "norm_label": "hasuserreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183"
     },
     {
       "community": 172,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
-      "label": "localPinVerifier.ts",
-      "norm_label": "localpinverifier.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L1"
+      "id": "reviews_markreviewhelpful",
+      "label": "markReviewHelpful()",
+      "norm_label": "markreviewhelpful()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 172,
+      "file_type": "code",
+      "id": "reviews_updatereview",
+      "label": "updateReview()",
+      "norm_label": "updatereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L48"
     },
     {
       "community": 1720,
@@ -184983,119 +185025,119 @@
     {
       "community": 173,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_createreview",
-      "label": "createReview()",
-      "norm_label": "createreview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L13"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_deletereview",
-      "label": "deleteReview()",
-      "norm_label": "deletereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L69"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L4"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_getreviewbyorderitem",
-      "label": "getReviewByOrderItem()",
-      "norm_label": "getreviewbyorderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L32"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductid",
-      "label": "getReviewsByProductId()",
-      "norm_label": "getreviewsbyproductid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L132"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductskuid",
-      "label": "getReviewsByProductSkuId()",
-      "norm_label": "getreviewsbyproductskuid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L83"
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_getuserreviews",
-      "label": "getUserReviews()",
-      "norm_label": "getuserreviews()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L99"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_getuserreviewsforproduct",
-      "label": "getUserReviewsForProduct()",
-      "norm_label": "getuserreviewsforproduct()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L113"
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L40"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_hasreviewfororderitem",
-      "label": "hasReviewForOrderItem()",
-      "norm_label": "hasreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L164"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_hasuserreviewfororderitem",
-      "label": "hasUserReviewForOrderItem()",
-      "norm_label": "hasuserreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L183"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_markreviewhelpful",
-      "label": "markReviewHelpful()",
-      "norm_label": "markreviewhelpful()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L148"
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 173,
       "file_type": "code",
-      "id": "reviews_updatereview",
-      "label": "updateReview()",
-      "norm_label": "updatereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L48"
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 1730,
@@ -206106,168 +206148,6 @@
     {
       "community": 272,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 272,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "storefrontobservability_resolveviewportbucket",
-      "label": "resolveViewportBucket()",
-      "norm_label": "resolveviewportbucket()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 273,
-      "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 274,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
       "norm_label": "versionchecker.ts",
@@ -206275,7 +206155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 272,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -206284,7 +206164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 272,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -206293,7 +206173,7 @@
       "source_location": "L192"
     },
     {
-      "community": 274,
+      "community": 272,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -206302,7 +206182,7 @@
       "source_location": "L16"
     },
     {
-      "community": 274,
+      "community": 272,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -206311,7 +206191,7 @@
       "source_location": "L135"
     },
     {
-      "community": 274,
+      "community": 272,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -206320,7 +206200,7 @@
       "source_location": "L141"
     },
     {
-      "community": 274,
+      "community": 272,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -206329,7 +206209,7 @@
       "source_location": "L174"
     },
     {
-      "community": 274,
+      "community": 272,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -206338,13 +206218,175 @@
       "source_location": "L151"
     },
     {
-      "community": 274,
+      "community": 272,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 273,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L229"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "storefrontobservability_resolveviewportbucket",
+      "label": "resolveViewportBucket()",
+      "norm_label": "resolveviewportbucket()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 274,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L265"
     },
     {
       "community": 275,
@@ -208162,7 +208204,7 @@
       "label": "allow()",
       "norm_label": "allow()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L44"
+      "source_location": "L45"
     },
     {
       "community": 291,
@@ -208171,7 +208213,7 @@
       "label": "close()",
       "norm_label": "close()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L66"
+      "source_location": "L67"
     },
     {
       "community": 291,
@@ -208180,7 +208222,7 @@
       "label": "insertSaleFact()",
       "norm_label": "insertsalefact()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L177"
+      "source_location": "L178"
     },
     {
       "community": 291,
@@ -208189,7 +208231,7 @@
       "label": "mark()",
       "norm_label": "mark()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L216"
+      "source_location": "L217"
     },
     {
       "community": 291,
@@ -208198,7 +208240,7 @@
       "label": "marksOf()",
       "norm_label": "marksof()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L235"
+      "source_location": "L236"
     },
     {
       "community": 291,
@@ -208207,7 +208249,7 @@
       "label": "seedStore()",
       "norm_label": "seedstore()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L123"
+      "source_location": "L124"
     },
     {
       "community": 291,
@@ -208216,7 +208258,7 @@
       "label": "sweep()",
       "norm_label": "sweep()",
       "source_file": "packages/athena-webapp/convex/reports/sweeper.test.ts",
-      "source_location": "L233"
+      "source_location": "L234"
     },
     {
       "community": 292,
@@ -222000,6 +222042,60 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
       "norm_label": "getstaffdisplayname()",
@@ -222007,7 +222103,7 @@
       "source_location": "L64"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -222016,7 +222112,7 @@
       "source_location": "L87"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -222025,7 +222121,7 @@
       "source_location": "L74"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -222034,7 +222130,7 @@
       "source_location": "L242"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -222043,7 +222139,7 @@
       "source_location": "L251"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
@@ -222052,7 +222148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -222061,7 +222157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -222070,7 +222166,7 @@
       "source_location": "L42"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -222079,7 +222175,7 @@
       "source_location": "L32"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -222088,7 +222184,7 @@
       "source_location": "L62"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -222097,7 +222193,7 @@
       "source_location": "L101"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -222106,7 +222202,7 @@
       "source_location": "L10"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
@@ -222115,7 +222211,7 @@
       "source_location": "L54"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -222124,7 +222220,7 @@
       "source_location": "L41"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -222133,7 +222229,7 @@
       "source_location": "L47"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -222142,7 +222238,7 @@
       "source_location": "L61"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -222151,7 +222247,7 @@
       "source_location": "L68"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
@@ -222160,7 +222256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -222169,7 +222265,7 @@
       "source_location": "L173"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -222178,7 +222274,7 @@
       "source_location": "L71"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -222187,7 +222283,7 @@
       "source_location": "L251"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -222196,7 +222292,7 @@
       "source_location": "L36"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -222205,7 +222301,7 @@
       "source_location": "L277"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -222214,7 +222310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -222223,7 +222319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -222232,7 +222328,7 @@
       "source_location": "L134"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -222241,7 +222337,7 @@
       "source_location": "L69"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -222250,7 +222346,7 @@
       "source_location": "L86"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -222259,7 +222355,7 @@
       "source_location": "L52"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -222268,7 +222364,7 @@
       "source_location": "L103"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -222277,7 +222373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -222286,7 +222382,7 @@
       "source_location": "L45"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -222295,7 +222391,7 @@
       "source_location": "L220"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -222304,7 +222400,7 @@
       "source_location": "L167"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -222313,7 +222409,7 @@
       "source_location": "L182"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -222322,7 +222418,7 @@
       "source_location": "L194"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -222331,7 +222427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -222340,7 +222436,7 @@
       "source_location": "L7332"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -222349,7 +222445,7 @@
       "source_location": "L7355"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -222358,7 +222454,7 @@
       "source_location": "L7374"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -222367,7 +222463,7 @@
       "source_location": "L103"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -222376,7 +222472,7 @@
       "source_location": "L347"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -222385,7 +222481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -222394,7 +222490,7 @@
       "source_location": "L28"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -222403,7 +222499,7 @@
       "source_location": "L37"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -222412,7 +222508,7 @@
       "source_location": "L12"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -222421,7 +222517,7 @@
       "source_location": "L6"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -222430,7 +222526,7 @@
       "source_location": "L49"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -222439,7 +222535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -222448,7 +222544,7 @@
       "source_location": "L171"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -222457,7 +222553,7 @@
       "source_location": "L302"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -222466,7 +222562,7 @@
       "source_location": "L319"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -222475,67 +222571,13 @@
       "source_location": "L312"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
       "norm_label": "showvalidationerror()",
       "source_file": "packages/athena-webapp/src/lib/pos/toastService.ts",
       "source_location": "L293"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
-      "label": "skuSearch.ts",
-      "norm_label": "skusearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "skusearch_isbarcodeshapedsearchquery",
-      "label": "isBarcodeShapedSearchQuery()",
-      "norm_label": "isbarcodeshapedsearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "skusearch_matchesskusearchterms",
-      "label": "matchesSkuSearchTerms()",
-      "norm_label": "matchesskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "skusearch_normalizeidentifier",
-      "label": "normalizeIdentifier()",
-      "norm_label": "normalizeidentifier()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "skusearch_normalizeskusearchquery",
-      "label": "normalizeSkuSearchQuery()",
-      "norm_label": "normalizeskusearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "skusearch_scoreskusearchterms",
-      "label": "scoreSkuSearchTerms()",
-      "norm_label": "scoreskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L18"
     },
     {
       "community": 44,
@@ -222801,6 +222843,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
+      "label": "skuSearch.ts",
+      "norm_label": "skusearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "skusearch_isbarcodeshapedsearchquery",
+      "label": "isBarcodeShapedSearchQuery()",
+      "norm_label": "isbarcodeshapedsearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "skusearch_matchesskusearchterms",
+      "label": "matchesSkuSearchTerms()",
+      "norm_label": "matchesskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "skusearch_normalizeidentifier",
+      "label": "normalizeIdentifier()",
+      "norm_label": "normalizeidentifier()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "skusearch_normalizeskusearchquery",
+      "label": "normalizeSkuSearchQuery()",
+      "norm_label": "normalizeskusearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "skusearch_scoreskusearchterms",
+      "label": "scoreSkuSearchTerms()",
+      "norm_label": "scoreskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
       "norm_label": "posappshellroutes.ts",
@@ -222808,7 +222904,7 @@
       "source_location": "L1"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -222817,7 +222913,7 @@
       "source_location": "L53"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -222826,7 +222922,7 @@
       "source_location": "L71"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -222835,7 +222931,7 @@
       "source_location": "L48"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -222844,7 +222940,7 @@
       "source_location": "L88"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
@@ -222853,7 +222949,7 @@
       "source_location": "L107"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
       "label": "posAppShellServiceWorkerStaging.test.ts",
@@ -222862,7 +222958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
       "label": "createServiceWorkerFixture()",
@@ -222871,7 +222967,7 @@
       "source_location": "L32"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache",
       "label": "MemoryCache",
@@ -222880,7 +222976,7 @@
       "source_location": "L14"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_keys",
       "label": ".keys()",
@@ -222889,7 +222985,7 @@
       "source_location": "L27"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_match",
       "label": ".match()",
@@ -222898,7 +222994,7 @@
       "source_location": "L17"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_put",
       "label": ".put()",
@@ -222907,7 +223003,7 @@
       "source_location": "L22"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -222916,7 +223012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -222925,7 +223021,7 @@
       "source_location": "L19"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -222934,7 +223030,7 @@
       "source_location": "L37"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -222943,7 +223039,7 @@
       "source_location": "L47"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -222952,7 +223048,7 @@
       "source_location": "L62"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -222961,7 +223057,7 @@
       "source_location": "L88"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -222970,7 +223066,7 @@
       "source_location": "L145"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -222979,7 +223075,7 @@
       "source_location": "L95"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -222988,7 +223084,7 @@
       "source_location": "L33"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -222997,7 +223093,7 @@
       "source_location": "L29"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -223006,7 +223102,7 @@
       "source_location": "L45"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -223015,7 +223111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -223024,7 +223120,7 @@
       "source_location": "L155"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -223033,7 +223129,7 @@
       "source_location": "L197"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -223042,7 +223138,7 @@
       "source_location": "L104"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -223051,7 +223147,7 @@
       "source_location": "L25"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -223060,7 +223156,7 @@
       "source_location": "L72"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -223069,7 +223165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -223078,7 +223174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -223087,7 +223183,7 @@
       "source_location": "L231"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -223096,7 +223192,7 @@
       "source_location": "L167"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -223105,7 +223201,7 @@
       "source_location": "L116"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -223114,7 +223210,7 @@
       "source_location": "L83"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -223123,7 +223219,7 @@
       "source_location": "L29"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyclosefixture",
       "label": "useDailyCloseFixture()",
@@ -223132,7 +223228,7 @@
       "source_location": "L102"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyopeningfixture",
       "label": "useDailyOpeningFixture()",
@@ -223141,7 +223237,7 @@
       "source_location": "L96"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyoperationsfixture",
       "label": "useDailyOperationsFixture()",
@@ -223150,7 +223246,7 @@
       "source_location": "L90"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "devfixtureactivation_useposhubfixture",
       "label": "usePosHubFixture()",
@@ -223159,7 +223255,7 @@
       "source_location": "L108"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "devfixtureactivation_useworkspacefixture",
       "label": "useWorkspaceFixture()",
@@ -223168,7 +223264,7 @@
       "source_location": "L46"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
       "label": "devFixtureActivation.ts",
@@ -223177,7 +223273,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -223186,7 +223282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -223195,7 +223291,7 @@
       "source_location": "L76"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -223204,7 +223300,7 @@
       "source_location": "L55"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -223213,7 +223309,7 @@
       "source_location": "L88"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -223222,7 +223318,7 @@
       "source_location": "L34"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -223231,7 +223327,7 @@
       "source_location": "L13"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -223240,7 +223336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -223249,7 +223345,7 @@
       "source_location": "L69"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -223258,7 +223354,7 @@
       "source_location": "L57"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -223267,7 +223363,7 @@
       "source_location": "L90"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -223276,67 +223372,13 @@
       "source_location": "L59"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
       "norm_label": ".constructor()",
       "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
       "source_location": "L62"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
     },
     {
       "community": 45,
@@ -223602,6 +223644,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
       "norm_label": "clearform()",
@@ -223609,7 +223705,7 @@
       "source_location": "L173"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -223618,7 +223714,7 @@
       "source_location": "L102"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -223627,7 +223723,7 @@
       "source_location": "L201"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -223636,7 +223732,7 @@
       "source_location": "L150"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -223645,7 +223741,7 @@
       "source_location": "L155"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -223654,7 +223750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -223663,7 +223759,7 @@
       "source_location": "L22"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -223672,7 +223768,7 @@
       "source_location": "L24"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -223681,7 +223777,7 @@
       "source_location": "L18"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -223690,7 +223786,7 @@
       "source_location": "L21"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -223699,7 +223795,7 @@
       "source_location": "L23"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -223708,7 +223804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -223717,7 +223813,7 @@
       "source_location": "L76"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -223726,7 +223822,7 @@
       "source_location": "L120"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -223735,7 +223831,7 @@
       "source_location": "L129"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -223744,7 +223840,7 @@
       "source_location": "L133"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -223753,7 +223849,7 @@
       "source_location": "L44"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -223762,7 +223858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -223771,7 +223867,7 @@
       "source_location": "L9"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -223780,7 +223876,7 @@
       "source_location": "L73"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -223789,7 +223885,7 @@
       "source_location": "L54"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -223798,7 +223894,7 @@
       "source_location": "L98"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -223807,66 +223903,12 @@
       "source_location": "L33"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
       "norm_label": "checkoutexpired.tsx",
       "source_file": "packages/storefront-webapp/src/components/states/checkout-expired/CheckoutExpired.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 454,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -235068,6 +235110,42 @@
     {
       "community": 602,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 602,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 603,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -235075,7 +235153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -235084,7 +235162,7 @@
       "source_location": "L34"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -235093,7 +235171,7 @@
       "source_location": "L29"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -235102,7 +235180,7 @@
       "source_location": "L56"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -235111,7 +235189,7 @@
       "source_location": "L39"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -235120,7 +235198,7 @@
       "source_location": "L99"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -235129,7 +235207,7 @@
       "source_location": "L74"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -235138,7 +235216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -235147,7 +235225,7 @@
       "source_location": "L21"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -235156,7 +235234,7 @@
       "source_location": "L42"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -235165,7 +235243,7 @@
       "source_location": "L80"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -235174,7 +235252,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -235183,7 +235261,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -235192,7 +235270,7 @@
       "source_location": "L12"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -235201,7 +235279,7 @@
       "source_location": "L127"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
@@ -235210,7 +235288,7 @@
       "source_location": "L99"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
       "label": "posRegisterSessionActivity.test.ts",
@@ -235219,7 +235297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildactivity",
       "label": "buildActivity()",
@@ -235228,7 +235306,7 @@
       "source_location": "L457"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildreport",
       "label": "buildReport()",
@@ -235237,7 +235315,7 @@
       "source_location": "L436"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "posregistersessionactivity_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -235246,7 +235324,7 @@
       "source_location": "L476"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
@@ -235255,7 +235333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -235264,7 +235342,7 @@
       "source_location": "L24"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -235273,7 +235351,7 @@
       "source_location": "L16"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -235282,7 +235360,7 @@
       "source_location": "L6"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -235291,7 +235369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -235300,7 +235378,7 @@
       "source_location": "L115"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -235309,49 +235387,13 @@
       "source_location": "L219"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
       "norm_label": "recordsequencegapobservation()",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
       "source_location": "L190"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
-      "label": "staffProof.ts",
-      "norm_label": "staffproof.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "staffproof_createposlocalstaffprooftoken",
-      "label": "createPosLocalStaffProofToken()",
-      "norm_label": "createposlocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "staffproof_hashposlocalstaffprooftoken",
-      "label": "hashPosLocalStaffProofToken()",
-      "norm_label": "hashposlocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "staffproof_tohex",
-      "label": "toHex()",
-      "norm_label": "tohex()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
-      "source_location": "L4"
     },
     {
       "community": 61,
@@ -235581,6 +235623,42 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
+      "label": "staffProof.ts",
+      "norm_label": "staffproof.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "staffproof_createposlocalstaffprooftoken",
+      "label": "createPosLocalStaffProofToken()",
+      "norm_label": "createposlocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "staffproof_hashposlocalstaffprooftoken",
+      "label": "hashPosLocalStaffProofToken()",
+      "norm_label": "hashposlocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "staffproof_tohex",
+      "label": "toHex()",
+      "norm_label": "tohex()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
       "norm_label": "buildconflict()",
@@ -235588,7 +235666,7 @@
       "source_location": "L387"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -235597,7 +235675,7 @@
       "source_location": "L407"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -235606,7 +235684,7 @@
       "source_location": "L282"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -235615,7 +235693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -235624,7 +235702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -235633,7 +235711,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -235642,7 +235720,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -235651,7 +235729,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -235660,7 +235738,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -235669,7 +235747,7 @@
       "source_location": "L177"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -235678,49 +235756,13 @@
       "source_location": "L68"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
-    },
-    {
-      "community": 613,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 613,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 613,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 613,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
     },
     {
       "community": 614,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2657
-- Graph nodes: 10829
-- Graph edges: 13205
+- Graph nodes: 10831
+- Graph edges: 13207
 - Communities: 2582
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/reports/sweeper.test.ts
+++ b/packages/athena-webapp/convex/reports/sweeper.test.ts
@@ -27,6 +27,7 @@ vi.mock("./foldDay", async (importOriginal) => {
 });
 
 import {
+  MAX_FACTS_PER_DAY,
   REPORTS_SWEEP_STORE_ALLOWLIST_ENV,
   parseStoreAllowlist,
   selectAcceptedClose,
@@ -822,5 +823,112 @@ describe("fold integration", () => {
     expect(days[0].status).toBe("provisional");
     expect(days[0].closeId).toBeUndefined();
     expect(days[0].closeVarianceMinor).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read caps
+// ---------------------------------------------------------------------------
+
+describe("fold read caps", () => {
+  it("refuses a day past the fact cap instead of folding a truncated total", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId, productSkuId } = await seedStore(t, "sweep-cap");
+    allow(storeId);
+
+    // One past the cap. Each fact is worth 100, so a truncated fold would
+    // still produce a large, plausible-looking number — which is exactly why
+    // silence here is dangerous.
+    const factCount = MAX_FACTS_PER_DAY + 1;
+    await t.run(async (ctx) => {
+      for (let i = 0; i < factCount; i += 1) {
+        await ctx.db.insert("reportFact", {
+          storeId,
+          sourceDomain: "pos",
+          sourceId: `txn-${i}`,
+          lineId: "1",
+          factKind: "sale",
+          fingerprint: `fp-${i}`,
+          fingerprintVersion: 1,
+          occurredAt: 1_000,
+          recordedAt: 1_000,
+          operatingDate: "2026-07-28",
+          currency: "GHS",
+          grossAmountMinor: 100,
+          netAmountMinor: 100,
+          taxAmountMinor: 0,
+          discountAmountMinor: 0,
+          quantity: 1,
+          productSkuId,
+        });
+      }
+    });
+    await mark(t, storeId, "2026-07-28");
+
+    const result = await sweep(t);
+
+    // Counted apart from a transient failure: this is a structural limit.
+    expect(result.capExceeded).toBe(1);
+    expect(result.foldFailures).toBe(0);
+    expect(result.daysFolded).toBe(0);
+
+    // Nothing written — no day document, no per-SKU rows. A wrong number is
+    // worse than an absent one, because it cannot be told apart from a real one.
+    const { days, skuDays } = await t.run(async (ctx) => ({
+      // eslint-disable-next-line @convex-dev/no-collect-in-query -- convex-test fixture read, not a production query
+      days: await ctx.db.query("reportDay").collect(),
+      // eslint-disable-next-line @convex-dev/no-collect-in-query -- convex-test fixture read, not a production query
+      skuDays: await ctx.db.query("reportSkuDay").collect(),
+    }));
+    expect(days).toHaveLength(0);
+    expect(skuDays).toHaveLength(0);
+
+    // The refusal stays on the queue under its own reason, so it is visible
+    // and so raising the cap heals it on a later sweep.
+    const marks = await marksOf(t);
+    expect(marks).toHaveLength(1);
+    expect(marks[0].reason).toBe("fact_cap_exceeded");
+  });
+
+  it("folds a day sitting exactly on the cap", async () => {
+    const t = convexTest(schema, modules);
+    const { storeId, productSkuId } = await seedStore(t, "sweep-at-cap");
+    allow(storeId);
+
+    // Exactly at the cap must still fold: the guard reads cap+1 precisely so a
+    // full page is not mistaken for a truncated one.
+    await t.run(async (ctx) => {
+      for (let i = 0; i < MAX_FACTS_PER_DAY; i += 1) {
+        await ctx.db.insert("reportFact", {
+          storeId,
+          sourceDomain: "pos",
+          sourceId: `txn-${i}`,
+          lineId: "1",
+          factKind: "sale",
+          fingerprint: `fp-${i}`,
+          fingerprintVersion: 1,
+          occurredAt: 1_000,
+          recordedAt: 1_000,
+          operatingDate: "2026-07-28",
+          currency: "GHS",
+          grossAmountMinor: 100,
+          netAmountMinor: 100,
+          taxAmountMinor: 0,
+          discountAmountMinor: 0,
+          quantity: 1,
+          productSkuId,
+        });
+      }
+    });
+    await mark(t, storeId, "2026-07-28");
+
+    const result = await sweep(t);
+
+    expect(result.capExceeded).toBe(0);
+    expect(result.daysFolded).toBe(1);
+
+    const day = await t.run(async (ctx) => ctx.db.query("reportDay").unique());
+    expect(day?.netSalesMinor).toBe(MAX_FACTS_PER_DAY * 100);
+    expect(day?.factCount).toBe(MAX_FACTS_PER_DAY);
   });
 });

--- a/packages/athena-webapp/convex/reports/sweeper.ts
+++ b/packages/athena-webapp/convex/reports/sweeper.ts
@@ -56,11 +56,36 @@ export type SweepResult = {
   marksExamined: number;
   daysFolded: number;
   foldFailures: number;
+  /** Days refused because they exceed a fold read cap (see DayCapExceeded). */
+  capExceeded: number;
   skippedNotAllowed: number;
   storesTouched: number;
   rangesComputed: number;
   rangesExpired: number;
 };
+
+/**
+ * A day holds more rows than a fold read is allowed to take.
+ *
+ * `.take(n)` truncates silently, so folding past the cap would write a
+ * confidently wrong total that is indistinguishable from a real one — the
+ * exact failure this layer exists to remove. The day is refused instead: no
+ * document is written, the mark is kept, and the sweep reports it separately
+ * from a transient failure. Raising the cap makes the next sweep succeed.
+ */
+export class DayCapExceeded extends Error {
+  constructor(
+    readonly operatingDate: string,
+    readonly cap: number,
+    readonly what: "facts" | "skuDays",
+  ) {
+    super(
+      `Operating day ${operatingDate} exceeds the ${what} fold cap of ${cap}; ` +
+        "refusing to fold a truncated day.",
+    );
+    this.name = "DayCapExceeded";
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Store allowlist
@@ -205,12 +230,34 @@ export async function foldAndReplaceDay(
   const store = await ctx.db.get("store", storeId);
   const storeCurrency = normalizeCurrencyCode(store?.currency);
 
+  // One past the cap, so a full page is distinguishable from a truncated one.
   const facts = await ctx.db
     .query("reportFact")
     .withIndex("by_storeId_operatingDate", (q) =>
       q.eq("storeId", storeId).eq("operatingDate", operatingDate),
     )
-    .take(MAX_FACTS_PER_DAY);
+    .take(MAX_FACTS_PER_DAY + 1);
+
+  if (facts.length > MAX_FACTS_PER_DAY) {
+    throw new DayCapExceeded(operatingDate, MAX_FACTS_PER_DAY, "facts");
+  }
+
+  // Read up front, and cap-check before anything is written: the sweep catches
+  // fold errors, and a caught error does NOT roll back writes already made in
+  // the same mutation. Throwing half-way through would commit a day document
+  // whose per-SKU rows were never reconciled.
+  const existingSkuDays = await ctx.db
+    .query("reportSkuDay")
+    .withIndex("by_storeId_operatingDate_productSkuId", (q) =>
+      q.eq("storeId", storeId).eq("operatingDate", operatingDate),
+    )
+    .take(MAX_SKU_DAY_ROWS_PER_DAY + 1);
+
+  // Past the cap, rows for SKUs that lost activity would never be deleted, so
+  // the day would keep stale per-SKU numbers. Refuse rather than half-reconcile.
+  if (existingSkuDays.length > MAX_SKU_DAY_ROWS_PER_DAY) {
+    throw new DayCapExceeded(operatingDate, MAX_SKU_DAY_ROWS_PER_DAY, "skuDays");
+  }
 
   const close = await loadAcceptedClose(ctx, storeId, operatingDate);
   const closeRef = close ? toCloseRef(close) : undefined;
@@ -263,12 +310,6 @@ export async function foldAndReplaceDay(
   }
 
   // --- reportSkuDay: replace the day's rows ---------------------------------
-  const existingSkuDays = await ctx.db
-    .query("reportSkuDay")
-    .withIndex("by_storeId_operatingDate_productSkuId", (q) =>
-      q.eq("storeId", storeId).eq("operatingDate", operatingDate),
-    )
-    .take(MAX_SKU_DAY_ROWS_PER_DAY);
 
   const seen = new Set<string>();
 
@@ -418,6 +459,7 @@ export async function sweepWithCtx(ctx: MutationCtx): Promise<SweepResult> {
     marksExamined: marks.length,
     daysFolded: 0,
     foldFailures: 0,
+    capExceeded: 0,
     skippedNotAllowed: 0,
     storesTouched: 0,
     rangesComputed: 0,
@@ -427,7 +469,12 @@ export async function sweepWithCtx(ctx: MutationCtx): Promise<SweepResult> {
   const touchedStores = new Map<string, Id<"store">>();
 
   for (const mark of marks) {
-    if (result.daysFolded + result.foldFailures >= SWEEP_DIRTY_BATCH) break;
+    if (
+      result.daysFolded + result.foldFailures + result.capExceeded >=
+      SWEEP_DIRTY_BATCH
+    ) {
+      break;
+    }
 
     const storeKey = String(mark.storeId);
 
@@ -451,15 +498,26 @@ export async function sweepWithCtx(ctx: MutationCtx): Promise<SweepResult> {
         preserveOpen: mark.reason === "day_open",
       });
       result.daysFolded += 1;
-    } catch {
+    } catch (error) {
       // Containment: a day that could not be folded goes back on the queue
       // under its own reason so the failure is visible and self-healing.
-      result.foldFailures += 1;
+      //
+      // An over-cap day is counted apart from a transient failure: nothing was
+      // written, and retrying will keep refusing until the cap is raised or the
+      // day's volume changes. It stays on the queue so the refusal is visible
+      // and so a raised cap heals it on the next sweep, but conflating it with
+      // a write failure would hide a structural limit behind a flaky-looking
+      // counter.
+      if (error instanceof DayCapExceeded) {
+        result.capExceeded += 1;
+      } else {
+        result.foldFailures += 1;
+      }
       await markDayDirty(
         ctx,
         mark.storeId,
         mark.operatingDate,
-        "write_failure",
+        error instanceof DayCapExceeded ? "fact_cap_exceeded" : "write_failure",
         now,
       );
     }

--- a/packages/athena-webapp/convex/schemas/reports/derived.ts
+++ b/packages/athena-webapp/convex/schemas/reports/derived.ts
@@ -137,6 +137,9 @@ export const reportDirtyDaySchema = v.object({
     v.literal("fold_version_bump"),
     v.literal("reseed"),
     v.literal("write_failure"),
+    // The day holds more rows than a fold read may take; folding it would
+    // write a silently truncated total. See DayCapExceeded in sweeper.ts.
+    v.literal("fact_cap_exceeded"),
   ),
   markedAt: v.number(),
 });


### PR DESCRIPTION
Closes the known gap from the reporting rebuild (#706): the sweeper's per-day fold reads had a cap with no overflow detection.

## Why

Both `foldAndReplaceDay` reads — `reportFact` and the `reportSkuDay` reconcile read — used `.take(cap)`. Past the cap that call truncates silently: the fold runs on whatever came back and writes a total that is confidently wrong and indistinguishable from a real one. That's the exact failure class this rebuild exists to remove, just relocated to a boundary condition instead of the everyday path.

At current volume (prod's busiest operating day is far under 2,000 facts) this has never fired. It's a correctness gap, not an active incident.

## What changed

- Both reads now take `cap + 1`, so a full page is distinguishable from a truncated one.
- Over the cap, the day is refused via a new `DayCapExceeded` error: **nothing is written** — no `reportDay`, no `reportSkuDay` rows.
- The dirty mark stays on the queue under a new `fact_cap_exceeded` reason, so the refusal is visible and a later cap increase heals it on the next sweep.
- The sweep counts refusals (`capExceeded`) separately from transient failures (`foldFailures`), since folding a structural limit into a flaky-looking counter would hide it.
- Both cap checks run **before any write**. The sweep loop catches fold errors, and a caught error does not roll back writes already made in the same Convex mutation — the sku-day check originally landed after the day document write, which would have committed a document whose per-SKU rows were never reconciled. Moved both checks to the top.

## Tests

- A day with `cap + 1` facts is refused: `capExceeded` increments, nothing is written, the mark carries `fact_cap_exceeded`.
- A day with exactly `cap` facts still folds (boundary check on the `+1` read).

## Claimed

Local validation only — not deployed to prod. Prod's data is well under the cap today, so this ships ahead of need rather than in response to one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
