### PR TITLE
feat(reports): refine workspace period interactions

### DIFF
--- a/docs/reports/2026-08-01-reporting-workspace-period-interactions-report.html
+++ b/docs/reports/2026-08-01-reporting-workspace-period-interactions-report.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="0518c00b47d68ca87f8f53325b7e03594ceb75a6b0f49321a1aea48d7e5d7edc">
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="4cf02ad97e014ed7629eeb36667e911050816b8e814b58a9158664da396417fd">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/docs/reports/2026-08-01-reporting-workspace-period-interactions-report.html
+++ b/docs/reports/2026-08-01-reporting-workspace-period-interactions-report.html
@@ -1,0 +1,320 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="0518c00b47d68ca87f8f53325b7e03594ceb75a6b0f49321a1aea48d7e5d7edc">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Reporting workspace period interactions</title>
+    <style>
+      :root {
+        --ink: #1f2933;
+        --muted: #596674;
+        --line: #d9e2ec;
+        --paper: #ffffff;
+        --soft: #f6f8fb;
+        --accent: #1d4ed8;
+        --accent-soft: #dbeafe;
+        --good: #166534;
+        --bad: #b91c1c;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--soft);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      main { max-width: 1120px; margin: 0 auto; padding: 48px 24px 72px; }
+      header { border-bottom: 1px solid var(--line); margin-bottom: 28px; padding-bottom: 28px; }
+      h1, h2, h3 { line-height: 1.18; letter-spacing: 0; }
+      h1 { font-size: 42px; max-width: 880px; margin: 0 0 16px; }
+      h2 { font-size: 28px; margin: 0 0 16px; }
+      p { margin: 0 0 14px; }
+      .lede { color: var(--muted); font-size: 18px; max-width: 880px; }
+      .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 20px; }
+      .pill { border: 1px solid var(--line); border-radius: 999px; background: var(--paper); color: var(--muted); font-size: 13px; padding: 6px 10px; }
+      .panel { background: var(--paper); border: 1px solid var(--line); border-radius: 8px; margin: 18px 0; padding: 22px; }
+      code { background: #eef2f7; border: 1px solid #d8dee8; border-radius: 5px; padding: 1px 5px; }
+      pre { overflow: auto; background: #111827; color: #e5e7eb; border-radius: 8px; padding: 16px; }
+      pre code { background: transparent; border: 0; color: inherit; padding: 0; }
+      table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+      th, td { border-bottom: 1px solid var(--line); padding: 11px 12px; text-align: left; vertical-align: top; }
+      th { background: #eef2f7; color: var(--muted); font-size: 13px; text-transform: uppercase; }
+      tr:last-child td { border-bottom: 0; }
+      .quiz-question { border-top: 1px solid var(--line); padding: 18px 0; }
+      .quiz-question:first-child { border-top: 0; }
+      fieldset { border: 0; margin: 0; padding: 0; }
+      legend { font-weight: 700; margin-bottom: 10px; }
+      label { display: block; border: 1px solid var(--line); border-radius: 8px; background: #fbfdff; margin: 8px 0; padding: 10px 12px; cursor: pointer; }
+      @media (hover: hover) and (pointer: fine) {
+        label:hover { border-color: #b6c5d8; }
+      }
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 8px;
+        background: var(--accent);
+        color: #ffffff;
+        cursor: pointer;
+        font-weight: 700;
+        padding: 11px 16px;
+        transition: transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+      }
+      button:active { transform: scale(0.97); }
+      button.secondary { background: #475569; }
+      .quiz-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
+      #quizResult { font-weight: 700; }
+      .answer-detail { display: none; border-top: 1px dashed var(--line); color: var(--muted); margin-top: 10px; padding-top: 10px; }
+      .answer-detail.visible { display: block; }
+      .correct { border-color: #86efac !important; background: #f0fdf4 !important; }
+      .incorrect { border-color: #fecaca !important; background: #fef2f2 !important; }
+      @media (prefers-reduced-motion: reduce) { button { transition-duration: 0ms; } }
+      @media (max-width: 820px) { h1 { font-size: 32px; } main { padding: 32px 16px 56px; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Reporting workspace period interactions</h1>
+        <p class="lede">How stable table context, explicit period focus, and report-day lifecycle now drive operator navigation.</p>
+        <div class="meta"><span class="pill">Delivery candidate</span><span class="pill">Branch: codex/refine-reporting-workspace-navigation</span><span class="pill">Code head: 0aae3a0a</span><span class="pill">Base: e0060fc9</span><span class="pill">PR: pending</span><span class="pill">Production deploy: pending</span><span class="pill">Local main alignment: pending</span></div>
+      </header>
+      <section class="panel"><h2>Executive Summary</h2>
+<p>Operators can now change a reporting date range without losing the surrounding day table. The selected range is highlighted inside a stable rendered scope, and choosing one day temporarily focuses that date without erasing the range it came from.</p>
+<p>Operational drill-downs now use the materialized report-day lifecycle on the surfaces that own those actions. Overview’s Today status links to Daily Operations or EOD Review, while Overview and standalone Items transaction metrics choose ordering from the same open-day rule. Days-table date links still open Items. The standalone Items route also presents its metrics as Operations-style cards while preserving the original reusable card variant.</p>
+</section>
+<section class="panel"><h2>Why This Mattered</h2>
+<p>Previously, the selected date range also defined the rows loaded into the Days table. Changing the range removed nearby context and could leave pagination on a page unrelated to the new start date. A single-day selection had no stable range to return to.</p>
+<p>Report destinations also lacked one authoritative definition of an in-progress day. Always forcing oldest-first Transactions made live operations less useful, while browser-clock inference would be wrong for store-local operating days and lifecycle transitions.</p>
+</section>
+<section class="panel"><h2>Mental Model</h2>
+<p>Treat the workspace as 3 independent questions. Rendered scope asks which bounded rows remain available. Period focus asks which rows and aggregates matter now. Lifecycle asks whether the materialized store day is still operationally open.</p>
+<ul>
+<li>Rendered table scope: daysTableStart and daysTableEnd feed the bounded listDays query.</li>
+<li>Selected range or day: daysStart, daysEnd, and selectedDay control emphasis and SKU mix.</li>
+<li>Day lifecycle: materialized report status is the authority for open-day navigation and transaction ordering; each surface consumes it through its existing read model.</li>
+</ul>
+</section>
+<section class="panel"><h2>Before and After Flow</h2>
+<p>Before: URL range → listDays range → replacement table rows. Date changes coupled query scope, visual focus, and pagination.</p>
+<p>After: URL table scope → stable listDays rows; selected range/day → highlighting and SKU mix; shared lifecycle helper → Daily Operations or EOD Review plus transaction ordering.</p>
+<p>A range start already present in the table moves directly to its containing page. If the range expands the table query, the panel records the pending start date and calculates the correct page after the expanded rows settle.</p>
+</section>
+<section class="panel"><h2>Surface Responsibilities</h2>
+<table>
+<thead><tr><th>Operator action</th><th>Destination behavior</th></tr></thead>
+<tbody>
+<tr><td>Overview Today status</td><td>The last authoritative trend day links to Daily Operations when open, or EOD Review when reconciled/amended.</td></tr>
+<tr><td>Overview Transactions metric</td><td>Today plus open omits <code>order</code> and uses the Transactions view’s newest-first default. Other overview periods request <code>oldestFirst</code>.</td></tr>
+<tr><td>Standalone Items day metrics</td><td>A single-day period whose matching <code>reportDay</code> is open omits <code>order</code>. Historic day, week, and month periods request <code>oldestFirst</code>.</td></tr>
+<tr><td>Days-table date</td><td>Still opens Items for that date. It does not jump directly to Daily Operations.</td></tr>
+</tbody>
+</table>
+</section>
+<section class="panel"><h2>Behavior Boundaries</h2>
+
+<ul>
+<li>A contained range keeps the existing rendered table scope. A wider union expands only while it stays within 92 days; otherwise the selected range becomes the fresh scope. The helper does not shrink a selected range that is itself wider than 92 days. The backend rejects that query instead of truncating it.</li>
+<li>Selecting a row focuses one day. Selecting it again, or using Show selected range, clears only selectedDay and restores the prior range focus.</li>
+<li>Only a single-day Items period with a matching open reportDay is Today in progress. Week and month periods remain historic-style navigation even if they include the open day.</li>
+<li>Missing lifecycle materialization fails conservatively per surface. Items falls back to historic ordering. Overview renders no transaction or status destination when it has no anchor range; a non-open anchor uses historic ordering.</li>
+<li>The Days table uses 14 rows per page. Expanded-range page targeting waits for the new rows because the old 14-row slices cannot locate a date outside their query scope.</li>
+<li>The <code>o</code> search parameter records the originating Reports URL. Daily Operations and Transactions preserve it so their standard back action can return the operator to the reporting context.</li>
+<li>The default embedded Items component keeps its card treatment; only the standalone route opts into the canvas variant.</li>
+<li>Access control, totals, cursor mechanics, fact limits, freshness authority, and newest-first day-table ordering are unchanged.</li>
+</ul>
+</section>
+<section class="panel"><h2>Validation and Delivery State</h2>
+<p>The code behavior is recorded at candidate head <code>0aae3a0a</code>. Focused tests and TypeScript passed against that head before this report was finalized. The first full <code>pr:athena</code> attempt reached the documentation gate and correctly required this solution note and report; the complete merge gate will be rerun after the report is committed.</p>
+<p>GitHub CI, merge, local-main fast-forward, Convex production deployment, Athena local-build deployment, and post-deploy health verification are pending. This report intentionally does not predict those outcomes.</p>
+<ul>
+<li>PASS at <code>0aae3a0a</code>: <code>bun run test -- convex/reports/queries.test.ts src/components/reports/ReportDaysPanel.test.tsx src/components/reports/ReportsItemsView.test.tsx src/components/reports/ReportsOverviewView.test.tsx</code> (78 tests).</li>
+<li>PASS at <code>0aae3a0a</code>: <code>bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json</code>.</li>
+<li>PASS: <code>bun run graphify:rebuild</code> after the final code edit.</li>
+<li>PENDING: complete <code>bun run pr:athena</code> rerun, GitHub CI, merge, local-main alignment, and production deploy.</li>
+</ul>
+</section>
+<section class="panel"><h2>Next-Time Guidance</h2>
+
+<ul>
+<li>Keep query scope, analytical focus, and operational lifecycle as separate state dimensions.</li>
+<li>When navigation depends on newly fetched rows, defer the derived page decision until those rows settle instead of calculating from stale data.</li>
+<li>Derive current-day behavior from report lifecycle state, never browser time.</li>
+<li>Carry the origin parameter across operational drill-downs so each owning workspace can offer a reliable return path.</li>
+<li>Cover contained and expanded range paths separately; only the expanded path exposes stale-row pagination errors.</li>
+</ul>
+</section>
+      
+<section class="panel">
+  <h2>Key Files</h2>
+  <table>
+    <thead><tr><th>File</th><th>Why It Matters</th></tr></thead>
+    <tbody><tr><td><code>packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx</code></td><td>Owns stable rendered rows, range/day emphasis, deferred page targeting, and day drill-down behavior.</td></tr>
+<tr><td><code>packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx</code></td><td>Owns URL state for selected range, stable table bounds, pagination, and selected day.</td></tr>
+<tr><td><code>packages/athena-webapp/src/components/reports/reportPeriodKeys.ts</code></td><td>Expands or replaces the table scope within the 92-day reporting read budget.</td></tr>
+<tr><td><code>packages/athena-webapp/shared/reportsContract.ts</code></td><td>Defines the shared lifecycle authority for Today in progress.</td></tr>
+<tr><td><code>packages/athena-webapp/convex/reports/queries.ts</code></td><td>Carries authoritative open-day classification with the selected Items period result.</td></tr>
+<tr><td><code>packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx</code></td><td>Maps lifecycle state to Daily Operations, EOD Review, and transaction ordering.</td></tr>
+<tr><td><code>packages/athena-webapp/src/components/reports/ReportsItemsPerformance.tsx</code></td><td>Provides canvas/card variants and period-aware transaction metric links.</td></tr>
+<tr><td><code>docs/solutions/architecture-patterns/athena-reporting-period-focus-and-lifecycle-authority-2026-08-01.md</code></td><td>Records the reusable authority and state-separation pattern for future reporting work.</td></tr></tbody>
+  </table>
+</section>
+
+      
+<section class="panel">
+  <h2>Subagent Evidence</h2>
+  <ul><li><strong>Session context researcher:</strong> Confirmed the candidate is directly atop origin/main, related it to the merged reporting baseline and completed Linear contracts, and preserved the pending merge/root/deploy finish line. Session extraction skills were unavailable, so it made no unsupported prior-session claims.</li>
+<li><strong>Delivered diff explorer:</strong> Mapped the backend contract, route state, presentation, navigation, tests, and generated artifacts. It identified the expanded-range stale-row pagination edge, which was fixed with a focused regression before delivery.</li></ul>
+</section>
+
+      
+<section id="quiz" class="panel">
+  <h2>Quiz: Pass Required</h2>
+  <p>You must score at least 8 out of 10 to pass.</p>
+  <form id="changeQuiz" data-threshold="8">
+    
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>1. A selected start date is outside the currently loaded rows, but the expanded table scope remains under 92 days. What should happen?</legend>
+    <label><input type="radio" name="q1" value="0" /> Keep the old query forever and highlight nothing</label>
+    <label><input type="radio" name="q1" value="1" /> Expand the query, temporarily use page 1, then move to the page containing the start date after rows settle</label>
+    <label><input type="radio" name="q1" value="2" /> Replace the table with only the selected day</label>
+  </fieldset>
+  <div class="answer-detail">The old rows cannot locate the new date. Deferring the final page avoids the former stale-row mistake while preserving bounded surrounding context.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>2. The union of the current table scope and a new 20-day range would exceed 92 days. Which scope is queried next?</legend>
+    <label><input type="radio" name="q2" value="0" /> The unbounded union</label>
+    <label><input type="radio" name="q2" value="1" /> The old table scope, ignoring the selection</label>
+    <label><input type="radio" name="q2" value="2" /> The new 20-day selected range as a fresh table scope</label>
+  </fieldset>
+  <div class="answer-detail">The union is rejected as context expansion, but the selected range itself is safely bounded. An independently over-wide selected range would still be rejected by the backend.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>3. An operator focuses one day inside a custom range, then activates that same row again. What remains?</legend>
+    <label><input type="radio" name="q3" value="0" /> The custom range, with its rows highlighted again</label>
+    <label><input type="radio" name="q3" value="1" /> The global trailing-14-day default</label>
+    <label><input type="radio" name="q3" value="2" /> A one-day table query</label>
+  </fieldset>
+  <div class="answer-detail">Only selectedDay is cleared. The selected range and stable table bounds remain, so the operator returns to the context they chose.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>4. A weekly Items period includes the store’s open report day. How are its Transactions metric links ordered?</legend>
+    <label><input type="radio" name="q4" value="0" /> Newest-first because any included open day controls the period</label>
+    <label><input type="radio" name="q4" value="1" /> No order because week periods cannot link to Transactions</label>
+    <label><input type="radio" name="q4" value="2" /> Oldest-first because only a single-day open period qualifies as Today in progress</label>
+  </fieldset>
+  <div class="answer-detail">The lifecycle exception is deliberately narrow. Multi-day periods retain chronological review ordering even when one constituent day is open.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>5. Items loads a single day but no matching materialized reportDay exists. What is the conservative transaction behavior?</legend>
+    <label><input type="radio" name="q5" value="0" /> Infer open from the browser date and omit order</label>
+    <label><input type="radio" name="q5" value="1" /> Treat it as not in progress and request oldest-first</label>
+    <label><input type="radio" name="q5" value="2" /> Disable all metrics</label>
+  </fieldset>
+  <div class="answer-detail">Items defaults isTodayInProgress to false. It never substitutes wall-clock inference for missing lifecycle materialization.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>6. Overview has no anchor day, so it cannot derive a transaction range. What should it render?</legend>
+    <label><input type="radio" name="q6" value="0" /> No Transactions or operational status destination</label>
+    <label><input type="radio" name="q6" value="1" /> An oldest-first link with today’s browser date</label>
+    <label><input type="radio" name="q6" value="2" /> A Daily Operations link without an operating date</label>
+  </fieldset>
+  <div class="answer-detail">Overview requires an authoritative anchor to construct both range and status destinations. Unlike Items, its fallback may be no link rather than a historic link.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>7. The Overview Today status says In progress. Which action opens Daily Operations?</legend>
+    <label><input type="radio" name="q7" value="0" /> Clicking any date in the Days table</label>
+    <label><input type="radio" name="q7" value="1" /> Clicking the Items units-sold metric</label>
+    <label><input type="radio" name="q7" value="2" /> Clicking View Daily Operations beside the Today status</label>
+  </fieldset>
+  <div class="answer-detail">Surface ownership matters: Days dates still drill into Items, while the Overview Today status owns the operational workspace destination.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>8. Why do report drill-down links carry the o parameter?</legend>
+    <label><input type="radio" name="q8" value="0" /> It selects oldest-first ordering</label>
+    <label><input type="radio" name="q8" value="1" /> It preserves the originating Reports URL for the destination’s back action</label>
+    <label><input type="radio" name="q8" value="2" /> It identifies the open reportDay</label>
+  </fieldset>
+  <div class="answer-detail">Ordering and lifecycle use separate fields. The origin parameter exists only to preserve a reliable return path across route ownership.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>9. A direct URL supplies a selected range wider than 92 days. What prevents silent partial reporting?</legend>
+    <label><input type="radio" name="q9" value="0" /> Backend range validation rejects the query</label>
+    <label><input type="radio" name="q9" value="1" /> The UI quietly truncates it to the newest 92 days</label>
+    <label><input type="radio" name="q9" value="2" /> Pagination hides the excess dates but totals remain complete</label>
+  </fieldset>
+  <div class="answer-detail">The scope helper limits expansion but does not sanitize an over-wide selected range. The backend fails closed rather than returning plausible partial data.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>10. After this report is committed, which finish-line claims are still invalid until externally proven?</legend>
+    <label><input type="radio" name="q10" value="0" /> Focused tests and TypeScript passed at code head 0aae3a0a</label>
+    <label><input type="radio" name="q10" value="1" /> Graphify was rebuilt after the final code edit</label>
+    <label><input type="radio" name="q10" value="2" /> GitHub CI is green, the PR is merged, local main is aligned, and production is deployed</label>
+  </fieldset>
+  <div class="answer-detail">Local evidence is complete for the stated commands, but CI, merge, root alignment, and deployment remain pending events until their systems report success.</div>
+</div>
+
+    <div class="quiz-actions">
+      <button type="button" id="gradeQuiz">Grade quiz</button>
+      <button type="button" class="secondary" id="resetQuiz">Reset</button>
+      <span id="quizResult" aria-live="polite"></span>
+    </div>
+  </form>
+</section>
+
+    </main>
+    <script>
+      const questions = Array.from(document.querySelectorAll(".quiz-question"));
+      const result = document.getElementById("quizResult");
+      const form = document.getElementById("changeQuiz");
+      const threshold = Number(form.dataset.threshold || 0);
+      function clearGrades() {
+        questions.forEach((question) => {
+          question.classList.remove("correct", "incorrect");
+          question.querySelector(".answer-detail").classList.remove("visible");
+        });
+        result.textContent = "";
+        result.style.color = "";
+      }
+      document.getElementById("gradeQuiz").addEventListener("click", () => {
+        clearGrades();
+        let score = 0;
+        questions.forEach((question, index) => {
+          const selected = document.querySelector(`input[name="q${index + 1}"]:checked`);
+          const isCorrect = selected && Number(selected.value) === Number(question.dataset.answer);
+          if (isCorrect) score += 1;
+          question.classList.add(isCorrect ? "correct" : "incorrect");
+          question.querySelector(".answer-detail").classList.add("visible");
+        });
+        const passed = score >= threshold;
+        result.textContent = passed
+          ? `Passed: ${score}/${questions.length}.`
+          : `Not passed: ${score}/${questions.length}. Review the report and try again.`;
+        result.style.color = passed ? "var(--good)" : "var(--bad)";
+      });
+      document.getElementById("resetQuiz").addEventListener("click", () => {
+        form.reset();
+        clearGrades();
+      });
+    </script>
+  </body>
+</html>

--- a/docs/solutions/architecture-patterns/athena-reporting-period-focus-and-lifecycle-authority-2026-08-01.md
+++ b/docs/solutions/architecture-patterns/athena-reporting-period-focus-and-lifecycle-authority-2026-08-01.md
@@ -21,7 +21,7 @@ tags:
   - date-range
   - lifecycle-authority
   - navigation
-delivery_diff_fingerprint: 0518c00b47d68ca87f8f53325b7e03594ceb75a6b0f49321a1aea48d7e5d7edc
+delivery_diff_fingerprint: 4cf02ad97e014ed7629eeb36667e911050816b8e814b58a9158664da396417fd
 ---
 
 # Athena Reporting Separates Rendered Scope, Period Focus, and Day Lifecycle

--- a/docs/solutions/architecture-patterns/athena-reporting-period-focus-and-lifecycle-authority-2026-08-01.md
+++ b/docs/solutions/architecture-patterns/athena-reporting-period-focus-and-lifecycle-authority-2026-08-01.md
@@ -1,0 +1,119 @@
+---
+title: "Athena Reporting Separates Rendered Scope, Period Focus, and Day Lifecycle"
+date: 2026-08-01
+category: architecture-patterns
+module: athena-webapp
+problem_type: architecture_pattern
+component: service_object
+resolution_type: code_fix
+severity: medium
+applies_when:
+  - "Changing date or date-range selection in the Reports workspace"
+  - "Linking report metrics to Transactions or Daily Operations"
+  - "Determining whether the current reporting day is still in progress"
+related_components:
+  - "reports-workspace-ui"
+  - "convex-reports"
+  - "tanstack-router-search-state"
+tags:
+  - reporting
+  - operating-day
+  - date-range
+  - lifecycle-authority
+  - navigation
+delivery_diff_fingerprint: 0518c00b47d68ca87f8f53325b7e03594ceb75a6b0f49321a1aea48d7e5d7edc
+---
+
+# Athena Reporting Separates Rendered Scope, Period Focus, and Day Lifecycle
+
+## Problem
+
+A reporting date range serves two different purposes: it tells the operator
+which days are in focus, and it can determine which rows are loaded. Coupling
+those purposes makes the table replace its context whenever the selection
+changes. The operator loses nearby dates, pagination can remain on a page that
+does not contain the new selection, and selecting one day has no stable range
+to return to.
+
+The same ambiguity appears in outbound navigation. Browser time cannot decide
+whether “today” is active for a store, and every report surface inventing that
+decision independently can choose a different transaction sort order or
+operational destination.
+
+## Solution
+
+Model the workspace with 3 explicit pieces of state:
+
+1. **Rendered table scope** (`daysTableStart` / `daysTableEnd`) controls the
+   bounded `listDays` query and stays stable while a new selection fits inside
+   the 92-day reporting limit.
+2. **Selected range** (`daysStart` / `daysEnd`) controls emphasis and aggregate
+   detail. Rows inside the range remain prominent; other rendered rows are
+   deemphasized rather than removed.
+3. **Selected day** (`selectedDay`) temporarily narrows emphasis and detail to
+   one date. Selecting it again clears only the day focus and returns to the
+   selected range.
+
+Range changes compute the page containing the range’s first date. This makes
+the focus visible immediately without changing the newest-first ordering of
+the day table.
+
+Treat report-day lifecycle as the authority for current-day behavior:
+
+```ts
+export function isReportingTodayInProgress(
+  status: ReportDayStatus | null | undefined,
+): boolean {
+  return status === "open";
+}
+```
+
+The server-shaped Items result exposes that decision for a day period. An
+in-progress day omits the Transactions `order` parameter so the destination
+uses its newest-first default. Historic days and multi-day periods explicitly
+request `oldestFirst`. Overview uses the same definition to expose Daily
+Operations for an open day and EOD Review for a reconciled or amended day.
+Both links carry the origin parameter so operators can return to Reports.
+
+## Why This Matters
+
+Rendered scope answers “what context can I still see?”, selection answers
+“what am I analyzing?”, and lifecycle answers “what operational phase is this
+day in?”. Keeping those concerns separate prevents a UI gesture from silently
+changing the query universe and prevents wall-clock guesses from overriding
+the store’s materialized reporting state.
+
+The pattern also keeps navigation semantics deterministic. Transaction order
+is a consequence of reporting lifecycle, not which component happened to
+construct the link.
+
+## Prevention
+
+- Preserve rendered table bounds separately from selected range bounds.
+- When a new range is outside the current table scope, expand only within the
+  reporting query limit; otherwise start a fresh bounded scope.
+- Recompute pagination from the first selected operating date after a range
+  change.
+- Do not use `new Date()` or browser timezone to classify a report day as open
+  or closed.
+- Put lifecycle classification in the shared reporting contract and carry the
+  result through server-shaped query responses.
+- Test range focus, single-day toggle-back, pagination targeting, open-day
+  navigation, historic-day ordering, and origin preservation independently.
+
+## Examples
+
+Before, choosing July 3–16 could leave the operator on the page containing
+July 31–17 or remove every non-selected row. After, the table navigates to the
+page containing July 3, keeps its bounded surrounding scope, highlights July
+3–16, and deemphasizes the remaining rows.
+
+Before, every report metric link requested oldest-first transactions. After,
+an `open` day renders newest-first by omitting `order`, while a reconciled day
+still requests `order=oldestFirst`.
+
+## Related
+
+- [Athena reporting: read-optimized redesign](../architecture/athena-reporting-read-optimized-redesign-2026-07-28.md)
+- [Athena Reports Bounds SKU Mix Aggregation Before Identity Hydration](athena-reports-sku-mix-aggregation-2026-07-30.md)
+- [Athena Daily Close Is A Store-Day Boundary](../logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 2699 files · ~0 words
+- 2700 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11008 nodes · 13408 edges · 2624 communities detected
+- 11013 nodes · 13413 edges · 2625 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2634,6 +2634,7 @@
 - [[_COMMUNITY_Community 2621|Community 2621]]
 - [[_COMMUNITY_Community 2622|Community 2622]]
 - [[_COMMUNITY_Community 2623|Community 2623]]
+- [[_COMMUNITY_Community 2624|Community 2624]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -3306,44 +3307,44 @@ Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
 ### Community 161 - "Community 161"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 162 - "Community 162"
 Cohesion: 0.31
 Nodes (12): backfillStoreSchedulesFromLegacyPolicyWithCtx(), buildBackfillRow(), buildCandidateWeeklyWindows(), compatibilityMetadata(), compatibilityOnlyRow(), findExistingScheduleToSkip(), firstPolicy(), isValidMinute() (+4 more)
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.28
 Nodes (11): defineCashControlsRead(), defineDailyCloseRead(), defineDailyOperationsRead(), defineInventoryCatalogRead(), defineInventoryCostOverlayRead(), defineOnlineOrdersRead(), defineOperationalWorkRead(), defineOrganizationRead() (+3 more)
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.33
 Nodes (11): closeCandidateOperatingRange(), emptyCloseSummary(), exactStatuses(), frozenFinancialSourceCounts(), frozenWeekMetricForDate(), matchesRequestedOperatingRange(), normalizeFrozenPaymentTotals(), recordValue() (+3 more)
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.29
 Nodes (12): buildCtx(), buildInventoryMovement(), buildMapping(), buildProductSku(), buildRegisterSession(), buildStaffProfile(), buildStore(), buildTerminal() (+4 more)
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.21
 Nodes (6): buildOperationalWorkItem(), createOperationalWorkItemWithCtx(), metadataArrayCount(), metadataNumber(), projectOperationalWorkItemForQueue(), sanitizeOperationalWorkItemDetails()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.18
 Nodes (4): findActivePendingCheckoutLookupAliasByCode(), listProductSkusByProductId(), normalizeLookupCode(), readAllQueryResults()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.18
 Nodes (4): cleanMetadataValue(), inclusiveDaySpan(), requireValidDateRange(), resolveSkuIdentity()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
-
-### Community 170 - "Community 170"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 171 - "Community 171"
 Cohesion: 0.17
@@ -3531,55 +3532,55 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 217 - "Community 217"
 Cohesion: 0.33
-Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 218 - "Community 218"
+Cohesion: 0.33
+Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+
+### Community 219 - "Community 219"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.4
 Nodes (9): anchorDate(), buildOverviewData(), comparisonBp(), emptySnapshot(), isUnsettled(), readRecentDays(), rebuildStoreOverview(), snapshotForDays() (+1 more)
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.2
 Nodes (0):
-
-### Community 229 - "Community 229"
-Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 230 - "Community 230"
 Cohesion: 0.31
@@ -3606,84 +3607,84 @@ Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
 ### Community 236 - "Community 236"
+Cohesion: 0.44
+Nodes (7): addOperatingDays(), dateRangeForItemsPeriod(), dateRangeForOverviewWindow(), isoWeekStart(), operatingDateToUtc(), tableRangeIncludingSelection(), utcToOperatingDate()
+
+### Community 237 - "Community 237"
 Cohesion: 0.24
 Nodes (3): mergeProductDataWithActiveProductRefresh(), stripSkus(), valuesMatch()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.36
 Nodes (8): collectUpdateStaticAssetUrls(), extractLinkHrefUrls(), extractScriptSrcUrls(), isStaticShellLinkTag(), maybeAddShellAssetUrl(), readTagAttribute(), stageUpdateStaticAssets(), waitForActiveServiceWorker()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.22
 Nodes (3): build(), forward(), ResizeObserverStub
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.31
 Nodes (7): architectureSolutionNote(), createFixtureRepo(), gitEnv(), nonFoundationalArchitectureSolutionNote(), runGit(), solutionNote(), write()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.38
 Nodes (9): assertFrontendDependencyParity(), checkFrontendDependencyParity(), collectDependencyDeclarations(), collectFrontendDependencyFailures(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall() (+1 more)
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.33
 Nodes (9): buildPartialDeliveryRunBaseline(), countBy(), createDeliveryRunLedger(), readDeliveryRunBaseline(), readDeliveryRunLedger(), readJsonOrNull(), summarizeDeliveryRunBaseline(), writeDeliveryRunLedger() (+1 more)
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.28
 Nodes (4): authoritativeDeficitPosition(), deficitLotSeed(), ledgeredDeficitLotSeed(), ledgeredDeficitPosition()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.28
 Nodes (3): deliveryDedupeKey(), joinKeyComponents(), normalizeRecipientEmail()
 
-### Community 249 - "Community 249"
+### Community 250 - "Community 250"
 Cohesion: 0.39
 Nodes (7): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 250 - "Community 250"
+### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (6): createNormalUserReadOperationAdapter(), createPublicReadOperationAdapter(), isAdmitted(), resolveReadOperationAdmission(), sharedDemoReadDenialError(), sharedDemoReadDenied()
 
-### Community 251 - "Community 251"
+### Community 252 - "Community 252"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.25
 Nodes (2): formatOperatingDate(), formatRegisterCloseoutVarianceAlertOperatingDate()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.39
 Nodes (7): findActivePendingCheckoutLookupAliasByCode(), firstEvidenceTime(), normalizePendingCheckoutLookupCode(), resolvePendingCheckoutSku(), resolvePendingCheckoutSkuFromItem(), retirePendingCheckoutLookupAliasForItem(), upsertPendingCheckoutLookupAlias()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.47
 Nodes (8): getTrustedCatalogPrice(), isDraftAllowedInTrustedCatalog(), isPendingCheckoutLookupAliasVisible(), isSuppressedByActiveLegacyImportProvisionalRow(), isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult(), searchProducts()
-
-### Community 255 - "Community 255"
-Cohesion: 0.22
-Nodes (0):
 
 ### Community 256 - "Community 256"
 Cohesion: 0.22
@@ -3694,140 +3695,140 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 258 - "Community 258"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 259 - "Community 259"
 Cohesion: 0.39
 Nodes (6): buildLookupRefs(), buildTraceEvent(), buildTraceRecord(), recordServiceCaseTraceBestEffort(), resolveOccurredAt(), safeTraceWrite()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
+Cohesion: 0.31
+Nodes (4): dayPeriodKey(), monthPeriodKey(), periodKeysForOperatingDate(), weekPeriodKey()
+
+### Community 262 - "Community 262"
 Cohesion: 0.25
 Nodes (2): getNextExpenseReportFilterSearch(), getNextExpenseReportPageSearch()
 
-### Community 261 - "Community 261"
+### Community 263 - "Community 263"
 Cohesion: 0.25
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 262 - "Community 262"
+### Community 264 - "Community 264"
 Cohesion: 0.28
 Nodes (4): cn(), formatCatalogMetric(), handleClearFilters(), handleQueryChange()
 
-### Community 263 - "Community 263"
-Cohesion: 0.5
-Nodes (6): addOperatingDays(), dateRangeForItemsPeriod(), dateRangeForOverviewWindow(), isoWeekStart(), operatingDateToUtc(), utcToOperatingDate()
-
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.42
 Nodes (7): buildCompletedSaleItems(), buildDemoTransactionNumber(), buildReadyItems(), buildSummary(), createSharedDemoDailyCloseFixture(), getOperatingDateTimestamp(), shiftOperatingDate()
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.25
 Nodes (2): isValidMessageBlocker(), isValidPriority()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.36
 Nodes (7): browserLocks(), clearCurrentPosLocalStorageEngine(), createCurrentPosLocalStorageEngineStore(), maintenanceResult(), maintenanceUnavailableResult(), openCurrentPosLocalStorageEngine(), runCurrentPosLocalStorageEngineOperation()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.25
 Nodes (2): canClearExactCloudClosedDrawer(), hasCommandIdentity()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.28
 Nodes (4): comparePendingEvents(), getPendingEventUploadSequence(), selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
-### Community 275 - "Community 275"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
 ### Community 276 - "Community 276"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 277 - "Community 277"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 278 - "Community 278"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
+### Community 277 - "Community 277"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 278 - "Community 278"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
 ### Community 279 - "Community 279"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+Cohesion: 0.22
+Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 281 - "Community 281"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 282 - "Community 282"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
-
-### Community 284 - "Community 284"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 286 - "Community 286"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 287 - "Community 287"
 Cohesion: 0.32
 Nodes (4): createProductsQueryCtx(), createSkuMutationCtx(), pendingCheckoutEvidence(), pendingCheckoutItem()
 
-### Community 287 - "Community 287"
+### Community 288 - "Community 288"
 Cohesion: 0.39
 Nodes (5): convertCloseoutRecords(), convertPayments(), migratePosAmountTableWithCtx(), pesewasPatchForRow(), upsertMigrationRun()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 291 - "Community 291"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 292 - "Community 292"
 Cohesion: 0.25
@@ -3838,36 +3839,36 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 294 - "Community 294"
-Cohesion: 0.36
-Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
-
-### Community 295 - "Community 295"
-Cohesion: 0.36
-Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
-
-### Community 296 - "Community 296"
-Cohesion: 0.5
-Nodes (7): addMetric(), applyToOpenDay(), factDeltas(), findExistingFact(), markDirty(), recordFacts(), toFactDoc()
-
-### Community 297 - "Community 297"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 295 - "Community 295"
+Cohesion: 0.36
+Nodes (4): buildCtx(), buildStaffProfile(), buildStore(), buildTerminal()
+
+### Community 296 - "Community 296"
+Cohesion: 0.36
+Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
+
+### Community 297 - "Community 297"
+Cohesion: 0.5
+Nodes (7): addMetric(), applyToOpenDay(), factDeltas(), findExistingFact(), markDirty(), recordFacts(), toFactDoc()
+
 ### Community 298 - "Community 298"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 299 - "Community 299"
 Cohesion: 0.5
 Nodes (7): candidateWindow(), computeExpectedDay(), diffMetrics(), foldedMetrics(), verifyDayWithCtx(), verifyStoreSummaryWithCtx(), zeroMetrics()
 
-### Community 299 - "Community 299"
+### Community 300 - "Community 300"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 300 - "Community 300"
+### Community 301 - "Community 301"
 Cohesion: 0.5
 Nodes (7): assertDefaultWorkflowTraceAccess(), assertWorkflowTraceAccess(), getRegisterSessionTraceIdentity(), getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx(), requireAdminWorkflowTraceAccess(), requireFullAdminOrManagerElevationTraceAccess()
-
-### Community 301 - "Community 301"
-Cohesion: 0.36
-Nodes (4): dayPeriodKey(), monthPeriodKey(), periodKeysForOperatingDate(), weekPeriodKey()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.25
@@ -4398,20 +4399,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 434 - "Community 434"
+Cohesion: 0.4
+Nodes (2): isSelectedDay(), selectDay()
+
+### Community 435 - "Community 435"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 437 - "Community 437"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.33
@@ -4514,52 +4515,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 463 - "Community 463"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 464 - "Community 464"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 464 - "Community 464"
+### Community 465 - "Community 465"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 465 - "Community 465"
+### Community 466 - "Community 466"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 466 - "Community 466"
+### Community 467 - "Community 467"
 Cohesion: 0.47
 Nodes (3): assertDeliveryDocumentationCheck(), findingsFrom(), isPolicyFailure()
 
-### Community 467 - "Community 467"
+### Community 468 - "Community 468"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 468 - "Community 468"
+### Community 469 - "Community 469"
 Cohesion: 0.47
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 469 - "Community 469"
+### Community 470 - "Community 470"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 470 - "Community 470"
+### Community 471 - "Community 471"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 471 - "Community 471"
+### Community 472 - "Community 472"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 472 - "Community 472"
+### Community 473 - "Community 473"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 473 - "Community 473"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 474 - "Community 474"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.4
@@ -4570,72 +4571,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 477 - "Community 477"
-Cohesion: 0.6
-Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 478 - "Community 478"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
 
 ### Community 479 - "Community 479"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
 
 ### Community 480 - "Community 480"
-Cohesion: 0.5
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
-
-### Community 481 - "Community 481"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 481 - "Community 481"
+Cohesion: 0.5
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 483 - "Community 483"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 484 - "Community 484"
 Cohesion: 0.6
 Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
 
-### Community 484 - "Community 484"
+### Community 485 - "Community 485"
 Cohesion: 0.5
 Nodes (2): historicalCostLane(), materializeDeferredAdjustmentWithCtx()
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.7
 Nodes (4): backfillStoreTimezoneAuthorityWithCtx(), buildRow(), listSchedulesForStore(), normalizeLimit()
 
-### Community 488 - "Community 488"
+### Community 489 - "Community 489"
 Cohesion: 0.5
 Nodes (2): recordNotificationFailureEventWithCtx(), recordTerminalDeliveryFailureEvent()
 
-### Community 489 - "Community 489"
+### Community 490 - "Community 490"
 Cohesion: 0.6
 Nodes (4): dedupeKey(), keyFor(), prepare(), stubCtx()
 
-### Community 490 - "Community 490"
+### Community 491 - "Community 491"
 Cohesion: 0.7
 Nodes (4): createNormalUserOperationAdapter(), createPublicOperationAdapter(), isAdmitted(), resolveOperationAdmission()
 
-### Community 491 - "Community 491"
+### Community 492 - "Community 492"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 492 - "Community 492"
+### Community 493 - "Community 493"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 493 - "Community 493"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 494 - "Community 494"
 Cohesion: 0.4
@@ -4646,116 +4647,116 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 496 - "Community 496"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 497 - "Community 497"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 497 - "Community 497"
+### Community 498 - "Community 498"
 Cohesion: 0.5
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 498 - "Community 498"
+### Community 499 - "Community 499"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 499 - "Community 499"
-Cohesion: 0.7
-Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 501 - "Community 501"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 502 - "Community 502"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 502 - "Community 502"
+### Community 503 - "Community 503"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 503 - "Community 503"
+### Community 504 - "Community 504"
 Cohesion: 0.6
 Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
-### Community 504 - "Community 504"
+### Community 505 - "Community 505"
 Cohesion: 0.6
 Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
-
-### Community 505 - "Community 505"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 506 - "Community 506"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 507 - "Community 507"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 508 - "Community 508"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 508 - "Community 508"
+### Community 509 - "Community 509"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 509 - "Community 509"
+### Community 510 - "Community 510"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 510 - "Community 510"
-Cohesion: 0.5
-Nodes (2): at(), seedVerifiableDay()
 
 ### Community 511 - "Community 511"
 Cohesion: 0.5
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): at(), seedVerifiableDay()
 
 ### Community 512 - "Community 512"
+Cohesion: 0.5
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 513 - "Community 513"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 513 - "Community 513"
+### Community 514 - "Community 514"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 514 - "Community 514"
+### Community 515 - "Community 515"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 515 - "Community 515"
+### Community 516 - "Community 516"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 516 - "Community 516"
+### Community 517 - "Community 517"
 Cohesion: 0.5
 Nodes (2): sharedDemoDenialError(), sharedDemoDenied()
 
-### Community 517 - "Community 517"
+### Community 518 - "Community 518"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 518 - "Community 518"
+### Community 519 - "Community 519"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
-
-### Community 520 - "Community 520"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 521 - "Community 521"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 522 - "Community 522"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 523 - "Community 523"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 523 - "Community 523"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.4
@@ -4766,12 +4767,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 526 - "Community 526"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 527 - "Community 527"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 527 - "Community 527"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.4
@@ -4782,12 +4783,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 530 - "Community 530"
-Cohesion: 0.7
-Nodes (4): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), routeTemplateMatches()
-
-### Community 531 - "Community 531"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 531 - "Community 531"
+Cohesion: 0.7
+Nodes (4): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), routeTemplateMatches()
 
 ### Community 532 - "Community 532"
 Cohesion: 0.4
@@ -4798,84 +4799,84 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 534 - "Community 534"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
-
-### Community 535 - "Community 535"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 535 - "Community 535"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 536 - "Community 536"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 537 - "Community 537"
-Cohesion: 0.5
-Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 0.5
-Nodes (2): getSelectedAppMessage(), sortAppMessages()
+Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
 ### Community 539 - "Community 539"
 Cohesion: 0.5
-Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
 ### Community 540 - "Community 540"
+Cohesion: 0.5
+Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
+
+### Community 541 - "Community 541"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 541 - "Community 541"
+### Community 542 - "Community 542"
 Cohesion: 0.6
 Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
 
-### Community 542 - "Community 542"
+### Community 543 - "Community 543"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 543 - "Community 543"
+### Community 544 - "Community 544"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 544 - "Community 544"
+### Community 545 - "Community 545"
 Cohesion: 0.5
 Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
-### Community 545 - "Community 545"
+### Community 546 - "Community 546"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 546 - "Community 546"
+### Community 547 - "Community 547"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 547 - "Community 547"
+### Community 548 - "Community 548"
 Cohesion: 0.8
 Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
-### Community 548 - "Community 548"
+### Community 549 - "Community 549"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 549 - "Community 549"
+### Community 550 - "Community 550"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 550 - "Community 550"
+### Community 551 - "Community 551"
 Cohesion: 0.6
 Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
 
-### Community 551 - "Community 551"
+### Community 552 - "Community 552"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 552 - "Community 552"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 553 - "Community 553"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 554 - "Community 554"
 Cohesion: 0.4
@@ -4890,108 +4891,108 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 557 - "Community 557"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 558 - "Community 558"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 558 - "Community 558"
+### Community 559 - "Community 559"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 559 - "Community 559"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 560 - "Community 560"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 561 - "Community 561"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 562 - "Community 562"
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 563 - "Community 563"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 563 - "Community 563"
+### Community 564 - "Community 564"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 564 - "Community 564"
+### Community 565 - "Community 565"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 565 - "Community 565"
+### Community 566 - "Community 566"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 566 - "Community 566"
+### Community 567 - "Community 567"
 Cohesion: 0.6
 Nodes (4): checkRegisterSessionAuthorityWriters(), collectRegisterSessionAuthorityWriterFindings(), listTypeScriptFiles(), normalizePath()
 
-### Community 567 - "Community 567"
+### Community 568 - "Community 568"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 568 - "Community 568"
+### Community 569 - "Community 569"
 Cohesion: 0.5
 Nodes (2): createSiblingPolicyFixture(), runGit()
 
-### Community 569 - "Community 569"
+### Community 570 - "Community 570"
 Cohesion: 0.6
 Nodes (3): errorMessage(), formatHumanReport(), runHarnessContractPreflight()
 
-### Community 570 - "Community 570"
+### Community 571 - "Community 571"
 Cohesion: 0.7
 Nodes (4): buildOperationalWorkRepairInvocation(), main(), parseOperationalWorkRepairArgs(), requireValue()
-
-### Community 571 - "Community 571"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 572 - "Community 572"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 573 - "Community 573"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 574 - "Community 574"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 574 - "Community 574"
+### Community 575 - "Community 575"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 575 - "Community 575"
+### Community 576 - "Community 576"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 576 - "Community 576"
+### Community 577 - "Community 577"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 577 - "Community 577"
+### Community 578 - "Community 578"
 Cohesion: 0.67
 Nodes (2): isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 578 - "Community 578"
+### Community 579 - "Community 579"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 579 - "Community 579"
+### Community 580 - "Community 580"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 580 - "Community 580"
+### Community 581 - "Community 581"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 581 - "Community 581"
+### Community 582 - "Community 582"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 582 - "Community 582"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 583 - "Community 583"
 Cohesion: 0.5
@@ -5006,20 +5007,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 586 - "Community 586"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 587 - "Community 587"
 Cohesion: 0.67
 Nodes (2): normalizeDisplayText(), presentPublicBannerMessage()
 
-### Community 587 - "Community 587"
+### Community 588 - "Community 588"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 588 - "Community 588"
-Cohesion: 0.67
-Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 589 - "Community 589"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): computeCatalogSummary(), refreshCatalogSummaryWithCtx()
 
 ### Community 590 - "Community 590"
 Cohesion: 0.5
@@ -5034,12 +5035,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 593 - "Community 593"
-Cohesion: 0.83
-Nodes (3): canonicalizeCostOverlayLineages(), frozenCostOverlayLineagesMatch(), readCostOverlaySkuLineagesWithCtx()
-
-### Community 594 - "Community 594"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 594 - "Community 594"
+Cohesion: 0.83
+Nodes (3): canonicalizeCostOverlayLineages(), frozenCostOverlayLineagesMatch(), readCostOverlaySkuLineagesWithCtx()
 
 ### Community 595 - "Community 595"
 Cohesion: 0.5
@@ -5058,40 +5059,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 599 - "Community 599"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 600 - "Community 600"
 Cohesion: 0.67
 Nodes (2): audit(), boundedText()
 
-### Community 600 - "Community 600"
+### Community 601 - "Community 601"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 601 - "Community 601"
+### Community 602 - "Community 602"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 602 - "Community 602"
+### Community 603 - "Community 603"
 Cohesion: 0.67
 Nodes (2): findNotificationKind(), getNotificationKind()
 
-### Community 603 - "Community 603"
+### Community 604 - "Community 604"
 Cohesion: 0.67
 Nodes (2): admitPublicMutation(), withOperationMutationAdmission()
 
-### Community 604 - "Community 604"
+### Community 605 - "Community 605"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 605 - "Community 605"
+### Community 606 - "Community 606"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 606 - "Community 606"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 607 - "Community 607"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 608 - "Community 608"
 Cohesion: 0.5
@@ -5102,56 +5103,56 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 610 - "Community 610"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 611 - "Community 611"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 611 - "Community 611"
+### Community 612 - "Community 612"
 Cohesion: 0.67
 Nodes (2): assertAppLoginEmailApproved(), authorizeEmailOtp()
 
-### Community 612 - "Community 612"
+### Community 613 - "Community 613"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 613 - "Community 613"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
-
 ### Community 614 - "Community 614"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Cohesion: 0.5
+Nodes (1): buildCtx()
 
 ### Community 615 - "Community 615"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 616 - "Community 616"
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+
+### Community 617 - "Community 617"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 618 - "Community 618"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 617 - "Community 617"
+### Community 619 - "Community 619"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 618 - "Community 618"
-Cohesion: 0.83
-Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
-
-### Community 619 - "Community 619"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 620 - "Community 620"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
 ### Community 621 - "Community 621"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 622 - "Community 622"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 623 - "Community 623"
 Cohesion: 0.5
@@ -5159,23 +5160,23 @@ Nodes (0):
 
 ### Community 624 - "Community 624"
 Cohesion: 0.5
-Nodes (1): buildCtx()
+Nodes (0):
 
 ### Community 625 - "Community 625"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 626 - "Community 626"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 627 - "Community 627"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 628 - "Community 628"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 629 - "Community 629"
 Cohesion: 0.5
@@ -5186,16 +5187,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 631 - "Community 631"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 632 - "Community 632"
 Cohesion: 0.83
 Nodes (3): factFingerprint(), fingerprintPayload(), stableStringHash()
 
-### Community 632 - "Community 632"
+### Community 633 - "Community 633"
 Cohesion: 0.67
 Nodes (2): fact(), sale()
-
-### Community 633 - "Community 633"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 634 - "Community 634"
 Cohesion: 0.5
@@ -5206,84 +5207,84 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 636 - "Community 636"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 637 - "Community 637"
 Cohesion: 0.83
 Nodes (3): createOpaqueTicket(), encodeBase64Url(), hashSharedDemoTicket()
 
-### Community 637 - "Community 637"
+### Community 638 - "Community 638"
 Cohesion: 0.67
 Nodes (2): runHourlyRestoreWithCtx(), sharedDemoRestoreEnabled()
-
-### Community 638 - "Community 638"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 639 - "Community 639"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 640 - "Community 640"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 641 - "Community 641"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 641 - "Community 641"
+### Community 642 - "Community 642"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 642 - "Community 642"
+### Community 643 - "Community 643"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 643 - "Community 643"
-Cohesion: 0.83
-Nodes (3): ensureTimezoneAuthorityForScheduleWithCtx(), listTimezoneVersionsForStoreWithCtx(), scheduleTimezoneContentHash()
 
 ### Community 644 - "Community 644"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): ensureTimezoneAuthorityForScheduleWithCtx(), listTimezoneVersionsForStoreWithCtx(), scheduleTimezoneContentHash()
 
 ### Community 645 - "Community 645"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 646 - "Community 646"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 647 - "Community 647"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 648 - "Community 648"
 Cohesion: 0.83
-Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 649 - "Community 649"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): isStorefrontSelectableSubcategory(), isStorefrontVisibleCategory(), isStorefrontVisibleSubcategory()
 
 ### Community 650 - "Community 650"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 651 - "Community 651"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 652 - "Community 652"
 Cohesion: 0.83
 Nodes (3): isLegacyNullPlaceholder(), normalizeSkuAttributeValue(), parseVariantAttributeValue()
 
-### Community 652 - "Community 652"
+### Community 653 - "Community 653"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 653 - "Community 653"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 654 - "Community 654"
 Cohesion: 0.67
-Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 655 - "Community 655"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getUpdateReadyBannerContent(), UpdateReadyMessageAdapter()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.5
@@ -5334,20 +5335,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 668 - "Community 668"
-Cohesion: 0.67
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 669 - "Community 669"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 670 - "Community 670"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 671 - "Community 671"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 672 - "Community 672"
 Cohesion: 0.5
@@ -5362,12 +5363,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 675 - "Community 675"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 676 - "Community 676"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 676 - "Community 676"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 677 - "Community 677"
 Cohesion: 0.5
@@ -5382,12 +5383,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 680 - "Community 680"
-Cohesion: 0.83
-Nodes (3): clampToToday(), ReportCalendar(), startOfLocalDay()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 681 - "Community 681"
-Cohesion: 0.67
-Nodes (2): isSelectedDay(), selectDay()
+Cohesion: 0.83
+Nodes (3): clampToToday(), ReportCalendar(), startOfLocalDay()
 
 ### Community 682 - "Community 682"
 Cohesion: 0.5
@@ -13157,6 +13158,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 2624 - "Community 2624"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **3 isolated node(s):** `StaleConstructionError`, `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -15966,489 +15971,491 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2381`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2382`** (1 nodes): `-cost-overlay-search.ts`
+- **Thin community `Community 2382`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2383`** (1 nodes): `cost-overlay.test.ts`
+- **Thin community `Community 2383`** (1 nodes): `-cost-overlay-search.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2384`** (1 nodes): `cost-overlay.tsx`
+- **Thin community `Community 2384`** (1 nodes): `cost-overlay.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2385`** (1 nodes): `review.tsx`
+- **Thin community `Community 2385`** (1 nodes): `cost-overlay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2386`** (1 nodes): `inventory-import.test.tsx`
+- **Thin community `Community 2386`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2387`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 2387`** (1 nodes): `inventory-import.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2388`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 2388`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2389`** (1 nodes): `index.tsx`
+- **Thin community `Community 2389`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2390`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 2390`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2391`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 2391`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2392`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 2392`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2393`** (1 nodes): `index.tsx`
+- **Thin community `Community 2393`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2394`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 2394`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2395`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 2395`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2396`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 2396`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2397`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 2397`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2398`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 2398`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2399`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 2399`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2400`** (1 nodes): `expense.index.test.tsx`
+- **Thin community `Community 2400`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2401`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 2401`** (1 nodes): `expense.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2402`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 2402`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2403`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 2403`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2404`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 2404`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2405`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 2405`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2406`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 2406`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2407`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 2407`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2408`** (1 nodes): `edit.tsx`
+- **Thin community `Community 2408`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2409`** (1 nodes): `index.tsx`
+- **Thin community `Community 2409`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2410`** (1 nodes): `archived.tsx`
+- **Thin community `Community 2410`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2411`** (1 nodes): `new.tsx`
+- **Thin community `Community 2411`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 2412`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2413`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 2413`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2414`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 2414`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2415`** (1 nodes): `index.tsx`
+- **Thin community `Community 2415`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2416`** (1 nodes): `new.tsx`
+- **Thin community `Community 2416`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2417`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2417`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2418`** (1 nodes): `$productSkuId.test.ts`
+- **Thin community `Community 2418`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2419`** (1 nodes): `index.test.ts`
+- **Thin community `Community 2419`** (1 nodes): `$productSkuId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2420`** (1 nodes): `items.tsx`
+- **Thin community `Community 2420`** (1 nodes): `index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2421`** (1 nodes): `reports.tsx`
+- **Thin community `Community 2421`** (1 nodes): `items.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2422`** (1 nodes): `index.tsx`
+- **Thin community `Community 2422`** (1 nodes): `reports.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2423`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 2423`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2424`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 2424`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2425`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 2425`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2426`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 2426`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2427`** (1 nodes): `index.tsx`
+- **Thin community `Community 2427`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2428`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 2428`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2429`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 2429`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2430`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 2430`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2431`** (1 nodes): `index.tsx`
+- **Thin community `Community 2431`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2432`** (1 nodes): `_authed-shell.test.tsx`
+- **Thin community `Community 2432`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2433`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 2433`** (1 nodes): `_authed-shell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2434`** (1 nodes): `app.route.test.tsx`
+- **Thin community `Community 2434`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2435`** (1 nodes): `app.test.tsx`
+- **Thin community `Community 2435`** (1 nodes): `app.route.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2436`** (1 nodes): `app.tsx`
+- **Thin community `Community 2436`** (1 nodes): `app.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2437`** (1 nodes): `demo.test.tsx`
+- **Thin community `Community 2437`** (1 nodes): `app.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2438`** (1 nodes): `demo.tsx`
+- **Thin community `Community 2438`** (1 nodes): `demo.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2439`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 2439`** (1 nodes): `demo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2440`** (1 nodes): `index.tsx`
+- **Thin community `Community 2440`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2441`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 2441`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2442`** (1 nodes): `landing.tsx`
+- **Thin community `Community 2442`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2443`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 2443`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2444`** (1 nodes): `_layout.index.tsx`
+- **Thin community `Community 2444`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2445`** (1 nodes): `_layout.tsx`
+- **Thin community `Community 2445`** (1 nodes): `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2446`** (1 nodes): `privacy.test.tsx`
+- **Thin community `Community 2446`** (1 nodes): `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2447`** (1 nodes): `privacy.tsx`
+- **Thin community `Community 2447`** (1 nodes): `privacy.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2448`** (1 nodes): `register-interest.tsx`
+- **Thin community `Community 2448`** (1 nodes): `privacy.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2449`** (1 nodes): `walkthrough.test.tsx`
+- **Thin community `Community 2449`** (1 nodes): `register-interest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2450`** (1 nodes): `walkthrough.tsx`
+- **Thin community `Community 2450`** (1 nodes): `walkthrough.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2451`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 2451`** (1 nodes): `walkthrough.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2452`** (1 nodes): `expenseStore.test.ts`
+- **Thin community `Community 2452`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2453`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 2453`** (1 nodes): `expenseStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2454`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 2454`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2455`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 2455`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2456`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 2456`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2457`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 2457`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2458`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 2458`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2459`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 2459`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2460`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 2460`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2461`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 2461`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2462`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 2462`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2463`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 2463`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2464`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 2464`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2465`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 2465`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2466`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 2466`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2467`** (1 nodes): `eodReviewFixtures.ts`
+- **Thin community `Community 2467`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2468`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 2468`** (1 nodes): `eodReviewFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2469`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 2469`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2470`** (1 nodes): `setup.ts`
+- **Thin community `Community 2470`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2471`** (1 nodes): `vite-env.d.ts`
+- **Thin community `Community 2471`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2472`** (1 nodes): `viteConfig.test.ts`
+- **Thin community `Community 2472`** (1 nodes): `vite-env.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2473`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2473`** (1 nodes): `viteConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2474`** (1 nodes): `types.ts`
+- **Thin community `Community 2474`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2475`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2475`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2476`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 2476`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2477`** (1 nodes): `global.d.ts`
+- **Thin community `Community 2477`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2478`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 2478`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2479`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 2479`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2480`** (1 nodes): `homepageSnapshot.test.ts`
+- **Thin community `Community 2480`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2481`** (1 nodes): `trackingEvents.test.ts`
+- **Thin community `Community 2481`** (1 nodes): `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2482`** (1 nodes): `types.ts`
+- **Thin community `Community 2482`** (1 nodes): `trackingEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2483`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 2483`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2484`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 2484`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2485`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 2485`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2486`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 2486`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2487`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 2487`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2488`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 2488`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2489`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 2489`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2490`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 2490`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2491`** (1 nodes): `schema.ts`
+- **Thin community `Community 2491`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2492`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 2492`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2493`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 2493`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2494`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 2494`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2495`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 2495`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2496`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 2496`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2497`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 2497`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2498`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 2498`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2499`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 2499`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2500`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 2500`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2501`** (1 nodes): `types.ts`
+- **Thin community `Community 2501`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2502`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2502`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2503`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 2503`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2504`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 2504`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2505`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 2505`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2506`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 2506`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2507`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 2507`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2508`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 2508`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2509`** (1 nodes): `constants.ts`
+- **Thin community `Community 2509`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2510`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 2510`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2511`** (1 nodes): `About.tsx`
+- **Thin community `Community 2511`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2512`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 2512`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2513`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 2513`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2514`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 2514`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2515`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 2515`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2516`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 2516`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2517`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 2517`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2518`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 2518`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2519`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 2519`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2520`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 2520`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2521`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 2521`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2522`** (1 nodes): `types.ts`
+- **Thin community `Community 2522`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2523`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 2523`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2524`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 2524`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2525`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 2525`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2526`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 2526`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2527`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 2527`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2528`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 2528`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2529`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 2529`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2530`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 2530`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2531`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 2531`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2532`** (1 nodes): `alert.tsx`
+- **Thin community `Community 2532`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2533`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 2533`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2534`** (1 nodes): `button.tsx`
+- **Thin community `Community 2534`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2535`** (1 nodes): `card.tsx`
+- **Thin community `Community 2535`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2536`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 2536`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2537`** (1 nodes): `command.tsx`
+- **Thin community `Community 2537`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2538`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 2538`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2539`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 2539`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2540`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 2540`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2541`** (1 nodes): `form.tsx`
+- **Thin community `Community 2541`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2542`** (1 nodes): `icons.tsx`
+- **Thin community `Community 2542`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2543`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 2543`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2544`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 2544`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2545`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 2545`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2546`** (1 nodes): `input.tsx`
+- **Thin community `Community 2546`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2547`** (1 nodes): `label.tsx`
+- **Thin community `Community 2547`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2548`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 2548`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2549`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 2549`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2550`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 2550`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2551`** (1 nodes): `index.ts`
+- **Thin community `Community 2551`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2552`** (1 nodes): `types.ts`
+- **Thin community `Community 2552`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2553`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 2553`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2554`** (1 nodes): `popover.tsx`
+- **Thin community `Community 2554`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2555`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 2555`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2556`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 2556`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2557`** (1 nodes): `select.tsx`
+- **Thin community `Community 2557`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2558`** (1 nodes): `separator.tsx`
+- **Thin community `Community 2558`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2559`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 2559`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2560`** (1 nodes): `table.tsx`
+- **Thin community `Community 2560`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2561`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 2561`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2562`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 2562`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2563`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 2563`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2564`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 2564`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2565`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 2565`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2566`** (1 nodes): `config.ts`
+- **Thin community `Community 2566`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2567`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
+- **Thin community `Community 2567`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2568`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 2568`** (1 nodes): `StorefrontObservabilityProvider.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2569`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 2569`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2570`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 2570`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2571`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 2571`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2572`** (1 nodes): `constants.ts`
+- **Thin community `Community 2572`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2573`** (1 nodes): `countries.ts`
+- **Thin community `Community 2573`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2574`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 2574`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2575`** (1 nodes): `ghana.ts`
+- **Thin community `Community 2575`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2576`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 2576`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2577`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 2577`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2578`** (1 nodes): `index.ts`
+- **Thin community `Community 2578`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2579`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 2579`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2580`** (1 nodes): `store.ts`
+- **Thin community `Community 2580`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2581`** (1 nodes): `bag.ts`
+- **Thin community `Community 2581`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2582`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 2582`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2583`** (1 nodes): `category.ts`
+- **Thin community `Community 2583`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2584`** (1 nodes): `organization.ts`
+- **Thin community `Community 2584`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2585`** (1 nodes): `product.ts`
+- **Thin community `Community 2585`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2586`** (1 nodes): `store.ts`
+- **Thin community `Community 2586`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2587`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 2587`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2588`** (1 nodes): `user.ts`
+- **Thin community `Community 2588`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2589`** (1 nodes): `states.ts`
+- **Thin community `Community 2589`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2590`** (1 nodes): `storefrontContextEvents.test.ts`
+- **Thin community `Community 2590`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2591`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 2591`** (1 nodes): `storefrontContextEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2592`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 2592`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2593`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 2593`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2594`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 2594`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2595`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 2595`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2596`** (1 nodes): `__root.tsx`
+- **Thin community `Community 2596`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2597`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 2597`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2598`** (1 nodes): `index.tsx`
+- **Thin community `Community 2598`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2599`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 2599`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2600`** (1 nodes): `index.tsx`
+- **Thin community `Community 2600`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2601`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 2601`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2602`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 2602`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2603`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 2603`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2604`** (1 nodes): `complete.tsx`
+- **Thin community `Community 2604`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2605`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 2605`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2606`** (1 nodes): `index.tsx`
+- **Thin community `Community 2606`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2607`** (1 nodes): `pending.tsx`
+- **Thin community `Community 2607`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2608`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 2608`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2609`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 2609`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2610`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 2610`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2611`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 2611`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2612`** (1 nodes): `index.js`
+- **Thin community `Community 2612`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2613`** (1 nodes): `check-register-session-authority-writers.test.ts`
+- **Thin community `Community 2613`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2614`** (1 nodes): `delivery-documentation-check.test.ts`
+- **Thin community `Community 2614`** (1 nodes): `check-register-session-authority-writers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2615`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 2615`** (1 nodes): `delivery-documentation-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2616`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 2616`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2617`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 2617`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2618`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 2618`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2619`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 2619`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2620`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 2620`** (1 nodes): `harness-behavior-scenarios.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2621`** (1 nodes): `operational-work-repair.test.ts`
+- **Thin community `Community 2621`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2622`** (1 nodes): `background.js`
+- **Thin community `Community 2622`** (1 nodes): `operational-work-repair.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 2623`** (1 nodes): `popup.js`
+- **Thin community `Community 2623`** (1 nodes): `background.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 2624`** (1 nodes): `popup.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -93791,7 +93791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L1026",
+      "source_location": "L1092",
       "target": "reportdayspanel_test_constructor",
       "weight": 1
     },
@@ -93803,7 +93803,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L245",
+      "source_location": "L260",
       "target": "reportdayspanel_cn",
       "weight": 1
     },
@@ -93815,7 +93815,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L138",
+      "source_location": "L139",
       "target": "reportdayspanel_isinselectedrange",
       "weight": 1
     },
@@ -93827,7 +93827,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L136",
+      "source_location": "L137",
       "target": "reportdayspanel_isselectedday",
       "weight": 1
     },
@@ -93851,7 +93851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L140",
+      "source_location": "L141",
       "target": "reportdayspanel_selectday",
       "weight": 1
     },
@@ -134075,7 +134075,7 @@
       "relation": "calls",
       "source": "reportdayspanel_isselectedday",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L142",
+      "source_location": "L143",
       "target": "reportdayspanel_selectday",
       "weight": 1
     },
@@ -173137,7 +173137,7 @@
       "label": "constructor()",
       "norm_label": "constructor()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L610"
+      "source_location": "L676"
     },
     {
       "community": 1277,
@@ -225805,7 +225805,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L212"
+      "source_location": "L227"
     },
     {
       "community": 434,
@@ -225814,7 +225814,7 @@
       "label": "isInSelectedRange()",
       "norm_label": "isinselectedrange()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L138"
+      "source_location": "L139"
     },
     {
       "community": 434,
@@ -225823,7 +225823,7 @@
       "label": "isSelectedDay()",
       "norm_label": "isselectedday()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L136"
+      "source_location": "L137"
     },
     {
       "community": 434,
@@ -225841,7 +225841,7 @@
       "label": "selectDay()",
       "norm_label": "selectday()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L140"
+      "source_location": "L141"
     },
     {
       "community": 435,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -13895,7 +13895,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getdailyoperationsapi",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4814",
+      "source_location": "L4815",
       "target": "dailyoperationsview_dailyoperationsconnectedruntimeview",
       "weight": 1
     },
@@ -13979,7 +13979,7 @@
       "relation": "calls",
       "source": "dailyoperationsview_getsaturdayweekendoperatingdate",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4517",
+      "source_location": "L4518",
       "target": "dailyoperationsview_handleoperatingdatechange",
       "weight": 1
     },
@@ -23327,7 +23327,7 @@
       "relation": "calls",
       "source": "index_isodateoffset",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx",
-      "source_location": "L59",
+      "source_location": "L62",
       "target": "index_reportsoverviewroute",
       "weight": 1
     },
@@ -68099,7 +68099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L928",
+      "source_location": "L930",
       "target": "queries_test_seedrange",
       "weight": 1
     },
@@ -68147,7 +68147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L724",
+      "source_location": "L726",
       "target": "queries_test_seedskuday",
       "weight": 1
     },
@@ -68171,7 +68171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L547",
+      "source_location": "L560",
       "target": "queries_cleanmetadatavalue",
       "weight": 1
     },
@@ -68183,7 +68183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L302",
+      "source_location": "L303",
       "target": "queries_decodecursor",
       "weight": 1
     },
@@ -68195,7 +68195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L298",
+      "source_location": "L299",
       "target": "queries_encodecursor",
       "weight": 1
     },
@@ -68207,7 +68207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L41",
+      "source_location": "L42",
       "target": "queries_inclusivedayspan",
       "weight": 1
     },
@@ -68219,7 +68219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L342",
+      "source_location": "L343",
       "target": "queries_livepostransactioncount",
       "weight": 1
     },
@@ -68231,7 +68231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L47",
+      "source_location": "L48",
       "target": "queries_requirevaliddaterange",
       "weight": 1
     },
@@ -68243,7 +68243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L554",
+      "source_location": "L567",
       "target": "queries_resolveskuidentity",
       "weight": 1
     },
@@ -68255,7 +68255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L808",
+      "source_location": "L821",
       "target": "queries_sum",
       "weight": 1
     },
@@ -68267,7 +68267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L57",
+      "source_location": "L58",
       "target": "queries_toreportdayrow",
       "weight": 1
     },
@@ -68279,7 +68279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L79",
+      "source_location": "L80",
       "target": "queries_toskuperiodrow",
       "weight": 1
     },
@@ -68291,7 +68291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L331",
+      "source_location": "L332",
       "target": "queries_transactioncountfromclosesummary",
       "weight": 1
     },
@@ -68303,7 +68303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_queries_ts",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L587",
+      "source_location": "L600",
       "target": "queries_withskuidentity",
       "weight": 1
     },
@@ -77735,7 +77735,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L210",
+      "source_location": "L222",
       "target": "reportscontract_dayperiodkey",
       "weight": 1
     },
@@ -77747,8 +77747,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L254",
+      "source_location": "L266",
       "target": "reportscontract_descendingsortkey",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_shared_reportscontract_ts",
+      "_tgt": "reportscontract_isreportingtodayinprogress",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_shared_reportscontract_ts",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L55",
+      "target": "reportscontract_isreportingtodayinprogress",
       "weight": 1
     },
     {
@@ -77759,7 +77771,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L214",
+      "source_location": "L226",
       "target": "reportscontract_monthperiodkey",
       "weight": 1
     },
@@ -77771,7 +77783,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L264",
+      "source_location": "L276",
       "target": "reportscontract_normalizecurrencycode",
       "weight": 1
     },
@@ -77783,7 +77795,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L243",
+      "source_location": "L255",
       "target": "reportscontract_periodkeysforoperatingdate",
       "weight": 1
     },
@@ -77795,7 +77807,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L219",
+      "source_location": "L231",
       "target": "reportscontract_trailingthreemonthsstart",
       "weight": 1
     },
@@ -77807,7 +77819,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_shared_reportscontract_ts",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L233",
+      "source_location": "L245",
       "target": "reportscontract_weekperiodkey",
       "weight": 1
     },
@@ -84275,7 +84287,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L3643",
+      "source_location": "L3644",
       "target": "dailyoperationsview_cn",
       "weight": 1
     },
@@ -84287,7 +84299,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4807",
+      "source_location": "L4808",
       "target": "dailyoperationsview_dailyoperationsconnectedruntimeview",
       "weight": 1
     },
@@ -84299,7 +84311,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4855",
+      "source_location": "L4856",
       "target": "dailyoperationsview_dailyoperationsruntimeview",
       "weight": 1
     },
@@ -84503,7 +84515,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L3551",
+      "source_location": "L3552",
       "target": "dailyoperationsview_getworkflowsearch",
       "weight": 1
     },
@@ -84515,7 +84527,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4515",
+      "source_location": "L4516",
       "target": "dailyoperationsview_handleoperatingdatechange",
       "weight": 1
     },
@@ -84527,7 +84539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4529",
+      "source_location": "L4530",
       "target": "dailyoperationsview_handletimelinesheetopenchange",
       "weight": 1
     },
@@ -93779,7 +93791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L847",
+      "source_location": "L1026",
       "target": "reportdayspanel_test_constructor",
       "weight": 1
     },
@@ -93791,8 +93803,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L212",
+      "source_location": "L245",
       "target": "reportdayspanel_cn",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
+      "_tgt": "reportdayspanel_isinselectedrange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
+      "source_location": "L138",
+      "target": "reportdayspanel_isinselectedrange",
       "weight": 1
     },
     {
@@ -93803,8 +93827,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L112",
+      "source_location": "L136",
       "target": "reportdayspanel_isselectedday",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
+      "_tgt": "reportdayspanel_pagecontainingdate",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
+      "source_location": "L31",
+      "target": "reportdayspanel_pagecontainingdate",
       "weight": 1
     },
     {
@@ -93815,7 +93851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L114",
+      "source_location": "L140",
       "target": "reportdayspanel_selectday",
       "weight": 1
     },
@@ -94007,7 +94043,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L50",
+      "source_location": "L52",
       "target": "reportperiodkeys_addoperatingdays",
       "weight": 1
     },
@@ -94019,7 +94055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L84",
+      "source_location": "L117",
       "target": "reportperiodkeys_daterangeforitemsperiod",
       "weight": 1
     },
@@ -94031,7 +94067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L62",
+      "source_location": "L95",
       "target": "reportperiodkeys_daterangeforoverviewwindow",
       "weight": 1
     },
@@ -94043,7 +94079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L56",
+      "source_location": "L89",
       "target": "reportperiodkeys_isoweekstart",
       "weight": 1
     },
@@ -94055,7 +94091,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L42",
+      "source_location": "L44",
       "target": "reportperiodkeys_operatingdatetoutc",
       "weight": 1
     },
@@ -94067,8 +94103,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L108",
+      "source_location": "L141",
       "target": "reportperiodkeys_periodkeyforselection",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
+      "_tgt": "reportperiodkeys_tablerangeincludingselection",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L63",
+      "target": "reportperiodkeys_tablerangeincludingselection",
       "weight": 1
     },
     {
@@ -94079,7 +94127,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L123",
+      "source_location": "L156",
       "target": "reportperiodkeys_todayoperatingdateguess",
       "weight": 1
     },
@@ -94091,7 +94139,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L46",
+      "source_location": "L48",
       "target": "reportperiodkeys_utctooperatingdate",
       "weight": 1
     },
@@ -94151,7 +94199,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsitemsperformance_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsItemsPerformance.tsx",
-      "source_location": "L177",
+      "source_location": "L207",
       "target": "reportsitemsperformance_cn",
       "weight": 1
     },
@@ -94175,7 +94223,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsitemsview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsItemsView.tsx",
-      "source_location": "L57",
+      "source_location": "L62",
       "target": "reportsitemsview_handlepagechange",
       "weight": 1
     },
@@ -94283,7 +94331,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx",
-      "source_location": "L119",
+      "source_location": "L134",
       "target": "reportsoverviewview_test_harness",
       "weight": 1
     },
@@ -94295,7 +94343,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx",
-      "source_location": "L363",
+      "source_location": "L404",
       "target": "reportsoverviewview_test_linkedrange",
       "weight": 1
     },
@@ -94307,7 +94355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx",
-      "source_location": "L75",
+      "source_location": "L82",
       "target": "reportsoverviewview_test_snapshot",
       "weight": 1
     },
@@ -94319,7 +94367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsoverviewview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx",
-      "source_location": "L111",
+      "source_location": "L115",
       "target": "reportsoverviewview_cn",
       "weight": 1
     },
@@ -94331,7 +94379,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_reports_reportsoverviewview_tsx",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx",
-      "source_location": "L29",
+      "source_location": "L32",
       "target": "reportsoverviewview_comparisonfor",
       "weight": 1
     },
@@ -114179,7 +114227,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
-      "source_location": "L14",
+      "source_location": "L21",
       "target": "index_dailyoperationsroute",
       "weight": 1
     },
@@ -114491,7 +114539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_index_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx",
-      "source_location": "L29",
+      "source_location": "L32",
       "target": "index_isodateoffset",
       "weight": 1
     },
@@ -114503,7 +114551,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_index_tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx",
-      "source_location": "L42",
+      "source_location": "L45",
       "target": "index_reportsoverviewroute",
       "weight": 1
     },
@@ -129635,7 +129683,7 @@
       "relation": "calls",
       "source": "queries_inclusivedayspan",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L51",
+      "source_location": "L52",
       "target": "queries_requirevaliddaterange",
       "weight": 1
     },
@@ -129647,7 +129695,7 @@
       "relation": "calls",
       "source": "queries_cleanmetadatavalue",
       "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L564",
+      "source_location": "L577",
       "target": "queries_resolveskuidentity",
       "weight": 1
     },
@@ -134027,7 +134075,7 @@
       "relation": "calls",
       "source": "reportdayspanel_isselectedday",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L116",
+      "source_location": "L142",
       "target": "reportdayspanel_selectday",
       "weight": 1
     },
@@ -134111,7 +134159,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_operatingdatetoutc",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L51",
+      "source_location": "L53",
       "target": "reportperiodkeys_addoperatingdays",
       "weight": 1
     },
@@ -134123,7 +134171,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_utctooperatingdate",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L53",
+      "source_location": "L55",
       "target": "reportperiodkeys_addoperatingdays",
       "weight": 1
     },
@@ -134135,7 +134183,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_addoperatingdays",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L93",
+      "source_location": "L126",
       "target": "reportperiodkeys_daterangeforitemsperiod",
       "weight": 1
     },
@@ -134147,7 +134195,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_isoweekstart",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L92",
+      "source_location": "L125",
       "target": "reportperiodkeys_daterangeforitemsperiod",
       "weight": 1
     },
@@ -134159,7 +134207,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_operatingdatetoutc",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L96",
+      "source_location": "L129",
       "target": "reportperiodkeys_daterangeforitemsperiod",
       "weight": 1
     },
@@ -134171,7 +134219,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_utctooperatingdate",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L100",
+      "source_location": "L133",
       "target": "reportperiodkeys_daterangeforitemsperiod",
       "weight": 1
     },
@@ -134183,7 +134231,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_addoperatingdays",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L73",
+      "source_location": "L106",
       "target": "reportperiodkeys_daterangeforoverviewwindow",
       "weight": 1
     },
@@ -134195,7 +134243,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_isoweekstart",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L70",
+      "source_location": "L103",
       "target": "reportperiodkeys_daterangeforoverviewwindow",
       "weight": 1
     },
@@ -134207,7 +134255,7 @@
       "relation": "calls",
       "source": "reportperiodkeys_addoperatingdays",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L59",
+      "source_location": "L92",
       "target": "reportperiodkeys_isoweekstart",
       "weight": 1
     },
@@ -134219,8 +134267,20 @@
       "relation": "calls",
       "source": "reportperiodkeys_operatingdatetoutc",
       "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L57",
+      "source_location": "L90",
       "target": "reportperiodkeys_isoweekstart",
+      "weight": 1
+    },
+    {
+      "_src": "reportperiodkeys_tablerangeincludingselection",
+      "_tgt": "reportperiodkeys_operatingdatetoutc",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "reportperiodkeys_operatingdatetoutc",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L79",
+      "target": "reportperiodkeys_tablerangeincludingselection",
       "weight": 1
     },
     {
@@ -134231,7 +134291,7 @@
       "relation": "calls",
       "source": "reportscontract_dayperiodkey",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L247",
+      "source_location": "L259",
       "target": "reportscontract_periodkeysforoperatingdate",
       "weight": 1
     },
@@ -134243,7 +134303,7 @@
       "relation": "calls",
       "source": "reportscontract_monthperiodkey",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L249",
+      "source_location": "L261",
       "target": "reportscontract_periodkeysforoperatingdate",
       "weight": 1
     },
@@ -134255,7 +134315,7 @@
       "relation": "calls",
       "source": "reportscontract_weekperiodkey",
       "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L248",
+      "source_location": "L260",
       "target": "reportscontract_periodkeysforoperatingdate",
       "weight": 1
     },
@@ -173077,7 +173137,7 @@
       "label": "constructor()",
       "norm_label": "constructor()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx",
-      "source_location": "L431"
+      "source_location": "L610"
     },
     {
       "community": 1277,
@@ -173311,7 +173371,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsItemsPerformance.tsx",
-      "source_location": "L177"
+      "source_location": "L93"
     },
     {
       "community": 1282,
@@ -173347,7 +173407,7 @@
       "label": "handlePageChange()",
       "norm_label": "handlepagechange()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsItemsView.tsx",
-      "source_location": "L57"
+      "source_location": "L62"
     },
     {
       "community": 1284,
@@ -178981,7 +179041,7 @@
       "label": "DailyOperationsRoute()",
       "norm_label": "dailyoperationsroute()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
-      "source_location": "L14"
+      "source_location": "L21"
     },
     {
       "community": 1438,
@@ -184917,119 +184977,119 @@
     {
       "community": 161,
       "file_type": "code",
-      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
-      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
-      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L321"
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "backfillstoreschedules_buildbackfillrow",
-      "label": "buildBackfillRow()",
-      "norm_label": "buildbackfillrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L185"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "backfillstoreschedules_buildcandidateweeklywindows",
-      "label": "buildCandidateWeeklyWindows()",
-      "norm_label": "buildcandidateweeklywindows()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L161"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "backfillstoreschedules_compatibilitymetadata",
-      "label": "compatibilityMetadata()",
-      "norm_label": "compatibilitymetadata()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L133"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "backfillstoreschedules_compatibilityonlyrow",
-      "label": "compatibilityOnlyRow()",
-      "norm_label": "compatibilityonlyrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L172"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "backfillstoreschedules_findexistingscheduletoskip",
-      "label": "findExistingScheduleToSkip()",
-      "norm_label": "findexistingscheduletoskip()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L114"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "backfillstoreschedules_firstpolicy",
-      "label": "firstPolicy()",
-      "norm_label": "firstpolicy()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 161,
+      "file_type": "code",
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L75"
     },
     {
       "community": 161,
       "file_type": "code",
-      "id": "backfillstoreschedules_isvalidminute",
-      "label": "isValidMinute()",
-      "norm_label": "isvalidminute()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listpoliciesforstoreaction",
-      "label": "listPoliciesForStoreAction()",
-      "norm_label": "listpoliciesforstoreaction()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "backfillstoreschedules_listschedulesforstorebystatus",
-      "label": "listSchedulesForStoreByStatus()",
-      "norm_label": "listschedulesforstorebystatus()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "backfillstoreschedules_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "backfillstoreschedules_trustedtimezoneforstore",
-      "label": "trustedTimezoneForStore()",
-      "norm_label": "trustedtimezoneforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 161,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
-      "label": "backfillStoreSchedules.ts",
-      "norm_label": "backfillstoreschedules.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
-      "source_location": "L1"
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 1610,
@@ -185124,119 +185184,119 @@
     {
       "community": 162,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
-      "label": "readDefinitions.ts",
-      "norm_label": "readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "id": "backfillstoreschedules_backfillstoreschedulesfromlegacypolicywithctx",
+      "label": "backfillStoreSchedulesFromLegacyPolicyWithCtx()",
+      "norm_label": "backfillstoreschedulesfromlegacypolicywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L321"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_buildbackfillrow",
+      "label": "buildBackfillRow()",
+      "norm_label": "buildbackfillrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L185"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_buildcandidateweeklywindows",
+      "label": "buildCandidateWeeklyWindows()",
+      "norm_label": "buildcandidateweeklywindows()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_compatibilitymetadata",
+      "label": "compatibilityMetadata()",
+      "norm_label": "compatibilitymetadata()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_compatibilityonlyrow",
+      "label": "compatibilityOnlyRow()",
+      "norm_label": "compatibilityonlyrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_findexistingscheduletoskip",
+      "label": "findExistingScheduleToSkip()",
+      "norm_label": "findexistingscheduletoskip()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_firstpolicy",
+      "label": "firstPolicy()",
+      "norm_label": "firstpolicy()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_isvalidminute",
+      "label": "isValidMinute()",
+      "norm_label": "isvalidminute()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listpoliciesforstoreaction",
+      "label": "listPoliciesForStoreAction()",
+      "norm_label": "listpoliciesforstoreaction()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_listschedulesforstorebystatus",
+      "label": "listSchedulesForStoreByStatus()",
+      "norm_label": "listschedulesforstorebystatus()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "backfillstoreschedules_trustedtimezoneforstore",
+      "label": "trustedTimezoneForStore()",
+      "norm_label": "trustedtimezoneforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 162,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoreschedules_ts",
+      "label": "backfillStoreSchedules.ts",
+      "norm_label": "backfillstoreschedules.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreSchedules.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_definecashcontrolsread",
-      "label": "defineCashControlsRead()",
-      "norm_label": "definecashcontrolsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_definedailycloseread",
-      "label": "defineDailyCloseRead()",
-      "norm_label": "definedailycloseread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_definedailyoperationsread",
-      "label": "defineDailyOperationsRead()",
-      "norm_label": "definedailyoperationsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycatalogread",
-      "label": "defineInventoryCatalogRead()",
-      "norm_label": "defineinventorycatalogread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_defineinventorycostoverlayread",
-      "label": "defineInventoryCostOverlayRead()",
-      "norm_label": "defineinventorycostoverlayread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L639"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_defineonlineordersread",
-      "label": "defineOnlineOrdersRead()",
-      "norm_label": "defineonlineordersread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_defineoperationalworkread",
-      "label": "defineOperationalWorkRead()",
-      "norm_label": "defineoperationalworkread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_defineorganizationread",
-      "label": "defineOrganizationRead()",
-      "norm_label": "defineorganizationread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_defineposread",
-      "label": "definePosRead()",
-      "norm_label": "defineposread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_definereadoperation",
-      "label": "defineReadOperation()",
-      "norm_label": "definereadoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_definestockadjustmentsread",
-      "label": "defineStockAdjustmentsRead()",
-      "norm_label": "definestockadjustmentsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 162,
-      "file_type": "code",
-      "id": "readdefinitions_validatereadoperationdefinition",
-      "label": "validateReadOperationDefinition()",
-      "norm_label": "validatereadoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
-      "source_location": "L753"
     },
     {
       "community": 1620,
@@ -185331,119 +185391,119 @@
     {
       "community": 163,
       "file_type": "code",
-      "id": "frozenmetricauthority_closecandidateoperatingrange",
-      "label": "closeCandidateOperatingRange()",
-      "norm_label": "closecandidateoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_emptyclosesummary",
-      "label": "emptyCloseSummary()",
-      "norm_label": "emptyclosesummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_exactstatuses",
-      "label": "exactStatuses()",
-      "norm_label": "exactstatuses()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_finitenumber",
-      "label": "finiteNumber()",
-      "norm_label": "finitenumber()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
-      "label": "frozenFinancialSourceCounts()",
-      "norm_label": "frozenfinancialsourcecounts()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_frozenweekmetricfordate",
-      "label": "frozenWeekMetricForDate()",
-      "norm_label": "frozenweekmetricfordate()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L481"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
-      "label": "matchesRequestedOperatingRange()",
-      "norm_label": "matchesrequestedoperatingrange()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
-      "label": "normalizeFrozenPaymentTotals()",
-      "norm_label": "normalizefrozenpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_recordvalue",
-      "label": "recordValue()",
-      "norm_label": "recordvalue()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
-      "label": "resolveFrozenDailyCloseAuthority()",
-      "norm_label": "resolvefrozendailycloseauthority()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L393"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_samedailycloseid",
-      "label": "sameDailyCloseId()",
-      "norm_label": "samedailycloseid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L386"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "frozenmetricauthority_usablefrozenweeksummary",
-      "label": "usableFrozenWeekSummary()",
-      "norm_label": "usablefrozenweeksummary()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 163,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
-      "label": "frozenMetricAuthority.ts",
-      "norm_label": "frozenmetricauthority.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_readdefinitions_ts",
+      "label": "readDefinitions.ts",
+      "norm_label": "readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_definecashcontrolsread",
+      "label": "defineCashControlsRead()",
+      "norm_label": "definecashcontrolsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_definedailycloseread",
+      "label": "defineDailyCloseRead()",
+      "norm_label": "definedailycloseread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_definedailyoperationsread",
+      "label": "defineDailyOperationsRead()",
+      "norm_label": "definedailyoperationsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycatalogread",
+      "label": "defineInventoryCatalogRead()",
+      "norm_label": "defineinventorycatalogread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_defineinventorycostoverlayread",
+      "label": "defineInventoryCostOverlayRead()",
+      "norm_label": "defineinventorycostoverlayread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L639"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_defineonlineordersread",
+      "label": "defineOnlineOrdersRead()",
+      "norm_label": "defineonlineordersread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_defineoperationalworkread",
+      "label": "defineOperationalWorkRead()",
+      "norm_label": "defineoperationalworkread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_defineorganizationread",
+      "label": "defineOrganizationRead()",
+      "norm_label": "defineorganizationread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_defineposread",
+      "label": "definePosRead()",
+      "norm_label": "defineposread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_definereadoperation",
+      "label": "defineReadOperation()",
+      "norm_label": "definereadoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_definestockadjustmentsread",
+      "label": "defineStockAdjustmentsRead()",
+      "norm_label": "definestockadjustmentsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 163,
+      "file_type": "code",
+      "id": "readdefinitions_validatereadoperationdefinition",
+      "label": "validateReadOperationDefinition()",
+      "norm_label": "validatereadoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readDefinitions.ts",
+      "source_location": "L753"
     },
     {
       "community": 1630,
@@ -185538,118 +185598,118 @@
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L956"
+      "id": "frozenmetricauthority_closecandidateoperatingrange",
+      "label": "closeCandidateOperatingRange()",
+      "norm_label": "closecandidateoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L199"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1109"
+      "id": "frozenmetricauthority_emptyclosesummary",
+      "label": "emptyCloseSummary()",
+      "norm_label": "emptyclosesummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L62"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildmapping",
-      "label": "buildMapping()",
-      "norm_label": "buildmapping()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1213"
+      "id": "frozenmetricauthority_exactstatuses",
+      "label": "exactStatuses()",
+      "norm_label": "exactstatuses()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L96"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildproductsku",
-      "label": "buildProductSku()",
-      "norm_label": "buildproductsku()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1130"
+      "id": "frozenmetricauthority_finitenumber",
+      "label": "finiteNumber()",
+      "norm_label": "finitenumber()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L91"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1169"
+      "id": "frozenmetricauthority_frozenfinancialsourcecounts",
+      "label": "frozenFinancialSourceCounts()",
+      "norm_label": "frozenfinancialsourcecounts()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L133"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstaffprofile",
-      "label": "buildStaffProfile()",
-      "norm_label": "buildstaffprofile()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1065"
+      "id": "frozenmetricauthority_frozenweekmetricfordate",
+      "label": "frozenWeekMetricForDate()",
+      "norm_label": "frozenweekmetricfordate()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L481"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildstore",
-      "label": "buildStore()",
-      "norm_label": "buildstore()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1052"
+      "id": "frozenmetricauthority_matchesrequestedoperatingrange",
+      "label": "matchesRequestedOperatingRange()",
+      "norm_label": "matchesrequestedoperatingrange()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L102"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1149"
+      "id": "frozenmetricauthority_normalizefrozenpaymenttotals",
+      "label": "normalizeFrozenPaymentTotals()",
+      "norm_label": "normalizefrozenpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L241"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildtransaction",
-      "label": "buildTransaction()",
-      "norm_label": "buildtransaction()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1189"
+      "id": "frozenmetricauthority_recordvalue",
+      "label": "recordValue()",
+      "norm_label": "recordvalue()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L85"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_buildworkitem",
-      "label": "buildWorkItem()",
-      "norm_label": "buildworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L1079"
+      "id": "frozenmetricauthority_resolvefrozendailycloseauthority",
+      "label": "resolveFrozenDailyCloseAuthority()",
+      "norm_label": "resolvefrozendailycloseauthority()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L393"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_defaultargs",
-      "label": "defaultArgs()",
-      "norm_label": "defaultargs()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L909"
+      "id": "frozenmetricauthority_samedailycloseid",
+      "label": "sameDailyCloseId()",
+      "norm_label": "samedailycloseid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L386"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "openworkinventoryreviews_test_expectrejectedcontext",
-      "label": "expectRejectedContext()",
-      "norm_label": "expectrejectedcontext()",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
-      "source_location": "L891"
+      "id": "frozenmetricauthority_usablefrozenweeksummary",
+      "label": "usableFrozenWeekSummary()",
+      "norm_label": "usablefrozenweeksummary()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
+      "source_location": "L273"
     },
     {
       "community": 164,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
-      "label": "openWorkInventoryReviews.test.ts",
-      "norm_label": "openworkinventoryreviews.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyoperations_frozenmetricauthority_ts",
+      "label": "frozenMetricAuthority.ts",
+      "norm_label": "frozenmetricauthority.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyOperations/frozenMetricAuthority.ts",
       "source_location": "L1"
     },
     {
@@ -185745,118 +185805,118 @@
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_approvalrequesttransactionid",
-      "label": "approvalRequestTransactionId()",
-      "norm_label": "approvalrequesttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L400"
+      "id": "openworkinventoryreviews_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L956"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_authorizeoperationalworksummaryread",
-      "label": "authorizeOperationalWorkSummaryRead()",
-      "norm_label": "authorizeoperationalworksummaryread()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L62"
+      "id": "openworkinventoryreviews_test_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1109"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_buildoperationalworkitem",
-      "label": "buildOperationalWorkItem()",
-      "norm_label": "buildoperationalworkitem()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L487"
+      "id": "openworkinventoryreviews_test_buildmapping",
+      "label": "buildMapping()",
+      "norm_label": "buildmapping()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1213"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_createoperationalworkitemwithctx",
-      "label": "createOperationalWorkItemWithCtx()",
-      "norm_label": "createoperationalworkitemwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L514"
+      "id": "openworkinventoryreviews_test_buildproductsku",
+      "label": "buildProductSku()",
+      "norm_label": "buildproductsku()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1130"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_filterarchivedpendingcheckoutworkitems",
-      "label": "filterArchivedPendingCheckoutWorkItems()",
-      "norm_label": "filterarchivedpendingcheckoutworkitems()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L86"
+      "id": "openworkinventoryreviews_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1169"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_formatregistersyncreviewtitle",
-      "label": "formatRegisterSyncReviewTitle()",
-      "norm_label": "formatregistersyncreviewtitle()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L481"
+      "id": "openworkinventoryreviews_test_buildstaffprofile",
+      "label": "buildStaffProfile()",
+      "norm_label": "buildstaffprofile()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1065"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_metadataarraycount",
-      "label": "metadataArrayCount()",
-      "norm_label": "metadataarraycount()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L133"
+      "id": "openworkinventoryreviews_test_buildstore",
+      "label": "buildStore()",
+      "norm_label": "buildstore()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1052"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_metadatanumber",
-      "label": "metadataNumber()",
-      "norm_label": "metadatanumber()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L125"
+      "id": "openworkinventoryreviews_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1149"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_projectoperationalworkitemforqueue",
-      "label": "projectOperationalWorkItemForQueue()",
-      "norm_label": "projectoperationalworkitemforqueue()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L370"
+      "id": "openworkinventoryreviews_test_buildtransaction",
+      "label": "buildTransaction()",
+      "norm_label": "buildtransaction()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1189"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_sanitizeapprovalrequestmetadata",
-      "label": "sanitizeApprovalRequestMetadata()",
-      "norm_label": "sanitizeapprovalrequestmetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L425"
+      "id": "openworkinventoryreviews_test_buildworkitem",
+      "label": "buildWorkItem()",
+      "norm_label": "buildworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L1079"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_sanitizeoperationalworkitemdetails",
-      "label": "sanitizeOperationalWorkItemDetails()",
-      "norm_label": "sanitizeoperationalworkitemdetails()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L293"
+      "id": "openworkinventoryreviews_test_defaultargs",
+      "label": "defaultArgs()",
+      "norm_label": "defaultargs()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L909"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
-      "label": "updateOperationalWorkItemStatusWithCtx()",
-      "norm_label": "updateoperationalworkitemstatuswithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
-      "source_location": "L549"
+      "id": "openworkinventoryreviews_test_expectrejectedcontext",
+      "label": "expectRejectedContext()",
+      "norm_label": "expectrejectedcontext()",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
+      "source_location": "L891"
     },
     {
       "community": 165,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
-      "label": "operationalWorkItems.ts",
-      "norm_label": "operationalworkitems.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "id": "packages_athena_webapp_convex_operations_openworkinventoryreviews_test_ts",
+      "label": "openWorkInventoryReviews.test.ts",
+      "norm_label": "openworkinventoryreviews.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/openWorkInventoryReviews.test.ts",
       "source_location": "L1"
     },
     {
@@ -185952,118 +186012,118 @@
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_createcustomer",
-      "label": "createCustomer()",
-      "norm_label": "createcustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L132"
+      "id": "operationalworkitems_approvalrequesttransactionid",
+      "label": "approvalRequestTransactionId()",
+      "norm_label": "approvalrequesttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L400"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_fullnamefromparts",
-      "label": "fullNameFromParts()",
-      "norm_label": "fullnamefromparts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L58"
+      "id": "operationalworkitems_authorizeoperationalworksummaryread",
+      "label": "authorizeOperationalWorkSummaryRead()",
+      "norm_label": "authorizeoperationalworksummaryread()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L62"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_guestresult",
-      "label": "guestResult()",
-      "norm_label": "guestresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L111"
+      "id": "operationalworkitems_buildoperationalworkitem",
+      "label": "buildOperationalWorkItem()",
+      "norm_label": "buildoperationalworkitem()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L487"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_linktoguest",
-      "label": "linkToGuest()",
-      "norm_label": "linktoguest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L348"
+      "id": "operationalworkitems_createoperationalworkitemwithctx",
+      "label": "createOperationalWorkItemWithCtx()",
+      "norm_label": "createoperationalworkitemwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L514"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_linktostorefrontuser",
-      "label": "linkToStoreFrontUser()",
-      "norm_label": "linktostorefrontuser()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L290"
+      "id": "operationalworkitems_filterarchivedpendingcheckoutworkitems",
+      "label": "filterArchivedPendingCheckoutWorkItems()",
+      "norm_label": "filterarchivedpendingcheckoutworkitems()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L86"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_poscustomerresult",
-      "label": "posCustomerResult()",
-      "norm_label": "poscustomerresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L71"
+      "id": "operationalworkitems_formatregistersyncreviewtitle",
+      "label": "formatRegisterSyncReviewTitle()",
+      "norm_label": "formatregistersyncreviewtitle()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L481"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_resolveguestmatch",
-      "label": "resolveGuestMatch()",
-      "norm_label": "resolveguestmatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L478"
+      "id": "operationalworkitems_metadataarraycount",
+      "label": "metadataArrayCount()",
+      "norm_label": "metadataarraycount()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L133"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_resolveposcustomerselection",
-      "label": "resolvePosCustomerSelection()",
-      "norm_label": "resolveposcustomerselection()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L267"
+      "id": "operationalworkitems_metadatanumber",
+      "label": "metadataNumber()",
+      "norm_label": "metadatanumber()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L125"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_resolvestorefrontusermatch",
-      "label": "resolveStoreFrontUserMatch()",
-      "norm_label": "resolvestorefrontusermatch()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L384"
+      "id": "operationalworkitems_projectoperationalworkitemforqueue",
+      "label": "projectOperationalWorkItemForQueue()",
+      "norm_label": "projectoperationalworkitemforqueue()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L370"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_storefrontresult",
-      "label": "storefrontResult()",
-      "norm_label": "storefrontresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L90"
+      "id": "operationalworkitems_sanitizeapprovalrequestmetadata",
+      "label": "sanitizeApprovalRequestMetadata()",
+      "norm_label": "sanitizeapprovalrequestmetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L425"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomer",
-      "label": "updateCustomer()",
-      "norm_label": "updatecustomer()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L220"
+      "id": "operationalworkitems_sanitizeoperationalworkitemdetails",
+      "label": "sanitizeOperationalWorkItemDetails()",
+      "norm_label": "sanitizeoperationalworkitemdetails()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L293"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "assigncustomer_updatecustomerstats",
-      "label": "updateCustomerStats()",
-      "norm_label": "updatecustomerstats()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
-      "source_location": "L251"
+      "id": "operationalworkitems_updateoperationalworkitemstatuswithctx",
+      "label": "updateOperationalWorkItemStatusWithCtx()",
+      "norm_label": "updateoperationalworkitemstatuswithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
+      "source_location": "L549"
     },
     {
       "community": 166,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
-      "label": "assignCustomer.ts",
-      "norm_label": "assigncustomer.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalworkitems_ts",
+      "label": "operationalWorkItems.ts",
+      "norm_label": "operationalworkitems.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalWorkItems.ts",
       "source_location": "L1"
     },
     {
@@ -186159,118 +186219,118 @@
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L97"
+      "id": "assigncustomer_createcustomer",
+      "label": "createCustomer()",
+      "norm_label": "createcustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L132"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
-      "label": "findActiveProvisionalImportSkuForStoreSku()",
-      "norm_label": "findactiveprovisionalimportskuforstoresku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L120"
+      "id": "assigncustomer_fullnamefromparts",
+      "label": "fullNameFromParts()",
+      "norm_label": "fullnamefromparts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L58"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubybarcode",
-      "label": "findStoreSkuByBarcode()",
-      "norm_label": "findstoreskubybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L62"
+      "id": "assigncustomer_guestresult",
+      "label": "guestResult()",
+      "norm_label": "guestresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L111"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_findstoreskubysku",
-      "label": "findStoreSkuBySku()",
-      "norm_label": "findstoreskubysku()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L77"
+      "id": "assigncustomer_linktoguest",
+      "label": "linkToGuest()",
+      "norm_label": "linktoguest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L348"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_getcategorybyid",
-      "label": "getCategoryById()",
-      "norm_label": "getcategorybyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L29"
+      "id": "assigncustomer_linktostorefrontuser",
+      "label": "linkToStoreFrontUser()",
+      "norm_label": "linktostorefrontuser()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L290"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_getcolorbyid",
-      "label": "getColorById()",
-      "norm_label": "getcolorbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L40"
+      "id": "assigncustomer_poscustomerresult",
+      "label": "posCustomerResult()",
+      "norm_label": "poscustomerresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L71"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_getproductbyid",
-      "label": "getProductById()",
-      "norm_label": "getproductbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L25"
+      "id": "assigncustomer_resolveguestmatch",
+      "label": "resolveGuestMatch()",
+      "norm_label": "resolveguestmatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L478"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_isconvexproductid",
-      "label": "isConvexProductId()",
-      "norm_label": "isconvexproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L11"
+      "id": "assigncustomer_resolveposcustomerselection",
+      "label": "resolvePosCustomerSelection()",
+      "norm_label": "resolveposcustomerselection()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L267"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_listmatchingstoreskus",
-      "label": "listMatchingStoreSkus()",
-      "norm_label": "listmatchingstoreskus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L140"
+      "id": "assigncustomer_resolvestorefrontusermatch",
+      "label": "resolveStoreFrontUserMatch()",
+      "norm_label": "resolvestorefrontusermatch()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L384"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_listproductskusbyproductid",
-      "label": "listProductSkusByProductId()",
-      "norm_label": "listproductskusbyproductid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L51"
+      "id": "assigncustomer_storefrontresult",
+      "label": "storefrontResult()",
+      "norm_label": "storefrontresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L90"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_normalizelookupcode",
-      "label": "normalizeLookupCode()",
-      "norm_label": "normalizelookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L92"
+      "id": "assigncustomer_updatecustomer",
+      "label": "updateCustomer()",
+      "norm_label": "updatecustomer()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L220"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "catalogrepository_readallqueryresults",
-      "label": "readAllQueryResults()",
-      "norm_label": "readallqueryresults()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
-      "source_location": "L15"
+      "id": "assigncustomer_updatecustomerstats",
+      "label": "updateCustomerStats()",
+      "norm_label": "updatecustomerstats()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
+      "source_location": "L251"
     },
     {
       "community": 167,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
-      "label": "catalogRepository.ts",
-      "norm_label": "catalogrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_ts",
+      "label": "assignCustomer.ts",
+      "norm_label": "assigncustomer.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.ts",
       "source_location": "L1"
     },
     {
@@ -186366,119 +186426,119 @@
     {
       "community": 168,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_queries_ts",
-      "label": "queries.ts",
-      "norm_label": "queries.ts",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "id": "catalogrepository_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_findactiveprovisionalimportskuforstoresku",
+      "label": "findActiveProvisionalImportSkuForStoreSku()",
+      "norm_label": "findactiveprovisionalimportskuforstoresku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_findstoreskubybarcode",
+      "label": "findStoreSkuByBarcode()",
+      "norm_label": "findstoreskubybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_findstoreskubysku",
+      "label": "findStoreSkuBySku()",
+      "norm_label": "findstoreskubysku()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_getcategorybyid",
+      "label": "getCategoryById()",
+      "norm_label": "getcategorybyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_getcolorbyid",
+      "label": "getColorById()",
+      "norm_label": "getcolorbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_getproductbyid",
+      "label": "getProductById()",
+      "norm_label": "getproductbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_isconvexproductid",
+      "label": "isConvexProductId()",
+      "norm_label": "isconvexproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_listmatchingstoreskus",
+      "label": "listMatchingStoreSkus()",
+      "norm_label": "listmatchingstoreskus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_listproductskusbyproductid",
+      "label": "listProductSkusByProductId()",
+      "norm_label": "listproductskusbyproductid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_normalizelookupcode",
+      "label": "normalizeLookupCode()",
+      "norm_label": "normalizelookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L92"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "catalogrepository_readallqueryresults",
+      "label": "readAllQueryResults()",
+      "norm_label": "readallqueryresults()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 168,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_catalogrepository_ts",
+      "label": "catalogRepository.ts",
+      "norm_label": "catalogrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/catalogRepository.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_cleanmetadatavalue",
-      "label": "cleanMetadataValue()",
-      "norm_label": "cleanmetadatavalue()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L547"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_decodecursor",
-      "label": "decodeCursor()",
-      "norm_label": "decodecursor()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L302"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_encodecursor",
-      "label": "encodeCursor()",
-      "norm_label": "encodecursor()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L298"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_livepostransactioncount",
-      "label": "livePosTransactionCount()",
-      "norm_label": "livepostransactioncount()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L342"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_requirevaliddaterange",
-      "label": "requireValidDateRange()",
-      "norm_label": "requirevaliddaterange()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_resolveskuidentity",
-      "label": "resolveSkuIdentity()",
-      "norm_label": "resolveskuidentity()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L554"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_sum",
-      "label": "sum()",
-      "norm_label": "sum()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L808"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_toreportdayrow",
-      "label": "toReportDayRow()",
-      "norm_label": "toreportdayrow()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_toskuperiodrow",
-      "label": "toSkuPeriodRow()",
-      "norm_label": "toskuperiodrow()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_transactioncountfromclosesummary",
-      "label": "transactionCountFromCloseSummary()",
-      "norm_label": "transactioncountfromclosesummary()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L331"
-    },
-    {
-      "community": 168,
-      "file_type": "code",
-      "id": "queries_withskuidentity",
-      "label": "withSkuIdentity()",
-      "norm_label": "withskuidentity()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
-      "source_location": "L587"
     },
     {
       "community": 1680,
@@ -186573,119 +186633,119 @@
     {
       "community": 169,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
-      "label": "ProductView.tsx",
-      "norm_label": "productview.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "id": "packages_athena_webapp_convex_reports_queries_ts",
+      "label": "queries.ts",
+      "norm_label": "queries.ts",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
       "source_location": "L1"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_archivedproductnestedorigin",
-      "label": "archivedProductNestedOrigin()",
-      "norm_label": "archivedproductnestedorigin()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L107"
+      "id": "queries_cleanmetadatavalue",
+      "label": "cleanMetadataValue()",
+      "norm_label": "cleanmetadatavalue()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L560"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_buildvariantskumoneypayload",
-      "label": "buildVariantSkuMoneyPayload()",
-      "norm_label": "buildvariantskumoneypayload()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L67"
+      "id": "queries_decodecursor",
+      "label": "decodeCursor()",
+      "norm_label": "decodecursor()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L303"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_createvariantsku",
-      "label": "createVariantSku()",
-      "norm_label": "createvariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L346"
+      "id": "queries_encodecursor",
+      "label": "encodeCursor()",
+      "norm_label": "encodecursor()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L299"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_decodeoriginvalue",
-      "label": "decodeOriginValue()",
-      "norm_label": "decodeoriginvalue()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L93"
+      "id": "queries_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L42"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_deleteactiveproduct",
-      "label": "deleteActiveProduct()",
-      "norm_label": "deleteactiveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L177"
+      "id": "queries_livepostransactioncount",
+      "label": "livePosTransactionCount()",
+      "norm_label": "livepostransactioncount()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L343"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_getarchivedproductredirect",
-      "label": "getArchivedProductRedirect()",
-      "norm_label": "getarchivedproductredirect()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L74"
+      "id": "queries_requirevaliddaterange",
+      "label": "requireValidDateRange()",
+      "norm_label": "requirevaliddaterange()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L48"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L506"
+      "id": "queries_resolveskuidentity",
+      "label": "resolveSkuIdentity()",
+      "norm_label": "resolveskuidentity()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L567"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_modifyproduct",
-      "label": "modifyProduct()",
-      "norm_label": "modifyproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L271"
+      "id": "queries_sum",
+      "label": "sum()",
+      "norm_label": "sum()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L821"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L490"
+      "id": "queries_toreportdayrow",
+      "label": "toReportDayRow()",
+      "norm_label": "toreportdayrow()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L58"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_resolvelegacytaxonomysavegate",
-      "label": "resolveLegacyTaxonomySaveGate()",
-      "norm_label": "resolvelegacytaxonomysavegate()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L40"
+      "id": "queries_toskuperiodrow",
+      "label": "toSkuPeriodRow()",
+      "norm_label": "toskuperiodrow()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L80"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_saveproduct",
-      "label": "saveProduct()",
-      "norm_label": "saveproduct()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L217"
+      "id": "queries_transactioncountfromclosesummary",
+      "label": "transactionCountFromCloseSummary()",
+      "norm_label": "transactioncountfromclosesummary()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L332"
     },
     {
       "community": 169,
       "file_type": "code",
-      "id": "productview_updatevariantsku",
-      "label": "updateVariantSku()",
-      "norm_label": "updatevariantsku()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
-      "source_location": "L404"
+      "id": "queries_withskuidentity",
+      "label": "withSkuIdentity()",
+      "norm_label": "withskuidentity()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.ts",
+      "source_location": "L600"
     },
     {
       "community": 1690,
@@ -187149,119 +187209,119 @@
     {
       "community": 170,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "packages_athena_webapp_src_components_add_product_productview_tsx",
+      "label": "ProductView.tsx",
+      "norm_label": "productview.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L1"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 170,
-      "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "id": "productview_archivedproductnestedorigin",
+      "label": "archivedProductNestedOrigin()",
+      "norm_label": "archivedproductnestedorigin()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
       "source_location": "L107"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "productview_buildvariantskumoneypayload",
+      "label": "buildVariantSkuMoneyPayload()",
+      "norm_label": "buildvariantskumoneypayload()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L67"
     },
     {
       "community": 170,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "productview_createvariantsku",
+      "label": "createVariantSku()",
+      "norm_label": "createvariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L346"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_decodeoriginvalue",
+      "label": "decodeOriginValue()",
+      "norm_label": "decodeoriginvalue()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L93"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_deleteactiveproduct",
+      "label": "deleteActiveProduct()",
+      "norm_label": "deleteactiveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L177"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_getarchivedproductredirect",
+      "label": "getArchivedProductRedirect()",
+      "norm_label": "getarchivedproductredirect()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L506"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_modifyproduct",
+      "label": "modifyProduct()",
+      "norm_label": "modifyproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L271"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L490"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_resolvelegacytaxonomysavegate",
+      "label": "resolveLegacyTaxonomySaveGate()",
+      "norm_label": "resolvelegacytaxonomysavegate()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L40"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_saveproduct",
+      "label": "saveProduct()",
+      "norm_label": "saveproduct()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L217"
+    },
+    {
+      "community": 170,
+      "file_type": "code",
+      "id": "productview_updatevariantsku",
+      "label": "updateVariantSku()",
+      "norm_label": "updatevariantsku()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductView.tsx",
+      "source_location": "L404"
     },
     {
       "community": 1700,
@@ -198579,92 +198639,92 @@
     {
       "community": 217,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 217,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 217,
       "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 217,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2170,
@@ -198759,92 +198819,92 @@
     {
       "community": 218,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_rail_test_ts",
-      "label": "rail.test.ts",
-      "norm_label": "rail.test.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_insertdelivery",
-      "label": "insertDelivery()",
-      "norm_label": "insertdelivery()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1495"
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_insertterminalhealthintent",
-      "label": "insertTerminalHealthIntent()",
-      "norm_label": "insertterminalhealthintent()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L99"
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_listdeliveries",
-      "label": "listDeliveries()",
-      "norm_label": "listdeliveries()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L129"
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_listoperationalevents",
-      "label": "listOperationalEvents()",
-      "norm_label": "listoperationalevents()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L133"
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_reserveone",
-      "label": "reserveOne()",
-      "norm_label": "reserveone()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L873"
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_seedorgstore",
-      "label": "seedOrgStore()",
-      "norm_label": "seedorgstore()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L58"
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_seedsweeperfixture",
-      "label": "seedSweeperFixture()",
-      "norm_label": "seedsweeperfixture()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1523"
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_seedterminal",
-      "label": "seedTerminal()",
-      "norm_label": "seedterminal()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L78"
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
     },
     {
       "community": 218,
       "file_type": "code",
-      "id": "rail_test_stubprodtransport",
-      "label": "stubProdTransport()",
-      "norm_label": "stubprodtransport()",
-      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
-      "source_location": "L1064"
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2180,
@@ -198939,92 +198999,92 @@
     {
       "community": 219,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_notifications_rail_test_ts",
+      "label": "rail.test.ts",
+      "norm_label": "rail.test.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_insertdelivery",
+      "label": "insertDelivery()",
+      "norm_label": "insertdelivery()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L1495"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_insertterminalhealthintent",
+      "label": "insertTerminalHealthIntent()",
+      "norm_label": "insertterminalhealthintent()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_listdeliveries",
+      "label": "listDeliveries()",
+      "norm_label": "listdeliveries()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_listoperationalevents",
+      "label": "listOperationalEvents()",
+      "norm_label": "listoperationalevents()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_reserveone",
+      "label": "reserveOne()",
+      "norm_label": "reserveone()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L873"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_seedorgstore",
+      "label": "seedOrgStore()",
+      "norm_label": "seedorgstore()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_seedsweeperfixture",
+      "label": "seedSweeperFixture()",
+      "norm_label": "seedsweeperfixture()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L1523"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_seedterminal",
+      "label": "seedTerminal()",
+      "norm_label": "seedterminal()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 219,
+      "file_type": "code",
+      "id": "rail_test_stubprodtransport",
+      "label": "stubProdTransport()",
+      "norm_label": "stubprodtransport()",
+      "source_file": "packages/athena-webapp/convex/notifications/rail.test.ts",
+      "source_location": "L1064"
     },
     {
       "community": 2190,
@@ -199470,91 +199530,91 @@
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 220,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -199650,91 +199710,91 @@
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 221,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -199830,91 +199890,91 @@
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 222,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -200010,92 +200070,92 @@
     {
       "community": 223,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 223,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 223,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2230,
@@ -200190,92 +200250,92 @@
     {
       "community": 224,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 224,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 224,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2240,
@@ -200370,92 +200430,92 @@
     {
       "community": 225,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 225,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L222"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
     },
     {
       "community": 225,
       "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 225,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L1"
     },
     {
       "community": 2250,
@@ -200550,92 +200610,92 @@
     {
       "community": 226,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2260,
@@ -200730,91 +200790,91 @@
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_anchordate",
-      "label": "anchorDate()",
-      "norm_label": "anchordate()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L130"
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_buildoverviewdata",
-      "label": "buildOverviewData()",
-      "norm_label": "buildoverviewdata()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L140"
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_comparisonbp",
-      "label": "comparisonBp()",
-      "norm_label": "comparisonbp()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L96"
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_emptysnapshot",
-      "label": "emptySnapshot()",
-      "norm_label": "emptysnapshot()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L48"
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_isunsettled",
-      "label": "isUnsettled()",
-      "norm_label": "isunsettled()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L53"
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_readrecentdays",
-      "label": "readRecentDays()",
-      "norm_label": "readrecentdays()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L231"
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_rebuildstoreoverview",
-      "label": "rebuildStoreOverview()",
-      "norm_label": "rebuildstoreoverview()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L245"
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_snapshotfordays",
-      "label": "snapshotForDays()",
-      "norm_label": "snapshotfordays()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L63"
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "overview_trustsummaryfordays",
-      "label": "trustSummaryForDays()",
-      "norm_label": "trustsummaryfordays()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L101"
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
     },
     {
       "community": 227,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_overview_ts",
-      "label": "overview.ts",
-      "norm_label": "overview.ts",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
     },
     {
@@ -200910,92 +200970,92 @@
     {
       "community": 228,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_queries_test_ts",
-      "label": "queries.test.ts",
-      "norm_label": "queries.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "id": "overview_anchordate",
+      "label": "anchorDate()",
+      "norm_label": "anchordate()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "overview_buildoverviewdata",
+      "label": "buildOverviewData()",
+      "norm_label": "buildoverviewdata()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "overview_comparisonbp",
+      "label": "comparisonBp()",
+      "norm_label": "comparisonbp()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "overview_emptysnapshot",
+      "label": "emptySnapshot()",
+      "norm_label": "emptysnapshot()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "overview_isunsettled",
+      "label": "isUnsettled()",
+      "norm_label": "isunsettled()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "overview_readrecentdays",
+      "label": "readRecentDays()",
+      "norm_label": "readrecentdays()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "overview_rebuildstoreoverview",
+      "label": "rebuildStoreOverview()",
+      "norm_label": "rebuildstoreoverview()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "overview_snapshotfordays",
+      "label": "snapshotForDays()",
+      "norm_label": "snapshotfordays()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "overview_trustsummaryfordays",
+      "label": "trustSummaryForDays()",
+      "norm_label": "trustsummaryfordays()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 228,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_overview_ts",
+      "label": "overview.ts",
+      "norm_label": "overview.ts",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_daymetrics",
-      "label": "dayMetrics()",
-      "norm_label": "daymetrics()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_handlerof",
-      "label": "handlerOf()",
-      "norm_label": "handlerof()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_seedday",
-      "label": "seedDay()",
-      "norm_label": "seedday()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L215"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_seedrange",
-      "label": "seedRange()",
-      "norm_label": "seedrange()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L928"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_seedreportday",
-      "label": "seedReportDay()",
-      "norm_label": "seedreportday()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L364"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_seedrollup",
-      "label": "seedRollup()",
-      "norm_label": "seedrollup()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L408"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_seedsku",
-      "label": "seedSku()",
-      "norm_label": "seedsku()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_seedskuday",
-      "label": "seedSkuDay()",
-      "norm_label": "seedskuday()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L724"
-    },
-    {
-      "community": 228,
-      "file_type": "code",
-      "id": "queries_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
-      "source_location": "L36"
     },
     {
       "community": 2280,
@@ -201090,92 +201150,92 @@
     {
       "community": 229,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_reports_queries_test_ts",
+      "label": "queries.test.ts",
+      "norm_label": "queries.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
       "source_location": "L1"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "queries_test_daymetrics",
+      "label": "dayMetrics()",
+      "norm_label": "daymetrics()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "queries_test_handlerof",
+      "label": "handlerOf()",
+      "norm_label": "handlerof()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "queries_test_seedday",
+      "label": "seedDay()",
+      "norm_label": "seedday()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "queries_test_seedrange",
+      "label": "seedRange()",
+      "norm_label": "seedrange()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L930"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "queries_test_seedreportday",
+      "label": "seedReportDay()",
+      "norm_label": "seedreportday()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L364"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "queries_test_seedrollup",
+      "label": "seedRollup()",
+      "norm_label": "seedrollup()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L408"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "queries_test_seedsku",
+      "label": "seedSku()",
+      "norm_label": "seedsku()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "queries_test_seedskuday",
+      "label": "seedSkuDay()",
+      "norm_label": "seedskuday()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L726"
+    },
+    {
+      "community": 229,
+      "file_type": "code",
+      "id": "queries_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/queries.test.ts",
+      "source_location": "L36"
     },
     {
       "community": 2290,
@@ -201337,7 +201397,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L3643"
+      "source_location": "L3644"
     },
     {
       "community": 23,
@@ -201346,7 +201406,7 @@
       "label": "DailyOperationsConnectedRuntimeView()",
       "norm_label": "dailyoperationsconnectedruntimeview()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4807"
+      "source_location": "L4808"
     },
     {
       "community": 23,
@@ -201355,7 +201415,7 @@
       "label": "DailyOperationsRuntimeView()",
       "norm_label": "dailyoperationsruntimeview()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4855"
+      "source_location": "L4856"
     },
     {
       "community": 23,
@@ -201517,7 +201577,7 @@
       "label": "handleOperatingDateChange()",
       "norm_label": "handleoperatingdatechange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4515"
+      "source_location": "L4516"
     },
     {
       "community": 23,
@@ -201526,7 +201586,7 @@
       "label": "handleTimelineSheetOpenChange()",
       "norm_label": "handletimelinesheetopenchange()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.tsx",
-      "source_location": "L4529"
+      "source_location": "L4530"
     },
     {
       "community": 23,
@@ -202692,92 +202752,92 @@
     {
       "community": 236,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
-      "label": "ProductContext.tsx",
-      "norm_label": "productcontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "id": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
+      "label": "reportPeriodKeys.ts",
+      "norm_label": "reportperiodkeys.ts",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
       "source_location": "L1"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_convertskutovariant",
-      "label": "convertSkuToVariant()",
-      "norm_label": "convertskutovariant()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L87"
+      "id": "reportperiodkeys_addoperatingdays",
+      "label": "addOperatingDays()",
+      "norm_label": "addoperatingdays()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L52"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_mergeproductdatawithactiveproductrefresh",
-      "label": "mergeProductDataWithActiveProductRefresh()",
-      "norm_label": "mergeproductdatawithactiveproductrefresh()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L114"
+      "id": "reportperiodkeys_daterangeforitemsperiod",
+      "label": "dateRangeForItemsPeriod()",
+      "norm_label": "daterangeforitemsperiod()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L117"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_mergeproductvariantswithactiveproductrefresh",
-      "label": "mergeProductVariantsWithActiveProductRefresh()",
-      "norm_label": "mergeproductvariantswithactiveproductrefresh()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L145"
+      "id": "reportperiodkeys_daterangeforoverviewwindow",
+      "label": "dateRangeForOverviewWindow()",
+      "norm_label": "daterangeforoverviewwindow()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L95"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_mergetrustedinventoryfinalizationintoproduct",
-      "label": "mergeTrustedInventoryFinalizationIntoProduct()",
-      "norm_label": "mergetrustedinventoryfinalizationintoproduct()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L219"
+      "id": "reportperiodkeys_isoweekstart",
+      "label": "isoWeekStart()",
+      "norm_label": "isoweekstart()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L89"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_mergetrustedinventoryfinalizationintovariants",
-      "label": "mergeTrustedInventoryFinalizationIntoVariants()",
-      "norm_label": "mergetrustedinventoryfinalizationintovariants()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L199"
+      "id": "reportperiodkeys_operatingdatetoutc",
+      "label": "operatingDateToUtc()",
+      "norm_label": "operatingdatetoutc()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L44"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_productprovider",
-      "label": "ProductProvider()",
-      "norm_label": "productprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L237"
+      "id": "reportperiodkeys_periodkeyforselection",
+      "label": "periodKeyForSelection()",
+      "norm_label": "periodkeyforselection()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L141"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_stripskus",
-      "label": "stripSkus()",
-      "norm_label": "stripskus()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L80"
+      "id": "reportperiodkeys_tablerangeincludingselection",
+      "label": "tableRangeIncludingSelection()",
+      "norm_label": "tablerangeincludingselection()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L63"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_useproduct",
-      "label": "useProduct()",
-      "norm_label": "useproduct()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L552"
+      "id": "reportperiodkeys_todayoperatingdateguess",
+      "label": "todayOperatingDateGuess()",
+      "norm_label": "todayoperatingdateguess()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L156"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "productcontext_valuesmatch",
-      "label": "valuesMatch()",
-      "norm_label": "valuesmatch()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
-      "source_location": "L76"
+      "id": "reportperiodkeys_utctooperatingdate",
+      "label": "utcToOperatingDate()",
+      "norm_label": "utctooperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "source_location": "L48"
     },
     {
       "community": 2360,
@@ -202872,92 +202932,92 @@
     {
       "community": 237,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
-      "label": "usePOSProducts.ts",
-      "norm_label": "useposproducts.ts",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "id": "packages_athena_webapp_src_contexts_productcontext_tsx",
+      "label": "ProductContext.tsx",
+      "norm_label": "productcontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
       "source_location": "L1"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_useposbarcodesearch",
-      "label": "usePOSBarcodeSearch()",
-      "norm_label": "useposbarcodesearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L21"
+      "id": "productcontext_convertskutovariant",
+      "label": "convertSkuToVariant()",
+      "norm_label": "convertskutovariant()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L87"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_usepospendingcheckoutitemforsale",
-      "label": "usePOSPendingCheckoutItemForSale()",
-      "norm_label": "usepospendingcheckoutitemforsale()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L46"
+      "id": "productcontext_mergeproductdatawithactiveproductrefresh",
+      "label": "mergeProductDataWithActiveProductRefresh()",
+      "norm_label": "mergeproductdatawithactiveproductrefresh()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L114"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_usepospendingcheckoutitemsforreview",
-      "label": "usePOSPendingCheckoutItemsForReview()",
-      "norm_label": "usepospendingcheckoutitemsforreview()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L49"
+      "id": "productcontext_mergeproductvariantswithactiveproductrefresh",
+      "label": "mergeProductVariantsWithActiveProductRefresh()",
+      "norm_label": "mergeproductvariantswithactiveproductrefresh()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L145"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_useposproductidsearch",
-      "label": "usePOSProductIdSearch()",
-      "norm_label": "useposproductidsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L28"
+      "id": "productcontext_mergetrustedinventoryfinalizationintoproduct",
+      "label": "mergeTrustedInventoryFinalizationIntoProduct()",
+      "norm_label": "mergetrustedinventoryfinalizationintoproduct()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L219"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_useposproductsearch",
-      "label": "usePOSProductSearch()",
-      "norm_label": "useposproductsearch()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L14"
+      "id": "productcontext_mergetrustedinventoryfinalizationintovariants",
+      "label": "mergeTrustedInventoryFinalizationIntoVariants()",
+      "norm_label": "mergetrustedinventoryfinalizationintovariants()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L199"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_useposquickaddproductsku",
-      "label": "usePOSQuickAddProductSku()",
-      "norm_label": "useposquickaddproductsku()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L44"
+      "id": "productcontext_productprovider",
+      "label": "ProductProvider()",
+      "norm_label": "productprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L237"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_useposregistercatalog",
-      "label": "usePOSRegisterCatalog()",
-      "norm_label": "useposregistercatalog()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L35"
+      "id": "productcontext_stripskus",
+      "label": "stripSkus()",
+      "norm_label": "stripskus()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L80"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_useposresolvependingcheckoutitemreview",
-      "label": "usePOSResolvePendingCheckoutItemReview()",
-      "norm_label": "useposresolvependingcheckoutitemreview()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L53"
+      "id": "productcontext_useproduct",
+      "label": "useProduct()",
+      "norm_label": "useproduct()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L552"
     },
     {
       "community": 237,
       "file_type": "code",
-      "id": "useposproducts_usepostransactioncomplete",
-      "label": "usePOSTransactionComplete()",
-      "norm_label": "usepostransactioncomplete()",
-      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
-      "source_location": "L42"
+      "id": "productcontext_valuesmatch",
+      "label": "valuesMatch()",
+      "norm_label": "valuesmatch()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.tsx",
+      "source_location": "L76"
     },
     {
       "community": 2370,
@@ -203052,92 +203112,92 @@
     {
       "community": 238,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_updateassetstaging_ts",
-      "label": "updateAssetStaging.ts",
-      "norm_label": "updateassetstaging.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "id": "packages_athena_webapp_src_hooks_useposproducts_ts",
+      "label": "usePOSProducts.ts",
+      "norm_label": "useposproducts.ts",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L1"
     },
     {
       "community": 238,
       "file_type": "code",
-      "id": "updateassetstaging_collectupdatestaticasseturls",
-      "label": "collectUpdateStaticAssetUrls()",
-      "norm_label": "collectupdatestaticasseturls()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L201"
+      "id": "useposproducts_useposbarcodesearch",
+      "label": "usePOSBarcodeSearch()",
+      "norm_label": "useposbarcodesearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L21"
     },
     {
       "community": 238,
       "file_type": "code",
-      "id": "updateassetstaging_extractlinkhrefurls",
-      "label": "extractLinkHrefUrls()",
-      "norm_label": "extractlinkhrefurls()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L226"
+      "id": "useposproducts_usepospendingcheckoutitemforsale",
+      "label": "usePOSPendingCheckoutItemForSale()",
+      "norm_label": "usepospendingcheckoutitemforsale()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L46"
     },
     {
       "community": 238,
       "file_type": "code",
-      "id": "updateassetstaging_extractscriptsrcurls",
-      "label": "extractScriptSrcUrls()",
-      "norm_label": "extractscriptsrcurls()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L219"
+      "id": "useposproducts_usepospendingcheckoutitemsforreview",
+      "label": "usePOSPendingCheckoutItemsForReview()",
+      "norm_label": "usepospendingcheckoutitemsforreview()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L49"
     },
     {
       "community": 238,
       "file_type": "code",
-      "id": "updateassetstaging_isstaticshelllinktag",
-      "label": "isStaticShellLinkTag()",
-      "norm_label": "isstaticshelllinktag()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L239"
+      "id": "useposproducts_useposproductidsearch",
+      "label": "usePOSProductIdSearch()",
+      "norm_label": "useposproductidsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L28"
     },
     {
       "community": 238,
       "file_type": "code",
-      "id": "updateassetstaging_maybeaddshellasseturl",
-      "label": "maybeAddShellAssetUrl()",
-      "norm_label": "maybeaddshellasseturl()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L254"
+      "id": "useposproducts_useposproductsearch",
+      "label": "usePOSProductSearch()",
+      "norm_label": "useposproductsearch()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L14"
     },
     {
       "community": 238,
       "file_type": "code",
-      "id": "updateassetstaging_readtagattribute",
-      "label": "readTagAttribute()",
-      "norm_label": "readtagattribute()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 238,
-      "file_type": "code",
-      "id": "updateassetstaging_stageupdatestaticassets",
-      "label": "stageUpdateStaticAssets()",
-      "norm_label": "stageupdatestaticassets()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "id": "useposproducts_useposquickaddproductsku",
+      "label": "usePOSQuickAddProductSku()",
+      "norm_label": "useposquickaddproductsku()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
       "source_location": "L44"
     },
     {
       "community": 238,
       "file_type": "code",
-      "id": "updateassetstaging_toserviceworkerresult",
-      "label": "toServiceWorkerResult()",
-      "norm_label": "toserviceworkerresult()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L289"
+      "id": "useposproducts_useposregistercatalog",
+      "label": "usePOSRegisterCatalog()",
+      "norm_label": "useposregistercatalog()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L35"
     },
     {
       "community": 238,
       "file_type": "code",
-      "id": "updateassetstaging_waitforactiveserviceworker",
-      "label": "waitForActiveServiceWorker()",
-      "norm_label": "waitforactiveserviceworker()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
-      "source_location": "L268"
+      "id": "useposproducts_useposresolvependingcheckoutitemreview",
+      "label": "usePOSResolvePendingCheckoutItemReview()",
+      "norm_label": "useposresolvependingcheckoutitemreview()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 238,
+      "file_type": "code",
+      "id": "useposproducts_usepostransactioncomplete",
+      "label": "usePOSTransactionComplete()",
+      "norm_label": "usepostransactioncomplete()",
+      "source_file": "packages/athena-webapp/src/hooks/usePOSProducts.ts",
+      "source_location": "L42"
     },
     {
       "community": 2380,
@@ -203160,6 +203220,15 @@
     {
       "community": 2382,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_test_ts",
+      "label": "index.test.ts",
+      "norm_label": "index.test.ts",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2383,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_search_ts",
       "label": "-cost-overlay-search.ts",
       "norm_label": "-cost-overlay-search.ts",
@@ -203167,7 +203236,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2383,
+      "community": 2384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_test_ts",
       "label": "cost-overlay.test.ts",
@@ -203176,7 +203245,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2384,
+      "community": 2385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_cost_overlay_tsx",
       "label": "cost-overlay.tsx",
@@ -203185,7 +203254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2385,
+      "community": 2386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_review_tsx",
       "label": "review.tsx",
@@ -203194,7 +203263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2386,
+      "community": 2387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_test_tsx",
       "label": "inventory-import.test.tsx",
@@ -203203,7 +203272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2387,
+      "community": 2388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_tsx",
       "label": "inventory-import.tsx",
@@ -203212,7 +203281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2388,
+      "community": 2389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_sku_activity_test_tsx",
       "label": "sku-activity.test.tsx",
@@ -203221,7 +203290,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2389,
+      "community": 239,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_update_updateassetstaging_ts",
+      "label": "updateAssetStaging.ts",
+      "norm_label": "updateassetstaging.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_collectupdatestaticasseturls",
+      "label": "collectUpdateStaticAssetUrls()",
+      "norm_label": "collectupdatestaticasseturls()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_extractlinkhrefurls",
+      "label": "extractLinkHrefUrls()",
+      "norm_label": "extractlinkhrefurls()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_extractscriptsrcurls",
+      "label": "extractScriptSrcUrls()",
+      "norm_label": "extractscriptsrcurls()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L219"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_isstaticshelllinktag",
+      "label": "isStaticShellLinkTag()",
+      "norm_label": "isstaticshelllinktag()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_maybeaddshellasseturl",
+      "label": "maybeAddShellAssetUrl()",
+      "norm_label": "maybeaddshellasseturl()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L254"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_readtagattribute",
+      "label": "readTagAttribute()",
+      "norm_label": "readtagattribute()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_stageupdatestaticassets",
+      "label": "stageUpdateStaticAssets()",
+      "norm_label": "stageupdatestaticassets()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_toserviceworkerresult",
+      "label": "toServiceWorkerResult()",
+      "norm_label": "toserviceworkerresult()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 239,
+      "file_type": "code",
+      "id": "updateassetstaging_waitforactiveserviceworker",
+      "label": "waitForActiveServiceWorker()",
+      "norm_label": "waitforactiveserviceworker()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateAssetStaging.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 2390,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_orderslug_index_tsx",
       "label": "index.tsx",
@@ -203230,97 +203389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_createremoteassisttransportclient",
-      "label": "createRemoteAssistTransportClient()",
-      "norm_label": "createremoteassisttransportclient()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_getremoteassisttransportclientfactory",
-      "label": "getRemoteAssistTransportClientFactory()",
-      "norm_label": "getremoteassisttransportclientfactory()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L21"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient",
-      "label": "LazyLiveKitRemoteAssistClient",
-      "norm_label": "lazylivekitremoteassistclient",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_connect",
-      "label": ".connect()",
-      "norm_label": ".connect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_loadclient",
-      "label": ".loadClient()",
-      "norm_label": ".loadclient()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_publish",
-      "label": ".publish()",
-      "norm_label": ".publish()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_subscribe",
-      "label": ".subscribe()",
-      "norm_label": ".subscribe()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_subscribetoconnectionstate",
-      "label": ".subscribeToConnectionState()",
-      "norm_label": ".subscribetoconnectionstate()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L64"
-    },
-    {
-      "community": 239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_transport_createremoteassisttransportclient_ts",
-      "label": "createRemoteAssistTransportClient.ts",
-      "norm_label": "createremoteassisttransportclient.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2390,
+      "community": 2391,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_all_index_tsx",
       "label": "all.index.tsx",
@@ -203329,7 +203398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2391,
+      "community": 2392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_cancelled_index_tsx",
       "label": "cancelled.index.tsx",
@@ -203338,7 +203407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2392,
+      "community": 2393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_completed_index_tsx",
       "label": "completed.index.tsx",
@@ -203347,7 +203416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2393,
+      "community": 2394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_index_tsx",
       "label": "index.tsx",
@@ -203356,7 +203425,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2394,
+      "community": 2395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_open_index_tsx",
       "label": "open.index.tsx",
@@ -203365,7 +203434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2395,
+      "community": 2396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_out_for_delivery_index_tsx",
       "label": "out-for-delivery.index.tsx",
@@ -203374,7 +203443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2396,
+      "community": 2397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_ready_index_tsx",
       "label": "ready.index.tsx",
@@ -203383,7 +203452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2397,
+      "community": 2398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_orders_refunded_index_tsx",
       "label": "refunded.index.tsx",
@@ -203392,21 +203461,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2398,
+      "community": 2399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_reportid_tsx",
       "label": "$reportId.tsx",
       "norm_label": "$reportid.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
-      "label": "expense-reports.index.tsx",
-      "norm_label": "expense-reports.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
       "source_location": "L1"
     },
     {
@@ -203754,95 +203814,104 @@
     {
       "community": 240,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
-      "label": "simple.test.ts",
-      "norm_label": "simple.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L1"
+      "id": "createremoteassisttransportclient_createremoteassisttransportclient",
+      "label": "createRemoteAssistTransportClient()",
+      "norm_label": "createremoteassisttransportclient()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L15"
     },
     {
       "community": 240,
       "file_type": "code",
-      "id": "simple_test_addtocart",
-      "label": "addToCart()",
-      "norm_label": "addtocart()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L249"
+      "id": "createremoteassisttransportclient_getremoteassisttransportclientfactory",
+      "label": "getRemoteAssistTransportClientFactory()",
+      "norm_label": "getremoteassisttransportclientfactory()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L21"
     },
     {
       "community": 240,
       "file_type": "code",
-      "id": "simple_test_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L173"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient",
+      "label": "LazyLiveKitRemoteAssistClient",
+      "norm_label": "lazylivekitremoteassistclient",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L27"
     },
     {
       "community": 240,
       "file_type": "code",
-      "id": "simple_test_formatpaymentmethod",
-      "label": "formatPaymentMethod()",
-      "norm_label": "formatpaymentmethod()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "simple_test_formatreceiptdate",
-      "label": "formatReceiptDate()",
-      "norm_label": "formatreceiptdate()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L225"
-    },
-    {
-      "community": 240,
-      "file_type": "code",
-      "id": "simple_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_connect",
+      "label": ".connect()",
+      "norm_label": ".connect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
       "source_location": "L38"
     },
     {
       "community": 240,
       "file_type": "code",
-      "id": "simple_test_removefromcart",
-      "label": "removeFromCart()",
-      "norm_label": "removefromcart()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L288"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L48"
     },
     {
       "community": 240,
       "file_type": "code",
-      "id": "simple_test_updatequantity",
-      "label": "updateQuantity()",
-      "norm_label": "updatequantity()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L311"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_loadclient",
+      "label": ".loadClient()",
+      "norm_label": ".loadclient()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L73"
     },
     {
       "community": 240,
       "file_type": "code",
-      "id": "simple_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L77"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_publish",
+      "label": ".publish()",
+      "norm_label": ".publish()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L53"
     },
     {
       "community": 240,
       "file_type": "code",
-      "id": "simple_test_validateinventorywithaggregation",
-      "label": "validateInventoryWithAggregation()",
-      "norm_label": "validateinventorywithaggregation()",
-      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
-      "source_location": "L130"
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_subscribe",
+      "label": ".subscribe()",
+      "norm_label": ".subscribe()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "createremoteassisttransportclient_lazylivekitremoteassistclient_subscribetoconnectionstate",
+      "label": ".subscribeToConnectionState()",
+      "norm_label": ".subscribetoconnectionstate()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_transport_createremoteassisttransportclient_ts",
+      "label": "createRemoteAssistTransportClient.ts",
+      "norm_label": "createremoteassisttransportclient.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/createRemoteAssistTransportClient.ts",
+      "source_location": "L1"
     },
     {
       "community": 2400,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_reports_index_tsx",
+      "label": "expense-reports.index.tsx",
+      "norm_label": "expense-reports.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2401,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_test_tsx",
       "label": "expense.index.test.tsx",
@@ -203851,7 +203920,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2401,
+      "community": 2402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_register_index_tsx",
       "label": "register.index.tsx",
@@ -203860,7 +203929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2402,
+      "community": 2403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_sessions_index_tsx",
       "label": "sessions.index.tsx",
@@ -203869,7 +203938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2403,
+      "community": 2404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_terminalid_tsx",
       "label": "$terminalId.tsx",
@@ -203878,7 +203947,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2404,
+      "community": 2405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_index_tsx",
       "label": "terminals.index.tsx",
@@ -203887,7 +203956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2405,
+      "community": 2406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_transactionid_tsx",
       "label": "$transactionId.tsx",
@@ -203896,7 +203965,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2406,
+      "community": 2407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_transactions_index_tsx",
       "label": "transactions.index.tsx",
@@ -203905,7 +203974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2407,
+      "community": 2408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_test_ts",
       "label": "procurement.index.test.ts",
@@ -203914,7 +203983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2408,
+      "community": 2409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_edit_tsx",
       "label": "edit.tsx",
@@ -203923,7 +203992,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2409,
+      "community": 241,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_simple_test_ts",
+      "label": "simple.test.ts",
+      "norm_label": "simple.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_addtocart",
+      "label": "addToCart()",
+      "norm_label": "addtocart()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L173"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_formatpaymentmethod",
+      "label": "formatPaymentMethod()",
+      "norm_label": "formatpaymentmethod()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_formatreceiptdate",
+      "label": "formatReceiptDate()",
+      "norm_label": "formatreceiptdate()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L225"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_removefromcart",
+      "label": "removeFromCart()",
+      "norm_label": "removefromcart()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L288"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_updatequantity",
+      "label": "updateQuantity()",
+      "norm_label": "updatequantity()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 241,
+      "file_type": "code",
+      "id": "simple_test_validateinventorywithaggregation",
+      "label": "validateInventoryWithAggregation()",
+      "norm_label": "validateinventorywithaggregation()",
+      "source_file": "packages/athena-webapp/src/tests/pos/simple.test.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 2410,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_productslug_index_tsx",
       "label": "index.tsx",
@@ -203932,97 +204091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 241,
-      "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_build",
-      "label": "build()",
-      "norm_label": "build()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_forward",
-      "label": "forward()",
-      "norm_label": "forward()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_pointercapturestub",
-      "label": "pointerCaptureStub()",
-      "norm_label": "pointercapturestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_pointerreleasestub",
-      "label": "pointerReleaseStub()",
-      "norm_label": "pointerreleasestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub",
-      "label": "ResizeObserverStub",
-      "norm_label": "resizeobserverstub",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_observe",
-      "label": ".observe()",
-      "norm_label": ".observe()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 241,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_unobserve",
-      "label": ".unobserve()",
-      "norm_label": ".unobserve()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 2410,
+      "community": 2411,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_archived_tsx",
       "label": "archived.tsx",
@@ -204031,7 +204100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2411,
+      "community": 2412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_new_tsx",
       "label": "new.tsx",
@@ -204040,7 +204109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2412,
+      "community": 2413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_new_tsx",
       "label": "new.tsx",
@@ -204049,7 +204118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2413,
+      "community": 2414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_unresolved_tsx",
       "label": "unresolved.tsx",
@@ -204058,7 +204127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2414,
+      "community": 2415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_promocodeslug_tsx",
       "label": "$promoCodeSlug.tsx",
@@ -204067,7 +204136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2415,
+      "community": 2416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_index_tsx",
       "label": "index.tsx",
@@ -204076,7 +204145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2416,
+      "community": 2417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_promo_codes_new_tsx",
       "label": "new.tsx",
@@ -204085,7 +204154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2417,
+      "community": 2418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_index_test_ts",
       "label": "index.test.ts",
@@ -204094,7 +204163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2418,
+      "community": 2419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_productskuid_test_ts",
       "label": "$productSkuId.test.ts",
@@ -204103,7 +204172,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2419,
+      "community": 242,
+      "file_type": "code",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_build",
+      "label": "build()",
+      "norm_label": "build()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_forward",
+      "label": "forward()",
+      "norm_label": "forward()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_pointercapturestub",
+      "label": "pointerCaptureStub()",
+      "norm_label": "pointercapturestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_pointerreleasestub",
+      "label": "pointerReleaseStub()",
+      "norm_label": "pointerreleasestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub",
+      "label": "ResizeObserverStub",
+      "norm_label": "resizeobserverstub",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub_observe",
+      "label": ".observe()",
+      "norm_label": ".observe()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 242,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub_unobserve",
+      "label": ".unobserve()",
+      "norm_label": ".unobserve()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 2420,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_index_test_ts",
       "label": "index.test.ts",
@@ -204112,97 +204271,7 @@
       "source_location": "L1"
     },
     {
-      "community": 242,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_rewards_ts",
-      "label": "rewards.ts",
-      "norm_label": "rewards.ts",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_awardpointsforguestorders",
-      "label": "awardPointsForGuestOrders()",
-      "norm_label": "awardpointsforguestorders()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_awardpointsforpastorder",
-      "label": "awardPointsForPastOrder()",
-      "norm_label": "awardpointsforpastorder()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_geteligiblepastorders",
-      "label": "getEligiblePastOrders()",
-      "norm_label": "geteligiblepastorders()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_getorderrewardpoints",
-      "label": "getOrderRewardPoints()",
-      "norm_label": "getorderrewardpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L175"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_getpointhistory",
-      "label": "getPointHistory()",
-      "norm_label": "getpointhistory()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_getrewardtiers",
-      "label": "getRewardTiers()",
-      "norm_label": "getrewardtiers()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L90"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_getuserpoints",
-      "label": "getUserPoints()",
-      "norm_label": "getuserpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 242,
-      "file_type": "code",
-      "id": "rewards_redeemrewardpoints",
-      "label": "redeemRewardPoints()",
-      "norm_label": "redeemrewardpoints()",
-      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 2420,
+      "community": 2421,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_tsx",
       "label": "items.tsx",
@@ -204211,7 +204280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2421,
+      "community": 2422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_tsx",
       "label": "reports.tsx",
@@ -204220,7 +204289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2422,
+      "community": 2423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_index_tsx",
       "label": "index.tsx",
@@ -204229,7 +204298,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2423,
+      "community": 2424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_new_index_tsx",
       "label": "new.index.tsx",
@@ -204238,7 +204307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2424,
+      "community": 2425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_active_cases_index_tsx",
       "label": "active-cases.index.tsx",
@@ -204247,7 +204316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2425,
+      "community": 2426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_appointments_index_tsx",
       "label": "appointments.index.tsx",
@@ -204256,7 +204325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2426,
+      "community": 2427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_catalog_management_index_tsx",
       "label": "catalog-management.index.tsx",
@@ -204265,7 +204334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2427,
+      "community": 2428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_index_tsx",
       "label": "index.tsx",
@@ -204274,7 +204343,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2428,
+      "community": 2429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_services_intake_index_tsx",
       "label": "intake.index.tsx",
@@ -204283,7 +204352,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2429,
+      "community": 243,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_rewards_ts",
+      "label": "rewards.ts",
+      "norm_label": "rewards.ts",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_awardpointsforguestorders",
+      "label": "awardPointsForGuestOrders()",
+      "norm_label": "awardpointsforguestorders()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L198"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_awardpointsforpastorder",
+      "label": "awardPointsForPastOrder()",
+      "norm_label": "awardpointsforpastorder()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_geteligiblepastorders",
+      "label": "getEligiblePastOrders()",
+      "norm_label": "geteligiblepastorders()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_getorderrewardpoints",
+      "label": "getOrderRewardPoints()",
+      "norm_label": "getorderrewardpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L175"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_getpointhistory",
+      "label": "getPointHistory()",
+      "norm_label": "getpointhistory()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_getrewardtiers",
+      "label": "getRewardTiers()",
+      "norm_label": "getrewardtiers()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L90"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_getuserpoints",
+      "label": "getUserPoints()",
+      "norm_label": "getuserpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 243,
+      "file_type": "code",
+      "id": "rewards_redeemrewardpoints",
+      "label": "redeemRewardPoints()",
+      "norm_label": "redeemrewardpoints()",
+      "source_file": "packages/storefront-webapp/src/api/rewards.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 2430,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_test_tsx",
       "label": "$traceId.test.tsx",
@@ -204292,97 +204451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_architecturesolutionnote",
-      "label": "architectureSolutionNote()",
-      "norm_label": "architecturesolutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_extracttemplateblock",
-      "label": "extractTemplateBlock()",
-      "norm_label": "extracttemplateblock()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_gitenv",
-      "label": "gitEnv()",
-      "norm_label": "gitenv()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_linechanges",
-      "label": "lineChanges()",
-      "norm_label": "linechanges()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_nonfoundationalarchitecturesolutionnote",
-      "label": "nonFoundationalArchitectureSolutionNote()",
-      "norm_label": "nonfoundationalarchitecturesolutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L123"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_solutionnote",
-      "label": "solutionNote()",
-      "norm_label": "solutionnote()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "compound_solution_check_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 243,
-      "file_type": "code",
-      "id": "scripts_compound_solution_check_test_ts",
-      "label": "compound-solution-check.test.ts",
-      "norm_label": "compound-solution-check.test.ts",
-      "source_file": "scripts/compound-solution-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2430,
+      "community": 2431,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_users_userid_tsx",
       "label": "users.$userId.tsx",
@@ -204391,7 +204460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2431,
+      "community": 2432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_index_tsx",
       "label": "index.tsx",
@@ -204400,7 +204469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2432,
+      "community": 2433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_shell_test_tsx",
       "label": "_authed-shell.test.tsx",
@@ -204409,7 +204478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2433,
+      "community": 2434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_test_tsx",
       "label": "_authed.test.tsx",
@@ -204418,7 +204487,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2434,
+      "community": 2435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_route_test_tsx",
       "label": "app.route.test.tsx",
@@ -204427,7 +204496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2435,
+      "community": 2436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_test_tsx",
       "label": "app.test.tsx",
@@ -204436,7 +204505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2436,
+      "community": 2437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_app_tsx",
       "label": "app.tsx",
@@ -204445,7 +204514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2437,
+      "community": 2438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_test_tsx",
       "label": "demo.test.tsx",
@@ -204454,7 +204523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2438,
+      "community": 2439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_tsx",
       "label": "demo.tsx",
@@ -204463,7 +204532,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2439,
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_architecturesolutionnote",
+      "label": "architectureSolutionNote()",
+      "norm_label": "architecturesolutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_extracttemplateblock",
+      "label": "extractTemplateBlock()",
+      "norm_label": "extracttemplateblock()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L131"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_gitenv",
+      "label": "gitEnv()",
+      "norm_label": "gitenv()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_linechanges",
+      "label": "lineChanges()",
+      "norm_label": "linechanges()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_nonfoundationalarchitecturesolutionnote",
+      "label": "nonFoundationalArchitectureSolutionNote()",
+      "norm_label": "nonfoundationalarchitecturesolutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_solutionnote",
+      "label": "solutionNote()",
+      "norm_label": "solutionnote()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "compound_solution_check_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 244,
+      "file_type": "code",
+      "id": "scripts_compound_solution_check_test_ts",
+      "label": "compound-solution-check.test.ts",
+      "norm_label": "compound-solution-check.test.ts",
+      "source_file": "scripts/compound-solution-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2440,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_test_tsx",
       "label": "index.test.tsx",
@@ -204472,97 +204631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_assertfrontenddependencyparity",
-      "label": "assertFrontendDependencyParity()",
-      "norm_label": "assertfrontenddependencyparity()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_checkfrontenddependencyparity",
-      "label": "checkFrontendDependencyParity()",
-      "norm_label": "checkfrontenddependencyparity()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_collectdependencydeclarations",
-      "label": "collectDependencyDeclarations()",
-      "norm_label": "collectdependencydeclarations()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_collectfrontenddependencyfailures",
-      "label": "collectFrontendDependencyFailures()",
-      "norm_label": "collectfrontenddependencyfailures()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L123"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_formatfailuremessage",
-      "label": "formatFailureMessage()",
-      "norm_label": "formatfailuremessage()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L185"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_installedversion",
-      "label": "installedVersion()",
-      "norm_label": "installedversion()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_readmanifest",
-      "label": "readManifest()",
-      "norm_label": "readmanifest()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_runfrozeninstall",
-      "label": "runFrozenInstall()",
-      "norm_label": "runfrozeninstall()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "frontend_dependency_parity_satisfiesdeclaredversion",
-      "label": "satisfiesDeclaredVersion()",
-      "norm_label": "satisfiesdeclaredversion()",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 244,
-      "file_type": "code",
-      "id": "scripts_frontend_dependency_parity_ts",
-      "label": "frontend-dependency-parity.ts",
-      "norm_label": "frontend-dependency-parity.ts",
-      "source_file": "scripts/frontend-dependency-parity.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2440,
+      "community": 2441,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -204571,7 +204640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2441,
+      "community": 2442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_join_team_index_tsx",
       "label": "join-team.index.tsx",
@@ -204580,7 +204649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2442,
+      "community": 2443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_landing_tsx",
       "label": "landing.tsx",
@@ -204589,7 +204658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2443,
+      "community": 2444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_test_tsx",
       "label": "_layout.index.test.tsx",
@@ -204598,7 +204667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2444,
+      "community": 2445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_index_tsx",
       "label": "_layout.index.tsx",
@@ -204607,7 +204676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2445,
+      "community": 2446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_tsx",
       "label": "_layout.tsx",
@@ -204616,7 +204685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2446,
+      "community": 2447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_test_tsx",
       "label": "privacy.test.tsx",
@@ -204625,7 +204694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2447,
+      "community": 2448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_privacy_tsx",
       "label": "privacy.tsx",
@@ -204634,7 +204703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2448,
+      "community": 2449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_register_interest_tsx",
       "label": "register-interest.tsx",
@@ -204643,7 +204712,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2449,
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_assertfrontenddependencyparity",
+      "label": "assertFrontendDependencyParity()",
+      "norm_label": "assertfrontenddependencyparity()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_checkfrontenddependencyparity",
+      "label": "checkFrontendDependencyParity()",
+      "norm_label": "checkfrontenddependencyparity()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_collectdependencydeclarations",
+      "label": "collectDependencyDeclarations()",
+      "norm_label": "collectdependencydeclarations()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_collectfrontenddependencyfailures",
+      "label": "collectFrontendDependencyFailures()",
+      "norm_label": "collectfrontenddependencyfailures()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_formatfailuremessage",
+      "label": "formatFailureMessage()",
+      "norm_label": "formatfailuremessage()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L185"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_installedversion",
+      "label": "installedVersion()",
+      "norm_label": "installedversion()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_readmanifest",
+      "label": "readManifest()",
+      "norm_label": "readmanifest()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_runfrozeninstall",
+      "label": "runFrozenInstall()",
+      "norm_label": "runfrozeninstall()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "frontend_dependency_parity_satisfiesdeclaredversion",
+      "label": "satisfiesDeclaredVersion()",
+      "norm_label": "satisfiesdeclaredversion()",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 245,
+      "file_type": "code",
+      "id": "scripts_frontend_dependency_parity_ts",
+      "label": "frontend-dependency-parity.ts",
+      "norm_label": "frontend-dependency-parity.ts",
+      "source_file": "scripts/frontend-dependency-parity.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2450,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_test_tsx",
       "label": "walkthrough.test.tsx",
@@ -204652,97 +204811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_comparedeterministically",
-      "label": "compareDeterministically()",
-      "norm_label": "comparedeterministically()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L94"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_isjsonobject",
-      "label": "isJsonObject()",
-      "norm_label": "isjsonobject()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_normalizegraphjsonartifact",
-      "label": "normalizeGraphJsonArtifact()",
-      "norm_label": "normalizegraphjsonartifact()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L184"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_normalizegraphjsoncontents",
-      "label": "normalizeGraphJsonContents()",
-      "norm_label": "normalizegraphjsoncontents()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L168"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_resolvegraphifypython",
-      "label": "resolveGraphifyPython()",
-      "norm_label": "resolvegraphifypython()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_rungraphifyrebuild",
-      "label": "runGraphifyRebuild()",
-      "norm_label": "rungraphifyrebuild()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_sortjsonarray",
-      "label": "sortJsonArray()",
-      "norm_label": "sortjsonarray()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "graphify_rebuild_sortjsonvalue",
-      "label": "sortJsonValue()",
-      "norm_label": "sortjsonvalue()",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 245,
-      "file_type": "code",
-      "id": "scripts_graphify_rebuild_ts",
-      "label": "graphify-rebuild.ts",
-      "norm_label": "graphify-rebuild.ts",
-      "source_file": "scripts/graphify-rebuild.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2450,
+      "community": 2451,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_walkthrough_tsx",
       "label": "walkthrough.tsx",
@@ -204751,7 +204820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2451,
+      "community": 2452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storessettingsaccordion_tsx",
       "label": "StoresSettingsAccordion.tsx",
@@ -204760,7 +204829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2452,
+      "community": 2453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_test_ts",
       "label": "expenseStore.test.ts",
@@ -204769,7 +204838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2453,
+      "community": 2454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -204778,7 +204847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2454,
+      "community": 2455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_test_tsx",
       "label": "foundations-content.test.tsx",
@@ -204787,7 +204856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2455,
+      "community": 2456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_stories_tsx",
       "label": "Introduction.stories.tsx",
@@ -204796,7 +204865,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2456,
+      "community": 2457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_test_tsx",
       "label": "introduction-content.test.tsx",
@@ -204805,7 +204874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2457,
+      "community": 2458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_guidance_introduction_content_tsx",
       "label": "introduction-content.tsx",
@@ -204814,7 +204883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2458,
+      "community": 2459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_adminshell_stories_tsx",
       "label": "AdminShell.stories.tsx",
@@ -204823,7 +204892,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2459,
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_comparedeterministically",
+      "label": "compareDeterministically()",
+      "norm_label": "comparedeterministically()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_isjsonobject",
+      "label": "isJsonObject()",
+      "norm_label": "isjsonobject()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L130"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_normalizegraphjsonartifact",
+      "label": "normalizeGraphJsonArtifact()",
+      "norm_label": "normalizegraphjsonartifact()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_normalizegraphjsoncontents",
+      "label": "normalizeGraphJsonContents()",
+      "norm_label": "normalizegraphjsoncontents()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_resolvegraphifypython",
+      "label": "resolveGraphifyPython()",
+      "norm_label": "resolvegraphifypython()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L103"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_rungraphifyrebuild",
+      "label": "runGraphifyRebuild()",
+      "norm_label": "rungraphifyrebuild()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L194"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_sortjsonarray",
+      "label": "sortJsonArray()",
+      "norm_label": "sortjsonarray()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "graphify_rebuild_sortjsonvalue",
+      "label": "sortJsonValue()",
+      "norm_label": "sortjsonvalue()",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 246,
+      "file_type": "code",
+      "id": "scripts_graphify_rebuild_ts",
+      "label": "graphify-rebuild.ts",
+      "norm_label": "graphify-rebuild.ts",
+      "source_file": "scripts/graphify-rebuild.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2460,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_stories_tsx",
       "label": "View.stories.tsx",
@@ -204832,97 +204991,7 @@
       "source_location": "L1"
     },
     {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_buildpartialdeliveryrunbaseline",
-      "label": "buildPartialDeliveryRunBaseline()",
-      "norm_label": "buildpartialdeliveryrunbaseline()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_countby",
-      "label": "countBy()",
-      "norm_label": "countby()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_createdeliveryrunledger",
-      "label": "createDeliveryRunLedger()",
-      "norm_label": "createdeliveryrunledger()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L109"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_readdeliveryrunbaseline",
-      "label": "readDeliveryRunBaseline()",
-      "norm_label": "readdeliveryrunbaseline()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L244"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_readdeliveryrunledger",
-      "label": "readDeliveryRunLedger()",
-      "norm_label": "readdeliveryrunledger()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_readjsonornull",
-      "label": "readJsonOrNull()",
-      "norm_label": "readjsonornull()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_summarizedeliveryrunbaseline",
-      "label": "summarizeDeliveryRunBaseline()",
-      "norm_label": "summarizedeliveryrunbaseline()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_writedeliveryrunledger",
-      "label": "writeDeliveryRunLedger()",
-      "norm_label": "writedeliveryrunledger()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "harness_delivery_run_ledger_writejson",
-      "label": "writeJson()",
-      "norm_label": "writejson()",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 246,
-      "file_type": "code",
-      "id": "scripts_harness_delivery_run_ledger_ts",
-      "label": "harness-delivery-run-ledger.ts",
-      "norm_label": "harness-delivery-run-ledger.ts",
-      "source_file": "scripts/harness-delivery-run-ledger.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2460,
+      "community": 2461,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_admin_shell_patterns_test_tsx",
       "label": "admin-shell-patterns.test.tsx",
@@ -204931,7 +205000,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2461,
+      "community": 2462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_test_tsx",
       "label": "view-patterns.test.tsx",
@@ -204940,7 +205009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2462,
+      "community": 2463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_surfaces_stories_tsx",
       "label": "Surfaces.stories.tsx",
@@ -204949,7 +205018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2463,
+      "community": 2464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dashboardworkspace_stories_tsx",
       "label": "DashboardWorkspace.stories.tsx",
@@ -204958,7 +205027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2464,
+      "community": 2465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_dataworkspace_stories_tsx",
       "label": "DataWorkspace.stories.tsx",
@@ -204967,7 +205036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2465,
+      "community": 2466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_settingsworkspace_stories_tsx",
       "label": "SettingsWorkspace.stories.tsx",
@@ -204976,7 +205045,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2466,
+      "community": 2467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_reference_fixtures_test_tsx",
       "label": "reference-fixtures.test.tsx",
@@ -204985,7 +205054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2467,
+      "community": 2468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_eodreviewfixtures_ts",
       "label": "eodReviewFixtures.ts",
@@ -204994,7 +205063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2468,
+      "community": 2469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_config_test_ts",
       "label": "storybook-config.test.ts",
@@ -205003,7 +205072,97 @@
       "source_location": "L1"
     },
     {
-      "community": 2469,
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_buildpartialdeliveryrunbaseline",
+      "label": "buildPartialDeliveryRunBaseline()",
+      "norm_label": "buildpartialdeliveryrunbaseline()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L251"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_countby",
+      "label": "countBy()",
+      "norm_label": "countby()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_createdeliveryrunledger",
+      "label": "createDeliveryRunLedger()",
+      "norm_label": "createdeliveryrunledger()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L109"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_readdeliveryrunbaseline",
+      "label": "readDeliveryRunBaseline()",
+      "norm_label": "readdeliveryrunbaseline()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L244"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_readdeliveryrunledger",
+      "label": "readDeliveryRunLedger()",
+      "norm_label": "readdeliveryrunledger()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L237"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_readjsonornull",
+      "label": "readJsonOrNull()",
+      "norm_label": "readjsonornull()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_summarizedeliveryrunbaseline",
+      "label": "summarizeDeliveryRunBaseline()",
+      "norm_label": "summarizedeliveryrunbaseline()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_writedeliveryrunledger",
+      "label": "writeDeliveryRunLedger()",
+      "norm_label": "writedeliveryrunledger()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "harness_delivery_run_ledger_writejson",
+      "label": "writeJson()",
+      "norm_label": "writejson()",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 247,
+      "file_type": "code",
+      "id": "scripts_harness_delivery_run_ledger_ts",
+      "label": "harness-delivery-run-ledger.ts",
+      "norm_label": "harness-delivery-run-ledger.ts",
+      "source_file": "scripts/harness-delivery-run-ledger.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2470,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_theme_decorator_test_ts",
       "label": "storybook-theme-decorator.test.ts",
@@ -205012,88 +205171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 247,
-      "file_type": "code",
-      "id": "effects_test_activedeficitledgerseed",
-      "label": "activeDeficitLedgerSeed()",
-      "norm_label": "activedeficitledgerseed()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "effects_test_authoritativedeficitposition",
-      "label": "authoritativeDeficitPosition()",
-      "norm_label": "authoritativedeficitposition()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "effects_test_baseargs",
-      "label": "baseArgs()",
-      "norm_label": "baseargs()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L199"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "effects_test_createeffectctx",
-      "label": "createEffectCtx()",
-      "norm_label": "createeffectctx()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "effects_test_deficitlotseed",
-      "label": "deficitLotSeed()",
-      "norm_label": "deficitlotseed()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "effects_test_ledgereddeficitlotseed",
-      "label": "ledgeredDeficitLotSeed()",
-      "norm_label": "ledgereddeficitlotseed()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "effects_test_ledgereddeficitposition",
-      "label": "ledgeredDeficitPosition()",
-      "norm_label": "ledgereddeficitposition()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L192"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "effects_test_productskuseed",
-      "label": "productSkuSeed()",
-      "norm_label": "productskuseed()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L232"
-    },
-    {
-      "community": 247,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventoryledger_effects_test_ts",
-      "label": "effects.test.ts",
-      "norm_label": "effects.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2470,
+      "community": 2471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_test_setup_ts",
       "label": "setup.ts",
@@ -205102,7 +205180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2471,
+      "community": 2472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_vite_env_d_ts",
       "label": "vite-env.d.ts",
@@ -205111,7 +205189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2472,
+      "community": 2473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_viteconfig_test_ts",
       "label": "viteConfig.test.ts",
@@ -205120,7 +205198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2473,
+      "community": 2474,
       "file_type": "code",
       "id": "packages_athena_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -205129,7 +205207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2474,
+      "community": 2475,
       "file_type": "code",
       "id": "packages_athena_webapp_types_ts",
       "label": "types.ts",
@@ -205138,7 +205216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2475,
+      "community": 2476,
       "file_type": "code",
       "id": "packages_athena_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -205147,7 +205225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2476,
+      "community": 2477,
       "file_type": "code",
       "id": "packages_storefront_webapp_eslint_config_js",
       "label": "eslint.config.js",
@@ -205156,7 +205234,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2477,
+      "community": 2478,
       "file_type": "code",
       "id": "packages_storefront_webapp_global_d_ts",
       "label": "global.d.ts",
@@ -205165,7 +205243,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2478,
+      "community": 2479,
       "file_type": "code",
       "id": "packages_storefront_webapp_playwright_config_ts",
       "label": "playwright.config.ts",
@@ -205174,7 +205252,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2479,
+      "community": 248,
+      "file_type": "code",
+      "id": "effects_test_activedeficitledgerseed",
+      "label": "activeDeficitLedgerSeed()",
+      "norm_label": "activedeficitledgerseed()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "effects_test_authoritativedeficitposition",
+      "label": "authoritativeDeficitPosition()",
+      "norm_label": "authoritativedeficitposition()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "effects_test_baseargs",
+      "label": "baseArgs()",
+      "norm_label": "baseargs()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L199"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "effects_test_createeffectctx",
+      "label": "createEffectCtx()",
+      "norm_label": "createeffectctx()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "effects_test_deficitlotseed",
+      "label": "deficitLotSeed()",
+      "norm_label": "deficitlotseed()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "effects_test_ledgereddeficitlotseed",
+      "label": "ledgeredDeficitLotSeed()",
+      "norm_label": "ledgereddeficitlotseed()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "effects_test_ledgereddeficitposition",
+      "label": "ledgeredDeficitPosition()",
+      "norm_label": "ledgereddeficitposition()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L192"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "effects_test_productskuseed",
+      "label": "productSkuSeed()",
+      "norm_label": "productskuseed()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L232"
+    },
+    {
+      "community": 248,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventoryledger_effects_test_ts",
+      "label": "effects.test.ts",
+      "norm_label": "effects.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/effects.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2480,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_test_ts",
       "label": "analytics.test.ts",
@@ -205183,88 +205342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 248,
-      "file_type": "code",
-      "id": "deliverypolicy_classifydeliveryresult",
-      "label": "classifyDeliveryResult()",
-      "norm_label": "classifydeliveryresult()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "deliverypolicy_computedeliveryleasems",
-      "label": "computeDeliveryLeaseMs()",
-      "norm_label": "computedeliveryleasems()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "deliverypolicy_deliverydedupekey",
-      "label": "deliveryDedupeKey()",
-      "norm_label": "deliverydedupekey()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L123"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "deliverypolicy_encodekeycomponent",
-      "label": "encodeKeyComponent()",
-      "norm_label": "encodekeycomponent()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "deliverypolicy_joinkeycomponents",
-      "label": "joinKeyComponents()",
-      "norm_label": "joinkeycomponents()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L119"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "deliverypolicy_nextbackoffms",
-      "label": "nextBackoffMs()",
-      "norm_label": "nextbackoffms()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "deliverypolicy_nextdispatchdelayms",
-      "label": "nextDispatchDelayMs()",
-      "norm_label": "nextdispatchdelayms()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "deliverypolicy_normalizerecipientemail",
-      "label": "normalizeRecipientEmail()",
-      "norm_label": "normalizerecipientemail()",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 248,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_deliverypolicy_ts",
-      "label": "deliveryPolicy.ts",
-      "norm_label": "deliverypolicy.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2480,
+      "community": 2481,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_homepagesnapshot_test_ts",
       "label": "homepageSnapshot.test.ts",
@@ -205273,7 +205351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2481,
+      "community": 2482,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_trackingevents_test_ts",
       "label": "trackingEvents.test.ts",
@@ -205282,7 +205360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2482,
+      "community": 2483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_types_ts",
       "label": "types.ts",
@@ -205291,7 +205369,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2483,
+      "community": 2484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_assets_icons_hearticonfilled_tsx",
       "label": "HeartIconFilled.tsx",
@@ -205300,7 +205378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2484,
+      "community": 2485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_defaultcatchboundary_tsx",
       "label": "DefaultCatchBoundary.tsx",
@@ -205309,7 +205387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2485,
+      "community": 2486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_test_tsx",
       "label": "HomePage.test.tsx",
@@ -205318,7 +205396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2486,
+      "community": 2487,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_test_tsx",
       "label": "ProductCard.test.tsx",
@@ -205327,7 +205405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2487,
+      "community": 2488,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_upsell_tsx",
       "label": "Upsell.tsx",
@@ -205336,7 +205414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2488,
+      "community": 2489,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_test_tsx",
       "label": "Checkout.test.tsx",
@@ -205345,7 +205423,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2489,
+      "community": 249,
+      "file_type": "code",
+      "id": "deliverypolicy_classifydeliveryresult",
+      "label": "classifyDeliveryResult()",
+      "norm_label": "classifydeliveryresult()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "deliverypolicy_computedeliveryleasems",
+      "label": "computeDeliveryLeaseMs()",
+      "norm_label": "computedeliveryleasems()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "deliverypolicy_deliverydedupekey",
+      "label": "deliveryDedupeKey()",
+      "norm_label": "deliverydedupekey()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L123"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "deliverypolicy_encodekeycomponent",
+      "label": "encodeKeyComponent()",
+      "norm_label": "encodekeycomponent()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "deliverypolicy_joinkeycomponents",
+      "label": "joinKeyComponents()",
+      "norm_label": "joinkeycomponents()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "deliverypolicy_nextbackoffms",
+      "label": "nextBackoffMs()",
+      "norm_label": "nextbackoffms()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "deliverypolicy_nextdispatchdelayms",
+      "label": "nextDispatchDelayMs()",
+      "norm_label": "nextdispatchdelayms()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "deliverypolicy_normalizerecipientemail",
+      "label": "normalizeRecipientEmail()",
+      "norm_label": "normalizerecipientemail()",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 249,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_notifications_deliverypolicy_ts",
+      "label": "deliveryPolicy.ts",
+      "norm_label": "deliverypolicy.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/deliveryPolicy.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2490,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkout_tsx",
       "label": "Checkout.tsx",
@@ -205354,88 +205513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 249,
-      "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L486"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L375"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L461"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L584"
-    },
-    {
-      "community": 249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2490,
+      "community": 2491,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerinfosection_tsx",
       "label": "CustomerInfoSection.tsx",
@@ -205444,7 +205522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2491,
+      "community": 2492,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_schema_ts",
       "label": "schema.ts",
@@ -205453,7 +205531,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2492,
+      "community": 2493,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetailssection_tsx",
       "label": "DeliveryDetailsSection.tsx",
@@ -205462,7 +205540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2493,
+      "community": 2494,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_test_ts",
       "label": "checkoutStorage.test.ts",
@@ -205471,7 +205549,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2494,
+      "community": 2495,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_test_ts",
       "label": "deliveryFees.test.ts",
@@ -205480,7 +205558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2495,
+      "community": 2496,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_test_ts",
       "label": "deriveCheckoutState.test.ts",
@@ -205489,7 +205567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2496,
+      "community": 2497,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_billingdetailsschema_ts",
       "label": "billingDetailsSchema.ts",
@@ -205498,7 +205576,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2497,
+      "community": 2498,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutformschema_ts",
       "label": "checkoutFormSchema.ts",
@@ -205507,21 +205585,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2498,
+      "community": 2499,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_customerdetailsschema_ts",
       "label": "customerDetailsSchema.ts",
       "norm_label": "customerdetailsschema.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/schemas/customerDetailsSchema.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2499,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
-      "label": "deliveryDetailsSchema.ts",
-      "norm_label": "deliverydetailsschema.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
       "source_location": "L1"
     },
     {
@@ -205860,86 +205929,95 @@
     {
       "community": 250,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_readadapters_ts",
-      "label": "readAdapters.ts",
-      "norm_label": "readadapters.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L486"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L375"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L461"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L584"
+    },
+    {
+      "community": 250,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
     },
     {
-      "community": 250,
-      "file_type": "code",
-      "id": "readadapters_createnormaluserreadoperationadapter",
-      "label": "createNormalUserReadOperationAdapter()",
-      "norm_label": "createnormaluserreadoperationadapter()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "readadapters_createpublicreadoperationadapter",
-      "label": "createPublicReadOperationAdapter()",
-      "norm_label": "createpublicreadoperationadapter()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "readadapters_createshareddemoreadoperationadapter",
-      "label": "createSharedDemoReadOperationAdapter()",
-      "norm_label": "createshareddemoreadoperationadapter()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "readadapters_isadmitted",
-      "label": "isAdmitted()",
-      "norm_label": "isadmitted()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "readadapters_isrecognizedshareddemoactorerror",
-      "label": "isRecognizedSharedDemoActorError()",
-      "norm_label": "isrecognizedshareddemoactorerror()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "readadapters_resolvereadoperationadmission",
-      "label": "resolveReadOperationAdmission()",
-      "norm_label": "resolvereadoperationadmission()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "readadapters_shareddemoreaddenialerror",
-      "label": "sharedDemoReadDenialError()",
-      "norm_label": "shareddemoreaddenialerror()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 250,
-      "file_type": "code",
-      "id": "readadapters_shareddemoreaddenied",
-      "label": "sharedDemoReadDenied()",
-      "norm_label": "shareddemoreaddenied()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
-      "source_location": "L191"
-    },
-    {
       "community": 2500,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_schemas_deliverydetailsschema_ts",
+      "label": "deliveryDetailsSchema.ts",
+      "norm_label": "deliverydetailsschema.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/schemas/deliveryDetailsSchema.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2501,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_ts",
       "label": "webOrderSchema.ts",
@@ -205948,7 +206026,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2501,
+      "community": 2502,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_types_ts",
       "label": "types.ts",
@@ -205957,7 +206035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2502,
+      "community": 2503,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_utils_test_ts",
       "label": "utils.test.ts",
@@ -205966,7 +206044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2503,
+      "community": 2504,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilterbar_tsx",
       "label": "ProductFilterBar.tsx",
@@ -205975,7 +206053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2504,
+      "community": 2505,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_test_tsx",
       "label": "BestSellersSection.test.tsx",
@@ -205984,7 +206062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2505,
+      "community": 2506,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_tsx",
       "label": "HomeHero.tsx",
@@ -205993,7 +206071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2506,
+      "community": 2507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homeherosection_tsx",
       "label": "HomeHeroSection.tsx",
@@ -206002,7 +206080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2507,
+      "community": 2508,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_test_ts",
       "label": "homePageContent.test.ts",
@@ -206011,7 +206089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2508,
+      "community": 2509,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilemenu_tsx",
       "label": "MobileMenu.tsx",
@@ -206020,7 +206098,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2509,
+      "community": 251,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_readadapters_ts",
+      "label": "readAdapters.ts",
+      "norm_label": "readadapters.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "readadapters_createnormaluserreadoperationadapter",
+      "label": "createNormalUserReadOperationAdapter()",
+      "norm_label": "createnormaluserreadoperationadapter()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "readadapters_createpublicreadoperationadapter",
+      "label": "createPublicReadOperationAdapter()",
+      "norm_label": "createpublicreadoperationadapter()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "readadapters_createshareddemoreadoperationadapter",
+      "label": "createSharedDemoReadOperationAdapter()",
+      "norm_label": "createshareddemoreadoperationadapter()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "readadapters_isadmitted",
+      "label": "isAdmitted()",
+      "norm_label": "isadmitted()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "readadapters_isrecognizedshareddemoactorerror",
+      "label": "isRecognizedSharedDemoActorError()",
+      "norm_label": "isrecognizedshareddemoactorerror()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "readadapters_resolvereadoperationadmission",
+      "label": "resolveReadOperationAdmission()",
+      "norm_label": "resolvereadoperationadmission()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "readadapters_shareddemoreaddenialerror",
+      "label": "sharedDemoReadDenialError()",
+      "norm_label": "shareddemoreaddenialerror()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L202"
+    },
+    {
+      "community": 251,
+      "file_type": "code",
+      "id": "readadapters_shareddemoreaddenied",
+      "label": "sharedDemoReadDenied()",
+      "norm_label": "shareddemoreaddenied()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.ts",
+      "source_location": "L191"
+    },
+    {
+      "community": 2510,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_constants_ts",
       "label": "constants.ts",
@@ -206029,88 +206188,7 @@
       "source_location": "L1"
     },
     {
-      "community": 251,
-      "file_type": "code",
-      "id": "managerelevations_assertactiveterminal",
-      "label": "assertActiveTerminal()",
-      "norm_label": "assertactiveterminal()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "managerelevations_endmanagerelevationwithctx",
-      "label": "endManagerElevationWithCtx()",
-      "norm_label": "endmanagerelevationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "managerelevations_getactivemanagerelevationbyidwithctx",
-      "label": "getActiveManagerElevationByIdWithCtx()",
-      "norm_label": "getactivemanagerelevationbyidwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "managerelevations_getactivemanagerelevationwithctx",
-      "label": "getActiveManagerElevationWithCtx()",
-      "norm_label": "getactivemanagerelevationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "managerelevations_getcandidateelevations",
-      "label": "getCandidateElevations()",
-      "norm_label": "getcandidateelevations()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "managerelevations_getstaffdisplayname",
-      "label": "getStaffDisplayName()",
-      "norm_label": "getstaffdisplayname()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "managerelevations_startmanagerelevationwithctx",
-      "label": "startManagerElevationWithCtx()",
-      "norm_label": "startmanagerelevationwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L188"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "managerelevations_toactiveelevation",
-      "label": "toActiveElevation()",
-      "norm_label": "toactiveelevation()",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 251,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_managerelevations_ts",
-      "label": "managerElevations.ts",
-      "norm_label": "managerelevations.ts",
-      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2510,
+      "community": 2511,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navbarconstants_ts",
       "label": "navBarConstants.ts",
@@ -206119,7 +206197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2511,
+      "community": 2512,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_about_tsx",
       "label": "About.tsx",
@@ -206128,7 +206206,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2512,
+      "community": 2513,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_aboutproduct_tsx",
       "label": "AboutProduct.tsx",
@@ -206137,7 +206215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2513,
+      "community": 2514,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_test_tsx",
       "label": "ProductActions.test.tsx",
@@ -206146,7 +206224,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2514,
+      "community": 2515,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productinfo_tsx",
       "label": "ProductInfo.tsx",
@@ -206155,7 +206233,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2515,
+      "community": 2516,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreviews_tsx",
       "label": "ProductReviews.tsx",
@@ -206164,7 +206242,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2516,
+      "community": 2517,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productsnavigationbar_tsx",
       "label": "ProductsNavigationBar.tsx",
@@ -206173,7 +206251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2517,
+      "community": 2518,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_errormessage_tsx",
       "label": "ErrorMessage.tsx",
@@ -206182,7 +206260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2518,
+      "community": 2519,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_existingreviewmessage_tsx",
       "label": "ExistingReviewMessage.tsx",
@@ -206191,7 +206269,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2519,
+      "community": 252,
+      "file_type": "code",
+      "id": "managerelevations_assertactiveterminal",
+      "label": "assertActiveTerminal()",
+      "norm_label": "assertactiveterminal()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "managerelevations_endmanagerelevationwithctx",
+      "label": "endManagerElevationWithCtx()",
+      "norm_label": "endmanagerelevationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "managerelevations_getactivemanagerelevationbyidwithctx",
+      "label": "getActiveManagerElevationByIdWithCtx()",
+      "norm_label": "getactivemanagerelevationbyidwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "managerelevations_getactivemanagerelevationwithctx",
+      "label": "getActiveManagerElevationWithCtx()",
+      "norm_label": "getactivemanagerelevationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "managerelevations_getcandidateelevations",
+      "label": "getCandidateElevations()",
+      "norm_label": "getcandidateelevations()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L68"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "managerelevations_getstaffdisplayname",
+      "label": "getStaffDisplayName()",
+      "norm_label": "getstaffdisplayname()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "managerelevations_startmanagerelevationwithctx",
+      "label": "startManagerElevationWithCtx()",
+      "norm_label": "startmanagerelevationwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L188"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "managerelevations_toactiveelevation",
+      "label": "toActiveElevation()",
+      "norm_label": "toactiveelevation()",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 252,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_managerelevations_ts",
+      "label": "managerElevations.ts",
+      "norm_label": "managerelevations.ts",
+      "source_file": "packages/athena-webapp/convex/operations/managerElevations.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2520,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_test_tsx",
       "label": "OrderItem.test.tsx",
@@ -206200,88 +206359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 252,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registercloseoutvarianceemail_ts",
-      "label": "registerCloseoutVarianceEmail.ts",
-      "norm_label": "registercloseoutvarianceemail.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_amountfrommetadata",
-      "label": "amountFromMetadata()",
-      "norm_label": "amountfrommetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L244"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_buildregisterreviewurl",
-      "label": "buildRegisterReviewUrl()",
-      "norm_label": "buildregisterreviewurl()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatoperatingdate",
-      "label": "formatOperatingDate()",
-      "norm_label": "formatoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L282"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatregistercloseoutvariancealertoperatingdate",
-      "label": "formatRegisterCloseoutVarianceAlertOperatingDate()",
-      "norm_label": "formatregistercloseoutvariancealertoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L207"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatregistercloseoutvariancealertreason",
-      "label": "formatRegisterCloseoutVarianceAlertReason()",
-      "norm_label": "formatregistercloseoutvariancealertreason()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatregisterlabel",
-      "label": "formatRegisterLabel()",
-      "norm_label": "formatregisterlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L252"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_formatsubmittedat",
-      "label": "formatSubmittedAt()",
-      "norm_label": "formatsubmittedat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L268"
-    },
-    {
-      "community": 252,
-      "file_type": "code",
-      "id": "registercloseoutvarianceemail_readcloseoutvariancemetadata",
-      "label": "readCloseoutVarianceMetadata()",
-      "norm_label": "readcloseoutvariancemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
-      "source_location": "L219"
-    },
-    {
-      "community": 2520,
+      "community": 2521,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_reviewform_tsx",
       "label": "ReviewForm.tsx",
@@ -206290,7 +206368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2521,
+      "community": 2522,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_successmessage_tsx",
       "label": "SuccessMessage.tsx",
@@ -206299,7 +206377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2522,
+      "community": 2523,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_types_ts",
       "label": "types.ts",
@@ -206308,7 +206386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2523,
+      "community": 2524,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedbag_tsx",
       "label": "SavedBag.tsx",
@@ -206317,7 +206395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2524,
+      "community": 2525,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_saved_items_savedicon_tsx",
       "label": "SavedIcon.tsx",
@@ -206326,7 +206404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2525,
+      "community": 2526,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_carticon_tsx",
       "label": "CartIcon.tsx",
@@ -206335,7 +206413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2526,
+      "community": 2527,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_shopping_bag_shoppingbag_test_tsx",
       "label": "ShoppingBag.test.tsx",
@@ -206344,7 +206422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2527,
+      "community": 2528,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -206353,7 +206431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2528,
+      "community": 2529,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_test_tsx",
       "label": "Maintenance.test.tsx",
@@ -206362,7 +206440,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2529,
+      "community": 253,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registercloseoutvarianceemail_ts",
+      "label": "registerCloseoutVarianceEmail.ts",
+      "norm_label": "registercloseoutvarianceemail.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registercloseoutvarianceemail_amountfrommetadata",
+      "label": "amountFromMetadata()",
+      "norm_label": "amountfrommetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L244"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registercloseoutvarianceemail_buildregisterreviewurl",
+      "label": "buildRegisterReviewUrl()",
+      "norm_label": "buildregisterreviewurl()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registercloseoutvarianceemail_formatoperatingdate",
+      "label": "formatOperatingDate()",
+      "norm_label": "formatoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L282"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registercloseoutvarianceemail_formatregistercloseoutvariancealertoperatingdate",
+      "label": "formatRegisterCloseoutVarianceAlertOperatingDate()",
+      "norm_label": "formatregistercloseoutvariancealertoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L207"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registercloseoutvarianceemail_formatregistercloseoutvariancealertreason",
+      "label": "formatRegisterCloseoutVarianceAlertReason()",
+      "norm_label": "formatregistercloseoutvariancealertreason()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registercloseoutvarianceemail_formatregisterlabel",
+      "label": "formatRegisterLabel()",
+      "norm_label": "formatregisterlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L252"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registercloseoutvarianceemail_formatsubmittedat",
+      "label": "formatSubmittedAt()",
+      "norm_label": "formatsubmittedat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L268"
+    },
+    {
+      "community": 253,
+      "file_type": "code",
+      "id": "registercloseoutvarianceemail_readcloseoutvariancemetadata",
+      "label": "readCloseoutVarianceMetadata()",
+      "norm_label": "readcloseoutvariancemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/registerCloseoutVarianceEmail.ts",
+      "source_location": "L219"
+    },
+    {
+      "community": 2530,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_maintenance_maintenance_tsx",
       "label": "Maintenance.tsx",
@@ -206371,88 +206530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 253,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_pendingcheckoutskuresolution_ts",
-      "label": "pendingCheckoutSkuResolution.ts",
-      "norm_label": "pendingcheckoutskuresolution.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "pendingcheckoutskuresolution_findactivependingcheckoutlookupaliasbycode",
-      "label": "findActivePendingCheckoutLookupAliasByCode()",
-      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "pendingcheckoutskuresolution_firstevidencetime",
-      "label": "firstEvidenceTime()",
-      "norm_label": "firstevidencetime()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "pendingcheckoutskuresolution_haspendingcheckouttransactionattribution",
-      "label": "hasPendingCheckoutTransactionAttribution()",
-      "norm_label": "haspendingcheckouttransactionattribution()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "pendingcheckoutskuresolution_normalizependingcheckoutlookupcode",
-      "label": "normalizePendingCheckoutLookupCode()",
-      "norm_label": "normalizependingcheckoutlookupcode()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "pendingcheckoutskuresolution_resolvependingcheckoutsku",
-      "label": "resolvePendingCheckoutSku()",
-      "norm_label": "resolvependingcheckoutsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "pendingcheckoutskuresolution_resolvependingcheckoutskufromitem",
-      "label": "resolvePendingCheckoutSkuFromItem()",
-      "norm_label": "resolvependingcheckoutskufromitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "pendingcheckoutskuresolution_retirependingcheckoutlookupaliasforitem",
-      "label": "retirePendingCheckoutLookupAliasForItem()",
-      "norm_label": "retirependingcheckoutlookupaliasforitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L271"
-    },
-    {
-      "community": 253,
-      "file_type": "code",
-      "id": "pendingcheckoutskuresolution_upsertpendingcheckoutlookupalias",
-      "label": "upsertPendingCheckoutLookupAlias()",
-      "norm_label": "upsertpendingcheckoutlookupalias()",
-      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
-      "source_location": "L218"
-    },
-    {
-      "community": 2530,
+      "community": 2531,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_animatedcard_tsx",
       "label": "AnimatedCard.tsx",
@@ -206461,7 +206539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2531,
+      "community": 2532,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_accordion_tsx",
       "label": "accordion.tsx",
@@ -206470,7 +206548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2532,
+      "community": 2533,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_alert_tsx",
       "label": "alert.tsx",
@@ -206479,7 +206557,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2533,
+      "community": 2534,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_breadcrumb_tsx",
       "label": "breadcrumb.tsx",
@@ -206488,7 +206566,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2534,
+      "community": 2535,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_button_tsx",
       "label": "button.tsx",
@@ -206497,7 +206575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2535,
+      "community": 2536,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_card_tsx",
       "label": "card.tsx",
@@ -206506,7 +206584,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2536,
+      "community": 2537,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_checkbox_tsx",
       "label": "checkbox.tsx",
@@ -206515,7 +206593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2537,
+      "community": 2538,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_command_tsx",
       "label": "command.tsx",
@@ -206524,7 +206602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2538,
+      "community": 2539,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_context_menu_tsx",
       "label": "context-menu.tsx",
@@ -206533,7 +206611,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2539,
+      "community": 254,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_pendingcheckoutskuresolution_ts",
+      "label": "pendingCheckoutSkuResolution.ts",
+      "norm_label": "pendingcheckoutskuresolution.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_findactivependingcheckoutlookupaliasbycode",
+      "label": "findActivePendingCheckoutLookupAliasByCode()",
+      "norm_label": "findactivependingcheckoutlookupaliasbycode()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_firstevidencetime",
+      "label": "firstEvidenceTime()",
+      "norm_label": "firstevidencetime()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_haspendingcheckouttransactionattribution",
+      "label": "hasPendingCheckoutTransactionAttribution()",
+      "norm_label": "haspendingcheckouttransactionattribution()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_normalizependingcheckoutlookupcode",
+      "label": "normalizePendingCheckoutLookupCode()",
+      "norm_label": "normalizependingcheckoutlookupcode()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_resolvependingcheckoutsku",
+      "label": "resolvePendingCheckoutSku()",
+      "norm_label": "resolvependingcheckoutsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_resolvependingcheckoutskufromitem",
+      "label": "resolvePendingCheckoutSkuFromItem()",
+      "norm_label": "resolvependingcheckoutskufromitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_retirependingcheckoutlookupaliasforitem",
+      "label": "retirePendingCheckoutLookupAliasForItem()",
+      "norm_label": "retirependingcheckoutlookupaliasforitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L271"
+    },
+    {
+      "community": 254,
+      "file_type": "code",
+      "id": "pendingcheckoutskuresolution_upsertpendingcheckoutlookupalias",
+      "label": "upsertPendingCheckoutLookupAlias()",
+      "norm_label": "upsertpendingcheckoutlookupalias()",
+      "source_file": "packages/athena-webapp/convex/pos/application/pendingCheckoutSkuResolution.ts",
+      "source_location": "L218"
+    },
+    {
+      "community": 2540,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dialog_tsx",
       "label": "dialog.tsx",
@@ -206542,88 +206701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 254,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
-      "label": "searchCatalog.ts",
-      "norm_label": "searchcatalog.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "searchcatalog_gettrustedcatalogprice",
-      "label": "getTrustedCatalogPrice()",
-      "norm_label": "gettrustedcatalogprice()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L69"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "searchcatalog_isdraftallowedintrustedcatalog",
-      "label": "isDraftAllowedInTrustedCatalog()",
-      "norm_label": "isdraftallowedintrustedcatalog()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "searchcatalog_ispendingcheckoutlookupaliasvisible",
-      "label": "isPendingCheckoutLookupAliasVisible()",
-      "norm_label": "ispendingcheckoutlookupaliasvisible()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "searchcatalog_issuppressedbyactivelegacyimportprovisionalrow",
-      "label": "isSuppressedByActiveLegacyImportProvisionalRow()",
-      "norm_label": "issuppressedbyactivelegacyimportprovisionalrow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "searchcatalog_istrustedcatalogresult",
-      "label": "isTrustedCatalogResult()",
-      "norm_label": "istrustedcatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "searchcatalog_lookupbybarcode",
-      "label": "lookupByBarcode()",
-      "norm_label": "lookupbybarcode()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L317"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "searchcatalog_mapskutocatalogresult",
-      "label": "mapSkuToCatalogResult()",
-      "norm_label": "mapskutocatalogresult()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 254,
-      "file_type": "code",
-      "id": "searchcatalog_searchproducts",
-      "label": "searchProducts()",
-      "norm_label": "searchproducts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 2540,
+      "community": 2541,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_dropdown_menu_tsx",
       "label": "dropdown-menu.tsx",
@@ -206632,7 +206710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2541,
+      "community": 2542,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_form_tsx",
       "label": "form.tsx",
@@ -206641,7 +206719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2542,
+      "community": 2543,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_icons_tsx",
       "label": "icons.tsx",
@@ -206650,7 +206728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2543,
+      "community": 2544,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_with_fallback_tsx",
       "label": "image-with-fallback.tsx",
@@ -206659,7 +206737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2544,
+      "community": 2545,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_otp_tsx",
       "label": "input-otp.tsx",
@@ -206668,7 +206746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2545,
+      "community": 2546,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_with_end_button_tsx",
       "label": "input-with-end-button.tsx",
@@ -206677,7 +206755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2546,
+      "community": 2547,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_input_tsx",
       "label": "input.tsx",
@@ -206686,7 +206764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2547,
+      "community": 2548,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -206695,7 +206773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2548,
+      "community": 2549,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodalform_tsx",
       "label": "LeaveAReviewModalForm.tsx",
@@ -206704,7 +206782,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2549,
+      "community": 255,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_searchcatalog_ts",
+      "label": "searchCatalog.ts",
+      "norm_label": "searchcatalog.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "searchcatalog_gettrustedcatalogprice",
+      "label": "getTrustedCatalogPrice()",
+      "norm_label": "gettrustedcatalogprice()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L69"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "searchcatalog_isdraftallowedintrustedcatalog",
+      "label": "isDraftAllowedInTrustedCatalog()",
+      "norm_label": "isdraftallowedintrustedcatalog()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "searchcatalog_ispendingcheckoutlookupaliasvisible",
+      "label": "isPendingCheckoutLookupAliasVisible()",
+      "norm_label": "ispendingcheckoutlookupaliasvisible()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "searchcatalog_issuppressedbyactivelegacyimportprovisionalrow",
+      "label": "isSuppressedByActiveLegacyImportProvisionalRow()",
+      "norm_label": "issuppressedbyactivelegacyimportprovisionalrow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "searchcatalog_istrustedcatalogresult",
+      "label": "isTrustedCatalogResult()",
+      "norm_label": "istrustedcatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "searchcatalog_lookupbybarcode",
+      "label": "lookupByBarcode()",
+      "norm_label": "lookupbybarcode()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L317"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "searchcatalog_mapskutocatalogresult",
+      "label": "mapSkuToCatalogResult()",
+      "norm_label": "mapskutocatalogresult()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 255,
+      "file_type": "code",
+      "id": "searchcatalog_searchproducts",
+      "label": "searchProducts()",
+      "norm_label": "searchproducts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 2550,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_action_modal_tsx",
       "label": "action-modal.tsx",
@@ -206713,88 +206872,7 @@
       "source_location": "L1"
     },
     {
-      "community": 255,
-      "file_type": "code",
-      "id": "collectterminaloperationalfacts_test_buildquery",
-      "label": "buildQuery()",
-      "norm_label": "buildquery()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L328"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "collectterminaloperationalfacts_test_buildqueryctx",
-      "label": "buildQueryCtx()",
-      "norm_label": "buildqueryctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "collectterminaloperationalfacts_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L236"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "collectterminaloperationalfacts_test_buildruntimestatus",
-      "label": "buildRuntimeStatus()",
-      "norm_label": "buildruntimestatus()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "collectterminaloperationalfacts_test_buildsyncconflict",
-      "label": "buildSyncConflict()",
-      "norm_label": "buildsyncconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L278"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "collectterminaloperationalfacts_test_buildsyncevent",
-      "label": "buildSyncEvent()",
-      "norm_label": "buildsyncevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L255"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "collectterminaloperationalfacts_test_buildterminal",
-      "label": "buildTerminal()",
-      "norm_label": "buildterminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "collectterminaloperationalfacts_test_emptysyncevidence",
-      "label": "emptySyncEvidence()",
-      "norm_label": "emptysyncevidence()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 255,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_collectterminaloperationalfacts_test_ts",
-      "label": "collectTerminalOperationalFacts.test.ts",
-      "norm_label": "collectterminaloperationalfacts.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2550,
+      "community": 2551,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_animations_welcomebackmodalanimations_ts",
       "label": "welcomeBackModalAnimations.ts",
@@ -206803,7 +206881,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2551,
+      "community": 2552,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_index_ts",
       "label": "index.ts",
@@ -206812,7 +206890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2552,
+      "community": 2553,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_types_ts",
       "label": "types.ts",
@@ -206821,7 +206899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2553,
+      "community": 2554,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_navigation_menu_tsx",
       "label": "navigation-menu.tsx",
@@ -206830,7 +206908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2554,
+      "community": 2555,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_popover_tsx",
       "label": "popover.tsx",
@@ -206839,7 +206917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2555,
+      "community": 2556,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_radio_group_tsx",
       "label": "radio-group.tsx",
@@ -206848,7 +206926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2556,
+      "community": 2557,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scroll_area_tsx",
       "label": "scroll-area.tsx",
@@ -206857,7 +206935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2557,
+      "community": 2558,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_select_tsx",
       "label": "select.tsx",
@@ -206866,7 +206944,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2558,
+      "community": 2559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_separator_tsx",
       "label": "separator.tsx",
@@ -206875,7 +206953,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2559,
+      "community": 256,
+      "file_type": "code",
+      "id": "collectterminaloperationalfacts_test_buildquery",
+      "label": "buildQuery()",
+      "norm_label": "buildquery()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L328"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "collectterminaloperationalfacts_test_buildqueryctx",
+      "label": "buildQueryCtx()",
+      "norm_label": "buildqueryctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "collectterminaloperationalfacts_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L236"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "collectterminaloperationalfacts_test_buildruntimestatus",
+      "label": "buildRuntimeStatus()",
+      "norm_label": "buildruntimestatus()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L194"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "collectterminaloperationalfacts_test_buildsyncconflict",
+      "label": "buildSyncConflict()",
+      "norm_label": "buildsyncconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L278"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "collectterminaloperationalfacts_test_buildsyncevent",
+      "label": "buildSyncEvent()",
+      "norm_label": "buildsyncevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "collectterminaloperationalfacts_test_buildterminal",
+      "label": "buildTerminal()",
+      "norm_label": "buildterminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "collectterminaloperationalfacts_test_emptysyncevidence",
+      "label": "emptySyncEvidence()",
+      "norm_label": "emptysyncevidence()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 256,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_collectterminaloperationalfacts_test_ts",
+      "label": "collectTerminalOperationalFacts.test.ts",
+      "norm_label": "collectterminaloperationalfacts.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/collectTerminalOperationalFacts.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 2560,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_sheet_tsx",
       "label": "sheet.tsx",
@@ -206884,88 +207043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 256,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrepository_test_ts",
-      "label": "terminalRepository.test.ts",
-      "norm_label": "terminalrepository.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrepository_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1386"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrepository_test_buildoperationalworkitem",
-      "label": "buildOperationalWorkItem()",
-      "norm_label": "buildoperationalworkitem()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1569"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrepository_test_buildquery",
-      "label": "buildQuery()",
-      "norm_label": "buildquery()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1418"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrepository_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1493"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrepository_test_buildruntimestatus",
-      "label": "buildRuntimeStatus()",
-      "norm_label": "buildruntimestatus()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1462"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrepository_test_buildsyncconflict",
-      "label": "buildSyncConflict()",
-      "norm_label": "buildsyncconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1549"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrepository_test_buildsyncevent",
-      "label": "buildSyncEvent()",
-      "norm_label": "buildsyncevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1511"
-    },
-    {
-      "community": 256,
-      "file_type": "code",
-      "id": "terminalrepository_test_buildsyncmapping",
-      "label": "buildSyncMapping()",
-      "norm_label": "buildsyncmapping()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
-      "source_location": "L1530"
-    },
-    {
-      "community": 2560,
+      "community": 2561,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_table_tsx",
       "label": "table.tsx",
@@ -206974,7 +207052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2561,
+      "community": 2562,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tabs_tsx",
       "label": "tabs.tsx",
@@ -206983,7 +207061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2562,
+      "community": 2563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_textarea_tsx",
       "label": "textarea.tsx",
@@ -206992,7 +207070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2563,
+      "community": 2564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_group_tsx",
       "label": "toggle-group.tsx",
@@ -207001,7 +207079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2564,
+      "community": 2565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_toggle_tsx",
       "label": "toggle.tsx",
@@ -207010,7 +207088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2565,
+      "community": 2566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_tooltip_tsx",
       "label": "tooltip.tsx",
@@ -207019,7 +207097,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2566,
+      "community": 2567,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_config_ts",
       "label": "config.ts",
@@ -207028,7 +207106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2567,
+      "community": 2568,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_test_tsx",
       "label": "StorefrontObservabilityProvider.test.tsx",
@@ -207037,7 +207115,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2568,
+      "community": 2569,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_use_store_modal_tsx",
       "label": "use-store-modal.tsx",
@@ -207046,7 +207124,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2569,
+      "community": 257,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrepository_test_ts",
+      "label": "terminalRepository.test.ts",
+      "norm_label": "terminalrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "terminalrepository_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1386"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "terminalrepository_test_buildoperationalworkitem",
+      "label": "buildOperationalWorkItem()",
+      "norm_label": "buildoperationalworkitem()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1569"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "terminalrepository_test_buildquery",
+      "label": "buildQuery()",
+      "norm_label": "buildquery()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1418"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "terminalrepository_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1493"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "terminalrepository_test_buildruntimestatus",
+      "label": "buildRuntimeStatus()",
+      "norm_label": "buildruntimestatus()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1462"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "terminalrepository_test_buildsyncconflict",
+      "label": "buildSyncConflict()",
+      "norm_label": "buildsyncconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1549"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "terminalrepository_test_buildsyncevent",
+      "label": "buildSyncEvent()",
+      "norm_label": "buildsyncevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1511"
+    },
+    {
+      "community": 257,
+      "file_type": "code",
+      "id": "terminalrepository_test_buildsyncmapping",
+      "label": "buildSyncMapping()",
+      "norm_label": "buildsyncmapping()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts",
+      "source_location": "L1530"
+    },
+    {
+      "community": 2570,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useorganizationmodal_tsx",
       "label": "useOrganizationModal.tsx",
@@ -207055,88 +207214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 257,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_reseedtestsupport_ts",
-      "label": "reseedTestSupport.ts",
-      "norm_label": "reseedtestsupport.ts",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "reseedtestsupport_seeddailyclose",
-      "label": "seedDailyClose()",
-      "norm_label": "seeddailyclose()",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L385"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "reseedtestsupport_seedonlineorder",
-      "label": "seedOnlineOrder()",
-      "norm_label": "seedonlineorder()",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L205"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "reseedtestsupport_seedpaymentallocation",
-      "label": "seedPaymentAllocation()",
-      "norm_label": "seedpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "reseedtestsupport_seedposcorrection",
-      "label": "seedPosCorrection()",
-      "norm_label": "seedposcorrection()",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L150"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "reseedtestsupport_seedpossale",
-      "label": "seedPosSale()",
-      "norm_label": "seedpossale()",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "reseedtestsupport_seedreceivingbatch",
-      "label": "seedReceivingBatch()",
-      "norm_label": "seedreceivingbatch()",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L419"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "reseedtestsupport_seedservicecase",
-      "label": "seedServiceCase()",
-      "norm_label": "seedservicecase()",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L327"
-    },
-    {
-      "community": 257,
-      "file_type": "code",
-      "id": "reseedtestsupport_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 2570,
+      "community": 2571,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_test_ts",
       "label": "useQueryEnabled.test.ts",
@@ -207145,7 +207223,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2571,
+      "community": 2572,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usestorefrontobservability_ts",
       "label": "useStorefrontObservability.ts",
@@ -207154,7 +207232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2572,
+      "community": 2573,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_constants_ts",
       "label": "constants.ts",
@@ -207163,7 +207241,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2573,
+      "community": 2574,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_countries_ts",
       "label": "countries.ts",
@@ -207172,7 +207250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2574,
+      "community": 2575,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_test_ts",
       "label": "feeUtils.test.ts",
@@ -207181,7 +207259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2575,
+      "community": 2576,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghana_ts",
       "label": "ghana.ts",
@@ -207190,7 +207268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2576,
+      "community": 2577,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_ghanaregions_ts",
       "label": "ghanaRegions.ts",
@@ -207199,7 +207277,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2577,
+      "community": 2578,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_maintenanceutils_test_ts",
       "label": "maintenanceUtils.test.ts",
@@ -207208,7 +207286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2578,
+      "community": 2579,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_index_ts",
       "label": "index.ts",
@@ -207217,7 +207295,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2579,
+      "community": 258,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_reseedtestsupport_ts",
+      "label": "reseedTestSupport.ts",
+      "norm_label": "reseedtestsupport.ts",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "reseedtestsupport_seeddailyclose",
+      "label": "seedDailyClose()",
+      "norm_label": "seeddailyclose()",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L385"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "reseedtestsupport_seedonlineorder",
+      "label": "seedOnlineOrder()",
+      "norm_label": "seedonlineorder()",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L205"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "reseedtestsupport_seedpaymentallocation",
+      "label": "seedPaymentAllocation()",
+      "norm_label": "seedpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "reseedtestsupport_seedposcorrection",
+      "label": "seedPosCorrection()",
+      "norm_label": "seedposcorrection()",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "reseedtestsupport_seedpossale",
+      "label": "seedPosSale()",
+      "norm_label": "seedpossale()",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "reseedtestsupport_seedreceivingbatch",
+      "label": "seedReceivingBatch()",
+      "norm_label": "seedreceivingbatch()",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L419"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "reseedtestsupport_seedservicecase",
+      "label": "seedServiceCase()",
+      "norm_label": "seedservicecase()",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L327"
+    },
+    {
+      "community": 258,
+      "file_type": "code",
+      "id": "reseedtestsupport_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/reseedTestSupport.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 2580,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_test_ts",
       "label": "productUtils.test.ts",
@@ -207226,88 +207385,7 @@
       "source_location": "L1"
     },
     {
-      "community": 258,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecasetracing_ts",
-      "label": "serviceCaseTracing.ts",
-      "norm_label": "servicecasetracing.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "servicecasetracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "servicecasetracing_buildeventkey",
-      "label": "buildEventKey()",
-      "norm_label": "buildeventkey()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "servicecasetracing_buildlookuprefs",
-      "label": "buildLookupRefs()",
-      "norm_label": "buildlookuprefs()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "servicecasetracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L212"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "servicecasetracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L137"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "servicecasetracing_recordservicecasetracebesteffort",
-      "label": "recordServiceCaseTraceBestEffort()",
-      "norm_label": "recordservicecasetracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L385"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "servicecasetracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 258,
-      "file_type": "code",
-      "id": "servicecasetracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 2580,
+      "community": 2581,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_store_ts",
       "label": "store.ts",
@@ -207316,7 +207394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2581,
+      "community": 2582,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bag_ts",
       "label": "bag.ts",
@@ -207325,7 +207403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2582,
+      "community": 2583,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_bagitem_ts",
       "label": "bagItem.ts",
@@ -207334,7 +207412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2583,
+      "community": 2584,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_category_ts",
       "label": "category.ts",
@@ -207343,7 +207421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2584,
+      "community": 2585,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_organization_ts",
       "label": "organization.ts",
@@ -207352,7 +207430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2585,
+      "community": 2586,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_product_ts",
       "label": "product.ts",
@@ -207361,7 +207439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2586,
+      "community": 2587,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_store_ts",
       "label": "store.ts",
@@ -207370,7 +207448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2587,
+      "community": 2588,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_subcategory_ts",
       "label": "subcategory.ts",
@@ -207379,7 +207457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2588,
+      "community": 2589,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_schemas_user_ts",
       "label": "user.ts",
@@ -207388,7 +207466,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2589,
+      "community": 259,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_servicecasetracing_ts",
+      "label": "serviceCaseTracing.ts",
+      "norm_label": "servicecasetracing.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "servicecasetracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "servicecasetracing_buildeventkey",
+      "label": "buildEventKey()",
+      "norm_label": "buildeventkey()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "servicecasetracing_buildlookuprefs",
+      "label": "buildLookupRefs()",
+      "norm_label": "buildlookuprefs()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "servicecasetracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L212"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "servicecasetracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "servicecasetracing_recordservicecasetracebesteffort",
+      "label": "recordServiceCaseTraceBestEffort()",
+      "norm_label": "recordservicecasetracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L385"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "servicecasetracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 259,
+      "file_type": "code",
+      "id": "servicecasetracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCaseTracing.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 2590,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_states_ts",
       "label": "states.ts",
@@ -207397,88 +207556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 259,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
-      "label": "buildCustomerObservabilityTimeline()",
-      "norm_label": "buildcustomerobservabilitytimeline()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getnonemptystring",
-      "label": "getNonEmptyString()",
-      "norm_label": "getnonemptystring()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventjourney",
-      "label": "getOperationalEventJourney()",
-      "norm_label": "getoperationaleventjourney()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventstatus",
-      "label": "getOperationalEventStatus()",
-      "norm_label": "getoperationaleventstatus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_getoperationaleventstep",
-      "label": "getOperationalEventStep()",
-      "norm_label": "getoperationaleventstep()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_isfailurestatus",
-      "label": "isFailureStatus()",
-      "norm_label": "isfailurestatus()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_isoperationaleventdoc",
-      "label": "isOperationalEventDoc()",
-      "norm_label": "isoperationaleventdoc()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L92"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "customerobservabilitytimelinedata_normalizeevent",
-      "label": "normalizeEvent()",
-      "norm_label": "normalizeevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
-      "label": "customerObservabilityTimelineData.ts",
-      "norm_label": "customerobservabilitytimelinedata.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 2590,
+      "community": 2591,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontcontextevents_test_ts",
       "label": "storefrontContextEvents.test.ts",
@@ -207487,7 +207565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2591,
+      "community": 2592,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_test_ts",
       "label": "storefrontFailureObservability.test.ts",
@@ -207496,7 +207574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2592,
+      "community": 2593,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontjourneyevents_test_ts",
       "label": "storefrontJourneyEvents.test.ts",
@@ -207505,7 +207583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2593,
+      "community": 2594,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_utils_test_ts",
       "label": "utils.test.ts",
@@ -207514,7 +207592,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2594,
+      "community": 2595,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routetree_gen_ts",
       "label": "routeTree.gen.ts",
@@ -207523,7 +207601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2595,
+      "community": 2596,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_test_ts",
       "label": "-homePageLoader.test.ts",
@@ -207532,7 +207610,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2596,
+      "community": 2597,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -207541,7 +207619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2597,
+      "community": 2598,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_orderitemid_review_tsx",
       "label": "$orderItemId.review.tsx",
@@ -207550,21 +207628,12 @@
       "source_location": "L1"
     },
     {
-      "community": 2598,
+      "community": 2599,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/_ordersLayout/shop/orders/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 2599,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
-      "label": "$subcategorySlug.tsx",
-      "norm_label": "$subcategoryslug.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
       "source_location": "L1"
     },
     {
@@ -207903,86 +207972,95 @@
     {
       "community": 260,
       "file_type": "code",
-      "id": "expensereportsview_expensereportmobilecard",
-      "label": "ExpenseReportMobileCard()",
-      "norm_label": "expensereportmobilecard()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L101"
+      "id": "customerobservabilitytimelinedata_buildcustomerobservabilitytimeline",
+      "label": "buildCustomerObservabilityTimeline()",
+      "norm_label": "buildcustomerobservabilitytimeline()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L206"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "expensereportsview_getexpensereporttimefilter",
-      "label": "getExpenseReportTimeFilter()",
-      "norm_label": "getexpensereporttimefilter()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L53"
+      "id": "customerobservabilitytimelinedata_getnonemptystring",
+      "label": "getNonEmptyString()",
+      "norm_label": "getnonemptystring()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L84"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "expensereportsview_getnextexpensereportfiltersearch",
-      "label": "getNextExpenseReportFilterSearch()",
-      "norm_label": "getnextexpensereportfiltersearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L91"
+      "id": "customerobservabilitytimelinedata_getoperationaleventjourney",
+      "label": "getOperationalEventJourney()",
+      "norm_label": "getoperationaleventjourney()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L98"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "expensereportsview_getnextexpensereportpagesearch",
-      "label": "getNextExpenseReportPageSearch()",
-      "norm_label": "getnextexpensereportpagesearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L75"
+      "id": "customerobservabilitytimelinedata_getoperationaleventstatus",
+      "label": "getOperationalEventStatus()",
+      "norm_label": "getoperationaleventstatus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L116"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "expensereportsview_getpageindexfromsearch",
-      "label": "getPageIndexFromSearch()",
-      "norm_label": "getpageindexfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L47"
+      "id": "customerobservabilitytimelinedata_getoperationaleventstep",
+      "label": "getOperationalEventStep()",
+      "norm_label": "getoperationaleventstep()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L102"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "expensereportsview_getstartofoperatingdate",
-      "label": "getStartOfOperatingDate()",
-      "norm_label": "getstartofoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L29"
+      "id": "customerobservabilitytimelinedata_isfailurestatus",
+      "label": "isFailureStatus()",
+      "norm_label": "isfailurestatus()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L88"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "expensereportsview_isonoperatingdate",
-      "label": "isOnOperatingDate()",
-      "norm_label": "isonoperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L37"
+      "id": "customerobservabilitytimelinedata_isoperationaleventdoc",
+      "label": "isOperationalEventDoc()",
+      "norm_label": "isoperationaleventdoc()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L92"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "expensereportsview_istoday",
-      "label": "isToday()",
-      "norm_label": "istoday()",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
-      "source_location": "L23"
+      "id": "customerobservabilitytimelinedata_normalizeevent",
+      "label": "normalizeEvent()",
+      "norm_label": "normalizeevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
+      "source_location": "L130"
     },
     {
       "community": 260,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
-      "label": "ExpenseReportsView.tsx",
-      "norm_label": "expensereportsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimelinedata_ts",
+      "label": "customerObservabilityTimelineData.ts",
+      "norm_label": "customerobservabilitytimelinedata.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimelineData.ts",
       "source_location": "L1"
     },
     {
       "community": 2600,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_subcategoryslug_tsx",
+      "label": "$subcategorySlug.tsx",
+      "norm_label": "$subcategoryslug.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/_shopLayout/shop/$categorySlug/$subcategorySlug.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2601,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shoplayout_shop_categoryslug_index_tsx",
       "label": "index.tsx",
@@ -207991,7 +208069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2601,
+      "community": 2602,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_rewards_index_tsx",
       "label": "rewards.index.tsx",
@@ -208000,7 +208078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2602,
+      "community": 2603,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_saved_index_tsx",
       "label": "shop.saved.index.tsx",
@@ -208009,7 +208087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2603,
+      "community": 2604,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_bag_index_tsx",
       "label": "bag.index.tsx",
@@ -208018,7 +208096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2604,
+      "community": 2605,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_complete_tsx",
       "label": "complete.tsx",
@@ -208027,7 +208105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2605,
+      "community": 2606,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_incomplete_tsx",
       "label": "incomplete.tsx",
@@ -208036,7 +208114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2606,
+      "community": 2607,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_index_tsx",
       "label": "index.tsx",
@@ -208045,7 +208123,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2607,
+      "community": 2608,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pending_tsx",
       "label": "pending.tsx",
@@ -208054,7 +208132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2608,
+      "community": 2609,
       "file_type": "code",
       "id": "packages_storefront_webapp_tailwind_config_js",
       "label": "tailwind.config.js",
@@ -208063,7 +208141,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2609,
+      "community": 261,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_reportscontract_ts",
+      "label": "reportsContract.ts",
+      "norm_label": "reportscontract.ts",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "reportscontract_dayperiodkey",
+      "label": "dayPeriodKey()",
+      "norm_label": "dayperiodkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "reportscontract_descendingsortkey",
+      "label": "descendingSortKey()",
+      "norm_label": "descendingsortkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L266"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "reportscontract_isreportingtodayinprogress",
+      "label": "isReportingTodayInProgress()",
+      "norm_label": "isreportingtodayinprogress()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "reportscontract_monthperiodkey",
+      "label": "monthPeriodKey()",
+      "norm_label": "monthperiodkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L226"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "reportscontract_normalizecurrencycode",
+      "label": "normalizeCurrencyCode()",
+      "norm_label": "normalizecurrencycode()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "reportscontract_periodkeysforoperatingdate",
+      "label": "periodKeysForOperatingDate()",
+      "norm_label": "periodkeysforoperatingdate()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "reportscontract_trailingthreemonthsstart",
+      "label": "trailingThreeMonthsStart()",
+      "norm_label": "trailingthreemonthsstart()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 261,
+      "file_type": "code",
+      "id": "reportscontract_weekperiodkey",
+      "label": "weekPeriodKey()",
+      "norm_label": "weekperiodkey()",
+      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 2610,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_storefront_boot_e2e_ts",
       "label": "storefront-boot.e2e.ts",
@@ -208072,88 +208231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 261,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
-      "label": "POSRegisterView.tsx",
-      "norm_label": "posregisterview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "posregisterview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L578"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "posregisterview_handlecmdk",
-      "label": "handleCmdK()",
-      "norm_label": "handlecmdk()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L2146"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "posregisterview_handlekeydown",
-      "label": "handleKeyDown()",
-      "norm_label": "handlekeydown()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L835"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "posregisterview_handleretry",
-      "label": "handleRetry()",
-      "norm_label": "handleretry()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L1653"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "posregisterview_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L781"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "posregisterview_isdebugshortcut",
-      "label": "isDebugShortcut()",
-      "norm_label": "isdebugshortcut()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L830"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "posregisterview_switch",
-      "label": "switch()",
-      "norm_label": "switch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L659"
-    },
-    {
-      "community": 261,
-      "file_type": "code",
-      "id": "posregisterview_usecollapsesidebarforposflow",
-      "label": "useCollapseSidebarForPosFlow()",
-      "norm_label": "usecollapsesidebarforposflow()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 2610,
+      "community": 2611,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_config_ts",
       "label": "vitest.config.ts",
@@ -208162,7 +208240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2611,
+      "community": 2612,
       "file_type": "code",
       "id": "packages_storefront_webapp_vitest_setup_ts",
       "label": "vitest.setup.ts",
@@ -208171,7 +208249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2612,
+      "community": 2613,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_index_js",
       "label": "index.js",
@@ -208180,7 +208258,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2613,
+      "community": 2614,
       "file_type": "code",
       "id": "scripts_check_register_session_authority_writers_test_ts",
       "label": "check-register-session-authority-writers.test.ts",
@@ -208189,7 +208267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2614,
+      "community": 2615,
       "file_type": "code",
       "id": "scripts_delivery_documentation_check_test_ts",
       "label": "delivery-documentation-check.test.ts",
@@ -208198,7 +208276,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2615,
+      "community": 2616,
       "file_type": "code",
       "id": "scripts_harness_app_registry_test_ts",
       "label": "harness-app-registry.test.ts",
@@ -208207,7 +208285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2616,
+      "community": 2617,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_test_ts",
       "label": "athena-runtime-app.test.ts",
@@ -208216,7 +208294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2617,
+      "community": 2618,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_storefront_runtime_api_test_ts",
       "label": "storefront-runtime-api.test.ts",
@@ -208225,7 +208303,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2618,
+      "community": 2619,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_valkey_runtime_app_test_ts",
       "label": "valkey-runtime-app.test.ts",
@@ -208234,7 +208312,88 @@
       "source_location": "L1"
     },
     {
-      "community": 2619,
+      "community": 262,
+      "file_type": "code",
+      "id": "expensereportsview_expensereportmobilecard",
+      "label": "ExpenseReportMobileCard()",
+      "norm_label": "expensereportmobilecard()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "expensereportsview_getexpensereporttimefilter",
+      "label": "getExpenseReportTimeFilter()",
+      "norm_label": "getexpensereporttimefilter()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L53"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "expensereportsview_getnextexpensereportfiltersearch",
+      "label": "getNextExpenseReportFilterSearch()",
+      "norm_label": "getnextexpensereportfiltersearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L91"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "expensereportsview_getnextexpensereportpagesearch",
+      "label": "getNextExpenseReportPageSearch()",
+      "norm_label": "getnextexpensereportpagesearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L75"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "expensereportsview_getpageindexfromsearch",
+      "label": "getPageIndexFromSearch()",
+      "norm_label": "getpageindexfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "expensereportsview_getstartofoperatingdate",
+      "label": "getStartOfOperatingDate()",
+      "norm_label": "getstartofoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L29"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "expensereportsview_isonoperatingdate",
+      "label": "isOnOperatingDate()",
+      "norm_label": "isonoperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "expensereportsview_istoday",
+      "label": "isToday()",
+      "norm_label": "istoday()",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 262,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportsview_tsx",
+      "label": "ExpenseReportsView.tsx",
+      "norm_label": "expensereportsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 2620,
       "file_type": "code",
       "id": "scripts_harness_behavior_scenarios_test_ts",
       "label": "harness-behavior-scenarios.test.ts",
@@ -208243,88 +208402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 262,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_products_tsx",
-      "label": "Products.tsx",
-      "norm_label": "products.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "products_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L467"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "products_formatcatalogmetric",
-      "label": "formatCatalogMetric()",
-      "norm_label": "formatcatalogmetric()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "products_getproductsearchpageindex",
-      "label": "getProductSearchPageIndex()",
-      "norm_label": "getproductsearchpageindex()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L42"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "products_handleclearfilters",
-      "label": "handleClearFilters()",
-      "norm_label": "handleclearfilters()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L261"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "products_handleopenquickadd",
-      "label": "handleOpenQuickAdd()",
-      "norm_label": "handleopenquickadd()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "products_handlequerychange",
-      "label": "handleQueryChange()",
-      "norm_label": "handlequerychange()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L241"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "products_handlequickaddsubmit",
-      "label": "handleQuickAddSubmit()",
-      "norm_label": "handlequickaddsubmit()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L191"
-    },
-    {
-      "community": 262,
-      "file_type": "code",
-      "id": "products_handlesearchpageindexchange",
-      "label": "handleSearchPageIndexChange()",
-      "norm_label": "handlesearchpageindexchange()",
-      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
-      "source_location": "L265"
-    },
-    {
-      "community": 2620,
+      "community": 2621,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_test_ts",
       "label": "harness-repo-validation.test.ts",
@@ -208333,7 +208411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2621,
+      "community": 2622,
       "file_type": "code",
       "id": "scripts_operational_work_repair_test_ts",
       "label": "operational-work-repair.test.ts",
@@ -208342,7 +208420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2622,
+      "community": 2623,
       "file_type": "code",
       "id": "tools_screen_redact_extension_background_js",
       "label": "background.js",
@@ -208351,7 +208429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 2623,
+      "community": 2624,
       "file_type": "code",
       "id": "tools_screen_redact_extension_popup_js",
       "label": "popup.js",
@@ -208362,86 +208440,167 @@
     {
       "community": 263,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportperiodkeys_ts",
-      "label": "reportPeriodKeys.ts",
-      "norm_label": "reportperiodkeys.ts",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisterview_tsx",
+      "label": "POSRegisterView.tsx",
+      "norm_label": "posregisterview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
       "source_location": "L1"
     },
     {
       "community": 263,
       "file_type": "code",
-      "id": "reportperiodkeys_addoperatingdays",
-      "label": "addOperatingDays()",
-      "norm_label": "addoperatingdays()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L50"
+      "id": "posregisterview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L578"
     },
     {
       "community": 263,
       "file_type": "code",
-      "id": "reportperiodkeys_daterangeforitemsperiod",
-      "label": "dateRangeForItemsPeriod()",
-      "norm_label": "daterangeforitemsperiod()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L84"
+      "id": "posregisterview_handlecmdk",
+      "label": "handleCmdK()",
+      "norm_label": "handlecmdk()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L2146"
     },
     {
       "community": 263,
       "file_type": "code",
-      "id": "reportperiodkeys_daterangeforoverviewwindow",
-      "label": "dateRangeForOverviewWindow()",
-      "norm_label": "daterangeforoverviewwindow()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L62"
+      "id": "posregisterview_handlekeydown",
+      "label": "handleKeyDown()",
+      "norm_label": "handlekeydown()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L835"
     },
     {
       "community": 263,
       "file_type": "code",
-      "id": "reportperiodkeys_isoweekstart",
-      "label": "isoWeekStart()",
-      "norm_label": "isoweekstart()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L56"
+      "id": "posregisterview_handleretry",
+      "label": "handleRetry()",
+      "norm_label": "handleretry()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L1653"
     },
     {
       "community": 263,
       "file_type": "code",
-      "id": "reportperiodkeys_operatingdatetoutc",
-      "label": "operatingDateToUtc()",
-      "norm_label": "operatingdatetoutc()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L42"
+      "id": "posregisterview_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L781"
     },
     {
       "community": 263,
       "file_type": "code",
-      "id": "reportperiodkeys_periodkeyforselection",
-      "label": "periodKeyForSelection()",
-      "norm_label": "periodkeyforselection()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L108"
+      "id": "posregisterview_isdebugshortcut",
+      "label": "isDebugShortcut()",
+      "norm_label": "isdebugshortcut()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L830"
     },
     {
       "community": 263,
       "file_type": "code",
-      "id": "reportperiodkeys_todayoperatingdateguess",
-      "label": "todayOperatingDateGuess()",
-      "norm_label": "todayoperatingdateguess()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L123"
+      "id": "posregisterview_switch",
+      "label": "switch()",
+      "norm_label": "switch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L659"
     },
     {
       "community": 263,
       "file_type": "code",
-      "id": "reportperiodkeys_utctooperatingdate",
-      "label": "utcToOperatingDate()",
-      "norm_label": "utctooperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportPeriodKeys.ts",
-      "source_location": "L46"
+      "id": "posregisterview_usecollapsesidebarforposflow",
+      "label": "useCollapseSidebarForPosFlow()",
+      "norm_label": "usecollapsesidebarforposflow()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx",
+      "source_location": "L77"
     },
     {
       "community": 264,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_products_tsx",
+      "label": "Products.tsx",
+      "norm_label": "products.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "products_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L467"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "products_formatcatalogmetric",
+      "label": "formatCatalogMetric()",
+      "norm_label": "formatcatalogmetric()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "products_getproductsearchpageindex",
+      "label": "getProductSearchPageIndex()",
+      "norm_label": "getproductsearchpageindex()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L42"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "products_handleclearfilters",
+      "label": "handleClearFilters()",
+      "norm_label": "handleclearfilters()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L261"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "products_handleopenquickadd",
+      "label": "handleOpenQuickAdd()",
+      "norm_label": "handleopenquickadd()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "products_handlequerychange",
+      "label": "handleQueryChange()",
+      "norm_label": "handlequerychange()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L241"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "products_handlequickaddsubmit",
+      "label": "handleQuickAddSubmit()",
+      "norm_label": "handlequickaddsubmit()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L191"
+    },
+    {
+      "community": 264,
+      "file_type": "code",
+      "id": "products_handlesearchpageindexchange",
+      "label": "handleSearchPageIndexChange()",
+      "norm_label": "handlesearchpageindexchange()",
+      "source_file": "packages/athena-webapp/src/components/products/Products.tsx",
+      "source_location": "L265"
+    },
+    {
+      "community": 265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemodailyclosefixture_ts",
       "label": "sharedDemoDailyCloseFixture.ts",
@@ -208450,7 +208609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "shareddemodailyclosefixture_buildcompletedsaleitems",
       "label": "buildCompletedSaleItems()",
@@ -208459,7 +208618,7 @@
       "source_location": "L63"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "shareddemodailyclosefixture_builddemotransactionnumber",
       "label": "buildDemoTransactionNumber()",
@@ -208468,7 +208627,7 @@
       "source_location": "L50"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "shareddemodailyclosefixture_buildreadyitems",
       "label": "buildReadyItems()",
@@ -208477,7 +208636,7 @@
       "source_location": "L104"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "shareddemodailyclosefixture_buildsummary",
       "label": "buildSummary()",
@@ -208486,7 +208645,7 @@
       "source_location": "L169"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "shareddemodailyclosefixture_createshareddemodailyclosefixture",
       "label": "createSharedDemoDailyCloseFixture()",
@@ -208495,7 +208654,7 @@
       "source_location": "L199"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "shareddemodailyclosefixture_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -208504,7 +208663,7 @@
       "source_location": "L45"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "shareddemodailyclosefixture_getoperatingdatetimestamp",
       "label": "getOperatingDateTimestamp()",
@@ -208513,7 +208672,7 @@
       "source_location": "L35"
     },
     {
-      "community": 264,
+      "community": 265,
       "file_type": "code",
       "id": "shareddemodailyclosefixture_shiftoperatingdate",
       "label": "shiftOperatingDate()",
@@ -208522,7 +208681,7 @@
       "source_location": "L28"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmanagement_tsx",
       "label": "StaffManagement.tsx",
@@ -208531,7 +208690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "staffmanagement_buildusername",
       "label": "buildUsername()",
@@ -208540,7 +208699,7 @@
       "source_location": "L95"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "staffmanagement_credentialstatusbadge",
       "label": "CredentialStatusBadge()",
@@ -208549,7 +208708,7 @@
       "source_location": "L133"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "staffmanagement_formatrolelabel",
       "label": "formatRoleLabel()",
@@ -208558,7 +208717,7 @@
       "source_location": "L122"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "staffmanagement_handledeactivate",
       "label": "handleDeactivate()",
@@ -208567,7 +208726,7 @@
       "source_location": "L790"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "staffmanagement_handlepinkeydown",
       "label": "handlePinKeyDown()",
@@ -208576,7 +208735,7 @@
       "source_location": "L626"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "staffmanagement_handlesubmit",
       "label": "handleSubmit()",
@@ -208585,7 +208744,7 @@
       "source_location": "L644"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "staffmanagement_normalizenamesegment",
       "label": "normalizeNameSegment()",
@@ -208594,7 +208753,7 @@
       "source_location": "L87"
     },
     {
-      "community": 265,
+      "community": 266,
       "file_type": "code",
       "id": "staffmanagement_staffprovisionform",
       "label": "StaffProvisionForm()",
@@ -208603,7 +208762,7 @@
       "source_location": "L170"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "fulfillmentview_handledeliveryrestrictiontoggle",
       "label": "handleDeliveryRestrictionToggle()",
@@ -208612,7 +208771,7 @@
       "source_location": "L155"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "fulfillmentview_handlepickuprestrictiontoggle",
       "label": "handlePickupRestrictionToggle()",
@@ -208621,7 +208780,7 @@
       "source_location": "L116"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "fulfillmentview_handlesavedeliveryrestriction",
       "label": "handleSaveDeliveryRestriction()",
@@ -208630,7 +208789,7 @@
       "source_location": "L203"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "fulfillmentview_handlesavepickuprestriction",
       "label": "handleSavePickupRestriction()",
@@ -208639,7 +208798,7 @@
       "source_location": "L194"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "fulfillmentview_savedeliveryrestriction",
       "label": "saveDeliveryRestriction()",
@@ -208648,7 +208807,7 @@
       "source_location": "L101"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "fulfillmentview_saveenabledeliverychanges",
       "label": "saveEnableDeliveryChanges()",
@@ -208657,7 +208816,7 @@
       "source_location": "L63"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "fulfillmentview_saveenablestorepickupchanges",
       "label": "saveEnableStorePickupChanges()",
@@ -208666,7 +208825,7 @@
       "source_location": "L40"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "fulfillmentview_savepickuprestriction",
       "label": "savePickupRestriction()",
@@ -208675,7 +208834,7 @@
       "source_location": "L86"
     },
     {
-      "community": 266,
+      "community": 267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_fulfillmentview_tsx",
       "label": "FulfillmentView.tsx",
@@ -208684,7 +208843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecoordinator_ts",
       "label": "updateCoordinator.ts",
@@ -208693,7 +208852,7 @@
       "source_location": "L1"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "updatecoordinator_areblockersequal",
       "label": "areBlockersEqual()",
@@ -208702,7 +208861,7 @@
       "source_location": "L484"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "updatecoordinator_compareblockers",
       "label": "compareBlockers()",
@@ -208711,7 +208870,7 @@
       "source_location": "L496"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "updatecoordinator_createtabid",
       "label": "createTabId()",
@@ -208720,7 +208879,7 @@
       "source_location": "L507"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "updatecoordinator_createupdatecoordinatorstore",
       "label": "createUpdateCoordinatorStore()",
@@ -208729,7 +208888,7 @@
       "source_location": "L108"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "updatecoordinator_isvalidmessageblocker",
       "label": "isValidMessageBlocker()",
@@ -208738,7 +208897,7 @@
       "source_location": "L448"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "updatecoordinator_isvalidpriority",
       "label": "isValidPriority()",
@@ -208747,7 +208906,7 @@
       "source_location": "L474"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "updatecoordinator_isvalidupdateapplyblockerinput",
       "label": "isValidUpdateApplyBlockerInput()",
@@ -208756,7 +208915,7 @@
       "source_location": "L468"
     },
     {
-      "community": 267,
+      "community": 268,
       "file_type": "code",
       "id": "updatecoordinator_isvalidupdatecoordinatormessage",
       "label": "isValidUpdateCoordinatorMessage()",
@@ -208765,7 +208924,7 @@
       "source_location": "L428"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "logger_logger",
       "label": "Logger",
@@ -208774,7 +208933,7 @@
       "source_location": "L12"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "logger_logger_constructor",
       "label": ".constructor()",
@@ -208783,7 +208942,7 @@
       "source_location": "L15"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "logger_logger_debug",
       "label": ".debug()",
@@ -208792,7 +208951,7 @@
       "source_location": "L45"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "logger_logger_error",
       "label": ".error()",
@@ -208801,7 +208960,7 @@
       "source_location": "L63"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "logger_logger_formatmessage",
       "label": ".formatMessage()",
@@ -208810,7 +208969,7 @@
       "source_location": "L30"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "logger_logger_info",
       "label": ".info()",
@@ -208819,7 +208978,7 @@
       "source_location": "L51"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "logger_logger_shouldlog",
       "label": ".shouldLog()",
@@ -208828,7 +208987,7 @@
       "source_location": "L20"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "logger_logger_warn",
       "label": ".warn()",
@@ -208837,93 +208996,12 @@
       "source_location": "L57"
     },
     {
-      "community": 268,
+      "community": 269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_logger_ts",
       "label": "logger.ts",
       "norm_label": "logger.ts",
       "source_file": "packages/athena-webapp/src/lib/logger.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "cart_assertvalidposcartline",
-      "label": "assertValidPosCartLine()",
-      "norm_label": "assertvalidposcartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "cart_calculateposcartlinesubtotal",
-      "label": "calculatePosCartLineSubtotal()",
-      "norm_label": "calculateposcartlinesubtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "cart_calculateposcarttotals",
-      "label": "calculatePosCartTotals()",
-      "norm_label": "calculateposcarttotals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "cart_calculatepositemtotal",
-      "label": "calculatePosItemTotal()",
-      "norm_label": "calculatepositemtotal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "cart_getposeffectiveprice",
-      "label": "getPosEffectivePrice()",
-      "norm_label": "getposeffectiveprice()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "cart_isposproductcartline",
-      "label": "isPosProductCartLine()",
-      "norm_label": "isposproductcartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "cart_isposservicecartline",
-      "label": "isPosServiceCartLine()",
-      "norm_label": "isposservicecartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "cart_roundposamount",
-      "label": "roundPosAmount()",
-      "norm_label": "roundposamount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
-      "label": "cart.ts",
-      "norm_label": "cart.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
       "source_location": "L1"
     },
     {
@@ -209262,6 +209340,87 @@
     {
       "community": 270,
       "file_type": "code",
+      "id": "cart_assertvalidposcartline",
+      "label": "assertValidPosCartLine()",
+      "norm_label": "assertvalidposcartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "cart_calculateposcartlinesubtotal",
+      "label": "calculatePosCartLineSubtotal()",
+      "norm_label": "calculateposcartlinesubtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "cart_calculateposcarttotals",
+      "label": "calculatePosCartTotals()",
+      "norm_label": "calculateposcarttotals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "cart_calculatepositemtotal",
+      "label": "calculatePosItemTotal()",
+      "norm_label": "calculatepositemtotal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "cart_getposeffectiveprice",
+      "label": "getPosEffectivePrice()",
+      "norm_label": "getposeffectiveprice()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "cart_isposproductcartline",
+      "label": "isPosProductCartLine()",
+      "norm_label": "isposproductcartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "cart_isposservicecartline",
+      "label": "isPosServiceCartLine()",
+      "norm_label": "isposservicecartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "cart_roundposamount",
+      "label": "roundPosAmount()",
+      "norm_label": "roundposamount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_domain_cart_ts",
+      "label": "cart.ts",
+      "norm_label": "cart.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/domain/cart.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 271,
+      "file_type": "code",
       "id": "indexeddbposlocalstorageengine_browserlocks",
       "label": "browserLocks()",
       "norm_label": "browserlocks()",
@@ -209269,7 +209428,7 @@
       "source_location": "L112"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_clearcurrentposlocalstorageengine",
       "label": "clearCurrentPosLocalStorageEngine()",
@@ -209278,7 +209437,7 @@
       "source_location": "L75"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_createcurrentposlocalstorageenginestore",
       "label": "createCurrentPosLocalStorageEngineStore()",
@@ -209287,7 +209446,7 @@
       "source_location": "L25"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_getcurrentposlocalstorageenginelifecyclehealth",
       "label": "getCurrentPosLocalStorageEngineLifecycleHealth()",
@@ -209296,7 +209455,7 @@
       "source_location": "L105"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_maintenanceresult",
       "label": "maintenanceResult()",
@@ -209305,7 +209464,7 @@
       "source_location": "L117"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_maintenanceunavailableresult",
       "label": "maintenanceUnavailableResult()",
@@ -209314,7 +209473,7 @@
       "source_location": "L127"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_opencurrentposlocalstorageengine",
       "label": "openCurrentPosLocalStorageEngine()",
@@ -209323,7 +209482,7 @@
       "source_location": "L31"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "indexeddbposlocalstorageengine_runcurrentposlocalstorageengineoperation",
       "label": "runCurrentPosLocalStorageEngineOperation()",
@@ -209332,7 +209491,7 @@
       "source_location": "L49"
     },
     {
-      "community": 270,
+      "community": 271,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_indexeddbposlocalstorageengine_ts",
       "label": "indexedDbPosLocalStorageEngine.ts",
@@ -209341,7 +209500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "localcommandgateway_blockedsalemessage",
       "label": "blockedSaleMessage()",
@@ -209350,7 +209509,7 @@
       "source_location": "L1058"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "localcommandgateway_canclearexactcloudcloseddrawer",
       "label": "canClearExactCloudClosedDrawer()",
@@ -209359,7 +209518,7 @@
       "source_location": "L1032"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "localcommandgateway_createlocalcommandgateway",
       "label": "createLocalCommandGateway()",
@@ -209368,7 +209527,7 @@
       "source_location": "L107"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "localcommandgateway_hascommandidentity",
       "label": "hasCommandIdentity()",
@@ -209377,7 +209536,7 @@
       "source_location": "L1086"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "localcommandgateway_haslocalsaleactivity",
       "label": "hasLocalSaleActivity()",
@@ -209386,7 +209545,7 @@
       "source_location": "L1011"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "localcommandgateway_isopenlocalregistersessionstatus",
       "label": "isOpenLocalRegisterSessionStatus()",
@@ -209395,7 +209554,7 @@
       "source_location": "L1046"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "localcommandgateway_resolvestaffprooftoken",
       "label": "resolveStaffProofToken()",
@@ -209404,7 +209563,7 @@
       "source_location": "L1002"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "localcommandgateway_tolocalusererror",
       "label": "toLocalUserError()",
@@ -209413,7 +209572,7 @@
       "source_location": "L1050"
     },
     {
-      "community": 271,
+      "community": 272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_ts",
       "label": "localCommandGateway.ts",
@@ -209422,7 +209581,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstore_test_ts",
       "label": "posLocalStore.test.ts",
@@ -209431,7 +209590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "poslocalstore_test_buildauthorityrecord",
       "label": "buildAuthorityRecord()",
@@ -209440,7 +209599,7 @@
       "source_location": "L20"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "poslocalstore_test_buildavailabilityrow",
       "label": "buildAvailabilityRow()",
@@ -209449,7 +209608,7 @@
       "source_location": "L76"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "poslocalstore_test_buildcashierpresencerecord",
       "label": "buildCashierPresenceRecord()",
@@ -209458,7 +209617,7 @@
       "source_location": "L51"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "poslocalstore_test_buildcatalogrow",
       "label": "buildCatalogRow()",
@@ -209467,7 +209626,7 @@
       "source_location": "L88"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "poslocalstore_test_buildservicecatalogrow",
       "label": "buildServiceCatalogRow()",
@@ -209476,7 +209635,7 @@
       "source_location": "L111"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "poslocalstore_test_createcontrolledindexeddb",
       "label": "createControlledIndexedDb()",
@@ -209485,7 +209644,7 @@
       "source_location": "L4181"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "poslocalstore_test_createsuccessfulrequest",
       "label": "createSuccessfulRequest()",
@@ -209494,7 +209653,7 @@
       "source_location": "L4295"
     },
     {
-      "community": 272,
+      "community": 273,
       "file_type": "code",
       "id": "poslocalstore_test_installclearableindexeddbmock",
       "label": "installClearableIndexedDbMock()",
@@ -209503,7 +209662,7 @@
       "source_location": "L138"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncscheduler_ts",
       "label": "syncScheduler.ts",
@@ -209512,7 +209671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "syncscheduler_comparependingevents",
       "label": "comparePendingEvents()",
@@ -209521,7 +209680,7 @@
       "source_location": "L371"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "syncscheduler_createposlocalsyncscheduler",
       "label": "createPosLocalSyncScheduler()",
@@ -209530,7 +209689,7 @@
       "source_location": "L92"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "syncscheduler_getcurrentbackoffdelay",
       "label": "getCurrentBackoffDelay()",
@@ -209539,7 +209698,7 @@
       "source_location": "L408"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "syncscheduler_geterrormessage",
       "label": "getErrorMessage()",
@@ -209548,7 +209707,7 @@
       "source_location": "L416"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "syncscheduler_getpendingeventcursorkey",
       "label": "getPendingEventCursorKey()",
@@ -209557,7 +209716,7 @@
       "source_location": "L392"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "syncscheduler_getpendingeventuploadsequence",
       "label": "getPendingEventUploadSequence()",
@@ -209566,7 +209725,7 @@
       "source_location": "L402"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "syncscheduler_selectnextorderedbatch",
       "label": "selectNextOrderedBatch()",
@@ -209575,7 +209734,7 @@
       "source_location": "L331"
     },
     {
-      "community": 273,
+      "community": 274,
       "file_type": "code",
       "id": "syncscheduler_selectorderedbatches",
       "label": "selectOrderedBatches()",
@@ -209584,7 +209743,7 @@
       "source_location": "L338"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_expense_useexpenseregisterviewmodel_test_ts",
       "label": "useExpenseRegisterViewModel.test.ts",
@@ -209593,7 +209752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_test_buildexpensecartitem",
       "label": "buildExpenseCartItem()",
@@ -209602,7 +209761,7 @@
       "source_location": "L220"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_test_buildproduct",
       "label": "buildProduct()",
@@ -209611,7 +209770,7 @@
       "source_location": "L241"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_test_buildregistercatalogavailabilityrow",
       "label": "buildRegisterCatalogAvailabilityRow()",
@@ -209620,7 +209779,7 @@
       "source_location": "L208"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_test_buildregistercatalogrow",
       "label": "buildRegisterCatalogRow()",
@@ -209629,7 +209788,7 @@
       "source_location": "L185"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_test_bumplocalexpenseeventreplay",
       "label": "bumpLocalExpenseEventReplay()",
@@ -209638,7 +209797,7 @@
       "source_location": "L340"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_test_deferred",
       "label": "deferred()",
@@ -209647,7 +209806,7 @@
       "source_location": "L259"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_test_enablelocalexpenseeventreplay",
       "label": "enableLocalExpenseEventReplay()",
@@ -209656,7 +209815,7 @@
       "source_location": "L336"
     },
     {
-      "community": 274,
+      "community": 275,
       "file_type": "code",
       "id": "useexpenseregisterviewmodel_test_seedactiveexpensecart",
       "label": "seedActiveExpenseCart()",
@@ -209665,250 +209824,7 @@
       "source_location": "L270"
     },
     {
-      "community": 275,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
-      "label": "applyAcceptedControlResult()",
-      "norm_label": "applyacceptedcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applykeyevent",
-      "label": "applyKeyEvent()",
-      "norm_label": "applykeyevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applypointerevent",
-      "label": "applyPointerEvent()",
-      "norm_label": "applypointerevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
-      "label": "applyRemoteAssistControlIntent()",
-      "norm_label": "applyremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
-      "label": "getRecentControlResult()",
-      "norm_label": "getrecentcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
-      "label": "getRemoteAssistControlTarget()",
-      "norm_label": "getremoteassistcontroltarget()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
-      "label": "prepareRemoteAssistControlIntent()",
-      "norm_label": "prepareremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_remembercontrolresult",
-      "label": "rememberControlResult()",
-      "norm_label": "remembercontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 275,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
-      "label": "applyRemoteAssistControlIntent.ts",
-      "norm_label": "applyremoteassistcontrolintent.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L1"
-    },
-    {
       "community": 276,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 276,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L222"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L283"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "foundations_content_detailviewrolecard",
-      "label": "DetailViewRoleCard()",
-      "norm_label": "detailviewrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L214"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L265"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L218"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L246"
-    },
-    {
-      "community": 277,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -209917,7 +209833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 276,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -209926,7 +209842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 278,
+      "community": 276,
       "file_type": "code",
       "id": "productutils_getpreferredsku",
       "label": "getPreferredSku()",
@@ -209935,7 +209851,7 @@
       "source_location": "L78"
     },
     {
-      "community": 278,
+      "community": 276,
       "file_type": "code",
       "id": "productutils_getproductname",
       "label": "getProductName()",
@@ -209944,7 +209860,7 @@
       "source_location": "L18"
     },
     {
-      "community": 278,
+      "community": 276,
       "file_type": "code",
       "id": "productutils_haslowstock",
       "label": "hasLowStock()",
@@ -209953,7 +209869,7 @@
       "source_location": "L52"
     },
     {
-      "community": 278,
+      "community": 276,
       "file_type": "code",
       "id": "productutils_issoldout",
       "label": "isSoldOut()",
@@ -209962,7 +209878,7 @@
       "source_location": "L45"
     },
     {
-      "community": 278,
+      "community": 276,
       "file_type": "code",
       "id": "productutils_sortproduct",
       "label": "sortProduct()",
@@ -209971,7 +209887,7 @@
       "source_location": "L82"
     },
     {
-      "community": 278,
+      "community": 276,
       "file_type": "code",
       "id": "productutils_sortskusbyavailabilitythenlength",
       "label": "sortSkusByAvailabilityThenLength()",
@@ -209980,7 +209896,7 @@
       "source_location": "L63"
     },
     {
-      "community": 278,
+      "community": 276,
       "file_type": "code",
       "id": "productutils_sortskusbylength",
       "label": "sortSkusByLength()",
@@ -209989,85 +209905,247 @@
       "source_location": "L59"
     },
     {
-      "community": 279,
+      "community": 277,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
+      "label": "applyAcceptedControlResult()",
+      "norm_label": "applyacceptedcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applykeyevent",
+      "label": "applyKeyEvent()",
+      "norm_label": "applykeyevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applypointerevent",
+      "label": "applyPointerEvent()",
+      "norm_label": "applypointerevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
+      "label": "applyRemoteAssistControlIntent()",
+      "norm_label": "applyremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
+      "label": "getRecentControlResult()",
+      "norm_label": "getrecentcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
+      "label": "getRemoteAssistControlTarget()",
+      "norm_label": "getremoteassistcontroltarget()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
+      "label": "prepareRemoteAssistControlIntent()",
+      "norm_label": "prepareremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_remembercontrolresult",
+      "label": "rememberControlResult()",
+      "norm_label": "remembercontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 277,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
+      "label": "applyRemoteAssistControlIntent.ts",
+      "norm_label": "applyremoteassistcontrolintent.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
       "source_location": "L1"
     },
     {
-      "community": 279,
+      "community": 278,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L182"
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 278,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
     },
     {
       "community": 279,
       "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L229"
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L222"
     },
     {
       "community": 279,
       "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L157"
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L283"
     },
     {
       "community": 279,
       "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
+      "id": "foundations_content_detailviewrolecard",
+      "label": "DetailViewRoleCard()",
+      "norm_label": "detailviewrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L363"
     },
     {
       "community": 279,
       "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L121"
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L214"
     },
     {
       "community": 279,
       "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L135"
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L342"
     },
     {
       "community": 279,
       "file_type": "code",
-      "id": "storefrontobservability_resolveviewportbucket",
-      "label": "resolveViewportBucket()",
-      "norm_label": "resolveviewportbucket()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 279,
-      "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
       "source_location": "L265"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L218"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L246"
+    },
+    {
+      "community": 279,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L1"
     },
     {
       "community": 28,
@@ -210477,6 +210555,87 @@
     {
       "community": 281,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L229"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storefrontobservability_resolveviewportbucket",
+      "label": "resolveViewportBucket()",
+      "norm_label": "resolveviewportbucket()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 281,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 282,
+      "file_type": "code",
       "id": "app_test_clusterredis",
       "label": "ClusterRedis",
       "norm_label": "clusterredis",
@@ -210484,7 +210643,7 @@
       "source_location": "L94"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "app_test_clusterredis_constructor",
       "label": ".constructor()",
@@ -210493,7 +210652,7 @@
       "source_location": "L95"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "app_test_createinmemoryredis",
       "label": "createInMemoryRedis()",
@@ -210502,7 +210661,7 @@
       "source_location": "L39"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "app_test_createresponserecorder",
       "label": "createResponseRecorder()",
@@ -210511,7 +210670,7 @@
       "source_location": "L12"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "app_test_createsilentlogger",
       "label": "createSilentLogger()",
@@ -210520,7 +210679,7 @@
       "source_location": "L31"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "app_test_log",
       "label": "log()",
@@ -210529,7 +210688,7 @@
       "source_location": "L297"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "app_test_standaloneredis",
       "label": "StandaloneRedis",
@@ -210538,7 +210697,7 @@
       "source_location": "L70"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "app_test_standaloneredis_constructor",
       "label": ".constructor()",
@@ -210547,7 +210706,7 @@
       "source_location": "L71"
     },
     {
-      "community": 281,
+      "community": 282,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_app_test_js",
       "label": "app.test.js",
@@ -210556,7 +210715,7 @@
       "source_location": "L1"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "coverage_toolchain_parity_assertcoveragetoolchainparity",
       "label": "assertCoverageToolchainParity()",
@@ -210565,7 +210724,7 @@
       "source_location": "L165"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "coverage_toolchain_parity_checkcoveragetoolchainparity",
       "label": "checkCoverageToolchainParity()",
@@ -210574,7 +210733,7 @@
       "source_location": "L137"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "coverage_toolchain_parity_collectcoveragetoolchainfailures",
       "label": "collectCoverageToolchainFailures()",
@@ -210583,7 +210742,7 @@
       "source_location": "L93"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "coverage_toolchain_parity_declaredversion",
       "label": "declaredVersion()",
@@ -210592,7 +210751,7 @@
       "source_location": "L51"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "coverage_toolchain_parity_formatfailuremessage",
       "label": "formatFailureMessage()",
@@ -210601,7 +210760,7 @@
       "source_location": "L143"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "coverage_toolchain_parity_installedversion",
       "label": "installedVersion()",
@@ -210610,7 +210769,7 @@
       "source_location": "L59"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "coverage_toolchain_parity_readmanifest",
       "label": "readManifest()",
@@ -210619,7 +210778,7 @@
       "source_location": "L47"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "coverage_toolchain_parity_runfrozeninstall",
       "label": "runFrozenInstall()",
@@ -210628,7 +210787,7 @@
       "source_location": "L149"
     },
     {
-      "community": 282,
+      "community": 283,
       "file_type": "code",
       "id": "scripts_coverage_toolchain_parity_ts",
       "label": "coverage-toolchain-parity.ts",
@@ -210637,7 +210796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_ts",
       "label": "r2.ts",
@@ -210646,7 +210805,7 @@
       "source_location": "L1"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "r2_deletedirectoryinr2",
       "label": "deleteDirectoryInR2()",
@@ -210655,7 +210814,7 @@
       "source_location": "L140"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "r2_deletefileinr2",
       "label": "deleteFileInR2()",
@@ -210664,7 +210823,7 @@
       "source_location": "L116"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "r2_getr2",
       "label": "getR2()",
@@ -210673,7 +210832,7 @@
       "source_location": "L69"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "r2_listitemsinr2directory",
       "label": "listItemsInR2Directory()",
@@ -210682,7 +210841,7 @@
       "source_location": "L188"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "r2_readenvvalue",
       "label": "readEnvValue()",
@@ -210691,7 +210850,7 @@
       "source_location": "L35"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "r2_resolver2configfromenv",
       "label": "resolveR2ConfigFromEnv()",
@@ -210700,7 +210859,7 @@
       "source_location": "L46"
     },
     {
-      "community": 283,
+      "community": 284,
       "file_type": "code",
       "id": "r2_uploadfiletor2",
       "label": "uploadFileToR2()",
@@ -210709,7 +210868,7 @@
       "source_location": "L98"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_repository_ts",
       "label": "repository.ts",
@@ -210718,7 +210877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "repository_createorreusereceiptsharetoken",
       "label": "createOrReuseReceiptShareToken()",
@@ -210727,7 +210886,7 @@
       "source_location": "L14"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "repository_createreceiptdeliveryattempt",
       "label": "createReceiptDeliveryAttempt()",
@@ -210736,7 +210895,7 @@
       "source_location": "L67"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "repository_listreceiptdeliveriesfortransaction",
       "label": "listReceiptDeliveriesForTransaction()",
@@ -210745,7 +210904,7 @@
       "source_location": "L171"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "repository_markreceiptdeliveryfailed",
       "label": "markReceiptDeliveryFailed()",
@@ -210754,7 +210913,7 @@
       "source_location": "L118"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "repository_markreceiptdeliveryprovideraccepted",
       "label": "markReceiptDeliveryProviderAccepted()",
@@ -210763,7 +210922,7 @@
       "source_location": "L100"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "repository_resolvereceiptsharetoken",
       "label": "resolveReceiptShareToken()",
@@ -210772,7 +210931,7 @@
       "source_location": "L46"
     },
     {
-      "community": 284,
+      "community": 285,
       "file_type": "code",
       "id": "repository_updatedeliverybyprovidermessageid",
       "label": "updateDeliveryByProviderMessageId()",
@@ -210781,7 +210940,7 @@
       "source_location": "L138"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_constructionanchor",
       "label": "constructionAnchor()",
@@ -210790,7 +210949,7 @@
       "source_location": "L34"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_constructionsource",
       "label": "constructionSource()",
@@ -210799,7 +210958,7 @@
       "source_location": "L52"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_createconstructionharness",
       "label": "createConstructionHarness()",
@@ -210808,7 +210967,7 @@
       "source_location": "L62"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_createmutationharness",
       "label": "createMutationHarness()",
@@ -210817,7 +210976,7 @@
       "source_location": "L231"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_gethandler",
       "label": "getHandler()",
@@ -210826,7 +210985,7 @@
       "source_location": "L23"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_orchestrationrun",
       "label": "orchestrationRun()",
@@ -210835,7 +210994,7 @@
       "source_location": "L338"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "inventoryimportcostoverlayorchestration_test_preparedrow",
       "label": "preparedRow()",
@@ -210844,7 +211003,7 @@
       "source_location": "L316"
     },
     {
-      "community": 285,
+      "community": 286,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlayorchestration_test_ts",
       "label": "inventoryImportCostOverlayOrchestration.test.ts",
@@ -210853,7 +211012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_products_sku_test_ts",
       "label": "products.sku.test.ts",
@@ -210862,7 +211021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_createproductsqueryctx",
       "label": "createProductsQueryCtx()",
@@ -210871,7 +211030,7 @@
       "source_location": "L305"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_createskumutationctx",
       "label": "createSkuMutationCtx()",
@@ -210880,7 +211039,7 @@
       "source_location": "L161"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_gethandler",
       "label": "getHandler()",
@@ -210889,7 +211048,7 @@
       "source_location": "L91"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_gettestscheduler",
       "label": "getTestScheduler()",
@@ -210898,7 +211057,7 @@
       "source_location": "L95"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_pendingcheckoutevidence",
       "label": "pendingCheckoutEvidence()",
@@ -210907,7 +211066,7 @@
       "source_location": "L101"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_pendingcheckoutitem",
       "label": "pendingCheckoutItem()",
@@ -210916,7 +211075,7 @@
       "source_location": "L113"
     },
     {
-      "community": 286,
+      "community": 287,
       "file_type": "code",
       "id": "products_sku_test_pendingcheckoutreviewworkitem",
       "label": "pendingCheckoutReviewWorkItem()",
@@ -210925,7 +211084,7 @@
       "source_location": "L139"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "migrateposamountstopesewas_convertcloseoutrecords",
       "label": "convertCloseoutRecords()",
@@ -210934,7 +211093,7 @@
       "source_location": "L48"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "migrateposamountstopesewas_convertpayments",
       "label": "convertPayments()",
@@ -210943,7 +211102,7 @@
       "source_location": "L38"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "migrateposamountstopesewas_migrateposamounttablewithctx",
       "label": "migratePosAmountTableWithCtx()",
@@ -210952,7 +211111,7 @@
       "source_location": "L150"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "migrateposamountstopesewas_pesewaspatchforrow",
       "label": "pesewasPatchForRow()",
@@ -210961,7 +211120,7 @@
       "source_location": "L73"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "migrateposamountstopesewas_posamountmigrationstatuswithctx",
       "label": "posAmountMigrationStatusWithCtx()",
@@ -210970,7 +211129,7 @@
       "source_location": "L196"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "migrateposamountstopesewas_topesewasoptional",
       "label": "toPesewasOptional()",
@@ -210979,7 +211138,7 @@
       "source_location": "L34"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "migrateposamountstopesewas_upsertmigrationrun",
       "label": "upsertMigrationRun()",
@@ -210988,7 +211147,7 @@
       "source_location": "L112"
     },
     {
-      "community": 287,
+      "community": 288,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateposamountstopesewas_ts",
       "label": "migratePosAmountsToPesewas.ts",
@@ -210997,7 +211156,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "config_buildmtncollectionscallbackurl",
       "label": "buildMtnCollectionsCallbackUrl()",
@@ -211006,7 +211165,7 @@
       "source_location": "L135"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "config_buildmtncollectionslookupprefixes",
       "label": "buildMtnCollectionsLookupPrefixes()",
@@ -211015,7 +211174,7 @@
       "source_location": "L43"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "config_istargetenvironment",
       "label": "isTargetEnvironment()",
@@ -211024,7 +211183,7 @@
       "source_location": "L67"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "config_readscopedvalue",
       "label": "readScopedValue()",
@@ -211033,7 +211192,7 @@
       "source_location": "L56"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "config_resolveconfigforprefix",
       "label": "resolveConfigForPrefix()",
@@ -211042,7 +211201,7 @@
       "source_location": "L73"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "config_resolvemtncollectionsconfigfromenv",
       "label": "resolveMtnCollectionsConfigFromEnv()",
@@ -211051,7 +211210,7 @@
       "source_location": "L108"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "config_toenvsegment",
       "label": "toEnvSegment()",
@@ -211060,84 +211219,12 @@
       "source_location": "L29"
     },
     {
-      "community": 288,
+      "community": 289,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_config_ts",
       "label": "config.ts",
       "norm_label": "config.ts",
       "source_file": "packages/athena-webapp/convex/mtn/config.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalauditeventwithctx",
-      "label": "recordApprovalAuditEventWithCtx()",
-      "norm_label": "recordapprovalauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
-      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
-      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L107"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
-      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
-      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L87"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
-      "label": "recordApprovalRequiredAuditEventWithCtx()",
-      "norm_label": "recordapprovalrequiredauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
-      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
-      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L117"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
-      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
-      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
-      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
-      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
-      "label": "approvalAuditEvents.ts",
-      "norm_label": "approvalauditevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
       "source_location": "L1"
     },
     {
@@ -211449,6 +211536,78 @@
     {
       "community": 290,
       "file_type": "code",
+      "id": "approvalauditevents_recordapprovalauditeventwithctx",
+      "label": "recordApprovalAuditEventWithCtx()",
+      "norm_label": "recordapprovalauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovaldecisionrecordedauditeventwithctx",
+      "label": "recordApprovalDecisionRecordedAuditEventWithCtx()",
+      "norm_label": "recordapprovaldecisionrecordedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L107"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalproofconsumedauditeventwithctx",
+      "label": "recordApprovalProofConsumedAuditEventWithCtx()",
+      "norm_label": "recordapprovalproofconsumedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovalrequiredauditeventwithctx",
+      "label": "recordApprovalRequiredAuditEventWithCtx()",
+      "norm_label": "recordapprovalrequiredauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "approvalauditevents_recordapprovedcommandappliedauditeventwithctx",
+      "label": "recordApprovedCommandAppliedAuditEventWithCtx()",
+      "norm_label": "recordapprovedcommandappliedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L117"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "approvalauditevents_recordasyncapprovalrequestcreatedauditeventwithctx",
+      "label": "recordAsyncApprovalRequestCreatedAuditEventWithCtx()",
+      "norm_label": "recordasyncapprovalrequestcreatedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "approvalauditevents_recordmanagerapprovalgrantedauditeventwithctx",
+      "label": "recordManagerApprovalGrantedAuditEventWithCtx()",
+      "norm_label": "recordmanagerapprovalgrantedauditeventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 290,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_approvalauditevents_ts",
+      "label": "approvalAuditEvents.ts",
+      "norm_label": "approvalauditevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/approvalAuditEvents.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 291,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_possessiontracing_ts",
       "label": "posSessionTracing.ts",
       "norm_label": "possessiontracing.ts",
@@ -211456,7 +211615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "possessiontracing_buildpossessiontraceevent",
       "label": "buildPosSessionTraceEvent()",
@@ -211465,7 +211624,7 @@
       "source_location": "L226"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "possessiontracing_buildpossessiontracerecord",
       "label": "buildPosSessionTraceRecord()",
@@ -211474,7 +211633,7 @@
       "source_location": "L142"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "possessiontracing_buildtracesummary",
       "label": "buildTraceSummary()",
@@ -211483,7 +211642,7 @@
       "source_location": "L105"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "possessiontracing_createpossessiontracerecorder",
       "label": "createPosSessionTraceRecorder()",
@@ -211492,7 +211651,7 @@
       "source_location": "L559"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "possessiontracing_formatpaymentmethod",
       "label": "formatPaymentMethod()",
@@ -211501,7 +211660,7 @@
       "source_location": "L218"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "possessiontracing_recordpossessiontracebesteffort",
       "label": "recordPosSessionTraceBestEffort()",
@@ -211510,7 +211669,7 @@
       "source_location": "L532"
     },
     {
-      "community": 290,
+      "community": 291,
       "file_type": "code",
       "id": "possessiontracing_safetracewrite",
       "label": "safeTraceWrite()",
@@ -211519,7 +211678,7 @@
       "source_location": "L524"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "expensesessioncommands_test_builditem",
       "label": "buildItem()",
@@ -211528,7 +211687,7 @@
       "source_location": "L1083"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "expensesessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -211537,7 +211696,7 @@
       "source_location": "L1077"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "expensesessioncommands_test_buildsession",
       "label": "buildSession()",
@@ -211546,7 +211705,7 @@
       "source_location": "L1073"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "expensesessioncommands_test_createcommandservice",
       "label": "createCommandService()",
@@ -211555,7 +211714,7 @@
       "source_location": "L1093"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "expensesessioncommands_test_createdependencies",
       "label": "createDependencies()",
@@ -211564,7 +211723,7 @@
       "source_location": "L813"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "expensesessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -211573,7 +211732,7 @@
       "source_location": "L900"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "expensesessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
@@ -211582,7 +211741,7 @@
       "source_location": "L793"
     },
     {
-      "community": 291,
+      "community": 292,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_expensesessioncommands_test_ts",
       "label": "expenseSessionCommands.test.ts",
@@ -211591,7 +211750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sessioncommands_test_ts",
       "label": "sessionCommands.test.ts",
@@ -211600,7 +211759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "sessioncommands_test_builditem",
       "label": "buildItem()",
@@ -211609,7 +211768,7 @@
       "source_location": "L3408"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "sessioncommands_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -211618,7 +211777,7 @@
       "source_location": "L3402"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "sessioncommands_test_buildsession",
       "label": "buildSession()",
@@ -211627,7 +211786,7 @@
       "source_location": "L3398"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "sessioncommands_test_createcommandservice",
       "label": "createCommandService()",
@@ -211636,7 +211795,7 @@
       "source_location": "L3418"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "sessioncommands_test_createdependencies",
       "label": "createDependencies()",
@@ -211645,7 +211804,7 @@
       "source_location": "L3125"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "sessioncommands_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -211654,7 +211813,7 @@
       "source_location": "L3222"
     },
     {
-      "community": 292,
+      "community": 293,
       "file_type": "code",
       "id": "sessioncommands_test_loadcommandservice",
       "label": "loadCommandService()",
@@ -211663,7 +211822,7 @@
       "source_location": "L3107"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_projectlocalevents_test_ts",
       "label": "projectLocalEvents.test.ts",
@@ -211672,7 +211831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "projectlocalevents_test_buildexpenserecordedevent",
       "label": "buildExpenseRecordedEvent()",
@@ -211681,7 +211840,7 @@
       "source_location": "L8009"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "projectlocalevents_test_buildpendingcheckoutitemdefinedevent",
       "label": "buildPendingCheckoutItemDefinedEvent()",
@@ -211690,7 +211849,7 @@
       "source_location": "L8092"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "projectlocalevents_test_buildregistercloseoutreviewfact",
       "label": "buildRegisterCloseoutReviewFact()",
@@ -211699,7 +211858,7 @@
       "source_location": "L9150"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "projectlocalevents_test_buildsaleclearedevent",
       "label": "buildSaleClearedEvent()",
@@ -211708,7 +211867,7 @@
       "source_location": "L8145"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "projectlocalevents_test_buildsalecompletedevent",
       "label": "buildSaleCompletedEvent()",
@@ -211717,7 +211876,7 @@
       "source_location": "L8046"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "projectlocalevents_test_buildserviceline",
       "label": "buildServiceLine()",
@@ -211726,7 +211885,7 @@
       "source_location": "L8125"
     },
     {
-      "community": 293,
+      "community": 294,
       "file_type": "code",
       "id": "projectlocalevents_test_createprojectionrepository",
       "label": "createProjectionRepository()",
@@ -211735,7 +211894,7 @@
       "source_location": "L8164"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_resolveterminalcloudrepair_test_ts",
       "label": "resolveTerminalCloudRepair.test.ts",
@@ -211744,7 +211903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildconflict",
       "label": "buildConflict()",
@@ -211753,7 +211912,7 @@
       "source_location": "L587"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildctx",
       "label": "buildCtx()",
@@ -211762,7 +211921,7 @@
       "source_location": "L440"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildevent",
       "label": "buildEvent()",
@@ -211771,7 +211930,7 @@
       "source_location": "L607"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildquery",
       "label": "buildQuery()",
@@ -211780,7 +211939,7 @@
       "source_location": "L499"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildstaffprofile",
       "label": "buildStaffProfile()",
@@ -211789,7 +211948,7 @@
       "source_location": "L566"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildstore",
       "label": "buildStore()",
@@ -211798,7 +211957,7 @@
       "source_location": "L578"
     },
     {
-      "community": 294,
+      "community": 295,
       "file_type": "code",
       "id": "resolveterminalcloudrepair_test_buildterminal",
       "label": "buildTerminal()",
@@ -211807,7 +211966,7 @@
       "source_location": "L553"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_buildgrant",
       "label": "buildGrant()",
@@ -211816,7 +211975,7 @@
       "source_location": "L93"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_getlivekitconfig",
       "label": "getLiveKitConfig()",
@@ -211825,7 +211984,7 @@
       "source_location": "L77"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_isalreadyexistserror",
       "label": "isAlreadyExistsError()",
@@ -211834,7 +211993,7 @@
       "source_location": "L106"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider",
       "label": "LiveKitRemoteAssistTransportProvider",
@@ -211843,7 +212002,7 @@
       "source_location": "L27"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_constructor",
       "label": ".constructor()",
@@ -211852,7 +212011,7 @@
       "source_location": "L30"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_ensureroom",
       "label": ".ensureRoom()",
@@ -211861,7 +212020,7 @@
       "source_location": "L54"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_livekitremoteassisttransportprovider_issuecredential",
       "label": ".issueCredential()",
@@ -211870,7 +212029,7 @@
       "source_location": "L32"
     },
     {
-      "community": 295,
+      "community": 296,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_livekitremoteassisttransportprovider_ts",
       "label": "LiveKitRemoteAssistTransportProvider.ts",
@@ -211879,7 +212038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "ingest_addmetric",
       "label": "addMetric()",
@@ -211888,7 +212047,7 @@
       "source_location": "L287"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "ingest_applytoopenday",
       "label": "applyToOpenDay()",
@@ -211897,7 +212056,7 @@
       "source_location": "L294"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "ingest_factdeltas",
       "label": "factDeltas()",
@@ -211906,7 +212065,7 @@
       "source_location": "L86"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "ingest_findexistingfact",
       "label": "findExistingFact()",
@@ -211915,7 +212074,7 @@
       "source_location": "L243"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "ingest_markdirty",
       "label": "markDirty()",
@@ -211924,7 +212083,7 @@
       "source_location": "L262"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "ingest_recordfacts",
       "label": "recordFacts()",
@@ -211933,7 +212092,7 @@
       "source_location": "L486"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "ingest_tofactdoc",
       "label": "toFactDoc()",
@@ -211942,7 +212101,7 @@
       "source_location": "L215"
     },
     {
-      "community": 296,
+      "community": 297,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_ingest_ts",
       "label": "ingest.ts",
@@ -211951,7 +212110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_sweeper_test_ts",
       "label": "sweeper.test.ts",
@@ -211960,7 +212119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sweeper_test_allow",
       "label": "allow()",
@@ -211969,7 +212128,7 @@
       "source_location": "L45"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sweeper_test_close",
       "label": "close()",
@@ -211978,7 +212137,7 @@
       "source_location": "L67"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sweeper_test_insertsalefact",
       "label": "insertSaleFact()",
@@ -211987,7 +212146,7 @@
       "source_location": "L178"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sweeper_test_mark",
       "label": "mark()",
@@ -211996,7 +212155,7 @@
       "source_location": "L217"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sweeper_test_marksof",
       "label": "marksOf()",
@@ -212005,7 +212164,7 @@
       "source_location": "L236"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sweeper_test_seedstore",
       "label": "seedStore()",
@@ -212014,7 +212173,7 @@
       "source_location": "L124"
     },
     {
-      "community": 297,
+      "community": 298,
       "file_type": "code",
       "id": "sweeper_test_sweep",
       "label": "sweep()",
@@ -212023,7 +212182,7 @@
       "source_location": "L234"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_verify_ts",
       "label": "verify.ts",
@@ -212032,7 +212191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_candidatewindow",
       "label": "candidateWindow()",
@@ -212041,7 +212200,7 @@
       "source_location": "L158"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_computeexpectedday",
       "label": "computeExpectedDay()",
@@ -212050,7 +212209,7 @@
       "source_location": "L180"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_diffmetrics",
       "label": "diffMetrics()",
@@ -212059,7 +212218,7 @@
       "source_location": "L417"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_foldedmetrics",
       "label": "foldedMetrics()",
@@ -212068,7 +212227,7 @@
       "source_location": "L430"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_verifydaywithctx",
       "label": "verifyDayWithCtx()",
@@ -212077,7 +212236,7 @@
       "source_location": "L442"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_verifystoresummarywithctx",
       "label": "verifyStoreSummaryWithCtx()",
@@ -212086,85 +212245,13 @@
       "source_location": "L491"
     },
     {
-      "community": 298,
+      "community": 299,
       "file_type": "code",
       "id": "verify_zerometrics",
       "label": "zeroMetrics()",
       "norm_label": "zerometrics()",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
       "source_location": "L143"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "offers_buildofferproductemailitem",
-      "label": "buildOfferProductEmailItem()",
-      "norm_label": "buildofferproductemailitem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "offers_createoffer",
-      "label": "createOffer()",
-      "norm_label": "createoffer()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L129"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "offers_formatofferproductprice",
-      "label": "formatOfferProductPrice()",
-      "norm_label": "formatofferproductprice()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "offers_getdiscountedofferproductprice",
-      "label": "getDiscountedOfferProductPrice()",
-      "norm_label": "getdiscountedofferproductprice()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "offers_getupsellproducts",
-      "label": "getUpsellProducts()",
-      "norm_label": "getupsellproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L793"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "offers_isduplicate",
-      "label": "isDuplicate()",
-      "norm_label": "isduplicate()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "offers_updatestorefrontactoremail",
-      "label": "updateStoreFrontActorEmail()",
-      "norm_label": "updatestorefrontactoremail()",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_offers_ts",
-      "label": "offers.ts",
-      "norm_label": "offers.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
-      "source_location": "L1"
     },
     {
       "community": 3,
@@ -213159,6 +213246,78 @@
     {
       "community": 300,
       "file_type": "code",
+      "id": "offers_buildofferproductemailitem",
+      "label": "buildOfferProductEmailItem()",
+      "norm_label": "buildofferproductemailitem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "offers_createoffer",
+      "label": "createOffer()",
+      "norm_label": "createoffer()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L129"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "offers_formatofferproductprice",
+      "label": "formatOfferProductPrice()",
+      "norm_label": "formatofferproductprice()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "offers_getdiscountedofferproductprice",
+      "label": "getDiscountedOfferProductPrice()",
+      "norm_label": "getdiscountedofferproductprice()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "offers_getupsellproducts",
+      "label": "getUpsellProducts()",
+      "norm_label": "getupsellproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L793"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "offers_isduplicate",
+      "label": "isDuplicate()",
+      "norm_label": "isduplicate()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "offers_updatestorefrontactoremail",
+      "label": "updateStoreFrontActorEmail()",
+      "norm_label": "updatestorefrontactoremail()",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_offers_ts",
+      "label": "offers.ts",
+      "norm_label": "offers.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/offers.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_public_ts",
       "label": "public.ts",
       "norm_label": "public.ts",
@@ -213166,7 +213325,7 @@
       "source_location": "L1"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "public_assertdefaultworkflowtraceaccess",
       "label": "assertDefaultWorkflowTraceAccess()",
@@ -213175,7 +213334,7 @@
       "source_location": "L112"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "public_assertworkflowtraceaccess",
       "label": "assertWorkflowTraceAccess()",
@@ -213184,7 +213343,7 @@
       "source_location": "L84"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "public_getregistersessiontraceidentity",
       "label": "getRegisterSessionTraceIdentity()",
@@ -213193,7 +213352,7 @@
       "source_location": "L127"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbyidwithctx",
       "label": "getWorkflowTraceViewByIdWithCtx()",
@@ -213202,7 +213361,7 @@
       "source_location": "L191"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "public_getworkflowtraceviewbylookupwithctx",
       "label": "getWorkflowTraceViewByLookupWithCtx()",
@@ -213211,7 +213370,7 @@
       "source_location": "L267"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "public_requireadminworkflowtraceaccess",
       "label": "requireAdminWorkflowTraceAccess()",
@@ -213220,85 +213379,13 @@
       "source_location": "L44"
     },
     {
-      "community": 300,
+      "community": 301,
       "file_type": "code",
       "id": "public_requirefulladminormanagerelevationtraceaccess",
       "label": "requireFullAdminOrManagerElevationTraceAccess()",
       "norm_label": "requirefulladminormanagerelevationtraceaccess()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/public.ts",
       "source_location": "L52"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_reportscontract_ts",
-      "label": "reportsContract.ts",
-      "norm_label": "reportscontract.ts",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "reportscontract_dayperiodkey",
-      "label": "dayPeriodKey()",
-      "norm_label": "dayperiodkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "reportscontract_descendingsortkey",
-      "label": "descendingSortKey()",
-      "norm_label": "descendingsortkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L254"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "reportscontract_monthperiodkey",
-      "label": "monthPeriodKey()",
-      "norm_label": "monthperiodkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L214"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "reportscontract_normalizecurrencycode",
-      "label": "normalizeCurrencyCode()",
-      "norm_label": "normalizecurrencycode()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L264"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "reportscontract_periodkeysforoperatingdate",
-      "label": "periodKeysForOperatingDate()",
-      "norm_label": "periodkeysforoperatingdate()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L243"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "reportscontract_trailingthreemonthsstart",
-      "label": "trailingThreeMonthsStart()",
-      "norm_label": "trailingthreemonthsstart()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L219"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "reportscontract_weekperiodkey",
-      "label": "weekPeriodKey()",
-      "norm_label": "weekperiodkey()",
-      "source_file": "packages/athena-webapp/shared/reportsContract.ts",
-      "source_location": "L233"
     },
     {
       "community": 302,
@@ -225705,6 +225792,60 @@
     {
       "community": 434,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
+      "label": "ReportDaysPanel.tsx",
+      "norm_label": "reportdayspanel.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 434,
+      "file_type": "code",
+      "id": "reportdayspanel_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
+      "source_location": "L212"
+    },
+    {
+      "community": 434,
+      "file_type": "code",
+      "id": "reportdayspanel_isinselectedrange",
+      "label": "isInSelectedRange()",
+      "norm_label": "isinselectedrange()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 434,
+      "file_type": "code",
+      "id": "reportdayspanel_isselectedday",
+      "label": "isSelectedDay()",
+      "norm_label": "isselectedday()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
+      "source_location": "L136"
+    },
+    {
+      "community": 434,
+      "file_type": "code",
+      "id": "reportdayspanel_pagecontainingdate",
+      "label": "pageContainingDate()",
+      "norm_label": "pagecontainingdate()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 434,
+      "file_type": "code",
+      "id": "reportdayspanel_selectday",
+      "label": "selectDay()",
+      "norm_label": "selectday()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
+      "source_location": "L140"
+    },
+    {
+      "community": 435,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
       "label": "ReviewsView.tsx",
       "norm_label": "reviewsview.tsx",
@@ -225712,7 +225853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "reviewsview_handleapprove",
       "label": "handleApprove()",
@@ -225721,7 +225862,7 @@
       "source_location": "L44"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "reviewsview_handlepublish",
       "label": "handlePublish()",
@@ -225730,7 +225871,7 @@
       "source_location": "L80"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "reviewsview_handlereject",
       "label": "handleReject()",
@@ -225739,7 +225880,7 @@
       "source_location": "L62"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "reviewsview_handleunpublish",
       "label": "handleUnpublish()",
@@ -225748,7 +225889,7 @@
       "source_location": "L98"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "reviewsview_header",
       "label": "Header()",
@@ -225757,7 +225898,7 @@
       "source_location": "L15"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogform_ts",
       "label": "serviceCatalogForm.ts",
@@ -225766,7 +225907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "servicecatalogform_formatservicecatalogname",
       "label": "formatServiceCatalogName()",
@@ -225775,7 +225916,7 @@
       "source_location": "L92"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "servicecatalogform_itemtoservicecatalogformstate",
       "label": "itemToServiceCatalogFormState()",
@@ -225784,7 +225925,7 @@
       "source_location": "L154"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "servicecatalogform_parseservicecatalogcreateform",
       "label": "parseServiceCatalogCreateForm()",
@@ -225793,7 +225934,7 @@
       "source_location": "L178"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "servicecatalogform_parseservicecatalogupdateform",
       "label": "parseServiceCatalogUpdateForm()",
@@ -225802,7 +225943,7 @@
       "source_location": "L203"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "servicecatalogform_validateservicecatalogform",
       "label": "validateServiceCatalogForm()",
@@ -225811,7 +225952,7 @@
       "source_location": "L102"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "feesview_formatdeliveryfeeinput",
       "label": "formatDeliveryFeeInput()",
@@ -225820,7 +225961,7 @@
       "source_location": "L31"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -225829,7 +225970,7 @@
       "source_location": "L162"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -225838,7 +225979,7 @@
       "source_location": "L88"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "feesview_parsedeliveryfeeinputs",
       "label": "parseDeliveryFeeInputs()",
@@ -225847,7 +225988,7 @@
       "source_location": "L45"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "feesview_parseoptionaldeliveryfeeinput",
       "label": "parseOptionalDeliveryFeeInput()",
@@ -225856,66 +225997,12 @@
       "source_location": "L35"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
       "norm_label": "feesview.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/FeesView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "image_uploader_ondragend",
-      "label": "onDragEnd()",
-      "norm_label": "ondragend()",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L101"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "image_uploader_ondrop",
-      "label": "onDrop()",
-      "norm_label": "ondrop()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "image_uploader_removeimage",
-      "label": "removeImage()",
-      "norm_label": "removeimage()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L31"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "image_uploader_unmarkfordeletion",
-      "label": "unmarkForDeletion()",
-      "norm_label": "unmarkfordeletion()",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 437,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
-      "label": "image-uploader.tsx",
-      "norm_label": "image-uploader.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
       "source_location": "L1"
     },
     {
@@ -228054,6 +228141,60 @@
     {
       "community": 463,
       "file_type": "code",
+      "id": "image_uploader_ondragend",
+      "label": "onDragEnd()",
+      "norm_label": "ondragend()",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L101"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
+      "id": "image_uploader_ondrop",
+      "label": "onDrop()",
+      "norm_label": "ondrop()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
+      "id": "image_uploader_removeimage",
+      "label": "removeImage()",
+      "norm_label": "removeimage()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L31"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
+      "id": "image_uploader_unmarkfordeletion",
+      "label": "unmarkForDeletion()",
+      "norm_label": "unmarkfordeletion()",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 463,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
+      "label": "image-uploader.tsx",
+      "norm_label": "image-uploader.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 464,
+      "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
       "norm_label": "getremainingforfreedelivery()",
@@ -228061,7 +228202,7 @@
       "source_location": "L138"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -228070,7 +228211,7 @@
       "source_location": "L100"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -228079,7 +228220,7 @@
       "source_location": "L74"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -228088,7 +228229,7 @@
       "source_location": "L34"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -228097,7 +228238,7 @@
       "source_location": "L17"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
@@ -228106,7 +228247,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
@@ -228115,7 +228256,7 @@
       "source_location": "L149"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -228124,7 +228265,7 @@
       "source_location": "L156"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -228133,7 +228274,7 @@
       "source_location": "L201"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -228142,7 +228283,7 @@
       "source_location": "L93"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -228151,7 +228292,7 @@
       "source_location": "L282"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
@@ -228160,7 +228301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "coverage_summary_test_coveragesummary",
       "label": "coverageSummary()",
@@ -228169,7 +228310,7 @@
       "source_location": "L27"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "coverage_summary_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -228178,7 +228319,7 @@
       "source_location": "L15"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "coverage_summary_test_write",
       "label": "write()",
@@ -228187,7 +228328,7 @@
       "source_location": "L21"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "coverage_summary_test_writepackagesummaries",
       "label": "writePackageSummaries()",
@@ -228196,7 +228337,7 @@
       "source_location": "L38"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "coverage_summary_test_writerealbaselinesummaries",
       "label": "writeRealBaselineSummaries()",
@@ -228205,7 +228346,7 @@
       "source_location": "L54"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "scripts_coverage_summary_test_ts",
       "label": "coverage-summary.test.ts",
@@ -228214,7 +228355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "delivery_documentation_check_assertdeliverydocumentationcheck",
       "label": "assertDeliveryDocumentationCheck()",
@@ -228223,7 +228364,7 @@
       "source_location": "L29"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "delivery_documentation_check_changedfiles",
       "label": "changedFiles()",
@@ -228232,7 +228373,7 @@
       "source_location": "L102"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "delivery_documentation_check_findingsfrom",
       "label": "findingsFrom()",
@@ -228241,7 +228382,7 @@
       "source_location": "L22"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "delivery_documentation_check_ispolicyfailure",
       "label": "isPolicyFailure()",
@@ -228250,7 +228391,7 @@
       "source_location": "L70"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "delivery_documentation_check_parseargs",
       "label": "parseArgs()",
@@ -228259,7 +228400,7 @@
       "source_location": "L74"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "scripts_delivery_documentation_check_ts",
       "label": "delivery-documentation-check.ts",
@@ -228268,7 +228409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
@@ -228277,7 +228418,7 @@
       "source_location": "L73"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -228286,7 +228427,7 @@
       "source_location": "L125"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -228295,7 +228436,7 @@
       "source_location": "L107"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -228304,7 +228445,7 @@
       "source_location": "L64"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -228313,7 +228454,7 @@
       "source_location": "L152"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
@@ -228322,7 +228463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "harness_inferential_review_test_commitfixturerepo",
       "label": "commitFixtureRepo()",
@@ -228331,7 +228472,7 @@
       "source_location": "L168"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -228340,7 +228481,7 @@
       "source_location": "L65"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "harness_inferential_review_test_gitfixtureenv",
       "label": "gitFixtureEnv()",
@@ -228349,7 +228490,7 @@
       "source_location": "L59"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "harness_inferential_review_test_runfixturecommand",
       "label": "runFixtureCommand()",
@@ -228358,7 +228499,7 @@
       "source_location": "L21"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -228367,66 +228508,12 @@
       "source_location": "L15"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
       "norm_label": "harness-inferential-review.test.ts",
       "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "harness_repo_validation_collectharnessrepovalidationcapabilities",
-      "label": "collectHarnessRepoValidationCapabilities()",
-      "norm_label": "collectharnessrepovalidationcapabilities()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "harness_repo_validation_collectharnessrepovalidationselection",
-      "label": "collectHarnessRepoValidationSelection()",
-      "norm_label": "collectharnessrepovalidationselection()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "harness_repo_validation_matchesharnessrepovalidationpath",
-      "label": "matchesHarnessRepoValidationPath()",
-      "norm_label": "matchesharnessrepovalidationpath()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "harness_repo_validation_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "harness_repo_validation_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "scripts_harness_repo_validation_ts",
-      "label": "harness-repo-validation.ts",
-      "norm_label": "harness-repo-validation.ts",
-      "source_file": "scripts/harness-repo-validation.ts",
       "source_location": "L1"
     },
     {
@@ -228684,6 +228771,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "harness_repo_validation_collectharnessrepovalidationcapabilities",
+      "label": "collectHarnessRepoValidationCapabilities()",
+      "norm_label": "collectharnessrepovalidationcapabilities()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "harness_repo_validation_collectharnessrepovalidationselection",
+      "label": "collectHarnessRepoValidationSelection()",
+      "norm_label": "collectharnessrepovalidationselection()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "harness_repo_validation_matchesharnessrepovalidationpath",
+      "label": "matchesHarnessRepoValidationPath()",
+      "norm_label": "matchesharnessrepovalidationpath()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "harness_repo_validation_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "harness_repo_validation_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "scripts_harness_repo_validation_ts",
+      "label": "harness-repo-validation.ts",
+      "norm_label": "harness-repo-validation.ts",
+      "source_file": "scripts/harness-repo-validation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "pre_push_validation_proof_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -228691,7 +228832,7 @@
       "source_location": "L20"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createspawn",
       "label": "createSpawn()",
@@ -228700,7 +228841,7 @@
       "source_location": "L63"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_log",
       "label": "log()",
@@ -228709,7 +228850,7 @@
       "source_location": "L147"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_warn",
       "label": "warn()",
@@ -228718,7 +228859,7 @@
       "source_location": "L287"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_write",
       "label": "write()",
@@ -228727,7 +228868,7 @@
       "source_location": "L14"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "scripts_pre_push_validation_proof_test_ts",
       "label": "pre-push-validation-proof.test.ts",
@@ -228736,7 +228877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "scripts_validate_plan_html_ts",
       "label": "validate-plan-html.ts",
@@ -228745,7 +228886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "validate_plan_html_collectdefaultplanhtmlfiles",
       "label": "collectDefaultPlanHtmlFiles()",
@@ -228754,7 +228895,7 @@
       "source_location": "L16"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "validate_plan_html_collectplanhtmlfindings",
       "label": "collectPlanHtmlFindings()",
@@ -228763,7 +228904,7 @@
       "source_location": "L31"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "validate_plan_html_hasremotereference",
       "label": "hasRemoteReference()",
@@ -228772,7 +228913,7 @@
       "source_location": "L27"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "validate_plan_html_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -228781,7 +228922,7 @@
       "source_location": "L12"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "validate_plan_html_runplanhtmlvalidation",
       "label": "runPlanHtmlValidation()",
@@ -228790,7 +228931,7 @@
       "source_location": "L119"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "closeouts_test_createcloseoutmappingholdctx",
       "label": "createCloseoutMappingHoldCtx()",
@@ -228799,7 +228940,7 @@
       "source_location": "L32"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "closeouts_test_creatependingitemadjustmentapprovalctx",
       "label": "createPendingItemAdjustmentApprovalCtx()",
@@ -228808,7 +228949,7 @@
       "source_location": "L184"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -228817,7 +228958,7 @@
       "source_location": "L28"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -228826,7 +228967,7 @@
       "source_location": "L24"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -228835,7 +228976,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "label": "paymentAllocationAttribution.ts",
@@ -228844,7 +228985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "paymentallocationattribution_buildinstorepaymentallocations",
       "label": "buildInStorePaymentAllocations()",
@@ -228853,7 +228994,7 @@
       "source_location": "L46"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "paymentallocationattribution_normalizeinstorepayments",
       "label": "normalizeInStorePayments()",
@@ -228862,7 +229003,7 @@
       "source_location": "L22"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
@@ -228871,7 +229012,7 @@
       "source_location": "L124"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "paymentallocationattribution_selectregistersessionforattribution",
       "label": "selectRegisterSessionForAttribution()",
@@ -228880,7 +229021,7 @@
       "source_location": "L87"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessionactivity_test_ts",
       "label": "registerSessionActivity.test.ts",
@@ -228889,7 +229030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "registersessionactivity_test_admissionawareauthimplementation",
       "label": "admissionAwareAuthImplementation()",
@@ -228898,7 +229039,7 @@
       "source_location": "L218"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "registersessionactivity_test_baseevent",
       "label": "baseEvent()",
@@ -228907,7 +229048,7 @@
       "source_location": "L27"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "registersessionactivity_test_basemapping",
       "label": "baseMapping()",
@@ -228916,7 +229057,7 @@
       "source_location": "L58"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "registersessionactivity_test_gethandler",
       "label": "getHandler()",
@@ -228925,7 +229066,7 @@
       "source_location": "L22"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -228934,7 +229075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildapprovalproof",
       "label": "buildApprovalProof()",
@@ -228943,7 +229084,7 @@
       "source_location": "L382"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -228952,7 +229093,7 @@
       "source_location": "L106"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -228961,7 +229102,7 @@
       "source_location": "L122"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -228970,7 +229111,7 @@
       "source_location": "L401"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealert_tsx",
       "label": "RegisterCloseoutVarianceAlert.tsx",
@@ -228979,7 +229120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealert",
       "label": "RegisterCloseoutVarianceAlert()",
@@ -228988,7 +229129,7 @@
       "source_location": "L59"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "registercloseoutvariancealert_sectionheading",
       "label": "SectionHeading()",
@@ -228997,7 +229138,7 @@
       "source_location": "L186"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "registercloseoutvariancealert_statusbadge",
       "label": "StatusBadge()",
@@ -229006,7 +229147,7 @@
       "source_location": "L196"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "registercloseoutvariancealert_summaryvaluestylefor",
       "label": "summaryValueStyleFor()",
@@ -229015,7 +229156,7 @@
       "source_location": "L224"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "homepagesnapshot_isdisplayablemarker",
       "label": "isDisplayableMarker()",
@@ -229024,7 +229165,7 @@
       "source_location": "L29"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "homepagesnapshot_presentsnapshotatrequesttime",
       "label": "presentSnapshotAtRequestTime()",
@@ -229033,7 +229174,7 @@
       "source_location": "L33"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "homepagesnapshot_resolvehomepagesnapshotbootstrap",
       "label": "resolveHomepageSnapshotBootstrap()",
@@ -229042,7 +229183,7 @@
       "source_location": "L53"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "homepagesnapshot_setbootstrapcookie",
       "label": "setBootstrapCookie()",
@@ -229051,7 +229192,7 @@
       "source_location": "L124"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_ts",
       "label": "homepageSnapshot.ts",
@@ -229060,7 +229201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "lifecycle_assertartifacttransition",
       "label": "assertArtifactTransition()",
@@ -229069,7 +229210,7 @@
       "source_location": "L59"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "lifecycle_assertruntransition",
       "label": "assertRunTransition()",
@@ -229078,7 +229219,7 @@
       "source_location": "L43"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "lifecycle_cantransitionartifact",
       "label": "canTransitionArtifact()",
@@ -229087,7 +229228,7 @@
       "source_location": "L52"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "lifecycle_cantransitionrun",
       "label": "canTransitionRun()",
@@ -229096,58 +229237,13 @@
       "source_location": "L36"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_lifecycle_ts",
       "label": "lifecycle.ts",
       "norm_label": "lifecycle.ts",
       "source_file": "packages/athena-webapp/convex/intelligence/lifecycle.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_providers_tanstack_ts",
-      "label": "tanstack.ts",
-      "norm_label": "tanstack.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "tanstack_createtanstackstructuredtextprovider",
-      "label": "createTanStackStructuredTextProvider()",
-      "norm_label": "createtanstackstructuredtextprovider()",
-      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "tanstack_extractstructuredoutput",
-      "label": "extractStructuredOutput()",
-      "norm_label": "extractstructuredoutput()",
-      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "tanstack_loadopenaiadapter",
-      "label": "loadOpenAiAdapter()",
-      "norm_label": "loadopenaiadapter()",
-      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "tanstack_loadtanstackai",
-      "label": "loadTanStackAi()",
-      "norm_label": "loadtanstackai()",
-      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
-      "source_location": "L143"
     },
     {
       "community": 48,
@@ -229395,6 +229491,51 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_intelligence_providers_tanstack_ts",
+      "label": "tanstack.ts",
+      "norm_label": "tanstack.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "tanstack_createtanstackstructuredtextprovider",
+      "label": "createTanStackStructuredTextProvider()",
+      "norm_label": "createtanstackstructuredtextprovider()",
+      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "tanstack_extractstructuredoutput",
+      "label": "extractStructuredOutput()",
+      "norm_label": "extractstructuredoutput()",
+      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
+      "source_location": "L134"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "tanstack_loadopenaiadapter",
+      "label": "loadOpenAiAdapter()",
+      "norm_label": "loadopenaiadapter()",
+      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "tanstack_loadtanstackai",
+      "label": "loadTanStackAi()",
+      "norm_label": "loadtanstackai()",
+      "source_file": "packages/athena-webapp/convex/intelligence/providers/tanstack.ts",
+      "source_location": "L143"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "featureditem_countfeaturedtargets",
       "label": "countFeaturedTargets()",
       "norm_label": "countfeaturedtargets()",
@@ -229402,7 +229543,7 @@
       "source_location": "L43"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "featureditem_getnextfeatureditemrank",
       "label": "getNextFeaturedItemRank()",
@@ -229411,7 +229552,7 @@
       "source_location": "L103"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "featureditem_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -229420,7 +229561,7 @@
       "source_location": "L23"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "featureditem_validatefeaturedplacement",
       "label": "validateFeaturedPlacement()",
@@ -229429,7 +229570,7 @@
       "source_location": "L52"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -229438,7 +229579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
@@ -229447,7 +229588,7 @@
       "source_location": "L114"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -229456,7 +229597,7 @@
       "source_location": "L39"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -229465,7 +229606,7 @@
       "source_location": "L19"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -229474,7 +229615,7 @@
       "source_location": "L81"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
@@ -229483,7 +229624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_storeschedule_test_ts",
       "label": "storeSchedule.test.ts",
@@ -229492,7 +229633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "storeschedule_test_baseschedule",
       "label": "baseSchedule()",
@@ -229501,7 +229642,7 @@
       "source_location": "L28"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "storeschedule_test_createbackfillctx",
       "label": "createBackfillCtx()",
@@ -229510,7 +229651,7 @@
       "source_location": "L545"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "storeschedule_test_policy",
       "label": "policy()",
@@ -229519,7 +229660,7 @@
       "source_location": "L527"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "storeschedule_test_readprojectfile",
       "label": "readProjectFile()",
@@ -229528,7 +229669,7 @@
       "source_location": "L25"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "commerceeffects_applycommerceinventoryeffectwithctx",
       "label": "applyCommerceInventoryEffectWithCtx()",
@@ -229537,7 +229678,7 @@
       "source_location": "L152"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "commerceeffects_outboundbasisfromeffect",
       "label": "outboundBasisFromEffect()",
@@ -229546,7 +229687,7 @@
       "source_location": "L79"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "commerceeffects_reportinglinecostfromeffect",
       "label": "reportingLineCostFromEffect()",
@@ -229555,7 +229696,7 @@
       "source_location": "L116"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "commerceeffects_uncostedoutboundbasis",
       "label": "uncostedOutboundBasis()",
@@ -229564,7 +229705,7 @@
       "source_location": "L64"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_commerceeffects_ts",
       "label": "commerceEffects.ts",
@@ -229573,7 +229714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "deficitresolutionwork_allocatedeferreddeficitcost",
       "label": "allocateDeferredDeficitCost()",
@@ -229582,7 +229723,7 @@
       "source_location": "L25"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "deficitresolutionwork_enqueuedeficitresolutionworkwithctx",
       "label": "enqueueDeficitResolutionWorkWithCtx()",
@@ -229591,7 +229732,7 @@
       "source_location": "L46"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "deficitresolutionwork_historicalcostlane",
       "label": "historicalCostLane()",
@@ -229600,7 +229741,7 @@
       "source_location": "L19"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "deficitresolutionwork_materializedeferredadjustmentwithctx",
       "label": "materializeDeferredAdjustmentWithCtx()",
@@ -229609,7 +229750,7 @@
       "source_location": "L107"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_deficitresolutionwork_ts",
       "label": "deficitResolutionWork.ts",
@@ -229618,7 +229759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "currency_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -229627,7 +229768,7 @@
       "source_location": "L9"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -229636,7 +229777,7 @@
       "source_location": "L5"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -229645,7 +229786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -229654,7 +229795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -229663,7 +229804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_ts",
       "label": "walkthroughRequestNotifications.ts",
@@ -229672,7 +229813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -229681,7 +229822,7 @@
       "source_location": "L27"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_classifydeliveryresult",
       "label": "classifyDeliveryResult()",
@@ -229690,7 +229831,7 @@
       "source_location": "L13"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_isdeliberateretryeligible",
       "label": "isDeliberateRetryEligible()",
@@ -229699,7 +229840,7 @@
       "source_location": "L20"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_nextbackoffms",
       "label": "nextBackoffMs()",
@@ -229708,7 +229849,7 @@
       "source_location": "L12"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
       "label": "backfillStoreTimezoneAuthorityWithCtx()",
@@ -229717,7 +229858,7 @@
       "source_location": "L127"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_buildrow",
       "label": "buildRow()",
@@ -229726,7 +229867,7 @@
       "source_location": "L47"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_listschedulesforstore",
       "label": "listSchedulesForStore()",
@@ -229735,7 +229876,7 @@
       "source_location": "L35"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_normalizelimit",
       "label": "normalizeLimit()",
@@ -229744,7 +229885,7 @@
       "source_location": "L28"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
       "label": "backfillStoreTimezoneAuthority.ts",
@@ -229753,7 +229894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dispatch_recordnotificationfailureeventwithctx",
       "label": "recordNotificationFailureEventWithCtx()",
@@ -229762,7 +229903,7 @@
       "source_location": "L401"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dispatch_recordterminaldeliveryfailureevent",
       "label": "recordTerminalDeliveryFailureEvent()",
@@ -229771,7 +229912,7 @@
       "source_location": "L428"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dispatch_resolverecipients",
       "label": "resolveRecipients()",
@@ -229780,7 +229921,7 @@
       "source_location": "L54"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "dispatch_suppressintentwithctx",
       "label": "suppressIntentWithCtx()",
@@ -229789,58 +229930,13 @@
       "source_location": "L86"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
       "label": "dispatch.ts",
       "norm_label": "dispatch.ts",
       "source_file": "packages/athena-webapp/convex/notifications/dispatch.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_registry_test_ts",
-      "label": "registry.test.ts",
-      "norm_label": "registry.test.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "registry_test_dedupekey",
-      "label": "dedupeKey()",
-      "norm_label": "dedupekey()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "registry_test_keyfor",
-      "label": "keyFor()",
-      "norm_label": "keyfor()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L376"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "registry_test_prepare",
-      "label": "prepare()",
-      "norm_label": "prepare()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "registry_test_stubctx",
-      "label": "stubCtx()",
-      "norm_label": "stubctx()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
-      "source_location": "L25"
     },
     {
       "community": 49,
@@ -230088,6 +230184,51 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_notifications_registry_test_ts",
+      "label": "registry.test.ts",
+      "norm_label": "registry.test.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "registry_test_dedupekey",
+      "label": "dedupeKey()",
+      "norm_label": "dedupekey()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "registry_test_keyfor",
+      "label": "keyFor()",
+      "norm_label": "keyfor()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
+      "source_location": "L376"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "registry_test_prepare",
+      "label": "prepare()",
+      "norm_label": "prepare()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "registry_test_stubctx",
+      "label": "stubCtx()",
+      "norm_label": "stubctx()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "adapters_createnormaluseroperationadapter",
       "label": "createNormalUserOperationAdapter()",
       "norm_label": "createnormaluseroperationadapter()",
@@ -230095,7 +230236,7 @@
       "source_location": "L13"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "adapters_createpublicoperationadapter",
       "label": "createPublicOperationAdapter()",
@@ -230104,7 +230245,7 @@
       "source_location": "L41"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "adapters_isadmitted",
       "label": "isAdmitted()",
@@ -230113,7 +230254,7 @@
       "source_location": "L115"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "adapters_resolveoperationadmission",
       "label": "resolveOperationAdmission()",
@@ -230122,7 +230263,7 @@
       "source_location": "L59"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_adapters_ts",
       "label": "adapters.ts",
@@ -230131,7 +230272,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "approvalrequesterchallenges_consumeapprovalrequesterchallengewithctx",
       "label": "consumeApprovalRequesterChallengeWithCtx()",
@@ -230140,7 +230281,7 @@
       "source_location": "L97"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "approvalrequesterchallenges_createapprovalrequesterchallengewithctx",
       "label": "createApprovalRequesterChallengeWithCtx()",
@@ -230149,7 +230290,7 @@
       "source_location": "L55"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "approvalrequesterchallenges_invalidapprovalrequesterchallengeresult",
       "label": "invalidApprovalRequesterChallengeResult()",
@@ -230158,7 +230299,7 @@
       "source_location": "L37"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "approvalrequesterchallenges_torequesterbinding",
       "label": "toRequesterBinding()",
@@ -230167,7 +230308,7 @@
       "source_location": "L44"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesterchallenges_ts",
       "label": "approvalRequesterChallenges.ts",
@@ -230176,7 +230317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -230185,7 +230326,7 @@
       "source_location": "L24"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -230194,7 +230335,7 @@
       "source_location": "L207"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -230203,7 +230344,7 @@
       "source_location": "L45"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -230212,7 +230353,7 @@
       "source_location": "L30"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -230221,7 +230362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "dailymanagerreportemail_test_ask",
       "label": "ask()",
@@ -230230,7 +230371,7 @@
       "source_location": "L322"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "dailymanagerreportemail_test_insertlegacydelivery",
       "label": "insertLegacyDelivery()",
@@ -230239,7 +230380,7 @@
       "source_location": "L293"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "dailymanagerreportemail_test_money",
       "label": "money()",
@@ -230248,7 +230389,7 @@
       "source_location": "L75"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "dailymanagerreportemail_test_seedstoreandrun",
       "label": "seedStoreAndRun()",
@@ -230257,7 +230398,7 @@
       "source_location": "L255"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "label": "dailyManagerReportEmail.test.ts",
@@ -230266,7 +230407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "operationalworkitems_test_approvalrequest",
       "label": "approvalRequest()",
@@ -230275,7 +230416,7 @@
       "source_location": "L45"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "operationalworkitems_test_createqueuecontext",
       "label": "createQueueContext()",
@@ -230284,7 +230425,7 @@
       "source_location": "L58"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "operationalworkitems_test_gethandler",
       "label": "getHandler()",
@@ -230293,7 +230434,7 @@
       "source_location": "L24"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "operationalworkitems_test_workitem",
       "label": "workItem()",
@@ -230302,7 +230443,7 @@
       "source_location": "L30"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_test_ts",
       "label": "operationalWorkItems.test.ts",
@@ -230311,7 +230452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "oweddailyclosesweep_completedoperatingdatesforstore",
       "label": "completedOperatingDatesForStore()",
@@ -230320,7 +230461,7 @@
       "source_location": "L149"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "oweddailyclosesweep_daysbetweenoperatingdates",
       "label": "daysBetweenOperatingDates()",
@@ -230329,7 +230470,7 @@
       "source_location": "L354"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "oweddailyclosesweep_listenabledeodpolicies",
       "label": "listEnabledEodPolicies()",
@@ -230338,7 +230479,7 @@
       "source_location": "L135"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "oweddailyclosesweep_selectoweddailyclosedates",
       "label": "selectOwedDailyCloseDates()",
@@ -230347,7 +230488,7 @@
       "source_location": "L84"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "label": "owedDailyCloseSweep.ts",
@@ -230356,7 +230497,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymenttotals_ts",
       "label": "paymentTotals.ts",
@@ -230365,7 +230506,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "paymenttotals_buildpaymenttotals",
       "label": "buildPaymentTotals()",
@@ -230374,7 +230515,7 @@
       "source_location": "L50"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "paymenttotals_listtransactionpayments",
       "label": "listTransactionPayments()",
@@ -230383,7 +230524,7 @@
       "source_location": "L11"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "paymenttotals_transactioncashdelta",
       "label": "transactionCashDelta()",
@@ -230392,7 +230533,7 @@
       "source_location": "L81"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "paymenttotals_transactionpaymenttotals",
       "label": "transactionPaymentTotals()",
@@ -230401,7 +230542,7 @@
       "source_location": "L25"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -230410,7 +230551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "staffcredentials_test_admissionawareauth",
       "label": "admissionAwareAuth()",
@@ -230419,7 +230560,7 @@
       "source_location": "L256"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "staffcredentials_test_createrestoredproofvalidationctx",
       "label": "createRestoredProofValidationCtx()",
@@ -230428,7 +230569,7 @@
       "source_location": "L271"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -230437,7 +230578,7 @@
       "source_location": "L81"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -230446,7 +230587,7 @@
       "source_location": "L267"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -230455,7 +230596,7 @@
       "source_location": "L319"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -230464,7 +230605,7 @@
       "source_location": "L346"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -230473,7 +230614,7 @@
       "source_location": "L303"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -230482,58 +230623,13 @@
       "source_location": "L333"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
       "norm_label": "assigncustomer.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/assignCustomer.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
-      "label": "registerLifecycleAuthority.ts",
-      "norm_label": "registerlifecycleauthority.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
-      "label": "acknowledgeRegisterLifecycleAuthority()",
-      "norm_label": "acknowledgeregisterlifecycleauthority()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_equivalentacknowledgement",
-      "label": "equivalentAcknowledgement()",
-      "norm_label": "equivalentacknowledgement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_isrevision",
-      "label": "isRevision()",
-      "norm_label": "isrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_normalizesafemetadata",
-      "label": "normalizeSafeMetadata()",
-      "norm_label": "normalizesafemetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
-      "source_location": "L145"
     },
     {
       "community": 5,
@@ -231465,6 +231561,51 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
+      "label": "registerLifecycleAuthority.ts",
+      "norm_label": "registerlifecycleauthority.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
+      "label": "acknowledgeRegisterLifecycleAuthority()",
+      "norm_label": "acknowledgeregisterlifecycleauthority()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_equivalentacknowledgement",
+      "label": "equivalentAcknowledgement()",
+      "norm_label": "equivalentacknowledgement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_isrevision",
+      "label": "isRevision()",
+      "norm_label": "isrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_normalizesafemetadata",
+      "label": "normalizeSafeMetadata()",
+      "norm_label": "normalizesafemetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/registerLifecycleAuthority.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
       "norm_label": "builddecision()",
@@ -231472,7 +231613,7 @@
       "source_location": "L107"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -231481,7 +231622,7 @@
       "source_location": "L117"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -231490,7 +231631,7 @@
       "source_location": "L91"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -231499,7 +231640,7 @@
       "source_location": "L99"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -231508,7 +231649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_reconcilesequencegaps_ts",
       "label": "reconcileSequenceGaps.ts",
@@ -231517,7 +231658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "reconcilesequencegaps_collectterminalevidence",
       "label": "collectTerminalEvidence()",
@@ -231526,7 +231667,7 @@
       "source_location": "L185"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "reconcilesequencegaps_issuegapprobe",
       "label": "issueGapProbe()",
@@ -231535,7 +231676,7 @@
       "source_location": "L249"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "reconcilesequencegaps_listheldeventsforcursor",
       "label": "listHeldEventsForCursor()",
@@ -231544,7 +231685,7 @@
       "source_location": "L156"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "reconcilesequencegaps_skipsequencegap",
       "label": "skipSequenceGap()",
@@ -231553,7 +231694,7 @@
       "source_location": "L295"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_policy_test_ts",
       "label": "policy.test.ts",
@@ -231562,7 +231703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "policy_test_baseinput",
       "label": "baseInput()",
@@ -231571,7 +231712,7 @@
       "source_location": "L1225"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "policy_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -231580,7 +231721,7 @@
       "source_location": "L1329"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "policy_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -231589,7 +231730,7 @@
       "source_location": "L1287"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "policy_test_emptysyncevidence",
       "label": "emptySyncEvidence()",
@@ -231598,7 +231739,7 @@
       "source_location": "L1267"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_test_ts",
       "label": "terminalRecoveryRepository.test.ts",
@@ -231607,7 +231748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildctx",
       "label": "buildCtx()",
@@ -231616,7 +231757,7 @@
       "source_location": "L381"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildqueryctx",
       "label": "buildQueryCtx()",
@@ -231625,7 +231766,7 @@
       "source_location": "L469"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_filterrows",
       "label": "filterRows()",
@@ -231634,7 +231775,7 @@
       "source_location": "L483"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_orderedrows",
       "label": "orderedRows()",
@@ -231643,7 +231784,7 @@
       "source_location": "L492"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "customers_requireposcustomeraccessbyid",
       "label": "requirePosCustomerAccessById()",
@@ -231652,7 +231793,7 @@
       "source_location": "L76"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "customers_requireposcustomerreadaccessbyid",
       "label": "requirePosCustomerReadAccessById()",
@@ -231661,7 +231802,7 @@
       "source_location": "L123"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "customers_requireposcustomerstoreaccess",
       "label": "requirePosCustomerStoreAccess()",
@@ -231670,7 +231811,7 @@
       "source_location": "L53"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "customers_requireposcustomerstorereadaccess",
       "label": "requirePosCustomerStoreReadAccess()",
@@ -231679,7 +231820,7 @@
       "source_location": "L99"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -231688,7 +231829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_posrecoverycodes_test_ts",
       "label": "posRecoveryCodes.test.ts",
@@ -231697,7 +231838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "posrecoverycodes_test_buildctx",
       "label": "buildCtx()",
@@ -231706,7 +231847,7 @@
       "source_location": "L565"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "posrecoverycodes_test_createfilter",
       "label": "createFilter()",
@@ -231715,7 +231856,7 @@
       "source_location": "L669"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "posrecoverycodes_test_createquery",
       "label": "createQuery()",
@@ -231724,7 +231865,7 @@
       "source_location": "L642"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "posrecoverycodes_test_gethandler",
       "label": "getHandler()",
@@ -231733,7 +231874,7 @@
       "source_location": "L25"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
@@ -231742,7 +231883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -231751,7 +231892,7 @@
       "source_location": "L106"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -231760,7 +231901,7 @@
       "source_location": "L34"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -231769,7 +231910,7 @@
       "source_location": "L24"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
@@ -231778,7 +231919,7 @@
       "source_location": "L371"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -231787,7 +231928,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -231796,7 +231937,7 @@
       "source_location": "L339"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "transactions_redactpospulsesummary",
       "label": "redactPosPulseSummary()",
@@ -231805,7 +231946,7 @@
       "source_location": "L307"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "transactions_requirepostransactionaccess",
       "label": "requirePosTransactionAccess()",
@@ -231814,7 +231955,7 @@
       "source_location": "L93"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "transactions_requirepostransactionstoreaccess",
       "label": "requirePosTransactionStoreAccess()",
@@ -231823,7 +231964,7 @@
       "source_location": "L64"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_policy_ts",
       "label": "policy.ts",
@@ -231832,7 +231973,7 @@
       "source_location": "L1"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "policy_denied",
       "label": "denied()",
@@ -231841,7 +231982,7 @@
       "source_location": "L96"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "policy_evaluateremoteassistpolicy",
       "label": "evaluateRemoteAssistPolicy()",
@@ -231850,7 +231991,7 @@
       "source_location": "L31"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "policy_isclientfresh",
       "label": "isClientFresh()",
@@ -231859,58 +232000,13 @@
       "source_location": "L88"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "policy_policydecisiontocommandresult",
       "label": "policyDecisionToCommandResult()",
       "norm_label": "policydecisiontocommandresult()",
       "source_file": "packages/athena-webapp/convex/remoteAssist/application/policy.ts",
       "source_location": "L76"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
-      "label": "remoteAssistReadRepository.ts",
-      "norm_label": "remoteassistreadrepository.ts",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
-      "label": "compareRemoteAssistSessionForSupportView()",
-      "norm_label": "compareremoteassistsessionforsupportview()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_createremoteassistreadrepository",
-      "label": "createRemoteAssistReadRepository()",
-      "norm_label": "createremoteassistreadrepository()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_toremoteassistclient",
-      "label": "toRemoteAssistClient()",
-      "norm_label": "toremoteassistclient()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "remoteassistreadrepository_toremoteassistsession",
-      "label": "toRemoteAssistSession()",
-      "norm_label": "toremoteassistsession()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
-      "source_location": "L121"
     },
     {
       "community": 51,
@@ -232158,6 +232254,51 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
+      "label": "remoteAssistReadRepository.ts",
+      "norm_label": "remoteassistreadrepository.ts",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
+      "label": "compareRemoteAssistSessionForSupportView()",
+      "norm_label": "compareremoteassistsessionforsupportview()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_createremoteassistreadrepository",
+      "label": "createRemoteAssistReadRepository()",
+      "norm_label": "createremoteassistreadrepository()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_toremoteassistclient",
+      "label": "toRemoteAssistClient()",
+      "norm_label": "toremoteassistclient()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "remoteassistreadrepository_toremoteassistsession",
+      "label": "toRemoteAssistSession()",
+      "norm_label": "toremoteassistsession()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistReadRepository.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_verify_test_ts",
       "label": "verify.test.ts",
       "norm_label": "verify.test.ts",
@@ -232165,7 +232306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "verify_test_at",
       "label": "at()",
@@ -232174,7 +232315,7 @@
       "source_location": "L31"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "verify_test_folddirtydays",
       "label": "foldDirtyDays()",
@@ -232183,7 +232324,7 @@
       "source_location": "L53"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "verify_test_runreseed",
       "label": "runReseed()",
@@ -232192,7 +232333,7 @@
       "source_location": "L40"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "verify_test_seedverifiableday",
       "label": "seedVerifiableDay()",
@@ -232201,7 +232342,7 @@
       "source_location": "L94"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
       "label": "serviceCases.test.ts",
@@ -232210,7 +232351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "servicecases_test_createinventoryusagectx",
       "label": "createInventoryUsageCtx()",
@@ -232219,7 +232360,7 @@
       "source_location": "L77"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "servicecases_test_expectindex",
       "label": "expectIndex()",
@@ -232228,7 +232369,7 @@
       "source_location": "L66"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "servicecases_test_gethandler",
       "label": "getHandler()",
@@ -232237,7 +232378,7 @@
       "source_location": "L73"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "servicecases_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -232246,7 +232387,7 @@
       "source_location": "L59"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
@@ -232255,7 +232396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -232264,7 +232405,7 @@
       "source_location": "L11"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -232273,7 +232414,7 @@
       "source_location": "L21"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -232282,7 +232423,7 @@
       "source_location": "L87"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -232291,7 +232432,7 @@
       "source_location": "L65"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "admission_test_admissioncontext",
       "label": "admissionContext()",
@@ -232300,7 +232441,7 @@
       "source_location": "L17"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "admission_test_configureadmissionenvironment",
       "label": "configureAdmissionEnvironment()",
@@ -232309,7 +232450,7 @@
       "source_location": "L60"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "admission_test_contextwith",
       "label": "contextWith()",
@@ -232318,7 +232459,7 @@
       "source_location": "L120"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "admission_test_invoke",
       "label": "invoke()",
@@ -232327,7 +232468,7 @@
       "source_location": "L14"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_admission_test_ts",
       "label": "admission.test.ts",
@@ -232336,7 +232477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "config_calculateshareddemoexpectedcash",
       "label": "calculateSharedDemoExpectedCash()",
@@ -232345,7 +232486,7 @@
       "source_location": "L23"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "config_isshareddemoenabled",
       "label": "isSharedDemoEnabled()",
@@ -232354,7 +232495,7 @@
       "source_location": "L33"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "config_readruntimeshareddemoconfig",
       "label": "readRuntimeSharedDemoConfig()",
@@ -232363,7 +232504,7 @@
       "source_location": "L59"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "config_readshareddemoconfig",
       "label": "readSharedDemoConfig()",
@@ -232372,7 +232513,7 @@
       "source_location": "L40"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_config_ts",
       "label": "config.ts",
@@ -232381,7 +232522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemoopeningbaseline",
       "label": "buildSharedDemoOpeningBaseline()",
@@ -232390,7 +232531,7 @@
       "source_location": "L63"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemostoredayevent",
       "label": "buildSharedDemoStoreDayEvent()",
@@ -232399,7 +232540,7 @@
       "source_location": "L105"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "openingbaseline_rollshareddemoopeningbaselinewithctx",
       "label": "rollSharedDemoOpeningBaselineWithCtx()",
@@ -232408,7 +232549,7 @@
       "source_location": "L132"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "openingbaseline_shareddemooperatingdaterange",
       "label": "sharedDemoOperatingDateRange()",
@@ -232417,7 +232558,7 @@
       "source_location": "L21"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_ts",
       "label": "openingBaseline.ts",
@@ -232426,7 +232567,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "operationadapter_createshareddemooperationadapter",
       "label": "createSharedDemoOperationAdapter()",
@@ -232435,7 +232576,7 @@
       "source_location": "L18"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "operationadapter_isrecognizedshareddemoactorerror",
       "label": "isRecognizedSharedDemoActorError()",
@@ -232444,7 +232585,7 @@
       "source_location": "L100"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "operationadapter_shareddemodenialerror",
       "label": "sharedDemoDenialError()",
@@ -232453,7 +232594,7 @@
       "source_location": "L124"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "operationadapter_shareddemodenied",
       "label": "sharedDemoDenied()",
@@ -232462,7 +232603,7 @@
       "source_location": "L108"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_operationadapter_ts",
       "label": "operationAdapter.ts",
@@ -232471,7 +232612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -232480,7 +232621,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -232489,7 +232630,7 @@
       "source_location": "L124"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -232498,7 +232639,7 @@
       "source_location": "L67"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -232507,7 +232648,7 @@
       "source_location": "L106"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -232516,7 +232657,7 @@
       "source_location": "L73"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "onlineorder_buildlookup",
       "label": "buildLookup()",
@@ -232525,7 +232666,7 @@
       "source_location": "L65"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "onlineorder_buildonlineordertraceseed",
       "label": "buildOnlineOrderTraceSeed()",
@@ -232534,7 +232675,7 @@
       "source_location": "L85"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "onlineorder_buildsafeexternalreferenceref",
       "label": "buildSafeExternalReferenceRef()",
@@ -232543,7 +232684,7 @@
       "source_location": "L53"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "onlineorder_stablefingerprint",
       "label": "stableFingerprint()",
@@ -232552,58 +232693,13 @@
       "source_location": "L43"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_ts",
       "label": "onlineOrder.ts",
       "norm_label": "onlineorder.ts",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/onlineOrder.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
-      "label": "queryUsage.test.ts",
-      "norm_label": "queryusage.test.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "queryusage_test_comparebyfields",
-      "label": "compareByFields()",
-      "norm_label": "comparebyfields()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "queryusage_test_createadmintracereadctx",
-      "label": "createAdminTraceReadCtx()",
-      "norm_label": "createadmintracereadctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L220"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "queryusage_test_createtestctx",
-      "label": "createTestCtx()",
-      "norm_label": "createtestctx()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L118"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "queryusage_test_deniedauthorizer",
-      "label": "deniedAuthorizer()",
-      "norm_label": "deniedauthorizer()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
-      "source_location": "L1071"
     },
     {
       "community": 52,
@@ -232851,6 +232947,51 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
+      "label": "queryUsage.test.ts",
+      "norm_label": "queryusage.test.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "queryusage_test_comparebyfields",
+      "label": "compareByFields()",
+      "norm_label": "comparebyfields()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "queryusage_test_createadmintracereadctx",
+      "label": "createAdminTraceReadCtx()",
+      "norm_label": "createadmintracereadctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "queryusage_test_createtestctx",
+      "label": "createTestCtx()",
+      "norm_label": "createtestctx()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "queryusage_test_deniedauthorizer",
+      "label": "deniedAuthorizer()",
+      "norm_label": "deniedauthorizer()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/queryUsage.test.ts",
+      "source_location": "L1071"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
       "norm_label": "getperiodrange()",
@@ -232858,7 +232999,7 @@
       "source_location": "L19"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -232867,7 +233008,7 @@
       "source_location": "L49"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -232876,7 +233017,7 @@
       "source_location": "L341"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -232885,7 +233026,7 @@
       "source_location": "L321"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -232894,7 +233035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -232903,7 +233044,7 @@
       "source_location": "L61"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -232912,7 +233053,7 @@
       "source_location": "L57"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -232921,7 +233062,7 @@
       "source_location": "L98"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -232930,7 +233071,7 @@
       "source_location": "L134"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -232939,7 +233080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -232948,7 +233089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -232957,7 +233098,7 @@
       "source_location": "L38"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -232966,7 +233107,7 @@
       "source_location": "L64"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -232975,7 +233116,7 @@
       "source_location": "L135"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -232984,7 +233125,7 @@
       "source_location": "L43"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -232993,7 +233134,7 @@
       "source_location": "L90"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -233002,7 +233143,7 @@
       "source_location": "L95"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -233011,7 +233152,7 @@
       "source_location": "L82"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -233020,7 +233161,7 @@
       "source_location": "L85"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -233029,7 +233170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -233038,7 +233179,7 @@
       "source_location": "L113"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -233047,7 +233188,7 @@
       "source_location": "L349"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -233056,7 +233197,7 @@
       "source_location": "L86"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -233065,7 +233206,7 @@
       "source_location": "L62"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -233074,7 +233215,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "cashierauthdialog_test_buildlocalauthorityrecord",
       "label": "buildLocalAuthorityRecord()",
@@ -233083,7 +233224,7 @@
       "source_location": "L121"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "cashierauthdialog_test_renderdialog",
       "label": "renderDialog()",
@@ -233092,7 +233233,7 @@
       "source_location": "L152"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitcredentials",
       "label": "submitCredentials()",
@@ -233101,7 +233242,7 @@
       "source_location": "L216"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitlockedcashierpin",
       "label": "submitLockedCashierPin()",
@@ -233110,7 +233251,7 @@
       "source_location": "L208"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -233119,7 +233260,7 @@
       "source_location": "L1"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -233128,7 +233269,7 @@
       "source_location": "L49"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -233137,7 +233278,7 @@
       "source_location": "L66"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -233146,7 +233287,7 @@
       "source_location": "L75"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -233155,7 +233296,7 @@
       "source_location": "L45"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -233164,7 +233305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_test_tsx",
       "label": "POSSettingsView.test.tsx",
@@ -233173,7 +233314,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "possettingsview_test_findtrigger",
       "label": "findTrigger()",
@@ -233182,7 +233323,7 @@
       "source_location": "L185"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "possettingsview_test_selectcontent",
       "label": "SelectContent()",
@@ -233191,7 +233332,7 @@
       "source_location": "L160"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "possettingsview_test_selectitem",
       "label": "SelectItem()",
@@ -233200,7 +233341,7 @@
       "source_location": "L163"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "possettingsview_test_selecttrigger",
       "label": "SelectTrigger()",
@@ -233209,7 +233350,7 @@
       "source_location": "L165"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -233218,7 +233359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "productslistview_handlecategorypageindexchange",
       "label": "handleCategoryPageIndexChange()",
@@ -233227,7 +233368,7 @@
       "source_location": "L220"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -233236,7 +233377,7 @@
       "source_location": "L108"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "productslistview_handlestorefrontvisibilitychange",
       "label": "handleStorefrontVisibilityChange()",
@@ -233245,58 +233386,13 @@
       "source_location": "L87"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
       "norm_label": "productactionstogglegroup()",
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L33"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "label": "PromoCodeView.tsx",
-      "norm_label": "promocodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "promocodeview_handleaddpromocode",
-      "label": "handleAddPromoCode()",
-      "norm_label": "handleaddpromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L158"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "promocodeview_handleupdatepromocode",
-      "label": "handleUpdatePromoCode()",
-      "norm_label": "handleupdatepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "promocodeview_updatehomepagediscountcode",
-      "label": "updateHomepageDiscountCode()",
-      "norm_label": "updatehomepagediscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L324"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "promocodeview_updateleaveareviewdiscountcode",
-      "label": "updateLeaveAReviewDiscountCode()",
-      "norm_label": "updateleaveareviewdiscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L379"
     },
     {
       "community": 53,
@@ -233535,6 +233631,51 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
+      "label": "PromoCodeView.tsx",
+      "norm_label": "promocodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "promocodeview_handleaddpromocode",
+      "label": "handleAddPromoCode()",
+      "norm_label": "handleaddpromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L158"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "promocodeview_handleupdatepromocode",
+      "label": "handleUpdatePromoCode()",
+      "norm_label": "handleupdatepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "promocodeview_updatehomepagediscountcode",
+      "label": "updateHomepageDiscountCode()",
+      "norm_label": "updatehomepagediscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L324"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "promocodeview_updateleaveareviewdiscountcode",
+      "label": "updateLeaveAReviewDiscountCode()",
+      "norm_label": "updateleaveareviewdiscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L379"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemosurfacecatalog_ts",
       "label": "sharedDemoSurfaceCatalog.ts",
       "norm_label": "shareddemosurfacecatalog.ts",
@@ -233542,7 +233683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_classifyathenaviewsurface",
       "label": "classifyAthenaViewSurface()",
@@ -233551,7 +233692,7 @@
       "source_location": "L352"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_isshareddemosurfacevisible",
       "label": "isSharedDemoSurfaceVisible()",
@@ -233560,7 +233701,7 @@
       "source_location": "L376"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_normalizepathname",
       "label": "normalizePathname()",
@@ -233569,7 +233710,7 @@
       "source_location": "L331"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_routetemplatematches",
       "label": "routeTemplateMatches()",
@@ -233578,7 +233719,7 @@
       "source_location": "L339"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_pulse_storepulsesummaryview_tsx",
       "label": "StorePulseSummaryView.tsx",
@@ -233587,7 +233728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "storepulsesummaryview_formatcomparisonhelper",
       "label": "formatComparisonHelper()",
@@ -233596,7 +233737,7 @@
       "source_location": "L163"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "storepulsesummaryview_formatxaxistick",
       "label": "formatXAxisTick()",
@@ -233605,7 +233746,7 @@
       "source_location": "L377"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "storepulsesummaryview_gettrendvalue",
       "label": "getTrendValue()",
@@ -233614,7 +233755,7 @@
       "source_location": "L310"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "storepulsesummaryview_helper",
       "label": "helper()",
@@ -233623,7 +233764,7 @@
       "source_location": "L200"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -233632,7 +233773,7 @@
       "source_location": "L101"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -233641,7 +233782,7 @@
       "source_location": "L55"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -233650,7 +233791,7 @@
       "source_location": "L77"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -233659,7 +233800,7 @@
       "source_location": "L65"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -233668,7 +233809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -233677,7 +233818,7 @@
       "source_location": "L7"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -233686,7 +233827,7 @@
       "source_location": "L69"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -233695,7 +233836,7 @@
       "source_location": "L44"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -233704,7 +233845,7 @@
       "source_location": "L103"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -233713,7 +233854,7 @@
       "source_location": "L1"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -233722,7 +233863,7 @@
       "source_location": "L12"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -233731,7 +233872,7 @@
       "source_location": "L20"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -233740,7 +233881,7 @@
       "source_location": "L24"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -233749,7 +233890,7 @@
       "source_location": "L8"
     },
     {
-      "community": 534,
+      "community": 535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -233758,7 +233899,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenselocalruntime_ts",
       "label": "useExpenseLocalRuntime.ts",
@@ -233767,7 +233908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "useexpenselocalruntime_createlocalid",
       "label": "createLocalId()",
@@ -233776,7 +233917,7 @@
       "source_location": "L23"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "useexpenselocalruntime_getexpenselocalstore",
       "label": "getExpenseLocalStore()",
@@ -233785,7 +233926,7 @@
       "source_location": "L12"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "useexpenselocalruntime_notifyexpenselocaleventappended",
       "label": "notifyExpenseLocalEventAppended()",
@@ -233794,7 +233935,7 @@
       "source_location": "L17"
     },
     {
-      "community": 535,
+      "community": 536,
       "file_type": "code",
       "id": "useexpenselocalruntime_useexpenselocalruntime",
       "label": "useExpenseLocalRuntime()",
@@ -233803,7 +233944,7 @@
       "source_location": "L31"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "appmessagesprovider_appmessagesprovider",
       "label": "AppMessagesProvider()",
@@ -233812,7 +233953,7 @@
       "source_location": "L28"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "appmessagesprovider_areblockersequal",
       "label": "areBlockersEqual()",
@@ -233821,7 +233962,7 @@
       "source_location": "L215"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "appmessagesprovider_aremessagesequal",
       "label": "areMessagesEqual()",
@@ -233830,7 +233971,7 @@
       "source_location": "L185"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "appmessagesprovider_getpreferredvariant",
       "label": "getPreferredVariant()",
@@ -233839,7 +233980,7 @@
       "source_location": "L203"
     },
     {
-      "community": 536,
+      "community": 537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagesprovider_tsx",
       "label": "AppMessagesProvider.tsx",
@@ -233848,7 +233989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "appactionblockers_compareappactionblockers",
       "label": "compareAppActionBlockers()",
@@ -233857,7 +233998,7 @@
       "source_location": "L41"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "appactionblockers_getselectedappactionblocker",
       "label": "getSelectedAppActionBlocker()",
@@ -233866,7 +234007,7 @@
       "source_location": "L26"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "appactionblockers_isvalidappactionblockerinput",
       "label": "isValidAppActionBlockerInput()",
@@ -233875,7 +234016,7 @@
       "source_location": "L30"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "appactionblockers_sortappactionblockers",
       "label": "sortAppActionBlockers()",
@@ -233884,7 +234025,7 @@
       "source_location": "L22"
     },
     {
-      "community": 537,
+      "community": 538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appactionblockers_ts",
       "label": "appActionBlockers.ts",
@@ -233893,7 +234034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "appmessages_compareappmessages",
       "label": "compareAppMessages()",
@@ -233902,7 +234043,7 @@
       "source_location": "L39"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "appmessages_getselectedappmessage",
       "label": "getSelectedAppMessage()",
@@ -233911,7 +234052,7 @@
       "source_location": "L27"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "appmessages_isvalidappmessageinput",
       "label": "isValidAppMessageInput()",
@@ -233920,7 +234061,7 @@
       "source_location": "L31"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "appmessages_sortappmessages",
       "label": "sortAppMessages()",
@@ -233929,57 +234070,12 @@
       "source_location": "L23"
     },
     {
-      "community": 538,
+      "community": 539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessages_ts",
       "label": "appMessages.ts",
       "norm_label": "appmessages.ts",
       "source_file": "packages/athena-webapp/src/lib/app-messages/appMessages.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "appupdatereload_cleartrackedbeforeunloadhandlers",
-      "label": "clearTrackedBeforeUnloadHandlers()",
-      "norm_label": "cleartrackedbeforeunloadhandlers()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "appupdatereload_getcapture",
-      "label": "getCapture()",
-      "norm_label": "getcapture()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "appupdatereload_installappupdateunloadpromptbypass",
-      "label": "installAppUpdateUnloadPromptBypass()",
-      "norm_label": "installappupdateunloadpromptbypass()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "appupdatereload_reloadbrowserforappupdate",
-      "label": "reloadBrowserForAppUpdate()",
-      "norm_label": "reloadbrowserforappupdate()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_ts",
-      "label": "appUpdateReload.ts",
-      "norm_label": "appupdatereload.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
       "source_location": "L1"
     },
     {
@@ -234219,6 +234315,51 @@
     {
       "community": 540,
       "file_type": "code",
+      "id": "appupdatereload_cleartrackedbeforeunloadhandlers",
+      "label": "clearTrackedBeforeUnloadHandlers()",
+      "norm_label": "cleartrackedbeforeunloadhandlers()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "appupdatereload_getcapture",
+      "label": "getCapture()",
+      "norm_label": "getcapture()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "appupdatereload_installappupdateunloadpromptbypass",
+      "label": "installAppUpdateUnloadPromptBypass()",
+      "norm_label": "installappupdateunloadpromptbypass()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "appupdatereload_reloadbrowserforappupdate",
+      "label": "reloadBrowserForAppUpdate()",
+      "norm_label": "reloadbrowserforappupdate()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 540,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_ts",
+      "label": "appUpdateReload.ts",
+      "norm_label": "appupdatereload.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 541,
+      "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
       "norm_label": "buffertohex()",
@@ -234226,7 +234367,7 @@
       "source_location": "L18"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -234235,7 +234376,7 @@
       "source_location": "L23"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -234244,7 +234385,7 @@
       "source_location": "L65"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -234253,7 +234394,7 @@
       "source_location": "L45"
     },
     {
-      "community": 540,
+      "community": 541,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -234262,7 +234403,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -234271,7 +234412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -234280,7 +234421,7 @@
       "source_location": "L39"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "runcommand_getshareddemodenial",
       "label": "getSharedDemoDenial()",
@@ -234289,7 +234430,7 @@
       "source_location": "L47"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -234298,7 +234439,7 @@
       "source_location": "L33"
     },
     {
-      "community": 541,
+      "community": 542,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -234307,7 +234448,7 @@
       "source_location": "L65"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -234316,7 +234457,7 @@
       "source_location": "L78"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -234325,7 +234466,7 @@
       "source_location": "L74"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -234334,7 +234475,7 @@
       "source_location": "L103"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -234343,7 +234484,7 @@
       "source_location": "L109"
     },
     {
-      "community": 542,
+      "community": 543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -234352,7 +234493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -234361,7 +234502,7 @@
       "source_location": "L75"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -234370,7 +234511,7 @@
       "source_location": "L26"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -234379,7 +234520,7 @@
       "source_location": "L38"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -234388,7 +234529,7 @@
       "source_location": "L4"
     },
     {
-      "community": 543,
+      "community": 544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -234397,7 +234538,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -234406,7 +234547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -234415,7 +234556,7 @@
       "source_location": "L13"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -234424,7 +234565,7 @@
       "source_location": "L31"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -234433,7 +234574,7 @@
       "source_location": "L37"
     },
     {
-      "community": 544,
+      "community": 545,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -234442,7 +234583,7 @@
       "source_location": "L59"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "expenselocalcommandgateway_createexpenselocalcommandgateway",
       "label": "createExpenseLocalCommandGateway()",
@@ -234451,7 +234592,7 @@
       "source_location": "L55"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "expenselocalcommandgateway_itempayload",
       "label": "itemPayload()",
@@ -234460,7 +234601,7 @@
       "source_location": "L282"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "expenselocalcommandgateway_reasonpayload",
       "label": "reasonPayload()",
@@ -234469,7 +234610,7 @@
       "source_location": "L303"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "expenselocalcommandgateway_resolvestaffprooftoken",
       "label": "resolveStaffProofToken()",
@@ -234478,7 +234619,7 @@
       "source_location": "L310"
     },
     {
-      "community": 545,
+      "community": 546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_ts",
       "label": "expenseLocalCommandGateway.ts",
@@ -234487,7 +234628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "localcommandgateway_test_appendopendrawer",
       "label": "appendOpenDrawer()",
@@ -234496,7 +234637,7 @@
       "source_location": "L22"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "localcommandgateway_test_blockdrawerauthority",
       "label": "blockDrawerAuthority()",
@@ -234505,7 +234646,7 @@
       "source_location": "L34"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "localcommandgateway_test_createblockedsalegateway",
       "label": "createBlockedSaleGateway()",
@@ -234514,7 +234655,7 @@
       "source_location": "L48"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "localcommandgateway_test_salecommandinput",
       "label": "saleCommandInput()",
@@ -234523,7 +234664,7 @@
       "source_location": "L11"
     },
     {
-      "community": 546,
+      "community": 547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_test_ts",
       "label": "localCommandGateway.test.ts",
@@ -234532,7 +234673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "localregisterreader_readlatestdrawerauthoritystate",
       "label": "readLatestDrawerAuthorityState()",
@@ -234541,7 +234682,7 @@
       "source_location": "L325"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "localregisterreader_readprojectedlocalregistermodel",
       "label": "readProjectedLocalRegisterModel()",
@@ -234550,7 +234691,7 @@
       "source_location": "L129"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "localregisterreader_readscopedpagesorfallback",
       "label": "readScopedPagesOrFallback()",
@@ -234559,7 +234700,7 @@
       "source_location": "L266"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "localregisterreader_readscopedposlocalevents",
       "label": "readScopedPosLocalEvents()",
@@ -234568,7 +234709,7 @@
       "source_location": "L86"
     },
     {
-      "community": 547,
+      "community": 548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localregisterreader_ts",
       "label": "localRegisterReader.ts",
@@ -234577,7 +234718,7 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerreadmodel_test_ts",
       "label": "registerReadModel.test.ts",
@@ -234586,7 +234727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "registerreadmodel_test_errorcodes",
       "label": "errorCodes()",
@@ -234595,7 +234736,7 @@
       "source_location": "L1565"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "registerreadmodel_test_event",
       "label": "event()",
@@ -234604,7 +234745,7 @@
       "source_location": "L1569"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftevent",
       "label": "serviceDraftEvent()",
@@ -234613,58 +234754,13 @@
       "source_location": "L1611"
     },
     {
-      "community": 548,
+      "community": 549,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftprelude",
       "label": "serviceDraftPrelude()",
       "norm_label": "servicedraftprelude()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts",
       "source_location": "L1593"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_runtimereadiness_ts",
-      "label": "runtimeReadiness.ts",
-      "norm_label": "runtimereadiness.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "runtimereadiness_emptyposterminalruntimereadiness",
-      "label": "emptyPosTerminalRuntimeReadiness()",
-      "norm_label": "emptyposterminalruntimereadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "runtimereadiness_getruntimevisibleactiveregistersession",
-      "label": "getRuntimeVisibleActiveRegisterSession()",
-      "norm_label": "getruntimevisibleactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "runtimereadiness_refreshterminalruntimereadiness",
-      "label": "refreshTerminalRuntimeReadiness()",
-      "norm_label": "refreshterminalruntimereadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 549,
-      "file_type": "code",
-      "id": "runtimereadiness_toruntimeactiveregistersession",
-      "label": "toRuntimeActiveRegisterSession()",
-      "norm_label": "toruntimeactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L179"
     },
     {
       "community": 55,
@@ -234894,6 +234990,51 @@
     {
       "community": 550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_runtimereadiness_ts",
+      "label": "runtimeReadiness.ts",
+      "norm_label": "runtimereadiness.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "runtimereadiness_emptyposterminalruntimereadiness",
+      "label": "emptyPosTerminalRuntimeReadiness()",
+      "norm_label": "emptyposterminalruntimereadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "runtimereadiness_getruntimevisibleactiveregistersession",
+      "label": "getRuntimeVisibleActiveRegisterSession()",
+      "norm_label": "getruntimevisibleactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "runtimereadiness_refreshterminalruntimereadiness",
+      "label": "refreshTerminalRuntimeReadiness()",
+      "norm_label": "refreshterminalruntimereadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 550,
+      "file_type": "code",
+      "id": "runtimereadiness_toruntimeactiveregistersession",
+      "label": "toRuntimeActiveRegisterSession()",
+      "norm_label": "toruntimeactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 551,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useregisterlifecycleauthorityruntime_ts",
       "label": "useRegisterLifecycleAuthorityRuntime.ts",
       "norm_label": "useregisterlifecycleauthorityruntime.ts",
@@ -234901,7 +235042,7 @@
       "source_location": "L1"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_applysnapshot",
       "label": "applySnapshot()",
@@ -234910,7 +235051,7 @@
       "source_location": "L389"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_isregisterlifecyclerepairclassification",
       "label": "isRegisterLifecycleRepairClassification()",
@@ -234919,7 +235060,7 @@
       "source_location": "L554"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_toobservation",
       "label": "toObservation()",
@@ -234928,7 +235069,7 @@
       "source_location": "L523"
     },
     {
-      "community": 550,
+      "community": 551,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_useregisterlifecycleauthorityruntime",
       "label": "useRegisterLifecycleAuthorityRuntime()",
@@ -234937,7 +235078,7 @@
       "source_location": "L53"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -234946,7 +235087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -234955,7 +235096,7 @@
       "source_location": "L42"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -234964,7 +235105,7 @@
       "source_location": "L29"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -234973,7 +235114,7 @@
       "source_location": "L49"
     },
     {
-      "community": 551,
+      "community": 552,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -234982,7 +235123,7 @@
       "source_location": "L14"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_ts",
       "label": "runtimeBuildMetadata.ts",
@@ -234991,7 +235132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "runtimebuildmetadata_getinitialruntimebuildmetadata",
       "label": "getInitialRuntimeBuildMetadata()",
@@ -235000,7 +235141,7 @@
       "source_location": "L16"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizedeploymetadata",
       "label": "normalizeDeployMetadata()",
@@ -235009,7 +235150,7 @@
       "source_location": "L49"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizemetadatavalue",
       "label": "normalizeMetadataValue()",
@@ -235018,7 +235159,7 @@
       "source_location": "L63"
     },
     {
-      "community": 552,
+      "community": 553,
       "file_type": "code",
       "id": "runtimebuildmetadata_readruntimebuildmetadata",
       "label": "readRuntimeBuildMetadata()",
@@ -235027,7 +235168,7 @@
       "source_location": "L32"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -235036,7 +235177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -235045,7 +235186,7 @@
       "source_location": "L184"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -235054,7 +235195,7 @@
       "source_location": "L200"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -235063,7 +235204,7 @@
       "source_location": "L244"
     },
     {
-      "community": 553,
+      "community": 554,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -235072,7 +235213,7 @@
       "source_location": "L206"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_ts",
       "label": "registerPosAppShellServiceWorker.ts",
@@ -235081,7 +235222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "registerposappshellserviceworker_isposappshellserviceworkerregistration",
       "label": "isPosAppShellServiceWorkerRegistration()",
@@ -235090,7 +235231,7 @@
       "source_location": "L52"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "registerposappshellserviceworker_registerposappshellserviceworker",
       "label": "registerPosAppShellServiceWorker()",
@@ -235099,7 +235240,7 @@
       "source_location": "L6"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "registerposappshellserviceworker_resetposappshellserviceworkerregistrationfortest",
       "label": "resetPosAppShellServiceWorkerRegistrationForTest()",
@@ -235108,7 +235249,7 @@
       "source_location": "L20"
     },
     {
-      "community": 554,
+      "community": 555,
       "file_type": "code",
       "id": "registerposappshellserviceworker_unregisterposappshellserviceworkerfordev",
       "label": "unregisterPosAppShellServiceWorkerForDev()",
@@ -235117,7 +235258,7 @@
       "source_location": "L24"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -235126,7 +235267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "root_getathenadocumenttitle",
       "label": "getAthenaDocumentTitle()",
@@ -235135,7 +235276,7 @@
       "source_location": "L89"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "root_rootcomponent",
       "label": "RootComponent()",
@@ -235144,7 +235285,7 @@
       "source_location": "L62"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "root_rootdocument",
       "label": "RootDocument()",
@@ -235153,7 +235294,7 @@
       "source_location": "L72"
     },
     {
-      "community": 555,
+      "community": 556,
       "file_type": "code",
       "id": "root_rootnotfound",
       "label": "RootNotFound()",
@@ -235162,7 +235303,7 @@
       "source_location": "L48"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -235171,7 +235312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -235180,7 +235321,7 @@
       "source_location": "L10"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -235189,7 +235330,7 @@
       "source_location": "L85"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -235198,7 +235339,7 @@
       "source_location": "L19"
     },
     {
-      "community": 556,
+      "community": 557,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -235207,7 +235348,7 @@
       "source_location": "L50"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "expensestore_expensecartitemsourcekey",
       "label": "expenseCartItemSourceKey()",
@@ -235216,7 +235357,7 @@
       "source_location": "L179"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "expensestore_ispendingoptimisticexpensecartitem",
       "label": "isPendingOptimisticExpenseCartItem()",
@@ -235225,7 +235366,7 @@
       "source_location": "L197"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "expensestore_mapexpensesessioncartitemtocartitem",
       "label": "mapExpenseSessionCartItemToCartItem()",
@@ -235234,7 +235375,7 @@
       "source_location": "L213"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "expensestore_sessionitemrepresentscartitem",
       "label": "sessionItemRepresentsCartItem()",
@@ -235243,7 +235384,7 @@
       "source_location": "L201"
     },
     {
-      "community": 557,
+      "community": 558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -235252,7 +235393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -235261,7 +235402,7 @@
       "source_location": "L93"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -235270,7 +235411,7 @@
       "source_location": "L75"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -235279,7 +235420,7 @@
       "source_location": "L4"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -235288,57 +235429,12 @@
       "source_location": "L47"
     },
     {
-      "community": 558,
+      "community": 559,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "category_getallcategories",
-      "label": "getAllCategories()",
-      "norm_label": "getallcategories()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "category_getallcategorieswithsubcategories",
-      "label": "getAllCategoriesWithSubcategories()",
-      "norm_label": "getallcategorieswithsubcategories()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "category_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "category_getcategory",
-      "label": "getCategory()",
-      "norm_label": "getcategory()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L1"
     },
     {
@@ -235569,6 +235665,51 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "category_getallcategories",
+      "label": "getAllCategories()",
+      "norm_label": "getallcategories()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "category_getallcategorieswithsubcategories",
+      "label": "getAllCategoriesWithSubcategories()",
+      "norm_label": "getallcategorieswithsubcategories()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "category_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "category_getcategory",
+      "label": "getCategory()",
+      "norm_label": "getcategory()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
@@ -235576,7 +235717,7 @@
       "source_location": "L4"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -235585,7 +235726,7 @@
       "source_location": "L24"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -235594,7 +235735,7 @@
       "source_location": "L6"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -235603,7 +235744,7 @@
       "source_location": "L42"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -235612,7 +235753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -235621,7 +235762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -235630,7 +235771,7 @@
       "source_location": "L28"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -235639,7 +235780,7 @@
       "source_location": "L5"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -235648,7 +235789,7 @@
       "source_location": "L7"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -235657,7 +235798,7 @@
       "source_location": "L46"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -235666,7 +235807,7 @@
       "source_location": "L137"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -235675,7 +235816,7 @@
       "source_location": "L176"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -235684,7 +235825,7 @@
       "source_location": "L105"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -235693,7 +235834,7 @@
       "source_location": "L31"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -235702,7 +235843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -235711,7 +235852,7 @@
       "source_location": "L102"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "homepagecontent_todisplayproduct",
       "label": "toDisplayProduct()",
@@ -235720,7 +235861,7 @@
       "source_location": "L70"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "homepagecontent_todisplaysku",
       "label": "toDisplaySku()",
@@ -235729,7 +235870,7 @@
       "source_location": "L54"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "homepagecontent_tofeatureditem",
       "label": "toFeaturedItem()",
@@ -235738,7 +235879,7 @@
       "source_location": "L78"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -235747,7 +235888,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -235756,7 +235897,7 @@
       "source_location": "L14"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -235765,7 +235906,7 @@
       "source_location": "L22"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -235774,7 +235915,7 @@
       "source_location": "L30"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -235783,7 +235924,7 @@
       "source_location": "L3"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
@@ -235792,7 +235933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontfailureobservability_ts",
       "label": "storefrontFailureObservability.ts",
@@ -235801,7 +235942,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "storefrontfailureobservability_createstorefrontfailureevent",
       "label": "createStorefrontFailureEvent()",
@@ -235810,7 +235951,7 @@
       "source_location": "L136"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "storefrontfailureobservability_emitstorefrontfailure",
       "label": "emitStorefrontFailure()",
@@ -235819,7 +235960,7 @@
       "source_location": "L154"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "storefrontfailureobservability_inferstorefrontjourneyfromroute",
       "label": "inferStorefrontJourneyFromRoute()",
@@ -235828,7 +235969,7 @@
       "source_location": "L25"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "storefrontfailureobservability_normalizestorefronterror",
       "label": "normalizeStorefrontError()",
@@ -235837,7 +235978,7 @@
       "source_location": "L47"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "check_register_session_authority_writers_checkregistersessionauthoritywriters",
       "label": "checkRegisterSessionAuthorityWriters()",
@@ -235846,7 +235987,7 @@
       "source_location": "L127"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "check_register_session_authority_writers_collectregistersessionauthoritywriterfindings",
       "label": "collectRegisterSessionAuthorityWriterFindings()",
@@ -235855,7 +235996,7 @@
       "source_location": "L37"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "check_register_session_authority_writers_listtypescriptfiles",
       "label": "listTypeScriptFiles()",
@@ -235864,7 +236005,7 @@
       "source_location": "L111"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "check_register_session_authority_writers_normalizepath",
       "label": "normalizePath()",
@@ -235873,7 +236014,7 @@
       "source_location": "L33"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "scripts_check_register_session_authority_writers_ts",
       "label": "check-register-session-authority-writers.ts",
@@ -235882,7 +236023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "convex_node_env_test_resolveesbuildwithenv",
       "label": "resolveEsbuildWithEnv()",
@@ -235891,7 +236032,7 @@
       "source_location": "L48"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "convex_node_env_test_resolvewithenv",
       "label": "resolveWithEnv()",
@@ -235900,7 +236041,7 @@
       "source_location": "L26"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "convex_node_env_test_withtempdir",
       "label": "withTempDir()",
@@ -235909,7 +236050,7 @@
       "source_location": "L6"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "convex_node_env_test_writenodeshim",
       "label": "writeNodeShim()",
@@ -235918,7 +236059,7 @@
       "source_location": "L16"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "scripts_convex_node_env_test_ts",
       "label": "convex-node-env.test.ts",
@@ -235927,7 +236068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "harness_contract_preflight_test_createrealauditfixturedrift",
       "label": "createRealAuditFixtureDrift()",
@@ -235936,7 +236077,7 @@
       "source_location": "L63"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "harness_contract_preflight_test_createsiblingpolicyfixture",
       "label": "createSiblingPolicyFixture()",
@@ -235945,7 +236086,7 @@
       "source_location": "L37"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "harness_contract_preflight_test_runcomposedpreflight",
       "label": "runComposedPreflight()",
@@ -235954,7 +236095,7 @@
       "source_location": "L239"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "harness_contract_preflight_test_rungit",
       "label": "runGit()",
@@ -235963,57 +236104,12 @@
       "source_location": "L23"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "scripts_harness_contract_preflight_test_ts",
       "label": "harness-contract-preflight.test.ts",
       "norm_label": "harness-contract-preflight.test.ts",
       "source_file": "scripts/harness-contract-preflight.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "harness_contract_preflight_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "harness_contract_preflight_formathumanreport",
-      "label": "formatHumanReport()",
-      "norm_label": "formathumanreport()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "harness_contract_preflight_runfocusedcontracttests",
-      "label": "runFocusedContractTests()",
-      "norm_label": "runfocusedcontracttests()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "harness_contract_preflight_runharnesscontractpreflight",
-      "label": "runHarnessContractPreflight()",
-      "norm_label": "runharnesscontractpreflight()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L111"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "scripts_harness_contract_preflight_ts",
-      "label": "harness-contract-preflight.ts",
-      "norm_label": "harness-contract-preflight.ts",
-      "source_file": "scripts/harness-contract-preflight.ts",
       "source_location": "L1"
     },
     {
@@ -236244,6 +236340,51 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "harness_contract_preflight_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "harness_contract_preflight_formathumanreport",
+      "label": "formatHumanReport()",
+      "norm_label": "formathumanreport()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "harness_contract_preflight_runfocusedcontracttests",
+      "label": "runFocusedContractTests()",
+      "norm_label": "runfocusedcontracttests()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "harness_contract_preflight_runharnesscontractpreflight",
+      "label": "runHarnessContractPreflight()",
+      "norm_label": "runharnesscontractpreflight()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "scripts_harness_contract_preflight_ts",
+      "label": "harness-contract-preflight.ts",
+      "norm_label": "harness-contract-preflight.ts",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "operational_work_repair_buildoperationalworkrepairinvocation",
       "label": "buildOperationalWorkRepairInvocation()",
       "norm_label": "buildoperationalworkrepairinvocation()",
@@ -236251,7 +236392,7 @@
       "source_location": "L57"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "operational_work_repair_main",
       "label": "main()",
@@ -236260,7 +236401,7 @@
       "source_location": "L73"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "operational_work_repair_parseoperationalworkrepairargs",
       "label": "parseOperationalWorkRepairArgs()",
@@ -236269,7 +236410,7 @@
       "source_location": "L14"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "operational_work_repair_requirevalue",
       "label": "requireValue()",
@@ -236278,7 +236419,7 @@
       "source_location": "L8"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "scripts_operational_work_repair_ts",
       "label": "operational-work-repair.ts",
@@ -236287,7 +236428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_log",
       "label": "log()",
@@ -236296,7 +236437,7 @@
       "source_location": "L77"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_spawn",
       "label": "spawn()",
@@ -236305,7 +236446,7 @@
       "source_location": "L69"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_withtemprepo",
       "label": "withTempRepo()",
@@ -236314,7 +236455,7 @@
       "source_location": "L14"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "pre_commit_generated_artifacts_test_writeconvexapifixture",
       "label": "writeConvexApiFixture()",
@@ -236323,7 +236464,7 @@
       "source_location": "L24"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "scripts_pre_commit_generated_artifacts_test_ts",
       "label": "pre-commit-generated-artifacts.test.ts",
@@ -236332,7 +236473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "pre_push_hook_test_createhookfixture",
       "label": "createHookFixture()",
@@ -236341,7 +236482,7 @@
       "source_location": "L18"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "pre_push_hook_test_isprocessalive",
       "label": "isProcessAlive()",
@@ -236350,7 +236491,7 @@
       "source_location": "L80"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "pre_push_hook_test_retainedlogpath",
       "label": "retainedLogPath()",
@@ -236359,7 +236500,7 @@
       "source_location": "L72"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "pre_push_hook_test_waitforfile",
       "label": "waitForFile()",
@@ -236368,7 +236509,7 @@
       "source_location": "L59"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "scripts_pre_push_hook_test_ts",
       "label": "pre-push-hook.test.ts",
@@ -236377,7 +236518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "scripts_worktree_manager_test_ts",
       "label": "worktree-manager.test.ts",
@@ -236386,7 +236527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "worktree_manager_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -236395,7 +236536,7 @@
       "source_location": "L17"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "worktree_manager_test_fixtureenv",
       "label": "fixtureEnv()",
@@ -236404,7 +236545,7 @@
       "source_location": "L73"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "worktree_manager_test_rungit",
       "label": "runGit()",
@@ -236413,7 +236554,7 @@
       "source_location": "L45"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "worktree_manager_test_runworktreemanager",
       "label": "runWorktreeManager()",
@@ -236422,7 +236563,7 @@
       "source_location": "L60"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "actionregistry_automationactionkey",
       "label": "automationActionKey()",
@@ -236431,7 +236572,7 @@
       "source_location": "L22"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "actionregistry_defineautomationaction",
       "label": "defineAutomationAction()",
@@ -236440,7 +236581,7 @@
       "source_location": "L29"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "actionregistry_registerautomationactions",
       "label": "registerAutomationActions()",
@@ -236449,7 +236590,7 @@
       "source_location": "L47"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_automation_actionregistry_ts",
       "label": "actionRegistry.ts",
@@ -236458,7 +236599,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "automationfoundation_evaluateautomationactionwithctx",
       "label": "evaluateAutomationActionWithCtx()",
@@ -236467,7 +236608,7 @@
       "source_location": "L77"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "automationfoundation_isvalidoperatingdate",
       "label": "isValidOperatingDate()",
@@ -236476,7 +236617,7 @@
       "source_location": "L43"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "automationfoundation_validateadapterdecision",
       "label": "validateAdapterDecision()",
@@ -236485,7 +236626,7 @@
       "source_location": "L56"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_automation_automationfoundation_ts",
       "label": "automationFoundation.ts",
@@ -236494,7 +236635,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "contextevents_test_buildcontexteventctx",
       "label": "buildContextEventCtx()",
@@ -236503,7 +236644,7 @@
       "source_location": "L213"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "contextevents_test_buildcontexteventquery",
       "label": "buildContextEventQuery()",
@@ -236512,7 +236653,7 @@
       "source_location": "L238"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "contextevents_test_gethandler",
       "label": "getHandler()",
@@ -236521,7 +236662,7 @@
       "source_location": "L12"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_contextevents_test_ts",
       "label": "contextEvents.test.ts",
@@ -236530,7 +236671,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "contextevents_buildcontexteventsemanticenvelopehash",
       "label": "buildContextEventSemanticEnvelopeHash()",
@@ -236539,7 +236680,7 @@
       "source_location": "L31"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "contextevents_iscontexteventwritequotaexceeded",
       "label": "isContextEventWriteQuotaExceeded()",
@@ -236548,7 +236689,7 @@
       "source_location": "L17"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "contextevents_selectcontexteventappendquotadecision",
       "label": "selectContextEventAppendQuotaDecision()",
@@ -236557,7 +236698,7 @@
       "source_location": "L21"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_contextevents_ts",
       "label": "contextEvents.ts",
@@ -236566,7 +236707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_createtemproot",
       "label": "createTempRoot()",
@@ -236575,7 +236716,7 @@
       "source_location": "L12"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_runpaginationcheck",
       "label": "runPaginationCheck()",
@@ -236584,7 +236725,7 @@
       "source_location": "L26"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_test_writeconvexfile",
       "label": "writeConvexFile()",
@@ -236593,48 +236734,12 @@
       "source_location": "L20"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convexpaginationantipatterncheck_test_ts",
       "label": "convexPaginationAntiPatternCheck.test.ts",
       "norm_label": "convexpaginationantipatterncheck.test.ts",
       "source_file": "packages/athena-webapp/convex/convexPaginationAntiPatternCheck.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "domain_maskreceiptphone",
-      "label": "maskReceiptPhone()",
-      "norm_label": "maskreceiptphone()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L67"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "domain_normalizereceiptphone",
-      "label": "normalizeReceiptPhone()",
-      "norm_label": "normalizereceiptphone()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "domain_statusisretryable",
-      "label": "statusIsRetryable()",
-      "norm_label": "statusisretryable()",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
-      "source_location": "L79"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
-      "label": "domain.ts",
-      "norm_label": "domain.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
       "source_location": "L1"
     },
     {
@@ -236865,6 +236970,42 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "domain_maskreceiptphone",
+      "label": "maskReceiptPhone()",
+      "norm_label": "maskreceiptphone()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "domain_normalizereceiptphone",
+      "label": "normalizeReceiptPhone()",
+      "norm_label": "normalizereceiptphone()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "domain_statusisretryable",
+      "label": "statusIsRetryable()",
+      "norm_label": "statusisretryable()",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_domain_ts",
+      "label": "domain.ts",
+      "norm_label": "domain.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/domain.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_token_ts",
       "label": "token.ts",
       "norm_label": "token.ts",
@@ -236872,7 +237013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "token_createreceiptsharetoken",
       "label": "createReceiptShareToken()",
@@ -236881,7 +237022,7 @@
       "source_location": "L9"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "token_hashreceiptsharetoken",
       "label": "hashReceiptShareToken()",
@@ -236890,7 +237031,7 @@
       "source_location": "L15"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "token_tohex",
       "label": "toHex()",
@@ -236899,7 +237040,7 @@
       "source_location": "L3"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_ts",
       "label": "webhookSecurity.ts",
@@ -236908,7 +237049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "webhooksecurity_timingsafeequal",
       "label": "timingSafeEqual()",
@@ -236917,7 +237058,7 @@
       "source_location": "L9"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "webhooksecurity_tohex",
       "label": "toHex()",
@@ -236926,7 +237067,7 @@
       "source_location": "L3"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "webhooksecurity_verifymetawebhooksignature",
       "label": "verifyMetaWebhookSignature()",
@@ -236935,7 +237076,7 @@
       "source_location": "L22"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "categories_removestorefronthiddencategories",
       "label": "removeStorefrontHiddenCategories()",
@@ -236944,7 +237085,7 @@
       "source_location": "L23"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "categories_removestorefronthiddensubcategories",
       "label": "removeStorefrontHiddenSubcategories()",
@@ -236953,7 +237094,7 @@
       "source_location": "L31"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "categories_shouldshowcategoryonstorefront",
       "label": "shouldShowCategoryOnStorefront()",
@@ -236962,7 +237103,7 @@
       "source_location": "L12"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_categories_ts",
       "label": "categories.ts",
@@ -236971,7 +237112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "checkout_hasallvisibilesessionitems",
       "label": "hasAllVisibileSessionItems()",
@@ -236980,7 +237121,7 @@
       "source_location": "L109"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "checkout_hasvalidcanonicalbagitem",
       "label": "hasValidCanonicalBagItem()",
@@ -236989,7 +237130,7 @@
       "source_location": "L84"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "checkout_hasvalidsessionitems",
       "label": "hasValidSessionItems()",
@@ -236998,7 +237139,7 @@
       "source_location": "L95"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_checkout_ts",
       "label": "checkout.ts",
@@ -237007,7 +237148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_utils_ts",
       "label": "utils.ts",
@@ -237016,7 +237157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "utils_getstoredatafromrequest",
       "label": "getStoreDataFromRequest()",
@@ -237025,7 +237166,7 @@
       "source_location": "L5"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "utils_getstorefrontactorfromrequest",
       "label": "getStorefrontActorFromRequest()",
@@ -237034,7 +237175,7 @@
       "source_location": "L19"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "utils_getstorefrontuserfromrequest",
       "label": "getStorefrontUserFromRequest()",
@@ -237043,7 +237184,7 @@
       "source_location": "L12"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_runs_test_ts",
       "label": "runs.test.ts",
@@ -237052,7 +237193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "runs_test_baseensurerunargs",
       "label": "baseEnsureRunArgs()",
@@ -237061,7 +237202,7 @@
       "source_location": "L600"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "runs_test_createdebugqueryrecorder",
       "label": "createDebugQueryRecorder()",
@@ -237070,7 +237211,7 @@
       "source_location": "L616"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "runs_test_gethandler",
       "label": "getHandler()",
@@ -237079,7 +237220,7 @@
       "source_location": "L596"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "bannermessage_normalizedisplaytext",
       "label": "normalizeDisplayText()",
@@ -237088,7 +237229,7 @@
       "source_location": "L63"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "bannermessage_presentpublicbannermessage",
       "label": "presentPublicBannerMessage()",
@@ -237097,7 +237238,7 @@
       "source_location": "L68"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "bannermessage_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -237106,7 +237247,7 @@
       "source_location": "L34"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -237115,7 +237256,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "bestseller_getnextbestsellerrank",
       "label": "getNextBestSellerRank()",
@@ -237124,7 +237265,7 @@
       "source_location": "L66"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "bestseller_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -237133,7 +237274,7 @@
       "source_location": "L20"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "bestseller_validatebestsellerplacement",
       "label": "validateBestSellerPlacement()",
@@ -237142,7 +237283,7 @@
       "source_location": "L40"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_ts",
       "label": "bestSeller.ts",
@@ -237151,7 +237292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "catalogsummary_computecatalogsummary",
       "label": "computeCatalogSummary()",
@@ -237160,7 +237301,7 @@
       "source_location": "L23"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "catalogsummary_markcatalogsummaryneedsrefresh",
       "label": "markCatalogSummaryNeedsRefresh()",
@@ -237169,7 +237310,7 @@
       "source_location": "L101"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "catalogsummary_refreshcatalogsummarywithctx",
       "label": "refreshCatalogSummaryWithCtx()",
@@ -237178,48 +237319,12 @@
       "source_location": "L77"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_catalogsummary_ts",
       "label": "catalogSummary.ts",
       "norm_label": "catalogsummary.ts",
       "source_file": "packages/athena-webapp/convex/inventory/catalogSummary.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "expensesessions_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L280"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "expensesessions_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "expensesessions_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
-      "label": "expenseSessions.test.ts",
-      "norm_label": "expensesessions.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
       "source_location": "L1"
     },
     {
@@ -237450,6 +237555,42 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "expensesessions_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
+      "source_location": "L280"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "expensesessions_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "expensesessions_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_expensesessions_test_ts",
+      "label": "expenseSessions.test.ts",
+      "norm_label": "expensesessions.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/expenseSessions.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "expensesessionexpiration_calculateexpensesessionexpiration",
       "label": "calculateExpenseSessionExpiration()",
       "norm_label": "calculateexpensesessionexpiration()",
@@ -237457,7 +237598,7 @@
       "source_location": "L21"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpiryduration",
       "label": "getExpenseSessionExpiryDuration()",
@@ -237466,7 +237607,7 @@
       "source_location": "L35"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "expensesessionexpiration_getexpensesessionexpirydurationminutes",
       "label": "getExpenseSessionExpiryDurationMinutes()",
@@ -237475,7 +237616,7 @@
       "source_location": "L45"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionexpiration_ts",
       "label": "expenseSessionExpiration.ts",
@@ -237484,7 +237625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_sessionexpiration_ts",
       "label": "sessionExpiration.ts",
@@ -237493,7 +237634,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "sessionexpiration_calculatesessionexpiration",
       "label": "calculateSessionExpiration()",
@@ -237502,7 +237643,7 @@
       "source_location": "L21"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpiryduration",
       "label": "getSessionExpiryDuration()",
@@ -237511,7 +237652,7 @@
       "source_location": "L35"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "sessionexpiration_getsessionexpirydurationminutes",
       "label": "getSessionExpiryDurationMinutes()",
@@ -237520,7 +237661,7 @@
       "source_location": "L45"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "inventoryimportcostoverlay_test_createpublicmutationharness",
       "label": "createPublicMutationHarness()",
@@ -237529,7 +237670,7 @@
       "source_location": "L96"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "inventoryimportcostoverlay_test_gethandler",
       "label": "getHandler()",
@@ -237538,7 +237679,7 @@
       "source_location": "L58"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "inventoryimportcostoverlay_test_overlayrun",
       "label": "overlayRun()",
@@ -237547,7 +237688,7 @@
       "source_location": "L203"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlay_test_ts",
       "label": "inventoryImportCostOverlay.test.ts",
@@ -237556,7 +237697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "inventoryimportcostoverlaylineage_canonicalizecostoverlaylineages",
       "label": "canonicalizeCostOverlayLineages()",
@@ -237565,7 +237706,7 @@
       "source_location": "L22"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "inventoryimportcostoverlaylineage_frozencostoverlaylineagesmatch",
       "label": "frozenCostOverlayLineagesMatch()",
@@ -237574,7 +237715,7 @@
       "source_location": "L39"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "inventoryimportcostoverlaylineage_readcostoverlayskulineageswithctx",
       "label": "readCostOverlaySkuLineagesWithCtx()",
@@ -237583,7 +237724,7 @@
       "source_location": "L51"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlaylineage_ts",
       "label": "inventoryImportCostOverlayLineage.ts",
@@ -237592,7 +237733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessionitems_ts",
       "label": "posSessionItems.ts",
@@ -237601,7 +237742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "possessionitems_requiresessionitemreadaccess",
       "label": "requireSessionItemReadAccess()",
@@ -237610,7 +237751,7 @@
       "source_location": "L95"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "possessionitems_requiresessionitemstoreaccess",
       "label": "requireSessionItemStoreAccess()",
@@ -237619,7 +237760,7 @@
       "source_location": "L64"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "possessionitems_usererrorfromsessionitemfailure",
       "label": "userErrorFromSessionItemFailure()",
@@ -237628,7 +237769,7 @@
       "source_location": "L36"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_possessions_trace_test_ts",
       "label": "posSessions.trace.test.ts",
@@ -237637,7 +237778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "possessions_trace_test_buildsession",
       "label": "buildSession()",
@@ -237646,7 +237787,7 @@
       "source_location": "L613"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "possessions_trace_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -237655,7 +237796,7 @@
       "source_location": "L240"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "possessions_trace_test_gethandler",
       "label": "getHandler()",
@@ -237664,7 +237805,7 @@
       "source_location": "L637"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_skusearch_test_ts",
       "label": "skuSearch.test.ts",
@@ -237673,7 +237814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "skusearch_test_baseseed",
       "label": "baseSeed()",
@@ -237682,7 +237823,7 @@
       "source_location": "L275"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "skusearch_test_createctx",
       "label": "createCtx()",
@@ -237691,7 +237832,7 @@
       "source_location": "L62"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "skusearch_test_gethandler",
       "label": "getHandler()",
@@ -237700,7 +237841,7 @@
       "source_location": "L58"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_valuation_test_ts",
       "label": "valuation.test.ts",
@@ -237709,7 +237850,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "valuation_test_deficitlot",
       "label": "deficitLot()",
@@ -237718,7 +237859,7 @@
       "source_location": "L38"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "valuation_test_knownposition",
       "label": "knownPosition()",
@@ -237727,7 +237868,7 @@
       "source_location": "L23"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "valuation_test_outboundbasis",
       "label": "outboundBasis()",
@@ -237736,7 +237877,7 @@
       "source_location": "L51"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestretention_ts",
       "label": "walkthroughRequestRetention.ts",
@@ -237745,7 +237886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "walkthroughrequestretention_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -237754,7 +237895,7 @@
       "source_location": "L70"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "walkthroughrequestretention_consumeprivacychallenge",
       "label": "consumePrivacyChallenge()",
@@ -237763,49 +237904,13 @@
       "source_location": "L76"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "walkthroughrequestretention_retentiondecision",
       "label": "retentionDecision()",
       "norm_label": "retentiondecision()",
       "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequestRetention.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughrequests_ts",
-      "label": "walkthroughRequests.ts",
-      "norm_label": "walkthroughrequests.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequests.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "walkthroughrequests_audit",
-      "label": "audit()",
-      "norm_label": "audit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequests.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "walkthroughrequests_boundedtext",
-      "label": "boundedText()",
-      "norm_label": "boundedtext()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequests.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "walkthroughrequests_keyedfingerprint",
-      "label": "keyedFingerprint()",
-      "norm_label": "keyedfingerprint()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequests.ts",
-      "source_location": "L28"
     },
     {
       "community": 6,
@@ -238683,6 +238788,42 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughrequests_ts",
+      "label": "walkthroughRequests.ts",
+      "norm_label": "walkthroughrequests.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequests.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "walkthroughrequests_audit",
+      "label": "audit()",
+      "norm_label": "audit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequests.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "walkthroughrequests_boundedtext",
+      "label": "boundedText()",
+      "norm_label": "boundedtext()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequests.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "walkthroughrequests_keyedfingerprint",
+      "label": "keyedFingerprint()",
+      "norm_label": "keyedfingerprint()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequests.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "collections_getcachedtokenrecord",
       "label": "getCachedTokenRecord()",
       "norm_label": "getcachedtokenrecord()",
@@ -238690,7 +238831,7 @@
       "source_location": "L26"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "collections_resolveaccesstokenforstore",
       "label": "resolveAccessTokenForStore()",
@@ -238699,7 +238840,7 @@
       "source_location": "L79"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "collections_resolveconfigforstore",
       "label": "resolveConfigForStore()",
@@ -238708,7 +238849,7 @@
       "source_location": "L33"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_collections_ts",
       "label": "collections.ts",
@@ -238717,7 +238858,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "normalize_maskmtnpartyid",
       "label": "maskMtnPartyId()",
@@ -238726,7 +238867,7 @@
       "source_location": "L10"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "normalize_normalizecollectionstransaction",
       "label": "normalizeCollectionsTransaction()",
@@ -238735,7 +238876,7 @@
       "source_location": "L18"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "normalize_parsecollectionsnotificationrequest",
       "label": "parseCollectionsNotificationRequest()",
@@ -238744,7 +238885,7 @@
       "source_location": "L52"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_normalize_ts",
       "label": "normalize.ts",
@@ -238753,7 +238894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_ts",
       "label": "registry.ts",
@@ -238762,7 +238903,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "registry_findnotificationkind",
       "label": "findNotificationKind()",
@@ -238771,7 +238912,7 @@
       "source_location": "L208"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "registry_getnotificationkind",
       "label": "getNotificationKind()",
@@ -238780,7 +238921,7 @@
       "source_location": "L218"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "registry_listnotificationkinds",
       "label": "listNotificationKinds()",
@@ -238789,7 +238930,7 @@
       "source_location": "L226"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_publicmutation_ts",
       "label": "publicMutation.ts",
@@ -238798,7 +238939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "publicmutation_admitpublicmutation",
       "label": "admitPublicMutation()",
@@ -238807,7 +238948,7 @@
       "source_location": "L25"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "publicmutation_resolveshareddemooperationadmission",
       "label": "resolveSharedDemoOperationAdmission()",
@@ -238816,7 +238957,7 @@
       "source_location": "L78"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "publicmutation_withoperationmutationadmission",
       "label": "withOperationMutationAdmission()",
@@ -238825,7 +238966,7 @@
       "source_location": "L70"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -238834,7 +238975,7 @@
       "source_location": "L98"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -238843,7 +238984,7 @@
       "source_location": "L56"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -238852,7 +238993,7 @@
       "source_location": "L49"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -238861,7 +239002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "automationpolicy_buildeodautomationdecisionevidence",
       "label": "buildEodAutomationDecisionEvidence()",
@@ -238870,7 +239011,7 @@
       "source_location": "L54"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "automationpolicy_numberfrommetadata",
       "label": "numberFromMetadata()",
@@ -238879,7 +239020,7 @@
       "source_location": "L45"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "automationpolicy_validateeodautomationpolicyforsnapshot",
       "label": "validateEodAutomationPolicyForSnapshot()",
@@ -238888,7 +239029,7 @@
       "source_location": "L133"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_automationpolicy_ts",
       "label": "automationPolicy.ts",
@@ -238897,7 +239038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "operationsqueryindexes_test_expectindex",
       "label": "expectIndex()",
@@ -238906,7 +239047,7 @@
       "source_location": "L18"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "operationsqueryindexes_test_getsource",
       "label": "getSource()",
@@ -238915,7 +239056,7 @@
       "source_location": "L25"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "operationsqueryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -238924,7 +239065,7 @@
       "source_location": "L11"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationsqueryindexes_test_ts",
       "label": "operationsQueryIndexes.test.ts",
@@ -238933,7 +239074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "oversizedoperationalworkrepair_test_queryresult",
       "label": "queryResult()",
@@ -238942,7 +239083,7 @@
       "source_location": "L31"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "oversizedoperationalworkrepair_test_repairdoc",
       "label": "repairDoc()",
@@ -238951,7 +239092,7 @@
       "source_location": "L39"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "oversizedoperationalworkrepair_test_workitem",
       "label": "workItem()",
@@ -238960,7 +239101,7 @@
       "source_location": "L11"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_test_ts",
       "label": "oversizedOperationalWorkRepair.test.ts",
@@ -238969,7 +239110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_test_ts",
       "label": "registerSessionTracing.test.ts",
@@ -238978,7 +239119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "registersessiontracing_test_buildctx",
       "label": "buildCtx()",
@@ -238987,7 +239128,7 @@
       "source_location": "L33"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "registersessiontracing_test_buildsession",
       "label": "buildSession()",
@@ -238996,49 +239137,13 @@
       "source_location": "L19"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "registersessiontracing_test_formatstoredtraceamount",
       "label": "formatStoredTraceAmount()",
       "norm_label": "formatstoredtraceamount()",
       "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.test.ts",
       "source_location": "L42"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
-      "label": "registerSessions.trace.test.ts",
-      "norm_label": "registersessions.trace.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "registersessions_trace_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "registersessions_trace_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L57"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "registersessions_trace_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
-      "source_location": "L211"
     },
     {
       "community": 61,
@@ -239268,6 +239373,42 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_registersessions_trace_test_ts",
+      "label": "registerSessions.trace.test.ts",
+      "norm_label": "registersessions.trace.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "registersessions_trace_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "registersessions_trace_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "registersessions_trace_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessions.trace.test.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_ts",
       "label": "serviceIntake.ts",
       "norm_label": "serviceintake.ts",
@@ -239275,7 +239416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "serviceintake_resolveserviceintakecustomerprofile",
       "label": "resolveServiceIntakeCustomerProfile()",
@@ -239284,7 +239425,7 @@
       "source_location": "L42"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "serviceintake_splitfullname",
       "label": "splitFullName()",
@@ -239293,7 +239434,7 @@
       "source_location": "L29"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "serviceintake_trimoptional",
       "label": "trimOptional()",
@@ -239302,7 +239443,7 @@
       "source_location": "L24"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "emailotp_assertapploginemailapproved",
       "label": "assertAppLoginEmailApproved()",
@@ -239311,7 +239452,7 @@
       "source_location": "L18"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "emailotp_authorizeemailotp",
       "label": "authorizeEmailOtp()",
@@ -239320,7 +239461,7 @@
       "source_location": "L24"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "emailotp_formatvalidtime",
       "label": "formatValidTime()",
@@ -239329,7 +239470,7 @@
       "source_location": "L44"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_otp_emailotp_ts",
       "label": "EmailOTP.ts",
@@ -239338,7 +239479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "adjusttransactionitems_test_basepayload",
       "label": "basePayload()",
@@ -239347,7 +239488,7 @@
       "source_location": "L329"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "adjusttransactionitems_test_createfakectx",
       "label": "createFakeCtx()",
@@ -239356,7 +239497,7 @@
       "source_location": "L144"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "adjusttransactionitems_test_mockcompletedtransaction",
       "label": "mockCompletedTransaction()",
@@ -239365,7 +239506,7 @@
       "source_location": "L355"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_adjusttransactionitems_test_ts",
       "label": "adjustTransactionItems.test.ts",
@@ -239374,7 +239515,43 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 614,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 614,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 614,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
@@ -239383,7 +239560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -239392,7 +239569,7 @@
       "source_location": "L34"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -239401,7 +239578,7 @@
       "source_location": "L29"
     },
     {
-      "community": 613,
+      "community": 615,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -239410,7 +239587,7 @@
       "source_location": "L56"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -239419,7 +239596,7 @@
       "source_location": "L39"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -239428,7 +239605,7 @@
       "source_location": "L99"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -239437,7 +239614,7 @@
       "source_location": "L74"
     },
     {
-      "community": 614,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -239446,7 +239623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -239455,7 +239632,7 @@
       "source_location": "L21"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -239464,7 +239641,7 @@
       "source_location": "L42"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -239473,7 +239650,7 @@
       "source_location": "L80"
     },
     {
-      "community": 615,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -239482,7 +239659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -239491,7 +239668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -239500,7 +239677,7 @@
       "source_location": "L12"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -239509,7 +239686,7 @@
       "source_location": "L127"
     },
     {
-      "community": 616,
+      "community": 618,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
@@ -239518,7 +239695,7 @@
       "source_location": "L99"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
       "label": "posRegisterSessionActivity.test.ts",
@@ -239527,7 +239704,7 @@
       "source_location": "L1"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildactivity",
       "label": "buildActivity()",
@@ -239536,7 +239713,7 @@
       "source_location": "L457"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildreport",
       "label": "buildReport()",
@@ -239545,85 +239722,13 @@
       "source_location": "L436"
     },
     {
-      "community": 617,
+      "community": 619,
       "file_type": "code",
       "id": "posregistersessionactivity_test_createfakerepository",
       "label": "createFakeRepository()",
       "norm_label": "createfakerepository()",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/posRegisterSessionActivity.test.ts",
       "source_location": "L476"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
-      "label": "registerCatalogRevision.ts",
-      "norm_label": "registercatalogrevision.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "registercatalogrevision_advanceregistercatalogrevision",
-      "label": "advanceRegisterCatalogRevision()",
-      "norm_label": "advanceregistercatalogrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "registercatalogrevision_readregistercatalogrevision",
-      "label": "readRegisterCatalogRevision()",
-      "norm_label": "readregistercatalogrevision()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 618,
-      "file_type": "code",
-      "id": "registercatalogrevision_readregistercatalogrevisionrow",
-      "label": "readRegisterCatalogRevisionRow()",
-      "norm_label": "readregistercatalogrevisionrow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
-      "label": "sequenceGapPolicy.ts",
-      "norm_label": "sequencegappolicy.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "sequencegappolicy_decidesequencegapaction",
-      "label": "decideSequenceGapAction()",
-      "norm_label": "decidesequencegapaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "sequencegappolicy_issequencegapresolved",
-      "label": "isSequenceGapResolved()",
-      "norm_label": "issequencegapresolved()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
-      "source_location": "L219"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "sequencegappolicy_recordsequencegapobservation",
-      "label": "recordSequenceGapObservation()",
-      "norm_label": "recordsequencegapobservation()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
-      "source_location": "L190"
     },
     {
       "community": 62,
@@ -239844,6 +239949,78 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
+      "label": "registerCatalogRevision.ts",
+      "norm_label": "registercatalogrevision.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "registercatalogrevision_advanceregistercatalogrevision",
+      "label": "advanceRegisterCatalogRevision()",
+      "norm_label": "advanceregistercatalogrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "registercatalogrevision_readregistercatalogrevision",
+      "label": "readRegisterCatalogRevision()",
+      "norm_label": "readregistercatalogrevision()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "registercatalogrevision_readregistercatalogrevisionrow",
+      "label": "readRegisterCatalogRevisionRow()",
+      "norm_label": "readregistercatalogrevisionrow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerCatalogRevision.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
+      "label": "sequenceGapPolicy.ts",
+      "norm_label": "sequencegappolicy.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "sequencegappolicy_decidesequencegapaction",
+      "label": "decideSequenceGapAction()",
+      "norm_label": "decidesequencegapaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "sequencegappolicy_issequencegapresolved",
+      "label": "isSequenceGapResolved()",
+      "norm_label": "issequencegapresolved()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
+      "source_location": "L219"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
+      "id": "sequencegappolicy_recordsequencegapobservation",
+      "label": "recordSequenceGapObservation()",
+      "norm_label": "recordsequencegapobservation()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/sequenceGapPolicy.ts",
+      "source_location": "L190"
+    },
+    {
+      "community": 622,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
       "norm_label": "staffproof.ts",
@@ -239851,7 +240028,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 622,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -239860,7 +240037,7 @@
       "source_location": "L10"
     },
     {
-      "community": 620,
+      "community": 622,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -239869,7 +240046,7 @@
       "source_location": "L16"
     },
     {
-      "community": 620,
+      "community": 622,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -239878,7 +240055,7 @@
       "source_location": "L4"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -239887,7 +240064,7 @@
       "source_location": "L387"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -239896,7 +240073,7 @@
       "source_location": "L407"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -239905,7 +240082,7 @@
       "source_location": "L282"
     },
     {
-      "community": 621,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -239914,7 +240091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -239923,7 +240100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -239932,7 +240109,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -239941,7 +240118,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 622,
+      "community": 624,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -239950,7 +240127,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -239959,7 +240136,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -239968,7 +240145,7 @@
       "source_location": "L177"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -239977,7 +240154,7 @@
       "source_location": "L68"
     },
     {
-      "community": 623,
+      "community": 625,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
@@ -239986,43 +240163,7 @@
       "source_location": "L195"
     },
     {
-      "community": 624,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 624,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 624,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 624,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_terminalappsessions_test_ts",
       "label": "terminalAppSessions.test.ts",
@@ -240031,7 +240172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "terminalappsessions_test_buildargs",
       "label": "buildArgs()",
@@ -240040,7 +240181,7 @@
       "source_location": "L366"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "terminalappsessions_test_buildctx",
       "label": "buildCtx()",
@@ -240049,7 +240190,7 @@
       "source_location": "L377"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "terminalappsessions_test_gethandler",
       "label": "getHandler()",
@@ -240058,7 +240199,7 @@
       "source_location": "L11"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_sessionservice_test_ts",
       "label": "sessionService.test.ts",
@@ -240067,7 +240208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "sessionservice_test_buildclient",
       "label": "buildClient()",
@@ -240076,7 +240217,7 @@
       "source_location": "L540"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "sessionservice_test_buildrepository",
       "label": "buildRepository()",
@@ -240085,7 +240226,7 @@
       "source_location": "L506"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "sessionservice_test_buildsession",
       "label": "buildSession()",
@@ -240094,7 +240235,7 @@
       "source_location": "L564"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_types_ts",
       "label": "types.ts",
@@ -240103,7 +240244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "types_sanitizeremoteassistmetadata",
       "label": "sanitizeRemoteAssistMetadata()",
@@ -240112,7 +240253,7 @@
       "source_location": "L169"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "types_sanitizeremoteassistvalue",
       "label": "sanitizeRemoteAssistValue()",
@@ -240121,7 +240262,7 @@
       "source_location": "L193"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "types_summarizeremoteassistreason",
       "label": "summarizeRemoteAssistReason()",
@@ -240130,7 +240271,7 @@
       "source_location": "L189"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_public_test_ts",
       "label": "public.test.ts",
@@ -240139,7 +240280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "public_test_buildclient",
       "label": "buildClient()",
@@ -240148,7 +240289,7 @@
       "source_location": "L324"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "public_test_buildsession",
       "label": "buildSession()",
@@ -240157,49 +240298,13 @@
       "source_location": "L349"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "public_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
       "source_location": "L45"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_remoteassist_transportinternal_ts",
-      "label": "transportInternal.ts",
-      "norm_label": "transportinternal.ts",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "transportinternal_remoteassisttransportok",
-      "label": "remoteAssistTransportOk()",
-      "norm_label": "remoteassisttransportok()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "transportinternal_remoteassisttransportusererror",
-      "label": "remoteAssistTransportUserError()",
-      "norm_label": "remoteassisttransportusererror()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.ts",
-      "source_location": "L252"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "transportinternal_tocredentialcontextreturn",
-      "label": "toCredentialContextReturn()",
-      "norm_label": "tocredentialcontextreturn()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.ts",
-      "source_location": "L239"
     },
     {
       "community": 63,
@@ -240420,6 +240525,42 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_remoteassist_transportinternal_ts",
+      "label": "transportInternal.ts",
+      "norm_label": "transportinternal.ts",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "transportinternal_remoteassisttransportok",
+      "label": "remoteAssistTransportOk()",
+      "norm_label": "remoteassisttransportok()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "transportinternal_remoteassisttransportusererror",
+      "label": "remoteAssistTransportUserError()",
+      "norm_label": "remoteassisttransportusererror()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.ts",
+      "source_location": "L252"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "transportinternal_tocredentialcontextreturn",
+      "label": "toCredentialContextReturn()",
+      "norm_label": "tocredentialcontextreturn()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transportInternal.ts",
+      "source_location": "L239"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "customrange_test_reportdayrow",
       "label": "reportDayRow()",
       "norm_label": "reportdayrow()",
@@ -240427,7 +240568,7 @@
       "source_location": "L102"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "customrange_test_seedproductsku",
       "label": "seedProductSku()",
@@ -240436,7 +240577,7 @@
       "source_location": "L48"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "customrange_test_seedstore",
       "label": "seedStore()",
@@ -240445,7 +240586,7 @@
       "source_location": "L29"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_customrange_test_ts",
       "label": "customRange.test.ts",
@@ -240454,7 +240595,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "fingerprint_factfingerprint",
       "label": "factFingerprint()",
@@ -240463,7 +240604,7 @@
       "source_location": "L50"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "fingerprint_fingerprintpayload",
       "label": "fingerprintPayload()",
@@ -240472,7 +240613,7 @@
       "source_location": "L20"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "fingerprint_stablestringhash",
       "label": "stableStringHash()",
@@ -240481,7 +240622,7 @@
       "source_location": "L36"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -240490,7 +240631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "foldday_test_fact",
       "label": "fact()",
@@ -240499,7 +240640,7 @@
       "source_location": "L77"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "foldday_test_sale",
       "label": "sale()",
@@ -240508,7 +240649,7 @@
       "source_location": "L96"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "foldday_test_shuffle",
       "label": "shuffle()",
@@ -240517,7 +240658,7 @@
       "source_location": "L107"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_test_ts",
       "label": "foldDay.test.ts",
@@ -240526,7 +240667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_rollups_test_ts",
       "label": "rollups.test.ts",
@@ -240535,7 +240676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "rollups_test_insertskuday",
       "label": "insertSkuDay()",
@@ -240544,7 +240685,7 @@
       "source_location": "L201"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "rollups_test_row",
       "label": "row()",
@@ -240553,7 +240694,7 @@
       "source_location": "L97"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "rollups_test_seedstorewithskus",
       "label": "seedStoreWithSkus()",
@@ -240562,7 +240703,7 @@
       "source_location": "L141"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "appointments_buildserviceappointment",
       "label": "buildServiceAppointment()",
@@ -240571,7 +240712,7 @@
       "source_location": "L28"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "appointments_closecurrentserviceappointmentworkitemswithctx",
       "label": "closeCurrentServiceAppointmentWorkItemsWithCtx()",
@@ -240580,7 +240721,7 @@
       "source_location": "L98"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "appointments_findoverlappingappointment",
       "label": "findOverlappingAppointment()",
@@ -240589,7 +240730,7 @@
       "source_location": "L72"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_appointments_ts",
       "label": "appointments.ts",
@@ -240598,7 +240739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "admission_consumeadmissionbudgetwithctx",
       "label": "consumeAdmissionBudgetWithCtx()",
@@ -240607,7 +240748,7 @@
       "source_location": "L39"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "admission_consumeshareddemoticketwithctx",
       "label": "consumeSharedDemoTicketWithCtx()",
@@ -240616,7 +240757,7 @@
       "source_location": "L53"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "admission_requirecurrentshareddemoadmissionfoundationwithctx",
       "label": "requireCurrentSharedDemoAdmissionFoundationWithCtx()",
@@ -240625,7 +240766,7 @@
       "source_location": "L20"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_admission_ts",
       "label": "admission.ts",
@@ -240634,7 +240775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "crypto_createopaqueticket",
       "label": "createOpaqueTicket()",
@@ -240643,7 +240784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "crypto_encodebase64url",
       "label": "encodeBase64Url()",
@@ -240652,7 +240793,7 @@
       "source_location": "L15"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "crypto_hashshareddemoticket",
       "label": "hashSharedDemoTicket()",
@@ -240661,7 +240802,7 @@
       "source_location": "L7"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_crypto_ts",
       "label": "crypto.ts",
@@ -240670,7 +240811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_scheduledrestore_ts",
       "label": "scheduledRestore.ts",
@@ -240679,7 +240820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "scheduledrestore_continuerestorewithctx",
       "label": "continueRestoreWithCtx()",
@@ -240688,7 +240829,7 @@
       "source_location": "L20"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "scheduledrestore_runhourlyrestorewithctx",
       "label": "runHourlyRestoreWithCtx()",
@@ -240697,7 +240838,7 @@
       "source_location": "L59"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "scheduledrestore_shareddemorestoreenabled",
       "label": "sharedDemoRestoreEnabled()",
@@ -240706,7 +240847,7 @@
       "source_location": "L7"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_replenishment_test_ts",
       "label": "replenishment.test.ts",
@@ -240715,7 +240856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "replenishment_test_createreplenishmentqueryctx",
       "label": "createReplenishmentQueryCtx()",
@@ -240724,7 +240865,7 @@
       "source_location": "L21"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "replenishment_test_getsource",
       "label": "getSource()",
@@ -240733,49 +240874,13 @@
       "source_location": "L7"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "replenishment_test_toasynciterable",
       "label": "toAsyncIterable()",
       "norm_label": "toasynciterable()",
       "source_file": "packages/athena-webapp/convex/stockOps/replenishment.test.ts",
       "source_location": "L11"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "checkoutsession_test_createreservationactivityctx",
-      "label": "createReservationActivityCtx()",
-      "norm_label": "createreservationactivityctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "checkoutsession_test_createscheduledrunmutationctx",
-      "label": "createScheduledRunMutationCtx()",
-      "norm_label": "createscheduledrunmutationctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.test.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "checkoutsession_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.test.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_checkoutsession_test_ts",
-      "label": "checkoutSession.test.ts",
-      "norm_label": "checkoutsession.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 64,
@@ -240996,6 +241101,42 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "checkoutsession_test_createreservationactivityctx",
+      "label": "createReservationActivityCtx()",
+      "norm_label": "createreservationactivityctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "checkoutsession_test_createscheduledrunmutationctx",
+      "label": "createScheduledRunMutationCtx()",
+      "norm_label": "createscheduledrunmutationctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.test.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "checkoutsession_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.test.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_checkoutsession_test_ts",
+      "label": "checkoutSession.test.ts",
+      "norm_label": "checkoutsession.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/checkoutSession.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "commercequeryindexes_test_expectindex",
       "label": "expectIndex()",
       "norm_label": "expectindex()",
@@ -241003,7 +241144,7 @@
       "source_location": "L19"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "commercequeryindexes_test_getsource",
       "label": "getSource()",
@@ -241012,7 +241153,7 @@
       "source_location": "L26"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "commercequeryindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -241021,7 +241162,7 @@
       "source_location": "L12"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_commercequeryindexes_test_ts",
       "label": "commerceQueryIndexes.test.ts",
@@ -241030,7 +241171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "customerengagementevents_findexistingcustomerprofileid",
       "label": "findExistingCustomerProfileId()",
@@ -241039,7 +241180,7 @@
       "source_location": "L21"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "customerengagementevents_getstoreorganizationid",
       "label": "getStoreOrganizationId()",
@@ -241048,7 +241189,7 @@
       "source_location": "L63"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "customerengagementevents_recordstorefrontcustomermilestone",
       "label": "recordStoreFrontCustomerMilestone()",
@@ -241057,7 +241198,7 @@
       "source_location": "L71"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_ts",
       "label": "customerEngagementEvents.ts",
@@ -241066,7 +241207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_returnexchangeoperations_test_ts",
       "label": "returnExchangeOperations.test.ts",
@@ -241075,7 +241216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createorderitem",
       "label": "createOrderItem()",
@@ -241084,7 +241225,7 @@
       "source_location": "L14"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "returnexchangeoperations_test_createreplacement",
       "label": "createReplacement()",
@@ -241093,7 +241234,7 @@
       "source_location": "L32"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "returnexchangeoperations_test_getsource",
       "label": "getSource()",
@@ -241102,7 +241243,7 @@
       "source_location": "L10"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "ensuretimezoneauthority_ensuretimezoneauthorityforschedulewithctx",
       "label": "ensureTimezoneAuthorityForScheduleWithCtx()",
@@ -241111,7 +241252,7 @@
       "source_location": "L26"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "ensuretimezoneauthority_listtimezoneversionsforstorewithctx",
       "label": "listTimezoneVersionsForStoreWithCtx()",
@@ -241120,7 +241261,7 @@
       "source_location": "L14"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "ensuretimezoneauthority_scheduletimezonecontenthash",
       "label": "scheduleTimezoneContentHash()",
@@ -241129,7 +241270,7 @@
       "source_location": "L7"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_ensuretimezoneauthority_ts",
       "label": "ensureTimezoneAuthority.ts",
@@ -241138,7 +241279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_surfacedefinition_ts",
       "label": "surfaceDefinition.ts",
@@ -241147,7 +241288,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "surfacedefinition_definesurfacecontext",
       "label": "defineSurfaceContext()",
@@ -241156,7 +241297,7 @@
       "source_location": "L16"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "surfacedefinition_findcontexteventdefinition",
       "label": "findContextEventDefinition()",
@@ -241165,7 +241306,7 @@
       "source_location": "L23"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "surfacedefinition_validatecontexteventpayload",
       "label": "validateContextEventPayload()",
@@ -241174,7 +241315,7 @@
       "source_location": "L30"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_poscatalogvisibility_ts",
       "label": "posCatalogVisibility.ts",
@@ -241183,7 +241324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "poscatalogvisibility_isposcatalogvisible",
       "label": "isPosCatalogVisible()",
@@ -241192,7 +241333,7 @@
       "source_location": "L13"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "poscatalogvisibility_isprojectionproductposcatalogvisible",
       "label": "isProjectionProductPosCatalogVisible()",
@@ -241201,7 +241342,7 @@
       "source_location": "L17"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "poscatalogvisibility_isprojectionskuposcatalogvisible",
       "label": "isProjectionSkuPosCatalogVisible()",
@@ -241210,7 +241351,7 @@
       "source_location": "L23"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_posterminalcapability_ts",
       "label": "posTerminalCapability.ts",
@@ -241219,7 +241360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "posterminalcapability_normalizeposterminaltransactioncapability",
       "label": "normalizePosTerminalTransactionCapability()",
@@ -241228,7 +241369,7 @@
       "source_location": "L13"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "posterminalcapability_posterminalcantransactproducts",
       "label": "posTerminalCanTransactProducts()",
@@ -241237,7 +241378,7 @@
       "source_location": "L23"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "posterminalcapability_posterminalcantransactservices",
       "label": "posTerminalCanTransactServices()",
@@ -241246,7 +241387,7 @@
       "source_location": "L27"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_staffdisplayname_ts",
       "label": "staffDisplayName.ts",
@@ -241255,7 +241396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplayname",
       "label": "formatStaffDisplayName()",
@@ -241264,7 +241405,7 @@
       "source_location": "L12"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "staffdisplayname_formatstaffdisplaynameorfallback",
       "label": "formatStaffDisplayNameOrFallback()",
@@ -241273,7 +241414,7 @@
       "source_location": "L46"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "staffdisplayname_normalizenamepart",
       "label": "normalizeNamePart()",
@@ -241282,7 +241423,7 @@
       "source_location": "L7"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_storefrontvisibility_ts",
       "label": "storefrontVisibility.ts",
@@ -241291,7 +241432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "storefrontvisibility_isstorefrontselectablesubcategory",
       "label": "isStorefrontSelectableSubcategory()",
@@ -241300,7 +241441,7 @@
       "source_location": "L32"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "storefrontvisibility_isstorefrontvisiblecategory",
       "label": "isStorefrontVisibleCategory()",
@@ -241309,49 +241450,13 @@
       "source_location": "L13"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "storefrontvisibility_isstorefrontvisiblesubcategory",
       "label": "isStorefrontVisibleSubcategory()",
       "norm_label": "isstorefrontvisiblesubcategory()",
       "source_file": "packages/athena-webapp/shared/storefrontVisibility.ts",
       "source_location": "L23"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "attributesmanager_attributesmanager",
-      "label": "AttributesManager()",
-      "norm_label": "attributesmanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L227"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "attributesmanager_colormanager",
-      "label": "ColorManager()",
-      "norm_label": "colormanager()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "attributesmanager_sidebar",
-      "label": "Sidebar()",
-      "norm_label": "sidebar()",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L27"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
-      "label": "AttributesManager.tsx",
-      "norm_label": "attributesmanager.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
-      "source_location": "L1"
     },
     {
       "community": 65,
@@ -241572,6 +241677,42 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "attributesmanager_attributesmanager",
+      "label": "AttributesManager()",
+      "norm_label": "attributesmanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L227"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "attributesmanager_colormanager",
+      "label": "ColorManager()",
+      "norm_label": "colormanager()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "attributesmanager_sidebar",
+      "label": "Sidebar()",
+      "norm_label": "sidebar()",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L27"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_attributesmanager_tsx",
+      "label": "AttributesManager.tsx",
+      "norm_label": "attributesmanager.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/AttributesManager.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "attributestable_getproductattribute",
       "label": "getProductAttribute()",
       "norm_label": "getproductattribute()",
@@ -241579,7 +241720,7 @@
       "source_location": "L62"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "attributestable_handlechange",
       "label": "handleChange()",
@@ -241588,7 +241729,7 @@
       "source_location": "L37"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "attributestable_onsubmit",
       "label": "onSubmit()",
@@ -241597,7 +241738,7 @@
       "source_location": "L216"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_attributestable_tsx",
       "label": "AttributesTable.tsx",
@@ -241606,7 +241747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productvariantattributes_ts",
       "label": "ProductVariantAttributes.ts",
@@ -241615,7 +241756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "productvariantattributes_islegacynullplaceholder",
       "label": "isLegacyNullPlaceholder()",
@@ -241624,7 +241765,7 @@
       "source_location": "L3"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "productvariantattributes_normalizeskuattributevalue",
       "label": "normalizeSkuAttributeValue()",
@@ -241633,7 +241774,7 @@
       "source_location": "L7"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "productvariantattributes_parsevariantattributevalue",
       "label": "parseVariantAttributeValue()",
@@ -241642,7 +241783,7 @@
       "source_location": "L17"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storefrontobservabilitypanel_tsx",
       "label": "StorefrontObservabilityPanel.tsx",
@@ -241651,7 +241792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_formatlabel",
       "label": "formatLabel()",
@@ -241660,7 +241801,7 @@
       "source_location": "L15"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_gettrafficsourcebadge",
       "label": "getTrafficSourceBadge()",
@@ -241669,7 +241810,7 @@
       "source_location": "L32"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "storefrontobservabilitypanel_summarycard",
       "label": "SummaryCard()",
@@ -241678,7 +241819,7 @@
       "source_location": "L19"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_utils_ts",
       "label": "utils.ts",
@@ -241687,7 +241828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "utils_countgroupedanalytics",
       "label": "countGroupedAnalytics()",
@@ -241696,7 +241837,7 @@
       "source_location": "L52"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "utils_groupanalytics",
       "label": "groupAnalytics()",
@@ -241705,7 +241846,7 @@
       "source_location": "L3"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "utils_groupproductviewsbyday",
       "label": "groupProductViewsByDay()",
@@ -241714,7 +241855,7 @@
       "source_location": "L90"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_update_updatereadybanner_tsx",
       "label": "UpdateReadyBanner.tsx",
@@ -241723,7 +241864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "updatereadybanner_getupdatereadybannercontent",
       "label": "getUpdateReadyBannerContent()",
@@ -241732,7 +241873,7 @@
       "source_location": "L63"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "updatereadybanner_updatereadybanner",
       "label": "UpdateReadyBanner()",
@@ -241741,7 +241882,7 @@
       "source_location": "L7"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "updatereadybanner_updatereadymessageadapter",
       "label": "UpdateReadyMessageAdapter()",
@@ -241750,7 +241891,7 @@
       "source_location": "L16"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "inputotp_headless_control_test_disconnect",
       "label": "disconnect()",
@@ -241759,7 +241900,7 @@
       "source_location": "L55"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "inputotp_headless_control_test_observe",
       "label": "observe()",
@@ -241768,7 +241909,7 @@
       "source_location": "L53"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "inputotp_headless_control_test_unobserve",
       "label": "unobserve()",
@@ -241777,7 +241918,7 @@
       "source_location": "L54"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_headless_control_test_tsx",
       "label": "InputOTP.headless-control.test.tsx",
@@ -241786,7 +241927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "animatedheight_test_constructor",
       "label": "constructor()",
@@ -241795,7 +241936,7 @@
       "source_location": "L35"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "animatedheight_test_disconnect",
       "label": "disconnect()",
@@ -241804,7 +241945,7 @@
       "source_location": "L40"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "animatedheight_test_observe",
       "label": "observe()",
@@ -241813,7 +241954,7 @@
       "source_location": "L39"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_animatedheight_test_tsx",
       "label": "AnimatedHeight.test.tsx",
@@ -241822,7 +241963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "flipnumber_defaultformatvalue",
       "label": "defaultFormatValue()",
@@ -241831,7 +241972,7 @@
       "source_location": "L18"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "flipnumber_flipnumber",
       "label": "FlipNumber()",
@@ -241840,7 +241981,7 @@
       "source_location": "L42"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "flipnumber_renderflipglyphs",
       "label": "renderFlipGlyphs()",
@@ -241849,7 +241990,7 @@
       "source_location": "L22"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_flipnumber_tsx",
       "label": "FlipNumber.tsx",
@@ -241858,7 +241999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "homepageproductpickerdialog_cn",
       "label": "cn()",
@@ -241867,7 +242008,7 @@
       "source_location": "L347"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "homepageproductpickerdialog_handleopenchange",
       "label": "handleOpenChange()",
@@ -241876,7 +242017,7 @@
       "source_location": "L246"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "homepageproductpickerdialog_handleselection",
       "label": "handleSelection()",
@@ -241885,48 +242026,12 @@
       "source_location": "L274"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_homepageproductpickerdialog_tsx",
       "label": "HomepageProductPickerDialog.tsx",
       "norm_label": "homepageproductpickerdialog.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/HomepageProductPickerDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L86"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L76"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "maintenancemessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
-      "source_location": "L52"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
-      "label": "MaintenanceMessageEditor.tsx",
-      "norm_label": "maintenancemessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
       "source_location": "L1"
     },
     {
@@ -242148,6 +242253,42 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "maintenancemessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L86"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L76"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "maintenancemessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L52"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_maintenancemessageeditor_tsx",
+      "label": "MaintenanceMessageEditor.tsx",
+      "norm_label": "maintenancemessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/MaintenanceMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_walkthroughrequestform_tsx",
       "label": "WalkthroughRequestForm.tsx",
       "norm_label": "walkthroughrequestform.tsx",
@@ -242155,7 +242296,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "walkthroughrequestform_descriptionids",
       "label": "descriptionIds()",
@@ -242164,7 +242305,7 @@
       "source_location": "L161"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "walkthroughrequestform_handlesubmit",
       "label": "handleSubmit()",
@@ -242173,7 +242314,7 @@
       "source_location": "L91"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "walkthroughrequestform_updatevalue",
       "label": "updateValue()",
@@ -242182,7 +242323,7 @@
       "source_location": "L80"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "controlloopfigures_evidencefigure",
       "label": "EvidenceFigure()",
@@ -242191,7 +242332,7 @@
       "source_location": "L112"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "controlloopfigures_oneplacefigure",
       "label": "OnePlaceFigure()",
@@ -242200,7 +242341,7 @@
       "source_location": "L13"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "controlloopfigures_wholeloopfigure",
       "label": "WholeLoopFigure()",
@@ -242209,7 +242350,7 @@
       "source_location": "L59"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_controlloopfigures_tsx",
       "label": "ControlLoopFigures.tsx",
@@ -242218,7 +242359,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "commandapprovaldialog_getasyncresolution",
       "label": "getAsyncResolution()",
@@ -242227,7 +242368,7 @@
       "source_location": "L79"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "commandapprovaldialog_getinlinemanagerresolution",
       "label": "getInlineManagerResolution()",
@@ -242236,7 +242377,7 @@
       "source_location": "L68"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "commandapprovaldialog_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -242245,7 +242386,7 @@
       "source_location": "L86"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_commandapprovaldialog_tsx",
       "label": "CommandApprovalDialog.tsx",
@@ -242254,7 +242395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "dailycloseview_test_disconnect",
       "label": "disconnect()",
@@ -242263,7 +242404,7 @@
       "source_location": "L358"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "dailycloseview_test_observe",
       "label": "observe()",
@@ -242272,7 +242413,7 @@
       "source_location": "L359"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "dailycloseview_test_unobserve",
       "label": "unobserve()",
@@ -242281,7 +242422,7 @@
       "source_location": "L360"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailycloseview_test_tsx",
       "label": "DailyCloseView.test.tsx",
@@ -242290,7 +242431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "operationsqueueview_test_disconnect",
       "label": "disconnect()",
@@ -242299,7 +242440,7 @@
       "source_location": "L267"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "operationsqueueview_test_observe",
       "label": "observe()",
@@ -242308,7 +242449,7 @@
       "source_location": "L268"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "operationsqueueview_test_unobserve",
       "label": "unobserve()",
@@ -242317,7 +242458,7 @@
       "source_location": "L269"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsqueueview_test_tsx",
       "label": "OperationsQueueView.test.tsx",
@@ -242326,7 +242467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "dailycloseformatting_formatdailyclosecompletedat",
       "label": "formatDailyCloseCompletedAt()",
@@ -242335,7 +242476,7 @@
       "source_location": "L29"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "dailycloseformatting_formatdailyclosemoney",
       "label": "formatDailyCloseMoney()",
@@ -242344,7 +242485,7 @@
       "source_location": "L3"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "dailycloseformatting_formatdailycloseoperatingdate",
       "label": "formatDailyCloseOperatingDate()",
@@ -242353,7 +242494,7 @@
       "source_location": "L14"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailycloseformatting_ts",
       "label": "dailyCloseFormatting.ts",
@@ -242362,7 +242503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "operationsmetricformatting_formatdeltapercent",
       "label": "formatDeltaPercent()",
@@ -242371,7 +242512,7 @@
       "source_location": "L6"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "operationsmetricformatting_formatmissingcomparisonlabel",
       "label": "formatMissingComparisonLabel()",
@@ -242380,7 +242521,7 @@
       "source_location": "L19"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "operationsmetricformatting_getdeltapercent",
       "label": "getDeltaPercent()",
@@ -242389,7 +242530,7 @@
       "source_location": "L13"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationsmetricformatting_tsx",
       "label": "operationsMetricFormatting.tsx",
@@ -242398,7 +242539,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivitytimelineadapter_ts",
       "label": "skuActivityTimelineAdapter.ts",
@@ -242407,7 +242548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "skuactivitytimelineadapter_buildskuactivitytimelineviewmodel",
       "label": "buildSkuActivityTimelineViewModel()",
@@ -242416,7 +242557,7 @@
       "source_location": "L76"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "skuactivitytimelineadapter_gettimelinequantity",
       "label": "getTimelineQuantity()",
@@ -242425,7 +242566,7 @@
       "source_location": "L58"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "skuactivitytimelineadapter_normalizesourcetype",
       "label": "normalizeSourceType()",
@@ -242434,7 +242575,7 @@
       "source_location": "L51"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "orderview_buildshareddemosessionorderupdate",
       "label": "buildSharedDemoSessionOrderUpdate()",
@@ -242443,7 +242584,7 @@
       "source_location": "L68"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "orderview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -242452,7 +242593,7 @@
       "source_location": "L127"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "orderview_toast",
       "label": "toast()",
@@ -242461,49 +242602,13 @@
       "source_location": "L321"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderview_tsx",
       "label": "OrderView.tsx",
       "norm_label": "orderview.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/OrderView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
-      "label": "ReturnExchangeView.tsx",
-      "norm_label": "returnexchangeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "returnexchangeview_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L145"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "returnexchangeview_resetreplacementfields",
-      "label": "resetReplacementFields()",
-      "norm_label": "resetreplacementfields()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L137"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "returnexchangeview_toggleitem",
-      "label": "toggleItem()",
-      "norm_label": "toggleitem()",
-      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
-      "source_location": "L123"
     },
     {
       "community": 67,
@@ -242715,6 +242820,42 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_returnexchangeview_tsx",
+      "label": "ReturnExchangeView.tsx",
+      "norm_label": "returnexchangeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "returnexchangeview_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L145"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "returnexchangeview_resetreplacementfields",
+      "label": "resetReplacementFields()",
+      "norm_label": "resetreplacementfields()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L137"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "returnexchangeview_toggleitem",
+      "label": "toggleItem()",
+      "norm_label": "toggleitem()",
+      "source_file": "packages/athena-webapp/src/components/orders/ReturnExchangeView.tsx",
+      "source_location": "L123"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "cashierauthdialog_cashierauthdialog",
       "label": "CashierAuthDialog()",
       "norm_label": "cashierauthdialog()",
@@ -242722,7 +242863,7 @@
       "source_location": "L57"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "cashierauthdialog_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -242731,7 +242872,7 @@
       "source_location": "L44"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "cashierauthdialog_isbrowseroffline",
       "label": "isBrowserOffline()",
@@ -242740,7 +242881,7 @@
       "source_location": "L53"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_tsx",
       "label": "CashierAuthDialog.tsx",
@@ -242749,7 +242890,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "newtransactionview_handlequickstart",
       "label": "handleQuickStart()",
@@ -242758,7 +242899,7 @@
       "source_location": "L92"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "newtransactionview_handlestarttransaction",
       "label": "handleStartTransaction()",
@@ -242767,7 +242908,7 @@
       "source_location": "L69"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "newtransactionview_navigation",
       "label": "Navigation()",
@@ -242776,7 +242917,7 @@
       "source_location": "L23"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_newtransactionview_tsx",
       "label": "NewTransactionView.tsx",
@@ -242785,7 +242926,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -242794,7 +242935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "productcard_handleaddselectedquantity",
       "label": "handleAddSelectedQuantity()",
@@ -242803,7 +242944,7 @@
       "source_location": "L80"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "productcard_normalizeproductattribute",
       "label": "normalizeProductAttribute()",
@@ -242812,7 +242953,7 @@
       "source_location": "L35"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "productcard_normalizequantity",
       "label": "normalizeQuantity()",
@@ -242821,7 +242962,7 @@
       "source_location": "L20"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_test_tsx",
       "label": "ProductStatus.test.tsx",
@@ -242830,7 +242971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productstatus_test_getstatusbadge",
       "label": "getStatusBadge()",
@@ -242839,7 +242980,7 @@
       "source_location": "L28"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productstatus_test_makeproduct",
       "label": "makeProduct()",
@@ -242848,7 +242989,7 @@
       "source_location": "L8"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productstatus_test_makevariant",
       "label": "makeVariant()",
@@ -242857,7 +242998,7 @@
       "source_location": "L18"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstock_tsx",
       "label": "ProductStock.tsx",
@@ -242866,7 +243007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "productstock_lowstockstatus",
       "label": "LowStockStatus()",
@@ -242875,7 +243016,7 @@
       "source_location": "L61"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "productstock_outofstockstatus",
       "label": "OutOfStockStatus()",
@@ -242884,7 +243025,7 @@
       "source_location": "L52"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "productstock_productstockstatus",
       "label": "ProductStockStatus()",
@@ -242893,7 +243034,7 @@
       "source_location": "L9"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_quickaddproductdialogutils_ts",
       "label": "quickAddProductDialogUtils.ts",
@@ -242902,7 +243043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "quickaddproductdialogutils_islikelyquickaddbarcode",
       "label": "isLikelyQuickAddBarcode()",
@@ -242911,7 +243052,7 @@
       "source_location": "L3"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "quickaddproductdialogutils_normalizequickaddinitiallookupcode",
       "label": "normalizeQuickAddInitialLookupCode()",
@@ -242920,7 +243061,7 @@
       "source_location": "L21"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "quickaddproductdialogutils_normalizequickaddlookupcode",
       "label": "normalizeQuickAddLookupCode()",
@@ -242929,7 +243070,7 @@
       "source_location": "L7"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_logic_ts",
       "label": "ProductsListView.logic.ts",
@@ -242938,7 +243079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "productslistview_logic_getcategoryproductpageindex",
       "label": "getCategoryProductPageIndex()",
@@ -242947,7 +243088,7 @@
       "source_location": "L10"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "productslistview_logic_getcategoryproductqueryoptions",
       "label": "getCategoryProductQueryOptions()",
@@ -242956,7 +243097,7 @@
       "source_location": "L37"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "productslistview_logic_writecategoryproductpagesearch",
       "label": "writeCategoryProductPageSearch()",
@@ -242965,7 +243106,7 @@
       "source_location": "L22"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "complimentaryproductsview_body",
       "label": "Body()",
@@ -242974,7 +243115,7 @@
       "source_location": "L16"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "complimentaryproductsview_complimentaryproductsview",
       "label": "ComplimentaryProductsView()",
@@ -242983,7 +243124,7 @@
       "source_location": "L35"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "complimentaryproductsview_navigation",
       "label": "Navigation()",
@@ -242992,7 +243133,7 @@
       "source_location": "L6"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_complimentary_complimentaryproductsview_tsx",
       "label": "ComplimentaryProductsView.tsx",
@@ -243001,7 +243142,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "data_table_handlepaginationchange",
       "label": "handlePaginationChange()",
@@ -243010,7 +243151,7 @@
       "source_location": "L80"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "data_table_handlerowclick",
       "label": "handleRowClick()",
@@ -243019,7 +243160,7 @@
       "source_location": "L120"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "data_table_handlerowkeydown",
       "label": "handleRowKeyDown()",
@@ -243028,49 +243169,13 @@
       "source_location": "L139"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_data_table_tsx",
       "label": "data-table.tsx",
       "norm_label": "data-table.tsx",
       "source_file": "packages/athena-webapp/src/components/products/products-table/components/data-table.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
-      "label": "promoCodeMoney.ts",
-      "norm_label": "promocodemoney.ts",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "promocodemoney_parsepromodiscountinput",
-      "label": "parsePromoDiscountInput()",
-      "norm_label": "parsepromodiscountinput()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountdisplaytext",
-      "label": "promoDiscountDisplayText()",
-      "norm_label": "promodiscountdisplaytext()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "promocodemoney_promodiscountinputvalue",
-      "label": "promoDiscountInputValue()",
-      "norm_label": "promodiscountinputvalue()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
-      "source_location": "L21"
     },
     {
       "community": 68,
@@ -243282,6 +243387,42 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodemoney_ts",
+      "label": "promoCodeMoney.ts",
+      "norm_label": "promocodemoney.ts",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "promocodemoney_parsepromodiscountinput",
+      "label": "parsePromoDiscountInput()",
+      "norm_label": "parsepromodiscountinput()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountdisplaytext",
+      "label": "promoDiscountDisplayText()",
+      "norm_label": "promodiscountdisplaytext()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "promocodemoney_promodiscountinputvalue",
+      "label": "promoDiscountInputValue()",
+      "norm_label": "promodiscountinputvalue()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/promoCodeMoney.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportcalendar_tsx",
       "label": "ReportCalendar.tsx",
       "norm_label": "reportcalendar.tsx",
@@ -243289,7 +243430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "reportcalendar_clamptotoday",
       "label": "clampToToday()",
@@ -243298,7 +243439,7 @@
       "source_location": "L15"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "reportcalendar_reportcalendar",
       "label": "ReportCalendar()",
@@ -243307,49 +243448,13 @@
       "source_location": "L20"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "reportcalendar_startoflocalday",
       "label": "startOfLocalDay()",
       "norm_label": "startoflocalday()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportCalendar.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
-      "label": "ReportDaysPanel.tsx",
-      "norm_label": "reportdayspanel.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
-      "id": "reportdayspanel_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L181"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
-      "id": "reportdayspanel_isselectedday",
-      "label": "isSelectedDay()",
-      "norm_label": "isselectedday()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L112"
-    },
-    {
-      "community": 681,
-      "file_type": "code",
-      "id": "reportdayspanel_selectday",
-      "label": "selectDay()",
-      "norm_label": "selectday()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx",
-      "source_location": "L114"
     },
     {
       "community": 682,
@@ -243403,7 +243508,7 @@
       "label": "Harness()",
       "norm_label": "harness()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx",
-      "source_location": "L119"
+      "source_location": "L134"
     },
     {
       "community": 683,
@@ -243412,7 +243517,7 @@
       "label": "linkedRange()",
       "norm_label": "linkedrange()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx",
-      "source_location": "L363"
+      "source_location": "L404"
     },
     {
       "community": 683,
@@ -243421,7 +243526,7 @@
       "label": "snapshot()",
       "norm_label": "snapshot()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx",
-      "source_location": "L75"
+      "source_location": "L82"
     },
     {
       "community": 684,
@@ -253924,7 +254029,7 @@
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx",
-      "source_location": "L111"
+      "source_location": "L115"
     },
     {
       "community": 870,
@@ -253933,7 +254038,7 @@
       "label": "comparisonFor()",
       "norm_label": "comparisonfor()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx",
-      "source_location": "L29"
+      "source_location": "L32"
     },
     {
       "community": 871,
@@ -257578,7 +257683,7 @@
       "label": "isoDateOffset()",
       "norm_label": "isodateoffset()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx",
-      "source_location": "L29"
+      "source_location": "L32"
     },
     {
       "community": 940,
@@ -257587,7 +257692,7 @@
       "label": "ReportsOverviewRoute()",
       "norm_label": "reportsoverviewroute()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx",
-      "source_location": "L42"
+      "source_location": "L45"
     },
     {
       "community": 940,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -84179,7 +84179,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx",
-      "source_location": "L3950",
+      "source_location": "L3954",
       "target": "dailyoperationsview_test_gettodayrefreshcalls",
       "weight": 1
     },
@@ -84191,7 +84191,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_components_operations_dailyoperationsview_test_tsx",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx",
-      "source_location": "L2328",
+      "source_location": "L2332",
       "target": "dailyoperationsview_test_rendercurrentstate",
       "weight": 1
     },
@@ -253147,7 +253147,7 @@
       "label": "getTodayRefreshCalls()",
       "norm_label": "gettodayrefreshcalls()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx",
-      "source_location": "L3950"
+      "source_location": "L3954"
     },
     {
       "community": 851,
@@ -253156,7 +253156,7 @@
       "label": "renderCurrentState()",
       "norm_label": "rendercurrentstate()",
       "source_file": "packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx",
-      "source_location": "L2328"
+      "source_location": "L2332"
     },
     {
       "community": 851,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 2699
-- Graph nodes: 11008
-- Graph edges: 13408
-- Communities: 2624
+- Code files discovered: 2700
+- Graph nodes: 11013
+- Graph edges: 13413
+- Communities: 2625
 
 ## Graph Hotspots
 - `dailyClose.ts` (93 edges, Community 0) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (15 edges, Community 129) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 281) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 282) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 129) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossCluster()` (4 edges, Community 129) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `invalidateAcrossClusterWithPipeline()` (4 edges, Community 129) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/reports/queries.test.ts
+++ b/packages/athena-webapp/convex/reports/queries.test.ts
@@ -469,6 +469,7 @@ describe("listPeriodSkus", () => {
     expect(result.totalNetSalesMinor).toBe(1_800);
     expect(result.totalUnitsSold).toBe(16);
     expect(result.totalTransactions).toBe(7);
+    expect(result.isTodayInProgress).toBe(false);
   });
 
   it("counts live POS transactions when an open day has no close yet", async () => {
@@ -522,6 +523,7 @@ describe("listPeriodSkus", () => {
 
     expect(result.totalUnitsSold).toBe(3);
     expect(result.totalTransactions).toBe(2);
+    expect(result.isTodayInProgress).toBe(true);
   });
 
   it("uses the linked product name when the SKU has no denormalized product name", async () => {

--- a/packages/athena-webapp/convex/reports/queries.ts
+++ b/packages/athena-webapp/convex/reports/queries.ts
@@ -5,6 +5,7 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { requireReportsStoreAccess } from "./access";
 import {
   dayPeriodKey,
+  isReportingTodayInProgress,
   trailingThreeMonthsStart,
 } from "../../shared/reportsContract";
 import { REPORT_SKU_PAGE_SIZE } from "../../shared/reportsContract";
@@ -389,6 +390,7 @@ export const listPeriodSkus = query({
     totalUnitsSold: number;
     totalTransactions: number;
     updatedAt: number | null;
+    isTodayInProgress: boolean;
   }> => {
     await requireReportsStoreAccess(ctx, args.storeId);
     const periodRange = periodDateRange(args.periodKey as ReportPeriodKey);
@@ -506,6 +508,10 @@ export const listPeriodSkus = query({
           : livePosTransactionCount(ctx, day);
       }),
     );
+    const selectedDayDate =
+      periodRange && periodRange.startDate === periodRange.endDate
+        ? periodRange.startDate
+        : null;
 
     return {
       rows,
@@ -523,6 +529,13 @@ export const listPeriodSkus = query({
         0,
       ),
       updatedAt: overview?.updatedAt ?? null,
+      isTodayInProgress:
+        selectedDayDate !== null &&
+        periodDays.some(
+          (day) =>
+            day.operatingDate === selectedDayDate &&
+            isReportingTodayInProgress(day.status),
+        ),
     };
   },
 });

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -6,7 +6,7 @@ This key-folder index highlights the main directories agents are likely to need 
 
 ## Core app surfaces
 
-- [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 130 file(s); key children: -app-entry-route.tsx, -authed-layout.tsx, -authenticated-layout.tsx, -demo-presentation.ts, -index-route-view.tsx.
+- [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 131 file(s); key children: -app-entry-route.tsx, -authed-layout.tsx, -authenticated-layout.tsx, -demo-presentation.ts, -index-route-view.tsx.
 - [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 760 file(s); key children: GenericComboBox.tsx, Navbar.test.tsx, Navbar.tsx, OrganizationView.test.tsx, OrganizationView.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 37 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.

--- a/packages/athena-webapp/docs/agent/route-index.md
+++ b/packages/athena-webapp/docs/agent/route-index.md
@@ -65,6 +65,7 @@ This route index enumerates the current files under `src/routes` so agents can o
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/approvals.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/approvals.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close-history.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close-history.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close.tsx)
+- [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.test.ts`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.test.ts)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.test.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.test.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.tsx)

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -638,6 +638,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/routes/_authed-shell.test.tsx`](../../src/routes/_authed-shell.test.tsx)
 - [`src/routes/_authed.route.test.tsx`](../../src/routes/_authed.route.test.tsx)
 - [`src/routes/_authed.test.tsx`](../../src/routes/_authed.test.tsx)
+- [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.test.ts`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.test.ts)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.test.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import.test.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/cost-overlay.test.ts`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/cost-overlay.test.ts)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.test.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.test.tsx)

--- a/packages/athena-webapp/shared/reportsContract.ts
+++ b/packages/athena-webapp/shared/reportsContract.ts
@@ -47,6 +47,18 @@ export const REPORT_DAY_STATUSES = [
 export type ReportDayStatus = (typeof REPORT_DAY_STATUSES)[number];
 
 /**
+ * Authoritative definition of "Today in progress" in reporting.
+ *
+ * Reporting follows the materialized day lifecycle, not a browser or server
+ * clock: the current operating day remains `open` until rollover advances it.
+ */
+export function isReportingTodayInProgress(
+  status: ReportDayStatus | null | undefined,
+): boolean {
+  return status === "open";
+}
+
+/**
  * Day-level metrics. One FIELD per metric — never one row per metric.
  * `grossProfitMinor` is null when any revenue lacks a cost basis; the
  * uncovered portion is reported honestly in `uncostedRevenueMinor`.

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -73,6 +73,10 @@ vi.mock("convex/react", () => ({
   useQuery: mockedHooks.useQuery,
 }));
 
+vi.mock("~/src/hooks/use-navigate-back", () => ({
+  useNavigateBack: () => vi.fn(),
+}));
+
 vi.mock("@/hooks/useProtectedAdminPageState", () => ({
   useProtectedAdminPageState: mockedHooks.useProtectedAdminPageState,
 }));

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -3528,6 +3528,7 @@ export function DailyOperationsViewContent({
           <PageLevelHeader
             eyebrow="Store Ops"
             title="Daily Operations"
+            showBackButton
             description="Review the store day, see what needs attention, and move into the workflow that owns the next action."
           />
 

--- a/packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx
@@ -263,6 +263,72 @@ describe("ReportDaysPanel", () => {
     );
   });
 
+  it("targets the selected start date after an expanded table range loads", async () => {
+    const user = userEvent.setup();
+    const onRangeChange = vi.fn();
+    const onPageChange = vi.fn();
+    const initialDays = Array.from({ length: 14 }, (_, index) => {
+      const date = new Date(Date.UTC(2026, 6, 28 - index));
+      return {
+        operatingDate: date.toISOString().slice(0, 10),
+        status: "reconciled",
+        currency: "USD",
+        netSalesMinor: 1000,
+        unitsSold: 1,
+        closeVarianceMinor: 0,
+      };
+    });
+    useQuery.mockReturnValue(initialDays);
+
+    const { rerender } = render(
+      <ReportDaysPanel
+        {...baseProps}
+        onPageChange={onPageChange}
+        onRangeChange={onRangeChange}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Change date range, currently Jul 15–28, 2026",
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Friday, July 3rd, 2026/i }),
+    );
+
+    expect(onRangeChange).toHaveBeenCalledWith(
+      { startDate: "2026-07-03", endDate: "2026-07-28" },
+      1,
+    );
+    expect(onPageChange).not.toHaveBeenCalled();
+
+    useQuery.mockReturnValue(
+      Array.from({ length: 26 }, (_, index) => {
+        const date = new Date(Date.UTC(2026, 6, 28 - index));
+        return {
+          operatingDate: date.toISOString().slice(0, 10),
+          status: "reconciled",
+          currency: "USD",
+          netSalesMinor: 1000,
+          unitsSold: 1,
+          closeVarianceMinor: 0,
+        };
+      }),
+    );
+    rerender(
+      <ReportDaysPanel
+        {...baseProps}
+        onPageChange={onPageChange}
+        onRangeChange={onRangeChange}
+        startDate="2026-07-03"
+        tableStartDate="2026-07-03"
+      />,
+    );
+
+    await waitFor(() => expect(onPageChange).toHaveBeenCalledWith(2));
+  });
+
   it("selects a day row while preserving the date drill-down", async () => {
     const user = userEvent.setup();
     const onRangeChange = vi.fn();

--- a/packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportDaysPanel.test.tsx
@@ -45,6 +45,8 @@ import { ReportDaysPanel } from "./ReportDaysPanel";
 const baseProps = {
   startDate: "2026-07-15",
   endDate: "2026-07-28",
+  tableStartDate: "2026-07-15",
+  tableEndDate: "2026-07-28",
   canResetRange: false,
   onRangeChange: vi.fn(),
   onRangeReset: vi.fn(),
@@ -219,6 +221,48 @@ describe("ReportDaysPanel", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("targets the page containing the first date of a newly selected range", async () => {
+    const user = userEvent.setup();
+    const onRangeChange = vi.fn();
+    const omittedDates = new Set(["2026-07-10", "2026-07-21"]);
+    useQuery.mockReturnValue(
+      Array.from({ length: 29 }, (_, index) => {
+        const date = new Date(Date.UTC(2026, 6, 31 - index));
+        return {
+          operatingDate: date.toISOString().slice(0, 10),
+          status: "reconciled",
+          currency: "USD",
+          netSalesMinor: 1000,
+          unitsSold: 1,
+          closeVarianceMinor: 0,
+        };
+      }).filter((day) => !omittedDates.has(day.operatingDate)),
+    );
+
+    render(
+      <ReportDaysPanel
+        {...baseProps}
+        onRangeChange={onRangeChange}
+        tableEndDate="2026-07-31"
+        tableStartDate="2026-07-03"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Change date range, currently Jul 15–28, 2026",
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /Friday, July 3rd, 2026/i }),
+    );
+
+    expect(onRangeChange).toHaveBeenCalledWith(
+      { startDate: "2026-07-03", endDate: "2026-07-28" },
+      2,
+    );
+  });
+
   it("selects a day row while preserving the date drill-down", async () => {
     const user = userEvent.setup();
     const onRangeChange = vi.fn();
@@ -381,6 +425,141 @@ describe("ReportDaysPanel", () => {
     expect(onRangeChange).not.toHaveBeenCalled();
   });
 
+  it("keeps the table scope visible while emphasizing only the selected range", () => {
+    useQuery.mockReturnValue([
+      {
+        operatingDate: "2026-07-20",
+        status: "reconciled",
+        currency: "USD",
+        netSalesMinor: 5600,
+        unitsSold: 8,
+      },
+      {
+        operatingDate: "2026-07-14",
+        status: "reconciled",
+        currency: "USD",
+        netSalesMinor: 4200,
+        unitsSold: 6,
+      },
+    ]);
+
+    render(
+      <ReportDaysPanel
+        {...baseProps}
+        endDate="2026-07-20"
+        startDate="2026-07-15"
+        tableEndDate="2026-07-28"
+        tableStartDate="2026-07-01"
+      />,
+    );
+
+    const selectedRangeRow = screen.getByRole("button", {
+      name: "Show products sold for Mon, Jul 20, 2026",
+    });
+    const outsideRangeRow = screen.getByRole("button", {
+      name: "Show products sold for Tue, Jul 14, 2026",
+    });
+    expect(selectedRangeRow).toHaveAttribute("data-highlighted", "true");
+    expect(selectedRangeRow).not.toHaveAttribute("data-deemphasized");
+    expect(outsideRangeRow).toHaveAttribute("data-deemphasized", "true");
+
+    const daysQuery = useQuery.mock.calls.find(
+      ([functionReference]) =>
+        getFunctionName(functionReference as never) ===
+        "reports/queries:listDays",
+    );
+    const skuMixQuery = useQuery.mock.calls.find(
+      ([functionReference]) =>
+        getFunctionName(functionReference as never) ===
+        "reports/queries:listRangeSkuMix",
+    );
+    expect(daysQuery?.[1]).toMatchObject({
+      startDate: "2026-07-01",
+      endDate: "2026-07-28",
+    });
+    expect(skuMixQuery?.[1]).toMatchObject({
+      startDate: "2026-07-15",
+      endDate: "2026-07-20",
+    });
+  });
+
+  it("returns from a selected day to the current selected range", async () => {
+    const user = userEvent.setup();
+    const onSelectedDateChange = vi.fn();
+    useQuery.mockReturnValue([
+      {
+        operatingDate: "2026-07-20",
+        status: "reconciled",
+        currency: "USD",
+        netSalesMinor: 5600,
+        unitsSold: 8,
+      },
+      {
+        operatingDate: "2026-07-19",
+        status: "reconciled",
+        currency: "USD",
+        netSalesMinor: 4200,
+        unitsSold: 6,
+      },
+      {
+        operatingDate: "2026-07-14",
+        status: "reconciled",
+        currency: "USD",
+        netSalesMinor: 2100,
+        unitsSold: 3,
+      },
+    ]);
+
+    const { rerender } = render(
+      <ReportDaysPanel
+        {...baseProps}
+        endDate="2026-07-20"
+        onSelectedDateChange={onSelectedDateChange}
+        selectedDate="2026-07-20"
+        startDate="2026-07-19"
+        tableEndDate="2026-07-28"
+        tableStartDate="2026-07-01"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Show products sold for Sun, Jul 19, 2026",
+      }),
+    ).toHaveAttribute("data-deemphasized", "true");
+
+    await user.click(
+      within(
+        screen.getByRole("button", {
+          name: "Clear day selection for Mon, Jul 20, 2026",
+        }),
+      ).getByText("$56"),
+    );
+    expect(onSelectedDateChange).toHaveBeenCalledWith(undefined);
+
+    rerender(
+      <ReportDaysPanel
+        {...baseProps}
+        endDate="2026-07-20"
+        onSelectedDateChange={onSelectedDateChange}
+        startDate="2026-07-19"
+        tableEndDate="2026-07-28"
+        tableStartDate="2026-07-01"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Show products sold for Sun, Jul 19, 2026",
+      }),
+    ).toHaveAttribute("data-highlighted", "true");
+    expect(
+      screen.getByRole("button", {
+        name: "Show products sold for Tue, Jul 14, 2026",
+      }),
+    ).toHaveAttribute("data-deemphasized", "true");
+  });
+
   it("clears single-day mode without changing the range or page", async () => {
     const user = userEvent.setup();
     const onRangeChange = vi.fn();
@@ -413,7 +592,7 @@ describe("ReportDaysPanel", () => {
     );
 
     await user.click(
-      screen.getByRole("button", { name: "Return to previous date range" }),
+      screen.getByRole("button", { name: "Return to selected date range" }),
     );
     expect(onSelectedDateChange).toHaveBeenCalledWith(undefined);
     expect(onRangeChange).not.toHaveBeenCalled();

--- a/packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "convex/react";
 import { Link, useParams } from "@tanstack/react-router";
 import { ArrowDown, RotateCcw } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   Table,
   TableBody,
@@ -31,12 +31,12 @@ const REPORT_DAYS_PAGE_SIZE = 14;
 function pageContainingDate(
   daysNewestFirst: Array<{ operatingDate: string }>,
   operatingDate: string,
-): number {
+): number | undefined {
   const dateIndex = daysNewestFirst.findIndex(
     (day) => day.operatingDate === operatingDate,
   );
   return dateIndex < 0
-    ? 1
+    ? undefined
     : Math.floor(dateIndex / REPORT_DAYS_PAGE_SIZE) + 1;
 }
 
@@ -77,6 +77,7 @@ export function ReportDaysPanel({
 }) {
   const { activeStore } = useGetActiveStore();
   const { orgUrlSlug, storeUrlSlug } = useParams({ strict: false });
+  const pendingRangeStart = useRef<string | null>(null);
   const {
     data: days,
     dataContext: settledDaysPage,
@@ -143,6 +144,17 @@ export function ReportDaysPanel({
     );
   };
 
+  useEffect(() => {
+    const targetDate = pendingRangeStart.current;
+    if (!targetDate || !daysNewestFirst || isRefreshing) return;
+
+    const targetPage = pageContainingDate(daysNewestFirst, targetDate);
+    pendingRangeStart.current = null;
+    if (targetPage !== undefined && targetPage !== page) {
+      onPageChange(targetPage);
+    }
+  }, [daysNewestFirst, isRefreshing, onPageChange, page]);
+
   return (
     <section className="space-y-layout-sm" data-testid="report-days-panel">
       <div className="flex flex-wrap items-center justify-end gap-layout-xs">
@@ -169,12 +181,15 @@ export function ReportDaysPanel({
         ) : null}
         <ReportDateRangeField
           endDate={endDate}
-          onSelect={(next) =>
-            onRangeChange(
-              next,
-              pageContainingDate(daysNewestFirst ?? [], next.startDate),
-            )
-          }
+          onSelect={(next) => {
+            const targetPage = pageContainingDate(
+              daysNewestFirst ?? [],
+              next.startDate,
+            );
+            pendingRangeStart.current =
+              targetPage === undefined ? next.startDate : null;
+            onRangeChange(next, targetPage ?? 1);
+          }}
           startDate={startDate}
         />
       </div>

--- a/packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportDaysPanel.tsx
@@ -28,16 +28,31 @@ import { ReportSkuMixChart } from "./ReportSkuMixChart";
 
 const REPORT_DAYS_PAGE_SIZE = 14;
 
+function pageContainingDate(
+  daysNewestFirst: Array<{ operatingDate: string }>,
+  operatingDate: string,
+): number {
+  const dateIndex = daysNewestFirst.findIndex(
+    (day) => day.operatingDate === operatingDate,
+  );
+  return dateIndex < 0
+    ? 1
+    : Math.floor(dateIndex / REPORT_DAYS_PAGE_SIZE) + 1;
+}
+
 /**
- * Day overview: `listDays` stays scoped to the operator's bounded range while
- * an optional day selection narrows only the product mix. The date link opens
- * the Items view scoped to that day's `d:` period key (via
+ * Day overview: `listDays` stays scoped to the stable table range while the
+ * selected range controls emphasis and the product mix. An optional day
+ * selection temporarily narrows both to one operating date. The date link
+ * opens the Items view scoped to that day's `d:` period key (via
  * `periodType`/`periodDate`, see `reports/items/index.tsx`).
  */
 export function ReportDaysPanel({
   canResetRange,
   startDate,
   endDate,
+  tableStartDate,
+  tableEndDate,
   onRangeChange,
   onRangeReset,
   onSelectedDateChange,
@@ -48,7 +63,12 @@ export function ReportDaysPanel({
   canResetRange: boolean;
   startDate: string;
   endDate: string;
-  onRangeChange: (next: { startDate: string; endDate: string }) => void;
+  tableStartDate: string;
+  tableEndDate: string;
+  onRangeChange: (
+    next: { startDate: string; endDate: string },
+    targetPage: number,
+  ) => void;
   onRangeReset: () => void;
   onSelectedDateChange: (date: string | undefined) => void;
   onPageChange: (page: number) => void;
@@ -66,7 +86,11 @@ export function ReportDaysPanel({
     useQuery(
       api.reports.queries.listDays,
       activeStore?._id
-        ? { storeId: activeStore._id, startDate, endDate }
+        ? {
+            storeId: activeStore._id,
+            startDate: tableStartDate,
+            endDate: tableEndDate,
+          }
         : "skip",
     ),
     page,
@@ -111,6 +135,8 @@ export function ReportDaysPanel({
   );
   const isSelectedDay = (operatingDate: string) =>
     selectedDate === operatingDate;
+  const isInSelectedRange = (operatingDate: string) =>
+    operatingDate >= startDate && operatingDate <= endDate;
   const selectDay = (operatingDate: string) => {
     onSelectedDateChange(
       isSelectedDay(operatingDate) ? undefined : operatingDate,
@@ -124,7 +150,7 @@ export function ReportDaysPanel({
           <Button
             aria-label={
               selectedDate !== undefined
-                ? "Return to previous date range"
+                ? "Return to selected date range"
                 : "Reset date range to default"
             }
             className="h-auto gap-2 px-layout-sm py-layout-xs text-sm font-normal text-muted-foreground"
@@ -138,12 +164,17 @@ export function ReportDaysPanel({
             variant="ghost"
           >
             <RotateCcw aria-hidden="true" className="h-4 w-4" />
-            {selectedDate !== undefined ? "Show full range" : "Reset range"}
+            {selectedDate !== undefined ? "Show selected range" : "Reset range"}
           </Button>
         ) : null}
         <ReportDateRangeField
           endDate={endDate}
-          onSelect={onRangeChange}
+          onSelect={(next) =>
+            onRangeChange(
+              next,
+              pageContainingDate(daysNewestFirst ?? [], next.startDate),
+            )
+          }
           startDate={startDate}
         />
       </div>
@@ -202,8 +233,10 @@ export function ReportDaysPanel({
                 <TableBody>
                   {visibleDays?.map((day) => {
                     const isSelected = isSelectedDay(day.operatingDate);
-                    const isDeemphasized =
-                      selectedDate !== undefined && !isSelected;
+                    const isHighlighted = selectedDate
+                      ? isSelected
+                      : isInSelectedRange(day.operatingDate);
+                    const isDeemphasized = !isHighlighted;
 
                     return (
                       <TableRow
@@ -217,6 +250,9 @@ export function ReportDaysPanel({
                         )}
                         data-deemphasized={
                           isDeemphasized ? "true" : undefined
+                        }
+                        data-highlighted={
+                          isHighlighted ? "true" : undefined
                         }
                         data-status={day.status}
                         key={day.operatingDate}
@@ -246,7 +282,7 @@ export function ReportDaysPanel({
                         <TableCell>
                           <Link
                             className={cn(
-                              isSelected && "font-medium text-foreground",
+                              isHighlighted && "font-medium text-foreground",
                             )}
                             params={{
                               orgUrlSlug: orgUrlSlug!,

--- a/packages/athena-webapp/src/components/reports/ReportPeriodMetrics.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportPeriodMetrics.tsx
@@ -28,6 +28,7 @@ export function ReportPeriodMetrics({
   snapshot,
   currency,
   comparison,
+  dailyOperationsLink,
   periodLabel,
   priorWindowLabel,
   eodReviewLink,
@@ -37,6 +38,11 @@ export function ReportPeriodMetrics({
   currency: string;
   /** Prior-window values for the comparable metrics; omit when not comparable. */
   comparison?: { netSalesMinor?: number; unitsSold?: number };
+  dailyOperationsLink?: {
+    orgUrlSlug: string;
+    search: Record<string, string>;
+    storeUrlSlug: string;
+  };
   eodReviewLink?: {
     orgUrlSlug: string;
     search: Record<string, string>;
@@ -51,26 +57,35 @@ export function ReportPeriodMetrics({
   };
 }) {
   const shouldReduceMotion = Boolean(useReducedMotion());
-  const periodStatus =
-    eodReviewLink
-      ? "Closed"
+  const statusLink = eodReviewLink
+    ? {
+        ...eodReviewLink,
+        label: "View EOD Review",
+        to: "/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close" as const,
+      }
+    : dailyOperationsLink
+      ? {
+          ...dailyOperationsLink,
+          label: "View Daily Operations",
+          to: "/$orgUrlSlug/store/$storeUrlSlug/operations" as const,
+        }
+      : undefined;
+  const periodStatus = eodReviewLink
+    ? "Closed"
+    : dailyOperationsLink
+      ? "In progress"
       : snapshot.unsettledDayCount === 0
-      ? undefined
-      : periodLabel === "Today"
-        ? "In progress"
-        : `${snapshot.unsettledDayCount.toLocaleString()} of ${snapshot.dayCount.toLocaleString()} reported ${
-            snapshot.dayCount === 1 ? "day" : "days"
-          } awaiting reconciliation`;
-  const showPeriodStatus = Boolean(periodStatus || eodReviewLink);
+        ? undefined
+        : periodLabel === "Today"
+          ? "In progress"
+          : `${snapshot.unsettledDayCount.toLocaleString()} of ${snapshot.dayCount.toLocaleString()} reported ${
+              snapshot.dayCount === 1 ? "day" : "days"
+            } awaiting reconciliation`;
+  const showPeriodStatus = Boolean(periodStatus || statusLink);
 
   return (
-    <section
-      data-testid={`report-period-metrics-${periodLabel}`}
-    >
-      <AnimatedHeight
-        animateFromZero
-        testId="report-period-status-transition"
-      >
+    <section data-testid={`report-period-metrics-${periodLabel}`}>
+      <AnimatedHeight animateFromZero testId="report-period-status-transition">
         <AnimatePresence initial={false}>
           {showPeriodStatus ? (
             <motion.div
@@ -91,20 +106,23 @@ export function ReportPeriodMetrics({
                 data-testid="report-period-status"
               >
                 {periodStatus ? <span>{periodStatus}</span> : null}
-                {eodReviewLink ? (
+                {statusLink ? (
                   <>
                     <span aria-hidden="true">·</span>
                     <Link
                       className="inline-flex items-center gap-1 rounded-sm font-medium text-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       params={{
-                        orgUrlSlug: eodReviewLink.orgUrlSlug,
-                        storeUrlSlug: eodReviewLink.storeUrlSlug,
+                        orgUrlSlug: statusLink.orgUrlSlug,
+                        storeUrlSlug: statusLink.storeUrlSlug,
                       }}
-                      search={eodReviewLink.search}
-                      to="/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close"
+                      search={statusLink.search}
+                      to={statusLink.to}
                     >
-                      View EOD Review
-                      <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5" />
+                      {statusLink.label}
+                      <ArrowUpRight
+                        aria-hidden="true"
+                        className="h-3.5 w-3.5"
+                      />
                     </Link>
                   </>
                 ) : null}

--- a/packages/athena-webapp/src/components/reports/ReportsItemsPerformance.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsItemsPerformance.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ComponentProps } from "react";
 import { Calendar as CalendarIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -19,8 +19,10 @@ import {
   getLocalDateFromOperatingDate,
   getLocalOperatingDate,
 } from "@/lib/operations/operatingDate";
+import { getOrigin } from "@/lib/navigationUtils";
 import type { ReportSkuSortBy } from "~/shared/reportsContract";
 import { FlipNumber } from "@/components/common/FlipNumber";
+import { OperationsSummaryMetric } from "@/components/operations/OperationsSummaryMetric";
 import { ReportCalendar } from "./ReportCalendar";
 import { ReportFreshness } from "./ReportFreshness";
 import {
@@ -36,6 +38,8 @@ import {
   formatUnits,
 } from "./reportFormat";
 
+export type ReportsItemsVariant = "card" | "canvas";
+
 export function ReportsItemsPerformance({
   currency,
   periodType,
@@ -46,9 +50,13 @@ export function ReportsItemsPerformance({
   totalTransactions,
   updatedAt,
   hasActivity,
+  isTodayInProgress,
   onPeriodTypeChange,
   onPeriodDateChange,
   onSortByChange,
+  orgUrlSlug,
+  storeUrlSlug,
+  variant,
 }: {
   currency: string;
   periodType: ReportPeriodType;
@@ -59,21 +67,43 @@ export function ReportsItemsPerformance({
   totalTransactions?: number;
   updatedAt?: number | null;
   hasActivity: boolean;
+  isTodayInProgress: boolean;
   onPeriodTypeChange: (periodType: ReportPeriodType) => void;
   onPeriodDateChange: (periodDate: string) => void;
   onSortByChange: (sortBy: ReportSkuSortBy) => void;
+  orgUrlSlug: string;
+  storeUrlSlug: string;
+  variant: ReportsItemsVariant;
 }) {
   const periodRange = dateRangeForItemsPeriod(periodType, periodDate);
   const selectedDate = getLocalDateFromOperatingDate(periodDate);
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
+  const transactionsSearch = {
+    endDate: periodRange.endDate,
+    o: getOrigin(),
+    startDate: periodRange.startDate,
+    ...(periodType === "day" && isTodayInProgress
+      ? {}
+      : { order: "oldestFirst" as const }),
+  };
 
   return (
     <section
       aria-labelledby="items-sales-title"
-      className="overflow-hidden rounded-xl border border-border bg-surface-raised shadow-surface"
+      className={cn(
+        variant === "card"
+          ? "overflow-hidden rounded-xl border border-border bg-surface-raised shadow-surface"
+          : "space-y-layout-lg",
+      )}
+      data-variant={variant}
       data-testid="items-report-workspace"
     >
-      <header className="space-y-layout-md p-layout-md md:p-layout-lg">
+      <header
+        className={cn(
+          "space-y-layout-md",
+          variant === "card" && "p-layout-md md:p-layout-lg",
+        )}
+      >
         <div className="space-y-1">
           <h2
             className="text-lg font-semibold tracking-tight text-foreground"
@@ -216,43 +246,134 @@ export function ReportsItemsPerformance({
         </div>
       </header>
 
-      <div className="flex flex-col gap-layout-sm border-t border-border bg-muted/20 px-layout-md py-layout-md sm:flex-row sm:items-end sm:justify-between md:px-layout-lg">
-        <div
-          aria-hidden={hasActivity ? undefined : true}
-          className={cn(
-            "flex flex-wrap items-start gap-layout-xl",
-            !hasActivity && "invisible",
-          )}
-          data-testid="items-period-metrics-reserved"
-        >
-          <Metric
-            formatValue={(value) => formatReportMoney(value, currency)}
-            label="Net sales"
-            testId={hasActivity ? "items-period-net-sales" : undefined}
-            value={totalNetSalesMinor ?? 0}
-          />
-          <Metric
-            formatValue={formatUnits}
-            label="Units sold"
-            numberTestId={
-              hasActivity ? "items-period-units-number" : undefined
-            }
-            testId={hasActivity ? "items-period-units-sold" : undefined}
-            value={totalUnitsSold ?? 0}
-          />
-          <Metric
-            formatValue={formatUnits}
-            label="Transactions"
-            numberTestId={
-              hasActivity ? "items-period-transactions-number" : undefined
-            }
-            testId={hasActivity ? "items-period-transactions" : undefined}
-            value={totalTransactions ?? 0}
-          />
+      {variant === "canvas" ? (
+        <div className="space-y-layout-sm">
+          <div
+            aria-hidden={hasActivity ? undefined : true}
+            className={cn(
+              "grid grid-cols-1 gap-layout-sm sm:grid-cols-3",
+              !hasActivity && "invisible",
+            )}
+            data-testid="items-period-metrics-reserved"
+          >
+            <MetricCard
+              formatValue={(value) => formatReportMoney(value, currency)}
+              label="Net sales"
+              link={{
+                ariaLabel: "Open transactions for net sales",
+                orgUrlSlug,
+                search: transactionsSearch,
+                storeUrlSlug,
+                to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
+              }}
+              testId={hasActivity ? "items-period-net-sales" : undefined}
+              value={totalNetSalesMinor ?? 0}
+            />
+            <MetricCard
+              formatValue={formatUnits}
+              label="Units sold"
+              numberTestId={
+                hasActivity ? "items-period-units-number" : undefined
+              }
+              testId={hasActivity ? "items-period-units-sold" : undefined}
+              value={totalUnitsSold ?? 0}
+            />
+            <MetricCard
+              formatValue={formatUnits}
+              label="Transactions"
+              link={{
+                ariaLabel: "Open transactions for transaction count",
+                orgUrlSlug,
+                search: transactionsSearch,
+                storeUrlSlug,
+                to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
+              }}
+              numberTestId={
+                hasActivity ? "items-period-transactions-number" : undefined
+              }
+              testId={hasActivity ? "items-period-transactions" : undefined}
+              value={totalTransactions ?? 0}
+            />
+          </div>
+          <div className="flex justify-end">
+            <ReportFreshness
+              delayedDataLabel="Item data"
+              updatedAt={updatedAt}
+            />
+          </div>
         </div>
-        <ReportFreshness delayedDataLabel="Item data" updatedAt={updatedAt} />
-      </div>
+      ) : (
+        <div className="flex flex-col gap-layout-sm border-t border-border bg-muted/20 px-layout-md py-layout-md sm:flex-row sm:items-end sm:justify-between md:px-layout-lg">
+          <div
+            aria-hidden={hasActivity ? undefined : true}
+            className={cn(
+              "flex flex-wrap items-start gap-layout-xl",
+              !hasActivity && "invisible",
+            )}
+            data-testid="items-period-metrics-reserved"
+          >
+            <Metric
+              formatValue={(value) => formatReportMoney(value, currency)}
+              label="Net sales"
+              testId={hasActivity ? "items-period-net-sales" : undefined}
+              value={totalNetSalesMinor ?? 0}
+            />
+            <Metric
+              formatValue={formatUnits}
+              label="Units sold"
+              numberTestId={
+                hasActivity ? "items-period-units-number" : undefined
+              }
+              testId={hasActivity ? "items-period-units-sold" : undefined}
+              value={totalUnitsSold ?? 0}
+            />
+            <Metric
+              formatValue={formatUnits}
+              label="Transactions"
+              numberTestId={
+                hasActivity ? "items-period-transactions-number" : undefined
+              }
+              testId={hasActivity ? "items-period-transactions" : undefined}
+              value={totalTransactions ?? 0}
+            />
+          </div>
+          <ReportFreshness delayedDataLabel="Item data" updatedAt={updatedAt} />
+        </div>
+      )}
     </section>
+  );
+}
+
+function MetricCard({
+  formatValue,
+  label,
+  link,
+  testId,
+  numberTestId,
+  value,
+}: {
+  formatValue: (value: number) => string;
+  label: string;
+  link?: ComponentProps<typeof OperationsSummaryMetric>["link"];
+  testId?: string;
+  numberTestId?: string;
+  value: number;
+}) {
+  return (
+    <div data-testid={testId}>
+      <OperationsSummaryMetric
+        label={label}
+        link={link}
+        value={
+          <FlipNumber
+            formatValue={formatValue}
+            testId={numberTestId}
+            transitionFromZero="fade"
+            value={value}
+          />
+        }
+      />
+    </div>
   );
 }
 

--- a/packages/athena-webapp/src/components/reports/ReportsItemsView.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsItemsView.test.tsx
@@ -21,18 +21,24 @@ vi.mock("@/hooks/use-navigate-back", () => ({
 vi.mock("@tanstack/react-router", () => ({
   Link: ({
     children,
+    params: linkParams,
     search: linkSearch,
     to,
     ...props
   }: {
     children?: React.ReactNode;
+    params?: unknown;
     search?: unknown;
     to: string;
   }) => {
-    delete (props as Record<string, unknown>).params;
     renderedLinkSearches.push(linkSearch);
     return (
-      <a href={to} {...props}>
+      <a
+        data-params={JSON.stringify(linkParams)}
+        data-search={JSON.stringify(linkSearch)}
+        href={to}
+        {...props}
+      >
         {children}
       </a>
     );
@@ -76,6 +82,7 @@ describe("ReportsItemsView", () => {
       totalUnitsSold: 16,
       totalTransactions: 7,
       updatedAt: null,
+      isTodayInProgress: false,
     });
 
     render(<ReportsItemsView {...baseProps} />);
@@ -454,6 +461,197 @@ describe("ReportsItemsView", () => {
     expect(performance).toContainElement(screen.getByTestId("report-freshness"));
     expect(performance).not.toContainElement(screen.getByRole("table"));
     expect(results).toContainElement(screen.getByRole("table"));
+  });
+
+  it("supports a canvas workspace with Operations metric cards", () => {
+    useQuery.mockReturnValue({
+      rows: [
+        {
+          productSkuId: "sku-1",
+          periodKey: "d:2026-07-28",
+          unitsSold: 16,
+          unitsReturned: 0,
+          grossSalesMinor: 1600,
+          netSalesMinor: 1600,
+          refundsMinor: 0,
+          uncostedRevenueMinor: 0,
+          grossProfitMinor: 800,
+        },
+      ],
+      continueCursor: null,
+      totalNetSalesMinor: 1600,
+      totalUnitsSold: 16,
+      totalTransactions: 7,
+      updatedAt: null,
+    });
+
+    render(<ReportsItemsView {...baseProps} variant="canvas" />);
+
+    const workspace = screen.getByTestId("items-report-workspace");
+    expect(workspace).toHaveAttribute("data-variant", "canvas");
+    expect(workspace).not.toHaveClass(
+      "rounded-xl",
+      "border",
+      "bg-surface-raised",
+      "shadow-surface",
+    );
+
+    for (const testId of [
+      "items-period-net-sales",
+      "items-period-units-sold",
+      "items-period-transactions",
+    ]) {
+      expect(screen.getByTestId(testId).firstElementChild).toHaveClass(
+        "rounded-lg",
+        "border",
+        "bg-surface",
+        "shadow-surface",
+      );
+    }
+  });
+
+  it("links sales and transaction metrics to oldest-first transactions for the selected period", () => {
+    useQuery.mockReturnValue({
+      rows: [
+        {
+          productSkuId: "sku-1",
+          periodKey: "w:2026-W31",
+          unitsSold: 16,
+          unitsReturned: 0,
+          grossSalesMinor: 1600,
+          netSalesMinor: 1600,
+          refundsMinor: 0,
+          uncostedRevenueMinor: 0,
+          grossProfitMinor: 800,
+        },
+      ],
+      continueCursor: null,
+      totalNetSalesMinor: 1600,
+      totalUnitsSold: 16,
+      totalTransactions: 7,
+      updatedAt: null,
+    });
+
+    render(
+      <ReportsItemsView
+        {...baseProps}
+        periodDate="2026-07-29"
+        periodType="week"
+        variant="canvas"
+      />,
+    );
+
+    for (const name of [
+      "Open transactions for net sales",
+      "Open transactions for transaction count",
+    ]) {
+      const link = screen.getByRole("link", { name });
+      expect(link).toHaveAttribute(
+        "href",
+        "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
+      );
+      expect(JSON.parse(link.dataset.search ?? "{}")).toEqual({
+        endDate: "2026-08-02",
+        o: expect.any(String),
+        order: "oldestFirst",
+        startDate: "2026-07-27",
+      });
+      expect(JSON.parse(link.dataset.params ?? "{}")).toEqual({
+        orgUrlSlug: "acme",
+        storeUrlSlug: "downtown",
+      });
+    }
+  });
+
+  it("lets an in-progress day use the transactions view's newest-first default", () => {
+    useQuery.mockReturnValue({
+      rows: [
+        {
+          productSkuId: "sku-1",
+          periodKey: "d:2026-08-01",
+          unitsSold: 1,
+          unitsReturned: 0,
+          grossSalesMinor: 100,
+          netSalesMinor: 100,
+          refundsMinor: 0,
+          uncostedRevenueMinor: 0,
+          grossProfitMinor: 50,
+        },
+      ],
+      continueCursor: null,
+      totalNetSalesMinor: 100,
+      totalUnitsSold: 1,
+      totalTransactions: 1,
+      updatedAt: null,
+      isTodayInProgress: true,
+    });
+
+    render(
+      <ReportsItemsView
+        {...baseProps}
+        periodDate="2026-08-01"
+        variant="canvas"
+      />,
+    );
+
+    for (const name of [
+      "Open transactions for net sales",
+      "Open transactions for transaction count",
+    ]) {
+      const link = screen.getByRole("link", { name });
+      expect(JSON.parse(link.dataset.search ?? "{}")).toEqual({
+        endDate: "2026-08-01",
+        o: expect.any(String),
+        startDate: "2026-08-01",
+      });
+    }
+  });
+
+  it("keeps a historic day oldest-first in the transactions view", () => {
+    useQuery.mockReturnValue({
+      rows: [
+        {
+          productSkuId: "sku-1",
+          periodKey: "d:2026-07-28",
+          unitsSold: 1,
+          unitsReturned: 0,
+          grossSalesMinor: 100,
+          netSalesMinor: 100,
+          refundsMinor: 0,
+          uncostedRevenueMinor: 0,
+          grossProfitMinor: 50,
+        },
+      ],
+      continueCursor: null,
+      totalNetSalesMinor: 100,
+      totalUnitsSold: 1,
+      totalTransactions: 1,
+      updatedAt: null,
+      isTodayInProgress: false,
+    });
+
+    render(<ReportsItemsView {...baseProps} variant="canvas" />);
+
+    const link = screen.getByRole("link", {
+      name: "Open transactions for transaction count",
+    });
+    expect(JSON.parse(link.dataset.search ?? "{}")).toEqual({
+      endDate: "2026-07-28",
+      o: expect.any(String),
+      order: "oldestFirst",
+      startDate: "2026-07-28",
+    });
+  });
+
+  it("retains the original card workspace as the default variant", () => {
+    useQuery.mockReturnValue({ rows: [], continueCursor: null });
+
+    render(<ReportsItemsView {...baseProps} />);
+
+    expect(screen.getByTestId("items-report-workspace")).toHaveAttribute(
+      "data-variant",
+      "card",
+    );
   });
 
   it("uses the shared animated data surface for full and empty states", async () => {

--- a/packages/athena-webapp/src/components/reports/ReportsItemsView.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsItemsView.tsx
@@ -8,7 +8,10 @@ import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { api } from "~/convex/_generated/api";
 import type { ReportSkuSortBy } from "~/shared/reportsContract";
 import { ReportBackLink } from "./ReportBackLink";
-import { ReportsItemsPerformance } from "./ReportsItemsPerformance";
+import {
+  ReportsItemsPerformance,
+  type ReportsItemsVariant,
+} from "./ReportsItemsPerformance";
 import { ReportsItemsTable } from "./ReportsItemsTable";
 import {
   periodKeyForSelection,
@@ -26,6 +29,7 @@ export function ReportsItemsView({
   onPeriodDateChange,
   onSortByChange,
   onCursorChange,
+  variant = "card",
 }: {
   periodType: ReportPeriodType;
   periodDate: string;
@@ -36,6 +40,7 @@ export function ReportsItemsView({
   onPeriodDateChange: (periodDate: string) => void;
   onSortByChange: (sortBy: ReportSkuSortBy) => void;
   onCursorChange: (cursor: string | undefined, cursorTrail: string[]) => void;
+  variant?: ReportsItemsVariant;
 }) {
   const { activeStore } = useGetActiveStore();
   const { orgUrlSlug, storeUrlSlug } = useParams({ strict: false });
@@ -84,16 +89,20 @@ export function ReportsItemsView({
         <ReportsItemsPerformance
           currency={activeStore?.currency ?? "USD"}
           hasActivity={hasActivity}
+          isTodayInProgress={result?.isTodayInProgress ?? false}
           onPeriodDateChange={onPeriodDateChange}
           onPeriodTypeChange={onPeriodTypeChange}
           onSortByChange={onSortByChange}
+          orgUrlSlug={orgUrlSlug!}
           periodDate={periodDate}
           periodType={periodType}
           sortBy={sortBy}
+          storeUrlSlug={storeUrlSlug!}
           totalNetSalesMinor={result?.totalNetSalesMinor}
           totalTransactions={result?.totalTransactions}
           totalUnitsSold={result?.totalUnitsSold}
           updatedAt={result?.updatedAt}
+          variant={variant}
         />
 
         {isInitialLoad || result === undefined ? null : (

--- a/packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx
@@ -37,7 +37,10 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
 vi.mock("@/hooks/useGetActiveStore", () => ({
-  default: () => ({ activeStore: { _id: "store-1", currency: "USD" }, isLoadingStores: false }),
+  default: () => ({
+    activeStore: { _id: "store-1", currency: "USD" },
+    isLoadingStores: false,
+  }),
 }));
 vi.mock("recharts", () => ({
   Area: ({
@@ -60,10 +63,14 @@ vi.mock("recharts", () => ({
           },
         })
       : null,
-  AreaChart: ({ children }: { children?: React.ReactNode }) => <svg>{children}</svg>,
+  AreaChart: ({ children }: { children?: React.ReactNode }) => (
+    <svg>{children}</svg>
+  ),
   CartesianGrid: () => null,
   Legend: () => null,
-  ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
   Tooltip: () => null,
   XAxis: () => null,
   YAxis: () => null,
@@ -97,7 +104,11 @@ const fixture: ReportOverviewData = {
   yesterday: snapshot({ netSalesMinor: 80_00, unitsSold: 8 }),
   weekToDate: snapshot({ dayCount: 5, netSalesMinor: 400_00 }),
   priorWeek: snapshot({ dayCount: 7, netSalesMinor: 350_00 }),
-  trailing30: snapshot({ dayCount: 30, netSalesMinor: 2500_00, grossProfitMinor: null }),
+  trailing30: snapshot({
+    dayCount: 30,
+    netSalesMinor: 2500_00,
+    grossProfitMinor: null,
+  }),
   trailing3Months: snapshot({ dayCount: 82, netSalesMinor: 7000_00 }),
   comparisons: {
     netSalesVsPriorWeekBp: 1250,
@@ -105,7 +116,11 @@ const fixture: ReportOverviewData = {
   },
   dailyTrend: [
     { operatingDate: "2026-07-26", netSalesMinor: 80_00, status: "reconciled" },
-    { operatingDate: "2026-07-27", netSalesMinor: 90_00, status: "provisional" },
+    {
+      operatingDate: "2026-07-27",
+      netSalesMinor: 90_00,
+      status: "provisional",
+    },
   ],
   trust: {
     reconciledDays: 25,
@@ -248,6 +263,27 @@ describe("ReportsOverviewView", () => {
     expect(screen.getByTestId("report-trust-summary")).toHaveTextContent(
       "30-day trend · 27 of 28 reported days reconciled · Today in progress",
     );
+    expect(screen.getByTestId("report-period-status")).toHaveTextContent(
+      "In progress",
+    );
+    const dailyOperationsLink = screen.getByRole("link", {
+      name: "View Daily Operations",
+    });
+    expect(dailyOperationsLink).toHaveAttribute(
+      "href",
+      "/$orgUrlSlug/store/$storeUrlSlug/operations",
+    );
+    expect(JSON.parse(dailyOperationsLink.dataset.params ?? "{}")).toEqual({
+      orgUrlSlug: "wigclub",
+      storeUrlSlug: "wigclub",
+    });
+    expect(JSON.parse(dailyOperationsLink.dataset.search ?? "{}")).toEqual({
+      o: expect.any(String),
+      operatingDate: "2026-07-29",
+    });
+    expect(
+      dailyOperationsLink.closest('[data-motion="period-status"]'),
+    ).not.toBeNull();
   });
 
   it("states the prior-week comparison in words rather than a bare percentage", async () => {
@@ -323,7 +359,12 @@ describe("ReportsOverviewView", () => {
     expect(
       screen.getByTestId("report-period-status-transition"),
     ).toHaveAttribute("data-motion", "height");
-    expect(eodReviewLink.closest('[data-motion="period-status"]')).not.toBeNull();
+    expect(
+      eodReviewLink.closest('[data-motion="period-status"]'),
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("link", { name: "View Daily Operations" }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Week to date" }));
     await waitFor(() =>
@@ -370,9 +411,15 @@ describe("ReportsOverviewView", () => {
 
     expect(linkedRange()).toEqual({
       endDate: "2026-07-30",
-      order: "oldestFirst",
+      order: undefined,
       startDate: "2026-07-30",
     });
+    expect(
+      JSON.parse(
+        screen.getByRole("link", { name: "Open transactions" }).dataset
+          .search ?? "{}",
+      ),
+    ).not.toHaveProperty("order");
 
     await user.click(screen.getByRole("tab", { name: "Week to date" }));
     expect(linkedRange()).toEqual({

--- a/packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx
+++ b/packages/athena-webapp/src/components/reports/ReportsOverviewView.tsx
@@ -8,7 +8,10 @@ import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { cn } from "@/lib/utils";
 import { getOrigin } from "@/lib/navigationUtils";
 import { api } from "~/convex/_generated/api";
-import type { ReportOverviewData } from "~/shared/reportsContract";
+import {
+  isReportingTodayInProgress,
+  type ReportOverviewData,
+} from "~/shared/reportsContract";
 import { ReportPeriodMetrics } from "./ReportPeriodMetrics";
 import { ReportFreshness } from "./ReportFreshness";
 import { ReportTrendChart } from "./ReportTrendChart";
@@ -99,6 +102,7 @@ export function ReportsOverviewView({
   const comparison = comparisonFor(overview, selectedWindow);
   const anchorDay = overview.dailyTrend.at(-1);
   const anchorOperatingDate = anchorDay?.operatingDate;
+  const isAnchorDayInProgress = isReportingTodayInProgress(anchorDay?.status);
   const isAnchorDayClosed =
     anchorDay?.status === "reconciled" || anchorDay?.status === "amended";
   const transactionsRange = anchorOperatingDate
@@ -151,6 +155,22 @@ export function ReportsOverviewView({
           <ReportPeriodMetrics
             comparison={comparison}
             currency={currency}
+            dailyOperationsLink={
+              selectedWindow === "today" &&
+              isAnchorDayInProgress &&
+              anchorOperatingDate &&
+              orgUrlSlug &&
+              storeUrlSlug
+                ? {
+                    orgUrlSlug,
+                    search: {
+                      o: getOrigin(),
+                      operatingDate: anchorOperatingDate,
+                    },
+                    storeUrlSlug,
+                  }
+                : undefined
+            }
             eodReviewLink={
               selectedWindow === "today" &&
               isAnchorDayClosed &&
@@ -177,8 +197,10 @@ export function ReportsOverviewView({
                     search: {
                       endDate: transactionsRange.endDate,
                       o: getOrigin(),
-                      order: "oldestFirst",
                       startDate: transactionsRange.startDate,
+                      ...(selectedWindow === "today" && isAnchorDayInProgress
+                        ? {}
+                        : { order: "oldestFirst" }),
                     },
                     storeUrlSlug,
                   }

--- a/packages/athena-webapp/src/components/reports/reportPeriodKeys.test.ts
+++ b/packages/athena-webapp/src/components/reports/reportPeriodKeys.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   dateRangeForItemsPeriod,
   dateRangeForOverviewWindow,
+  tableRangeIncludingSelection,
 } from "./reportPeriodKeys";
 
 describe("report period date ranges", () => {
@@ -44,5 +45,28 @@ describe("report period date ranges", () => {
       startDate: "2026-02-01",
       endDate: "2026-02-28",
     });
+  });
+
+  it("keeps the table stable for contained ranges and safely replaces over-wide scopes", () => {
+    expect(
+      tableRangeIncludingSelection(
+        { startDate: "2026-07-01", endDate: "2026-07-31" },
+        { startDate: "2026-07-15", endDate: "2026-07-20" },
+      ),
+    ).toEqual({ startDate: "2026-07-01", endDate: "2026-07-31" });
+
+    expect(
+      tableRangeIncludingSelection(
+        { startDate: "2026-07-01", endDate: "2026-07-31" },
+        { startDate: "2026-06-15", endDate: "2026-07-20" },
+      ),
+    ).toEqual({ startDate: "2026-06-15", endDate: "2026-07-31" });
+
+    expect(
+      tableRangeIncludingSelection(
+        { startDate: "2026-04-01", endDate: "2026-06-30" },
+        { startDate: "2026-07-15", endDate: "2026-07-20" },
+      ),
+    ).toEqual({ startDate: "2026-07-15", endDate: "2026-07-20" });
   });
 });

--- a/packages/athena-webapp/src/components/reports/reportPeriodKeys.ts
+++ b/packages/athena-webapp/src/components/reports/reportPeriodKeys.ts
@@ -39,6 +39,8 @@ export type ReportDateRange = {
   endDate: string;
 };
 
+const REPORT_DAYS_MAX_SPAN = 92;
+
 function operatingDateToUtc(value: string): Date {
   return new Date(`${value}T00:00:00.000Z`);
 }
@@ -51,6 +53,37 @@ function addOperatingDays(value: string, days: number): string {
   const date = operatingDateToUtc(value);
   date.setUTCDate(date.getUTCDate() + days);
   return utcToOperatingDate(date);
+}
+
+/**
+ * Keeps the rendered day scope stable while a new selection fits inside the
+ * reporting query's 92-day read budget. A distant selection starts a fresh
+ * scope instead of creating an invalid, ever-growing query range.
+ */
+export function tableRangeIncludingSelection(
+  tableRange: ReportDateRange,
+  selectedRange: ReportDateRange,
+): ReportDateRange {
+  const expandedRange = {
+    startDate:
+      selectedRange.startDate < tableRange.startDate
+        ? selectedRange.startDate
+        : tableRange.startDate,
+    endDate:
+      selectedRange.endDate > tableRange.endDate
+        ? selectedRange.endDate
+        : tableRange.endDate,
+  };
+  const inclusiveDays =
+    Math.floor(
+      (operatingDateToUtc(expandedRange.endDate).getTime() -
+        operatingDateToUtc(expandedRange.startDate).getTime()) /
+        86_400_000,
+    ) + 1;
+
+  return inclusiveDays <= REPORT_DAYS_MAX_SPAN
+    ? expandedRange
+    : selectedRange;
 }
 
 function isoWeekStart(value: string): string {

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.test.ts
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { dailyOperationsSearchSchema } from "./index";
+
+describe("daily operations search schema", () => {
+  it("preserves an origin for back navigation", () => {
+    expect(
+      dailyOperationsSearchSchema.parse({
+        o: "%2Fwigclub%2Fstore%2Fwigclub%2Freports",
+        operatingDate: "2026-07-29",
+      }),
+    ).toEqual({
+      o: "%2Fwigclub%2Fstore%2Fwigclub%2Freports",
+      operatingDate: "2026-07-29",
+    });
+  });
+});

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx
@@ -4,11 +4,18 @@ import { z } from "zod";
 import { DailyOperationsView } from "~/src/components/operations/DailyOperationsView";
 import { useDailyOperationsFixture } from "~/src/stories/operations/devFixtureActivation";
 
-const dailyOperationsSearchSchema = z.object({
+export const dailyOperationsSearchSchema = z.object({
   // Development-only screenshot fixtures; inert in production builds.
   fixture: z.string().optional(),
-  operatingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
-  weekEndOperatingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  o: z.string().optional(),
+  operatingDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  weekEndOperatingDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
 });
 
 function DailyOperationsRoute() {

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.test.ts
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.test.ts
@@ -12,6 +12,8 @@ describe("reports overview search schema", () => {
       window: "weekToDate" as const,
       daysStart: "2026-07-01",
       daysEnd: "2026-07-28",
+      daysTableStart: "2026-06-01",
+      daysTableEnd: "2026-07-31",
       daysPage: 2,
       selectedDay: "2026-07-16",
     };

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/index.tsx
@@ -12,6 +12,7 @@ import { ReportsOverviewView } from "@/components/reports/ReportsOverviewView";
 import {
   dateRangeForOverviewWindow,
   REPORT_OVERVIEW_WINDOWS,
+  tableRangeIncludingSelection,
   todayOperatingDateGuess,
   type ReportOverviewWindow,
 } from "@/components/reports/reportPeriodKeys";
@@ -22,6 +23,8 @@ export const reportsOverviewSearchSchema = z.object({
   window: z.enum(REPORT_OVERVIEW_WINDOWS).optional(),
   daysStart: dateSchema.optional(),
   daysEnd: dateSchema.optional(),
+  daysTableStart: dateSchema.optional(),
+  daysTableEnd: dateSchema.optional(),
   daysPage: z.coerce.number().int().positive().optional(),
   selectedDay: dateSchema.optional(),
 });
@@ -60,6 +63,8 @@ function ReportsOverviewRoute() {
   const defaultDaysStart = isoDateOffset(-13);
   const daysEnd = search.daysEnd ?? defaultDaysEnd;
   const daysStart = search.daysStart ?? defaultDaysStart;
+  const daysTableEnd = search.daysTableEnd ?? daysEnd;
+  const daysTableStart = search.daysTableStart ?? daysStart;
   const canResetDaysRange =
     daysStart !== defaultDaysStart || daysEnd !== defaultDaysEnd;
   const selectedWindow = search.window ?? "today";
@@ -102,18 +107,24 @@ function ReportsOverviewRoute() {
             }),
           })
         }
-        onRangeChange={(next) =>
+        onRangeChange={(next, targetPage) => {
+          const nextTableRange = tableRangeIncludingSelection(
+            { startDate: daysTableStart, endDate: daysTableEnd },
+            next,
+          );
           void navigate({
             replace: true,
             search: (current) => ({
               ...current,
               daysStart: next.startDate,
               daysEnd: next.endDate,
-              daysPage: undefined,
+              daysTableStart: nextTableRange.startDate,
+              daysTableEnd: nextTableRange.endDate,
+              daysPage: targetPage === 1 ? undefined : targetPage,
               selectedDay: undefined,
             }),
-          })
-        }
+          });
+        }}
         onRangeReset={() =>
           void navigate({
             replace: true,
@@ -138,6 +149,8 @@ function ReportsOverviewRoute() {
         page={search.daysPage ?? 1}
         selectedDate={search.selectedDay}
         startDate={daysStart}
+        tableEndDate={daysTableEnd}
+        tableStartDate={daysTableStart}
       />
     </div>
   );

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/index.tsx
@@ -95,6 +95,7 @@ function ReportsItemsRoute() {
         periodDate={periodDate}
         periodType={periodType}
         sortBy={(search.sortBy ?? "revenue") as ReportSkuSortBy}
+        variant="canvas"
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Reporting period changes now preserve the operator’s surrounding day context instead of replacing the table with only the selected dates. A temporary single-day focus returns to the selected range, expanded ranges navigate to the page containing their first materialized date, and the table remains bounded by the reporting read limit.

Operational drill-downs now follow one lifecycle definition: a materialized `open` report day is Today in progress. Open-day transaction links keep the destination’s newest-first default and expose Daily Operations; historic and multi-day links request oldest-first ordering, while closed Today links to EOD Review. Origin state is preserved across those destinations.

The standalone Items workspace now uses the canvas presentation with Operations metric cards and transaction drill-downs. The reusable card variant remains the component default for existing callers.

## Design decisions

- Separate rendered table bounds from selected range/day focus so visual context does not expand backend reads accidentally.
- Defer target-page calculation when a range expansion requires new rows; stale rows cannot locate a newly introduced start date.
- Define Today in progress from reporting lifecycle data rather than browser or server clocks.
- Keep the open-day ordering exception limited to single-day periods; week and month review remains chronological.

## Validation

- `bun run pr:athena` passed and recorded reusable pre-push proof.
- Full Athena, storefront, and root-script coverage passed.
- Harness review, inferential review, architecture checks, lint, type-check, generated-artifact checks, and Graphify freshness passed.
- Focused reporting coverage: 78 tests across day ranges, Overview, Items, and report queries.
- Daily Operations focused coverage: 90 tests.

The candidate’s mental model, failure boundaries, and scenario quiz are captured in [`docs/reports/2026-08-01-reporting-workspace-period-interactions-report.html`](https://github.com/kwam1na/athena/blob/codex/refine-reporting-workspace-navigation/docs/reports/2026-08-01-reporting-workspace-period-interactions-report.html).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/GPT--5-000000)
