### PR TITLE
[V26-1131]: Stop demo restore from querying retired replay tables

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -14147,7 +14147,7 @@
       "relation": "calls",
       "source": "domainrestore_liststorerows",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L476",
+      "source_location": "L439",
       "target": "domainrestore_capturebaselinedocumentswithctx",
       "weight": 1
     },
@@ -14159,7 +14159,7 @@
       "relation": "calls",
       "source": "domainrestore_withoutsystemfields",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L480",
+      "source_location": "L443",
       "target": "domainrestore_capturebaselinedocumentswithctx",
       "weight": 1
     },
@@ -14171,7 +14171,7 @@
       "relation": "calls",
       "source": "domainrestore_liststorerows",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L461",
+      "source_location": "L424",
       "target": "domainrestore_countmutabledemostorerowswithctx",
       "weight": 1
     },
@@ -14183,7 +14183,7 @@
       "relation": "calls",
       "source": "domainrestore_requireboundedbatch",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L229",
+      "source_location": "L226",
       "target": "domainrestore_liststorerows",
       "weight": 1
     },
@@ -14195,7 +14195,7 @@
       "relation": "calls",
       "source": "domainrestore_planbaselinedocumentpromotion",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L510",
+      "source_location": "L473",
       "target": "domainrestore_promotebaselinedocumentswithctx",
       "weight": 1
     },
@@ -14207,7 +14207,7 @@
       "relation": "calls",
       "source": "domainrestore_liststorerows",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L546",
+      "source_location": "L509",
       "target": "domainrestore_restoremutabledemostorerowswithctx",
       "weight": 1
     },
@@ -14219,7 +14219,7 @@
       "relation": "calls",
       "source": "domainrestore_remapdocumentids",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L590",
+      "source_location": "L553",
       "target": "domainrestore_restoremutabledemostorerowswithctx",
       "weight": 1
     },
@@ -14231,7 +14231,7 @@
       "relation": "calls",
       "source": "domainrestore_requirecurrentbaselinedocuments",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L549",
+      "source_location": "L512",
       "target": "domainrestore_restoremutabledemostorerowswithctx",
       "weight": 1
     },
@@ -69359,7 +69359,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L467",
+      "source_location": "L430",
       "target": "domainrestore_capturebaselinedocumentswithctx",
       "weight": 1
     },
@@ -69371,7 +69371,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L454",
+      "source_location": "L417",
       "target": "domainrestore_countmutabledemostorerowswithctx",
       "weight": 1
     },
@@ -69383,7 +69383,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L226",
+      "source_location": "L223",
       "target": "domainrestore_liststorerows",
       "weight": 1
     },
@@ -69395,7 +69395,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L166",
+      "source_location": "L163",
       "target": "domainrestore_planbaselinedocumentpromotion",
       "weight": 1
     },
@@ -69407,7 +69407,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L190",
+      "source_location": "L187",
       "target": "domainrestore_plandomainrestore",
       "weight": 1
     },
@@ -69419,7 +69419,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L491",
+      "source_location": "L454",
       "target": "domainrestore_promotebaselinedocumentswithctx",
       "weight": 1
     },
@@ -69431,7 +69431,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L207",
+      "source_location": "L204",
       "target": "domainrestore_remapdocumentids",
       "weight": 1
     },
@@ -69443,7 +69443,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L143",
+      "source_location": "L140",
       "target": "domainrestore_requireboundedbatch",
       "weight": 1
     },
@@ -69455,7 +69455,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L148",
+      "source_location": "L145",
       "target": "domainrestore_requirecurrentbaselinedocuments",
       "weight": 1
     },
@@ -69467,7 +69467,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L530",
+      "source_location": "L493",
       "target": "domainrestore_restoremutabledemostorerowswithctx",
       "weight": 1
     },
@@ -69479,7 +69479,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L219",
+      "source_location": "L216",
       "target": "domainrestore_withoutsystemfields",
       "weight": 1
     },
@@ -188620,7 +188620,7 @@
       "label": "captureBaselineDocumentsWithCtx()",
       "norm_label": "capturebaselinedocumentswithctx()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L467"
+      "source_location": "L430"
     },
     {
       "community": 183,
@@ -188629,7 +188629,7 @@
       "label": "countMutableDemoStoreRowsWithCtx()",
       "norm_label": "countmutabledemostorerowswithctx()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L454"
+      "source_location": "L417"
     },
     {
       "community": 183,
@@ -188638,7 +188638,7 @@
       "label": "listStoreRows()",
       "norm_label": "liststorerows()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L226"
+      "source_location": "L223"
     },
     {
       "community": 183,
@@ -188647,7 +188647,7 @@
       "label": "planBaselineDocumentPromotion()",
       "norm_label": "planbaselinedocumentpromotion()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L166"
+      "source_location": "L163"
     },
     {
       "community": 183,
@@ -188656,7 +188656,7 @@
       "label": "planDomainRestore()",
       "norm_label": "plandomainrestore()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L190"
+      "source_location": "L187"
     },
     {
       "community": 183,
@@ -188665,7 +188665,7 @@
       "label": "promoteBaselineDocumentsWithCtx()",
       "norm_label": "promotebaselinedocumentswithctx()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L491"
+      "source_location": "L454"
     },
     {
       "community": 183,
@@ -188674,7 +188674,7 @@
       "label": "remapDocumentIds()",
       "norm_label": "remapdocumentids()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L207"
+      "source_location": "L204"
     },
     {
       "community": 183,
@@ -188683,7 +188683,7 @@
       "label": "requireBoundedBatch()",
       "norm_label": "requireboundedbatch()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L143"
+      "source_location": "L140"
     },
     {
       "community": 183,
@@ -188692,7 +188692,7 @@
       "label": "requireCurrentBaselineDocuments()",
       "norm_label": "requirecurrentbaselinedocuments()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L148"
+      "source_location": "L145"
     },
     {
       "community": 183,
@@ -188701,7 +188701,7 @@
       "label": "restoreMutableDemoStoreRowsWithCtx()",
       "norm_label": "restoremutabledemostorerowswithctx()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L530"
+      "source_location": "L493"
     },
     {
       "community": 183,
@@ -188710,7 +188710,7 @@
       "label": "withoutSystemFields()",
       "norm_label": "withoutsystemfields()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L219"
+      "source_location": "L216"
     },
     {
       "community": 183,

--- a/packages/athena-webapp/convex/schemas/sharedDemo.ts
+++ b/packages/athena-webapp/convex/schemas/sharedDemo.ts
@@ -65,6 +65,8 @@ export const sharedDemoBaselineDocumentSchema = v.object({
     v.literal("reportingInventoryDeficitLedger"),
     v.literal("reportingInventoryDeficitLot"),
     v.literal("reportingInventoryDeficitResolutionWork"),
+    // Retain legacy baseline compatibility until captured documents using these
+    // retired table names have been purged from every deployment.
     v.literal("reportingInventoryOccurrenceReplay"),
     v.literal("reportingInventoryOccurrenceReplayLot"),
     v.literal("reportingInventoryOccurrenceReplayOutcome"),

--- a/packages/athena-webapp/convex/sharedDemo/domainRestore.test.ts
+++ b/packages/athena-webapp/convex/sharedDemo/domainRestore.test.ts
@@ -76,9 +76,6 @@ describe("shared demo domain restore registry", () => {
         "reportingInventoryDeficitLedger",
         "reportingInventoryDeficitLot",
         "reportingInventoryDeficitResolutionWork",
-        "reportingInventoryOccurrenceReplay",
-        "reportingInventoryOccurrenceReplayLot",
-        "reportingInventoryOccurrenceReplayOutcome",
         "reportingReconciliationDiscrepancy",
         "stockAdjustmentBatch",
         "cycleCountDraft",
@@ -117,6 +114,30 @@ describe("shared demo domain restore registry", () => {
     ).not.toContain("posTerminal");
   });
 
+  it("does not query occurrence replay tables removed from the deployed schema", () => {
+    const tableNames = SHARED_DEMO_MUTABLE_TABLES.map(
+      (entry) => entry.tableName,
+    );
+    const baselineSchema = readFileSync(
+      "convex/schemas/sharedDemo.ts",
+      "utf8",
+    );
+    const restoreSource = readFileSync(
+      "convex/sharedDemo/domainRestore.ts",
+      "utf8",
+    );
+
+    for (const tableName of [
+      "reportingInventoryOccurrenceReplay",
+      "reportingInventoryOccurrenceReplayLot",
+      "reportingInventoryOccurrenceReplayOutcome",
+    ]) {
+      expect(tableNames).not.toContain(tableName);
+      expect(restoreSource).not.toContain(`"${tableName}"`);
+      expect(baselineSchema).toContain(`v.literal("${tableName}")`);
+    }
+  });
+
   it("restores changed baseline rows, deletes demo additions, and ignores another tenant", () => {
     const plan = planDomainRestore({
       baseline: [{ _id: "base", storeId: "demo", value: "original" }],
@@ -140,9 +161,6 @@ describe("shared demo domain restore registry", () => {
     "reportingInventoryDeficitLedger",
     "reportingInventoryDeficitLot",
     "reportingInventoryDeficitResolutionWork",
-    "reportingInventoryOccurrenceReplay",
-    "reportingInventoryOccurrenceReplayLot",
-    "reportingInventoryOccurrenceReplayOutcome",
     "reportingReconciliationDiscrepancy",
   ])("converges visitor-created and mutated %s rows", (tableName) => {
     expect(
@@ -239,9 +257,6 @@ describe("shared demo domain restore registry", () => {
       "reportingInventoryDeficitLedger",
       "reportingInventoryDeficitLot",
       "reportingInventoryDeficitResolutionWork",
-      "reportingInventoryOccurrenceReplay",
-      "reportingInventoryOccurrenceReplayLot",
-      "reportingInventoryOccurrenceReplayOutcome",
       "reportingReconciliationDiscrepancy",
       "reportingIngress",
       "reportingIngressSourceReference",
@@ -285,10 +300,6 @@ describe("shared demo domain restore registry", () => {
     expect(source).toContain('"by_positionId_status"');
     expect(source).toContain('tableName === "reportingInventoryDeficitLot"');
     expect(source).toContain('"by_positionId"');
-    expect(source).toContain('tableName === "reportingInventoryOccurrenceReplayLot"');
-    expect(source).toContain('"by_replayId_status_occurredAt_outboundEffectId"');
-    expect(source).toContain('tableName === "reportingInventoryOccurrenceReplayOutcome"');
-    expect(source).toContain('"by_replayId_status"');
     expect(source).toContain("withIndex(indexName");
   });
 

--- a/packages/athena-webapp/convex/sharedDemo/domainRestore.ts
+++ b/packages/athena-webapp/convex/sharedDemo/domainRestore.ts
@@ -39,9 +39,6 @@ export const SHARED_DEMO_MUTABLE_TABLES = [
   { domain: "inventory", tableName: "reportingInventoryDeficitLedger" },
   { domain: "inventory", tableName: "reportingInventoryDeficitLot" },
   { domain: "inventory", tableName: "reportingInventoryDeficitResolutionWork" },
-  { domain: "inventory", tableName: "reportingInventoryOccurrenceReplay" },
-  { domain: "inventory", tableName: "reportingInventoryOccurrenceReplayLot" },
-  { domain: "inventory", tableName: "reportingInventoryOccurrenceReplayOutcome" },
   { domain: "inventory", tableName: "stockAdjustmentBatch" },
   { domain: "inventory", tableName: "cycleCountDraft" },
   { domain: "inventory", tableName: "cycleCountDraftLine" },
@@ -339,37 +336,6 @@ async function listStoreRows(ctx: any, tableName: string, storeId: Id<"store">) 
       tableName,
     );
   }
-  if (
-    tableName === "reportingInventoryOccurrenceReplayLot" ||
-    tableName === "reportingInventoryOccurrenceReplayOutcome"
-  ) {
-    const replays = requireBoundedBatch(
-      await ctx.db
-        .query("reportingInventoryOccurrenceReplay")
-        .withIndex("by_storeId_status_updatedAt", (q: any) =>
-          q.eq("storeId", storeId),
-        )
-        .take(RESTORE_BATCH_LIMIT + 1),
-      "reportingInventoryOccurrenceReplay",
-    );
-    const indexName =
-      tableName === "reportingInventoryOccurrenceReplayLot"
-        ? "by_replayId_status_occurredAt_outboundEffectId"
-        : "by_replayId_status";
-    return requireBoundedBatch(
-      (
-        await Promise.all(
-          replays.map((replay: any) =>
-            ctx.db
-              .query(tableName)
-              .withIndex(indexName, (q: any) => q.eq("replayId", replay._id))
-              .take(RESTORE_BATCH_LIMIT + 1),
-          ),
-        )
-      ).flat(),
-      tableName,
-    );
-  }
   if (tableName === "staffMessage") {
     return requireBoundedBatch(await ctx.db.query("staffMessage").withIndex("by_storeId_createdAt", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
   }
@@ -386,10 +352,7 @@ async function listStoreRows(ctx: any, tableName: string, storeId: Id<"store">) 
   if (tableName === "staffCredential") {
     return requireBoundedBatch(await query.withIndex("by_storeId_status", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
   }
-  if (
-    tableName === "reportingInventoryDeficitResolutionWork" ||
-    tableName === "reportingInventoryOccurrenceReplay"
-  ) {
+  if (tableName === "reportingInventoryDeficitResolutionWork") {
     return requireBoundedBatch(await query.withIndex("by_storeId_status_updatedAt", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
   }
   if (tableName === "dailyOpening") {


### PR DESCRIPTION
## Summary

Shared-demo restore now skips the 3 occurrence replay tables retired by the reporting rewrite, preventing restore leases from failing on indexes that no longer exist.

The baseline validator still accepts legacy captured table names so deployments remain compatible with persisted snapshots until those rows are purged.

## Why

The reporting schema removed `reportingInventoryOccurrenceReplay`, `reportingInventoryOccurrenceReplayLot`, and `reportingInventoryOccurrenceReplayOutcome`, but the dynamic restore registry and ownership traversal continued querying them. Type checking could not catch the drift because this boundary uses dynamic table and index names.

The regression test now distinguishes live restore enumeration from persisted baseline compatibility.

## Validation

- `bun run test -- convex/sharedDemo/domainRestore.test.ts` (22 passed)
- `bun run --filter '@athena/webapp' audit:convex`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run graphify:rebuild`
- `bun run pr:athena`
- Repository-wide defunct-table reference audit

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)

https://linear.app/v26-labs/issue/V26-1131/stop-shared-demo-restore-from-querying-retired-occurrence-replay
