### PR TITLE
fix(shared-demo): skip retired reporting tables

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -14231,7 +14231,7 @@
       "relation": "calls",
       "source": "domainrestore_liststorerows",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L439",
+      "source_location": "L296",
       "target": "domainrestore_capturebaselinedocumentswithctx",
       "weight": 1
     },
@@ -14243,7 +14243,7 @@
       "relation": "calls",
       "source": "domainrestore_withoutsystemfields",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L443",
+      "source_location": "L300",
       "target": "domainrestore_capturebaselinedocumentswithctx",
       "weight": 1
     },
@@ -14255,7 +14255,7 @@
       "relation": "calls",
       "source": "domainrestore_liststorerows",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L424",
+      "source_location": "L281",
       "target": "domainrestore_countmutabledemostorerowswithctx",
       "weight": 1
     },
@@ -14267,7 +14267,7 @@
       "relation": "calls",
       "source": "domainrestore_requireboundedbatch",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L226",
+      "source_location": "L148",
       "target": "domainrestore_liststorerows",
       "weight": 1
     },
@@ -14279,7 +14279,7 @@
       "relation": "calls",
       "source": "domainrestore_planbaselinedocumentpromotion",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L473",
+      "source_location": "L330",
       "target": "domainrestore_promotebaselinedocumentswithctx",
       "weight": 1
     },
@@ -14291,7 +14291,7 @@
       "relation": "calls",
       "source": "domainrestore_liststorerows",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L509",
+      "source_location": "L366",
       "target": "domainrestore_restoremutabledemostorerowswithctx",
       "weight": 1
     },
@@ -14303,7 +14303,7 @@
       "relation": "calls",
       "source": "domainrestore_remapdocumentids",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L553",
+      "source_location": "L410",
       "target": "domainrestore_restoremutabledemostorerowswithctx",
       "weight": 1
     },
@@ -14315,7 +14315,7 @@
       "relation": "calls",
       "source": "domainrestore_requirecurrentbaselinedocuments",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L512",
+      "source_location": "L369",
       "target": "domainrestore_restoremutabledemostorerowswithctx",
       "weight": 1
     },
@@ -69875,7 +69875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L430",
+      "source_location": "L287",
       "target": "domainrestore_capturebaselinedocumentswithctx",
       "weight": 1
     },
@@ -69887,7 +69887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L417",
+      "source_location": "L274",
       "target": "domainrestore_countmutabledemostorerowswithctx",
       "weight": 1
     },
@@ -69899,7 +69899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L223",
+      "source_location": "L145",
       "target": "domainrestore_liststorerows",
       "weight": 1
     },
@@ -69911,7 +69911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L163",
+      "source_location": "L85",
       "target": "domainrestore_planbaselinedocumentpromotion",
       "weight": 1
     },
@@ -69923,7 +69923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L187",
+      "source_location": "L109",
       "target": "domainrestore_plandomainrestore",
       "weight": 1
     },
@@ -69935,7 +69935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L454",
+      "source_location": "L311",
       "target": "domainrestore_promotebaselinedocumentswithctx",
       "weight": 1
     },
@@ -69947,7 +69947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L204",
+      "source_location": "L126",
       "target": "domainrestore_remapdocumentids",
       "weight": 1
     },
@@ -69959,7 +69959,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L140",
+      "source_location": "L62",
       "target": "domainrestore_requireboundedbatch",
       "weight": 1
     },
@@ -69971,7 +69971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L145",
+      "source_location": "L67",
       "target": "domainrestore_requirecurrentbaselinedocuments",
       "weight": 1
     },
@@ -69983,7 +69983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L493",
+      "source_location": "L350",
       "target": "domainrestore_restoremutabledemostorerowswithctx",
       "weight": 1
     },
@@ -69995,7 +69995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_shareddemo_domainrestore_ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L216",
+      "source_location": "L138",
       "target": "domainrestore_withoutsystemfields",
       "weight": 1
     },
@@ -189586,7 +189586,7 @@
       "label": "captureBaselineDocumentsWithCtx()",
       "norm_label": "capturebaselinedocumentswithctx()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L430"
+      "source_location": "L287"
     },
     {
       "community": 185,
@@ -189595,7 +189595,7 @@
       "label": "countMutableDemoStoreRowsWithCtx()",
       "norm_label": "countmutabledemostorerowswithctx()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L417"
+      "source_location": "L274"
     },
     {
       "community": 185,
@@ -189604,7 +189604,7 @@
       "label": "listStoreRows()",
       "norm_label": "liststorerows()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L223"
+      "source_location": "L145"
     },
     {
       "community": 185,
@@ -189613,7 +189613,7 @@
       "label": "planBaselineDocumentPromotion()",
       "norm_label": "planbaselinedocumentpromotion()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L163"
+      "source_location": "L85"
     },
     {
       "community": 185,
@@ -189622,7 +189622,7 @@
       "label": "planDomainRestore()",
       "norm_label": "plandomainrestore()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L187"
+      "source_location": "L109"
     },
     {
       "community": 185,
@@ -189631,7 +189631,7 @@
       "label": "promoteBaselineDocumentsWithCtx()",
       "norm_label": "promotebaselinedocumentswithctx()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L454"
+      "source_location": "L311"
     },
     {
       "community": 185,
@@ -189640,7 +189640,7 @@
       "label": "remapDocumentIds()",
       "norm_label": "remapdocumentids()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L204"
+      "source_location": "L126"
     },
     {
       "community": 185,
@@ -189649,7 +189649,7 @@
       "label": "requireBoundedBatch()",
       "norm_label": "requireboundedbatch()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L140"
+      "source_location": "L62"
     },
     {
       "community": 185,
@@ -189658,7 +189658,7 @@
       "label": "requireCurrentBaselineDocuments()",
       "norm_label": "requirecurrentbaselinedocuments()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L145"
+      "source_location": "L67"
     },
     {
       "community": 185,
@@ -189667,7 +189667,7 @@
       "label": "restoreMutableDemoStoreRowsWithCtx()",
       "norm_label": "restoremutabledemostorerowswithctx()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L493"
+      "source_location": "L350"
     },
     {
       "community": 185,
@@ -189676,7 +189676,7 @@
       "label": "withoutSystemFields()",
       "norm_label": "withoutsystemfields()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/domainRestore.ts",
-      "source_location": "L216"
+      "source_location": "L138"
     },
     {
       "community": 185,

--- a/packages/athena-webapp/convex/sharedDemo/domainRestore.test.ts
+++ b/packages/athena-webapp/convex/sharedDemo/domainRestore.test.ts
@@ -11,6 +11,47 @@ import {
   SHARED_DEMO_MUTABLE_TABLES,
 } from "./domainRestore";
 
+const RETIRED_REPORTING_TABLES = [
+  "reportingIngress",
+  "reportingIngressSourceReference",
+  "reportingIngressLine",
+  "reportingIngressConflict",
+  "reportingFact",
+  "reportingFactSourceReference",
+  "reportingFactProcessingAttempt",
+  "reportingQuarantine",
+  "reportingProjectionHealth",
+  "reportingReconciliationDiscrepancy",
+  "reportingProjectionGeneration",
+  "reportingProjectionActivation",
+  "reportingStoreDayProjection",
+  "reportingStoreIntradayProjection",
+  "reportingStoreIntradayScheduleState",
+  "reportingSkuDayProjection",
+  "reportingCurrentValuationProjection",
+  "reportingRangeProjection",
+  "reportingAttentionProjection",
+  "reportingDailyCloseProjection",
+  "reportingSkuInsightProjection",
+  "reportingMetricCoverage",
+  "reportingStorePeriodSummary",
+  "reportingSkuPeriodSummary",
+  "reportingSkuPeriodClassification",
+  "reportingPeriodRollup",
+  "reportingPeriodFacet",
+  "reportingInventoryExposureSummary",
+  "reportingInventoryMovementSummary",
+  "reportingInventoryPeriodSummary",
+  "reportingDailyCloseTrust",
+  "reportingReadCursorContext",
+  "reportingWorkspaceMaterializationEpoch",
+  "reportingWorkspaceReadModelActivation",
+  "reportingReadBundle",
+  "reportingReadBundleActivation",
+  "reportingProjectionEvidence",
+  "reportingSkuEvidence",
+] as const;
+
 describe("shared demo domain restore registry", () => {
   it("promotes metadata-only baseline documents without replacing POS sync snapshots", () => {
     const rows = [
@@ -56,7 +97,7 @@ describe("shared demo domain restore registry", () => {
 
   it("covers mutable tables and descendants for every approved demo domain", () => {
     expect([...new Set(SHARED_DEMO_MUTABLE_TABLES.map((entry) => entry.domain))]).toEqual([
-      "pos", "inventory", "cash", "orders", "operations", "reporting", "staff",
+      "pos", "inventory", "cash", "orders", "operations", "staff",
     ]);
     expect(SHARED_DEMO_MUTABLE_TABLES.map((entry) => entry.tableName)).toEqual(
       expect.arrayContaining([
@@ -76,7 +117,6 @@ describe("shared demo domain restore registry", () => {
         "reportingInventoryDeficitLedger",
         "reportingInventoryDeficitLot",
         "reportingInventoryDeficitResolutionWork",
-        "reportingReconciliationDiscrepancy",
         "stockAdjustmentBatch",
         "cycleCountDraft",
         "cycleCountDraftLine",
@@ -87,24 +127,6 @@ describe("shared demo domain restore registry", () => {
         "managerElevation",
         "operationalWorkItem",
         "paymentAllocation",
-        "reportingIngress",
-        "reportingIngressSourceReference",
-        "reportingIngressLine",
-        "reportingIngressConflict",
-        "reportingFact",
-        "reportingFactSourceReference",
-        "reportingFactProcessingAttempt",
-        "reportingQuarantine",
-        "reportingProjectionHealth",
-        "reportingProjectionGeneration",
-        "reportingProjectionActivation",
-        "reportingStoreDayProjection",
-        "reportingSkuDayProjection",
-        "reportingCurrentValuationProjection",
-        "reportingWorkspaceMaterializationEpoch",
-        "reportingWorkspaceReadModelActivation",
-        "reportingReadBundle",
-        "reportingReadBundleActivation",
         "staffMessage",
         "staffCredential",
       ]),
@@ -138,6 +160,26 @@ describe("shared demo domain restore registry", () => {
     }
   });
 
+  it("does not query reporting tables retired by the fact-ledger rebuild", () => {
+    const tableNames = SHARED_DEMO_MUTABLE_TABLES.map(
+      (entry) => entry.tableName,
+    );
+    const baselineSchema = readFileSync(
+      "convex/schemas/sharedDemo.ts",
+      "utf8",
+    );
+    const restoreSource = readFileSync(
+      "convex/sharedDemo/domainRestore.ts",
+      "utf8",
+    );
+
+    for (const tableName of RETIRED_REPORTING_TABLES) {
+      expect(tableNames).not.toContain(tableName);
+      expect(restoreSource).not.toContain(`"${tableName}"`);
+      expect(baselineSchema).toContain(`v.literal("${tableName}")`);
+    }
+  });
+
   it("restores changed baseline rows, deletes demo additions, and ignores another tenant", () => {
     const plan = planDomainRestore({
       baseline: [{ _id: "base", storeId: "demo", value: "original" }],
@@ -161,7 +203,6 @@ describe("shared demo domain restore registry", () => {
     "reportingInventoryDeficitLedger",
     "reportingInventoryDeficitLot",
     "reportingInventoryDeficitResolutionWork",
-    "reportingReconciliationDiscrepancy",
   ])("converges visitor-created and mutated %s rows", (tableName) => {
     expect(
       SHARED_DEMO_MUTABLE_TABLES.some((entry) => entry.tableName === tableName),
@@ -221,18 +262,9 @@ describe("shared demo domain restore registry", () => {
     expect(source).toContain('withIndex("by_storeId_operatingDate"');
   });
 
-  it("uses declared store-prefix indexes for reporting ingress descendants", () => {
+  it("uses declared store-prefix indexes for retained reporting inventory tables", () => {
     const source = readFileSync("convex/sharedDemo/domainRestore.ts", "utf8");
-    expect(source).toContain('tableName === "reportingIngress"');
-    expect(source).toContain('withIndex("by_storeId_status_acceptedAt"');
-    expect(source).toContain('withIndex("by_storeId_sourceType_sourceId"');
-    expect(source).toContain('withIndex("by_storeId_productSkuId_createdAt"');
-    expect(source).toContain('withIndex("by_storeId_status_detectedAt"');
-    expect(source).toContain('withIndex("by_storeId_outcome_startedAt"');
-    expect(source).toContain('withIndex("by_storeId_sourceDomain_projectionKind"');
     expect(source).toContain('withIndex("by_storeId_productSkuId_occurrenceAt"');
-    expect(source).toContain('withIndex("by_storeId_action_subject"');
-    expect(source).toContain('withIndex("by_storeId_terminalId_accountId"');
   });
 
   it("keeps approved-workflow descendants in the baseline schema", () => {
@@ -257,36 +289,9 @@ describe("shared demo domain restore registry", () => {
       "reportingInventoryDeficitLedger",
       "reportingInventoryDeficitLot",
       "reportingInventoryDeficitResolutionWork",
-      "reportingReconciliationDiscrepancy",
-      "reportingIngress",
-      "reportingIngressSourceReference",
-      "reportingIngressLine",
-      "reportingIngressConflict",
-      "reportingFact",
-      "reportingFactSourceReference",
-      "reportingFactProcessingAttempt",
-      "reportingQuarantine",
-      "reportingProjectionHealth",
-      "reportingProjectionGeneration",
-      "reportingProjectionActivation",
-      "reportingStoreDayProjection",
-      "reportingSkuDayProjection",
-      "reportingCurrentValuationProjection",
-      "reportingWorkspaceMaterializationEpoch",
-      "reportingWorkspaceReadModelActivation",
-      "reportingReadBundle",
-      "reportingReadBundleActivation",
     ]) {
       expect(source).toContain(`v.literal("${tableName}")`);
     }
-  });
-
-  it("walks reporting closure through deployed store and generation indexes", () => {
-    const source = readFileSync("convex/sharedDemo/domainRestore.ts", "utf8");
-    expect(source).toContain('"by_storeId_projectionKind_status"');
-    expect(source).toContain('"by_generationId_periodKey"');
-    expect(source).toContain('"by_sourceGenerationId_sourceWatermark"');
-    expect(source).not.toContain('.filter((q: any)');
   });
 
   it("uses indexed ownership traversal for mutable rows without a store index", () => {

--- a/packages/athena-webapp/convex/sharedDemo/domainRestore.ts
+++ b/packages/athena-webapp/convex/sharedDemo/domainRestore.ts
@@ -54,89 +54,11 @@ export const SHARED_DEMO_MUTABLE_TABLES = [
   { domain: "operations", tableName: "operationalEvent" },
   { domain: "operations", tableName: "paymentAllocation" },
   { domain: "operations", tableName: "dailyOpening" },
-  { domain: "reporting", tableName: "reportingIngress" },
-  { domain: "reporting", tableName: "reportingIngressSourceReference" },
-  { domain: "reporting", tableName: "reportingIngressLine" },
-  { domain: "reporting", tableName: "reportingIngressConflict" },
-  { domain: "reporting", tableName: "reportingFact" },
-  { domain: "reporting", tableName: "reportingFactSourceReference" },
-  { domain: "reporting", tableName: "reportingFactProcessingAttempt" },
-  { domain: "reporting", tableName: "reportingQuarantine" },
-  { domain: "reporting", tableName: "reportingProjectionHealth" },
-  { domain: "reporting", tableName: "reportingReconciliationDiscrepancy" },
-  { domain: "reporting", tableName: "reportingProjectionGeneration" },
-  { domain: "reporting", tableName: "reportingProjectionActivation" },
-  { domain: "reporting", tableName: "reportingStoreDayProjection" },
-  { domain: "reporting", tableName: "reportingStoreIntradayProjection" },
-  { domain: "reporting", tableName: "reportingStoreIntradayScheduleState" },
-  { domain: "reporting", tableName: "reportingSkuDayProjection" },
-  { domain: "reporting", tableName: "reportingCurrentValuationProjection" },
-  { domain: "reporting", tableName: "reportingRangeProjection" },
-  { domain: "reporting", tableName: "reportingAttentionProjection" },
-  { domain: "reporting", tableName: "reportingDailyCloseProjection" },
-  { domain: "reporting", tableName: "reportingSkuInsightProjection" },
-  { domain: "reporting", tableName: "reportingMetricCoverage" },
-  { domain: "reporting", tableName: "reportingStorePeriodSummary" },
-  { domain: "reporting", tableName: "reportingSkuPeriodSummary" },
-  { domain: "reporting", tableName: "reportingSkuPeriodClassification" },
-  { domain: "reporting", tableName: "reportingPeriodRollup" },
-  { domain: "reporting", tableName: "reportingPeriodFacet" },
-  { domain: "reporting", tableName: "reportingInventoryExposureSummary" },
-  { domain: "reporting", tableName: "reportingInventoryMovementSummary" },
-  { domain: "reporting", tableName: "reportingInventoryPeriodSummary" },
-  { domain: "reporting", tableName: "reportingDailyCloseTrust" },
-  { domain: "reporting", tableName: "reportingReadCursorContext" },
-  { domain: "reporting", tableName: "reportingWorkspaceMaterializationEpoch" },
-  { domain: "reporting", tableName: "reportingWorkspaceReadModelActivation" },
-  { domain: "reporting", tableName: "reportingReadBundle" },
-  { domain: "reporting", tableName: "reportingReadBundleActivation" },
-  { domain: "reporting", tableName: "reportingProjectionEvidence" },
-  { domain: "reporting", tableName: "reportingSkuEvidence" },
   { domain: "staff", tableName: "staffProfile" },
   { domain: "staff", tableName: "staffCredential" },
   { domain: "staff", tableName: "staffMessage" },
 ] as const;
 const RESTORE_BATCH_LIMIT = 500;
-const REPORTING_STORE_INDEXES: Record<string, string> = {
-  reportingAttentionProjection: "by_storeId_scope_primaryReason",
-  reportingCurrentValuationProjection: "by_storeId_productSkuId",
-  reportingDailyCloseProjection:
-    "by_storeId_operatingDate_acceptedCloseVersion",
-  reportingMetricCoverage: "by_storeId_metric_sourceDomain",
-  reportingProjectionActivation:
-    "by_storeId_projectionKind_activatedAt",
-  reportingProjectionEvidence: "by_storeId_factId",
-  reportingProjectionGeneration: "by_storeId_projectionKind_status",
-  reportingRangeProjection: "by_storeId_rangeStartDate_rangeEndDate",
-  reportingReadBundle: "by_storeId_createdAt",
-  reportingReadBundleActivation: "by_storeId_activatedAt",
-  reportingReadCursorContext: "by_storeId_athenaUserId_expiresAt",
-  reportingSkuDayProjection: "by_storeId_productSkuId_operatingDate",
-  reportingSkuEvidence: "by_storeId_productSkuId_recognitionAt_identityKey",
-  reportingStoreDayProjection: "by_storeId_operatingDate_metric",
-  reportingStoreIntradayProjection:
-    "by_storeId_operatingDate_checkpointAt",
-  reportingWorkspaceReadModelActivation:
-    "by_storeId_projectionKind_activatedAt",
-};
-
-const REPORTING_GENERATION_INDEXES: Record<string, string> = {
-  reportingDailyCloseTrust: "by_generationId_operatingDate",
-  reportingInventoryExposureSummary: "by_generationId_productSkuId",
-  reportingInventoryMovementSummary:
-    "by_generationId_periodKey_productSkuId",
-  reportingInventoryPeriodSummary: "by_generationId_periodKey",
-  reportingPeriodFacet: "by_generationId_periodKey_facet_value",
-  reportingPeriodRollup:
-    "by_generationId_periodKey_dimension_dimensionId",
-  reportingSkuInsightProjection: "by_generationId_productSkuId",
-  reportingSkuPeriodClassification: "by_gen_period_class_sku",
-  reportingSkuPeriodSummary:
-    "by_generationId_periodKey_productSkuId",
-  reportingStoreIntradayScheduleState: "by_generationId_operatingDate",
-  reportingStorePeriodSummary: "by_generationId_periodKey",
-};
-
 export function requireBoundedBatch<T>(rows: T[], tableName: string) {
   if (rows.length > RESTORE_BATCH_LIMIT) throw new Error(`Demo restore batch required for ${tableName}.`);
   return rows;
@@ -221,48 +143,6 @@ function withoutSystemFields(row: Record<string, unknown>) {
 // This is intentionally the sole dynamic-table adapter. Its table names are
 // frozen by SHARED_DEMO_MUTABLE_TABLES and validated by the schema union.
 async function listStoreRows(ctx: any, tableName: string, storeId: Id<"store">) {
-  const reportingStoreIndex = REPORTING_STORE_INDEXES[tableName];
-  if (reportingStoreIndex) {
-    return requireBoundedBatch(
-      await ctx.db
-        .query(tableName)
-        .withIndex(reportingStoreIndex, (q: any) => q.eq("storeId", storeId))
-        .take(RESTORE_BATCH_LIMIT + 1),
-      tableName,
-    );
-  }
-  const reportingGenerationIndex = REPORTING_GENERATION_INDEXES[tableName];
-  if (
-    reportingGenerationIndex ||
-    tableName === "reportingWorkspaceMaterializationEpoch"
-  ) {
-    const generations = await ctx.db
-      .query("reportingProjectionGeneration")
-      .withIndex("by_storeId_projectionKind_status", (q: any) =>
-        q.eq("storeId", storeId),
-      )
-      .take(RESTORE_BATCH_LIMIT + 1);
-    requireBoundedBatch(generations, "reportingProjectionGeneration");
-    const indexName =
-      reportingGenerationIndex ??
-      "by_sourceGenerationId_sourceWatermark";
-    const parentField = reportingGenerationIndex
-      ? "generationId"
-      : "sourceGenerationId";
-    const rows = (
-      await Promise.all(
-        generations.map((generation: any) =>
-          ctx.db
-            .query(tableName)
-            .withIndex(indexName, (q: any) =>
-              q.eq(parentField, generation._id),
-            )
-            .take(RESTORE_BATCH_LIMIT + 1),
-        ),
-      )
-    ).flat();
-    return requireBoundedBatch(rows, tableName);
-  }
   if (tableName === "posTransactionItem") {
     const parents = await ctx.db.query("posTransaction").withIndex("by_storeId", (q: any) => q.eq("storeId", storeId)).take(500);
     return requireBoundedBatch((await Promise.all(parents.map((parent: any) => ctx.db.query("posTransactionItem").withIndex("by_transactionId", (q: any) => q.eq("transactionId", parent._id)).take(RESTORE_BATCH_LIMIT + 1)))).flat(), tableName);
@@ -376,31 +256,8 @@ async function listStoreRows(ctx: any, tableName: string, storeId: Id<"store">) 
   if (tableName === "reportingInventoryPosition") {
     return requireBoundedBatch(await query.withIndex("by_storeId_productSkuId", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
   }
-  if (tableName === "reportingIngress") {
-    return requireBoundedBatch(await query.withIndex("by_storeId_status_acceptedAt", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
-  }
-  if (
-    tableName === "reportingIngressSourceReference" ||
-    tableName === "reportingFactSourceReference" ||
-    tableName === "reportingInventoryEffectSourceReference"
-  ) {
+  if (tableName === "reportingInventoryEffectSourceReference") {
     return requireBoundedBatch(await query.withIndex("by_storeId_sourceType_sourceId", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
-  }
-  if (tableName === "reportingIngressLine") {
-    return requireBoundedBatch(await query.withIndex("by_storeId_productSkuId_createdAt", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
-  }
-  if (
-    tableName === "reportingIngressConflict" ||
-    tableName === "reportingQuarantine" ||
-    tableName === "reportingReconciliationDiscrepancy"
-  ) {
-    return requireBoundedBatch(await query.withIndex("by_storeId_status_detectedAt", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
-  }
-  if (tableName === "reportingFactProcessingAttempt") {
-    return requireBoundedBatch(await query.withIndex("by_storeId_outcome_startedAt", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
-  }
-  if (tableName === "reportingProjectionHealth") {
-    return requireBoundedBatch(await query.withIndex("by_storeId_sourceDomain_projectionKind", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);
   }
   if (tableName === "reportingInventoryEffect") {
     return requireBoundedBatch(await query.withIndex("by_storeId_productSkuId_occurrenceAt", (q: any) => q.eq("storeId", storeId)).take(RESTORE_BATCH_LIMIT + 1), tableName);


### PR DESCRIPTION
## Summary
- remove retired reporting ingress and projection tables from shared-demo restore
- retain baseline validator compatibility for historical snapshots
- guard against runtime queries to the fact-ledger rebuild

## Validation
- bun run test -- convex/sharedDemo
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter @athena/webapp lint:convex:changed
- bun run graphify:rebuild
- bun run pr:athena