### PR TITLE
fix(pos): stop tearing down the receipt print window mid-print

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11013 nodes · 13413 edges · 2625 communities detected
+- 11014 nodes · 13414 edges · 2625 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -6456,47 +6456,47 @@ Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 948 - "Community 948"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 949 - "Community 949"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 950 - "Community 950"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 951 - "Community 951"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 952 - "Community 952"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 953 - "Community 953"
 Cohesion: 1.0
-Nodes (2): getHomepageSnapshot(), getStoredMarker()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 954 - "Community 954"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getHomepageSnapshot(), getStoredMarker()
 
 ### Community 955 - "Community 955"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 956 - "Community 956"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 957 - "Community 957"
 Cohesion: 1.0
-Nodes (2): getPreferredCardSku(), hasSellableAvailability()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 958 - "Community 958"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPreferredCardSku(), hasSellableAvailability()
 
 ### Community 959 - "Community 959"
 Cohesion: 0.67
@@ -6511,12 +6511,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 962 - "Community 962"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 963 - "Community 963"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 963 - "Community 963"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 964 - "Community 964"
 Cohesion: 0.67
@@ -6527,12 +6527,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 966 - "Community 966"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 967 - "Community 967"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 967 - "Community 967"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 968 - "Community 968"
 Cohesion: 0.67
@@ -6603,16 +6603,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 985 - "Community 985"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 986 - "Community 986"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 987 - "Community 987"
+### Community 986 - "Community 986"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 987 - "Community 987"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 988 - "Community 988"
 Cohesion: 1.0
@@ -6627,28 +6627,28 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 991 - "Community 991"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 992 - "Community 992"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 992 - "Community 992"
+### Community 993 - "Community 993"
 Cohesion: 1.0
 Nodes (2): gitFixtureEnv(), runGit()
 
-### Community 993 - "Community 993"
+### Community 994 - "Community 994"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 994 - "Community 994"
+### Community 995 - "Community 995"
 Cohesion: 1.0
 Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
-### Community 995 - "Community 995"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), runGit()
-
 ### Community 996 - "Community 996"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), runGit()
 
 ### Community 997 - "Community 997"
 Cohesion: 1.0
@@ -8168,11 +8168,11 @@ Nodes (0):
 
 ### Community 1376 - "Community 1376"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1377 - "Community 1377"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1378 - "Community 1378"
 Cohesion: 1.0
@@ -13165,505 +13165,505 @@ Nodes (0):
 ## Knowledge Gaps
 - **3 isolated node(s):** `StaleConstructionError`, `FakeMessageChannel`, `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 996`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
+- **Thin community `Community 997`** (2 nodes): `SharedDemoTicket.ts`, `authorizeSharedDemoTicket()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 998`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
+- **Thin community `Community 999`** (2 nodes): `scheduledRunLedger.test.ts`, `createLedgerCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 1000`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 1001`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 1002`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
+- **Thin community `Community 1003`** (2 nodes): `analyticsRow()`, `historicalStorefrontContextImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
+- **Thin community `Community 1004`** (2 nodes): `buildHistoricalStorefrontContextImportReport()`, `historicalStorefrontContextImportReport.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
+- **Thin community `Community 1005`** (2 nodes): `analyticsRow()`, `legacyStorefrontAnalytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 1006`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 1007`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 1008`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
+- **Thin community `Community 1009`** (2 nodes): `DailyManagerReportBordered()`, `DailyManagerReportBordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
+- **Thin community `Community 1010`** (2 nodes): `DailyManagerReportUnbordered()`, `DailyManagerReportUnbordered.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `OrderEmailPreview()`, `OrderEmail.tsx`
+- **Thin community `Community 1011`** (2 nodes): `OrderEmailPreview()`, `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `PosTerminalHealthAlert.tsx`, `PosTerminalHealthAlert()`
+- **Thin community `Community 1012`** (2 nodes): `PosTerminalHealthAlert.tsx`, `PosTerminalHealthAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `RegisterCloseoutMatchReportPreview.tsx`, `RegisterCloseoutMatchReportPreview()`
+- **Thin community `Community 1013`** (2 nodes): `RegisterCloseoutMatchReportPreview.tsx`, `RegisterCloseoutMatchReportPreview()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `RegisterCloseoutVarianceAlertPreview.tsx`, `RegisterCloseoutVarianceAlertPreview()`
+- **Thin community `Community 1014`** (2 nodes): `RegisterCloseoutVarianceAlertPreview.tsx`, `RegisterCloseoutVarianceAlertPreview()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 1015`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
+- **Thin community `Community 1016`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1017`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
+- **Thin community `Community 1018`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 1019`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 1020`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 1021`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 1022`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 1023`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 1024`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
+- **Thin community `Community 1025`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
+- **Thin community `Community 1026`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 1027`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 1028`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 1029`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 1030`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 1031`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 1032`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `createWorkContext()`, `inventoryImportCostOverlayWork.test.ts`
+- **Thin community `Community 1033`** (2 nodes): `createWorkContext()`, `inventoryImportCostOverlayWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 1034`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
+- **Thin community `Community 1035`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 1036`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 1037`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 1038`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `context()`, `commerceEffects.test.ts`
+- **Thin community `Community 1039`** (2 nodes): `context()`, `commerceEffects.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
+- **Thin community `Community 1040`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `scheduleWork.ts`, `scheduleReportingWorkBestEffort()`
+- **Thin community `Community 1041`** (2 nodes): `scheduleWork.ts`, `scheduleReportingWorkBestEffort()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
+- **Thin community `Community 1042`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 1043`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
+- **Thin community `Community 1044`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 1045`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 1046`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 1047`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
+- **Thin community `Community 1048`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
+- **Thin community `Community 1049`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
+- **Thin community `Community 1050`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `createCtx()`, `backfillStoreTimezoneAuthority.test.ts`
+- **Thin community `Community 1051`** (2 nodes): `createCtx()`, `backfillStoreTimezoneAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `createCtx()`, `migratePosAmountsToPesewas.test.ts`
+- **Thin community `Community 1052`** (2 nodes): `createCtx()`, `migratePosAmountsToPesewas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 1053`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `emitNotificationWithCtx()`, `emit.ts`
+- **Thin community `Community 1054`** (2 nodes): `emitNotificationWithCtx()`, `emit.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `sweeper.ts`, `terminalizeOrphanedDelivery()`
+- **Thin community `Community 1055`** (2 nodes): `sweeper.ts`, `terminalizeOrphanedDelivery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `transport.test.ts`, `stubFetch()`
+- **Thin community `Community 1056`** (2 nodes): `transport.test.ts`, `stubFetch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `transport.ts`, `sendNotificationEmail()`
+- **Thin community `Community 1057`** (2 nodes): `transport.ts`, `sendNotificationEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `declaresProtectedGateway()`, `effects.ts`
+- **Thin community `Community 1058`** (2 nodes): `declaresProtectedGateway()`, `effects.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `readAdapters.test.ts`, `demoCtx()`
+- **Thin community `Community 1059`** (2 nodes): `readAdapters.test.ts`, `demoCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `scopes.ts`, `resolveOperationScope()`
+- **Thin community `Community 1060`** (2 nodes): `scopes.ts`, `resolveOperationScope()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 1061`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 1062`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 1063`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 1064`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 1065`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 1066`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (2 nodes): `workItem()`, `logicalOperationalWork.test.ts`
+- **Thin community `Community 1067`** (2 nodes): `workItem()`, `logicalOperationalWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 1068`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (2 nodes): `fullWindow()`, `owedDailyCloseSweep.test.ts`
+- **Thin community `Community 1069`** (2 nodes): `fullWindow()`, `owedDailyCloseSweep.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
+- **Thin community `Community 1070`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
+- **Thin community `Community 1071`** (2 nodes): `paymentAllocations.test.ts`, `paymentContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (2 nodes): `registerCloseoutVarianceEmail.test.ts`, `getHandler()`
+- **Thin community `Community 1072`** (2 nodes): `registerCloseoutVarianceEmail.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
+- **Thin community `Community 1073`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 1074`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 1075`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 1076`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 1077`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (2 nodes): `redactSensitiveDiagnosticText()`, `diagnosticRedaction.ts`
+- **Thin community `Community 1078`** (2 nodes): `redactSensitiveDiagnosticText()`, `diagnosticRedaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 1079`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 1080`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
+- **Thin community `Community 1081`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
+- **Thin community `Community 1082`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (2 nodes): `resolveLocalSyncReview.test.ts`, `createFakeRepository()`
+- **Thin community `Community 1083`** (2 nodes): `resolveLocalSyncReview.test.ts`, `createFakeRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 1084`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 1085`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
+- **Thin community `Community 1086`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
+- **Thin community `Community 1087`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 1088`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 1089`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 1090`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
+- **Thin community `Community 1091`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 1092`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 1093`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 1094`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 1095`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (2 nodes): `remoteAssistRepository.ts`, `createRemoteAssistRepository()`
+- **Thin community `Community 1096`** (2 nodes): `remoteAssistRepository.ts`, `createRemoteAssistRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1097`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 1098`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 1099`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 1100`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (2 nodes): `context()`, `access.test.ts`
+- **Thin community `Community 1101`** (2 nodes): `context()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (2 nodes): `requireReportsStoreAccess()`, `access.ts`
+- **Thin community `Community 1102`** (2 nodes): `requireReportsStoreAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (2 nodes): `fact()`, `fingerprint.test.ts`
+- **Thin community `Community 1103`** (2 nodes): `fact()`, `fingerprint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
+- **Thin community `Community 1104`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 1105`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 1106`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (2 nodes): `contextFor()`, `actor.test.ts`
+- **Thin community `Community 1107`** (2 nodes): `contextFor()`, `actor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (2 nodes): `invoke()`, `enforcement.test.ts`
+- **Thin community `Community 1108`** (2 nodes): `invoke()`, `enforcement.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (2 nodes): `demoCtx()`, `operationAdapter.test.ts`
+- **Thin community `Community 1109`** (2 nodes): `demoCtx()`, `operationAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (2 nodes): `posStoreReadAccessCoverage.test.ts`, `source()`
+- **Thin community `Community 1110`** (2 nodes): `posStoreReadAccessCoverage.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
+- **Thin community `Community 1111`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (2 nodes): `provision.test.ts`, `seedDemoRegisterFoundation()`
+- **Thin community `Community 1112`** (2 nodes): `provision.test.ts`, `seedDemoRegisterFoundation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (2 nodes): `registerBaseline.test.ts`, `seedStoreWithRegister()`
+- **Thin community `Community 1113`** (2 nodes): `registerBaseline.test.ts`, `seedStoreWithRegister()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
+- **Thin community `Community 1114`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 1115`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 1116`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 1117`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 1118`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 1119`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 1120`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 1121`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 1122`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 1123`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 1124`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 1125`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 1126`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 1127`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 1128`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 1129`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 1130`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 1131`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (2 nodes): `createCtx()`, `ensureTimezoneAuthority.test.ts`
+- **Thin community `Community 1132`** (2 nodes): `createCtx()`, `ensureTimezoneAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
+- **Thin community `Community 1133`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 1134`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 1135`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 1136`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 1137`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 1138`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 1139`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 1140`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 1141`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (2 nodes): `posTerminalRegistrationError.ts`, `isPosRegisterNumberConflict()`
+- **Thin community `Community 1142`** (2 nodes): `posTerminalRegistrationError.ts`, `isPosRegisterNumberConflict()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
+- **Thin community `Community 1143`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 1144`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (2 nodes): `sharedDemoActionError.ts`, `isSharedDemoActionDeniedData()`
+- **Thin community `Community 1145`** (2 nodes): `sharedDemoActionError.ts`, `isSharedDemoActionDeniedData()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (2 nodes): `sharedDemoRegisterError.ts`, `isSharedDemoRegisterUnavailableError()`
+- **Thin community `Community 1146`** (2 nodes): `sharedDemoRegisterError.ts`, `isSharedDemoRegisterUnavailableError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 1147`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 1148`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 1149`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 1150`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 1151`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 1152`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 1153`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 1154`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 1155`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 1156`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 1157`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 1158`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 1159`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 1160`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 1161`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 1162`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
+- **Thin community `Community 1163`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 1164`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
+- **Thin community `Community 1165`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 1166`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 1167`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 1168`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 1169`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 1170`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 1171`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1172`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 1173`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 1174`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 1175`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 1176`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 1177`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 1178`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 1179`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `cn()`, `AppSettingsView.tsx`
+- **Thin community `Community 1180`** (2 nodes): `cn()`, `AppSettingsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 1181`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 1182`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `isEmailNotApprovedError()`, `LoginForm.tsx`
+- **Thin community `Community 1183`** (2 nodes): `isEmailNotApprovedError()`, `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 1184`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 1185`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 1186`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 1187`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 1188`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 1189`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 1190`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 1191`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 1192`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `AnimatedDataState()`, `AnimatedDataState.tsx`
+- **Thin community `Community 1193`** (2 nodes): `AnimatedDataState()`, `AnimatedDataState.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `AnimatedHeight()`, `AnimatedHeight.tsx`
+- **Thin community `Community 1194`** (2 nodes): `AnimatedHeight()`, `AnimatedHeight.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 1195`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `RegisterSessionIdentity.tsx`, `RegisterSessionIdentity()`
+- **Thin community `Community 1196`** (2 nodes): `RegisterSessionIdentity.tsx`, `RegisterSessionIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `registerSessionIdentityPresentation.ts`, `formatRegisterHeaderName()`
+- **Thin community `Community 1197`** (2 nodes): `registerSessionIdentityPresentation.ts`, `formatRegisterHeaderName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 1198`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 1199`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 1200`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 1201`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 1202`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 1203`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 1204`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `LandingGrain()`, `LandingGrain.tsx`
+- **Thin community `Community 1205`** (2 nodes): `LandingGrain()`, `LandingGrain.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `AutomationRevealScene()`, `AutomationRevealScene.tsx`
+- **Thin community `Community 1206`** (2 nodes): `AutomationRevealScene()`, `AutomationRevealScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `CashControlsScene()`, `CashControlsScene.tsx`
+- **Thin community `Community 1207`** (2 nodes): `CashControlsScene()`, `CashControlsScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `PosHubRoleSwitcher.tsx`, `PosHubRoleSwitcher()`
+- **Thin community `Community 1208`** (2 nodes): `PosHubRoleSwitcher.tsx`, `PosHubRoleSwitcher()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
+- **Thin community `Community 1209`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
+- **Thin community `Community 1210`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
+- **Thin community `Community 1211`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `useLandingTheme.ts`, `useLandingTheme()`
+- **Thin community `Community 1212`** (2 nodes): `useLandingTheme.ts`, `useLandingTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `renderWorkspace()`, `InventoryCostOverlayView.test.tsx`
+- **Thin community `Community 1213`** (2 nodes): `renderWorkspace()`, `InventoryCostOverlayView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 1214`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 1215`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 1216`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 1217`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 1218`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 1219`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 1220`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 1221`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 1222`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
+- **Thin community `Community 1223`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 1224`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 1225`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 1226`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 1227`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 1228`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 1229`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 1230`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
+- **Thin community `Community 1231`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 1232`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 1233`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 1234`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 1235`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 1236`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 1237`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 1238`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 1239`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 1240`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 1241`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 1242`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 1243`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 1244`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 1245`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 1246`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -13699,453 +13699,451 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 1247`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
+- **Thin community `Community 1248`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 1249`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 1250`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 1251`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 1252`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 1253`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 1254`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 1255`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
+- **Thin community `Community 1256`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 1257`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 1258`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 1259`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 1260`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 1261`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 1262`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 1263`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 1264`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 1265`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 1266`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 1267`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 1268`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 1269`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 1270`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 1271`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 1272`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 1273`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 1274`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 1275`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `ReportBackLink.tsx`, `ReportBackLink()`
+- **Thin community `Community 1276`** (2 nodes): `ReportBackLink.tsx`, `ReportBackLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `ReportDaysPanel.test.tsx`, `constructor()`
+- **Thin community `Community 1277`** (2 nodes): `ReportDaysPanel.test.tsx`, `constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `ReportFreshness.tsx`, `ReportFreshness()`
+- **Thin community `Community 1278`** (2 nodes): `ReportFreshness.tsx`, `ReportFreshness()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `ReportTrendChart.test.tsx`, `labelFormatter()`
+- **Thin community `Community 1279`** (2 nodes): `ReportTrendChart.test.tsx`, `labelFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `ReportTrustStrip.tsx`, `ReportTrustStrip()`
+- **Thin community `Community 1280`** (2 nodes): `ReportTrustStrip.tsx`, `ReportTrustStrip()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `ReportsCatalogLookup.test.tsx`, `result()`
+- **Thin community `Community 1281`** (2 nodes): `ReportsCatalogLookup.test.tsx`, `result()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `ReportsItemsPerformance.tsx`, `cn()`
+- **Thin community `Community 1282`** (2 nodes): `ReportsItemsPerformance.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `ReportsItemsTable.tsx`, `ReportsItemsTable()`
+- **Thin community `Community 1283`** (2 nodes): `ReportsItemsTable.tsx`, `ReportsItemsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `ReportsItemsView.tsx`, `handlePageChange()`
+- **Thin community `Community 1284`** (2 nodes): `ReportsItemsView.tsx`, `handlePageChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `ReportsLayout.tsx`, `cn()`
+- **Thin community `Community 1285`** (2 nodes): `ReportsLayout.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `ReportsSkuDetailView.tsx`, `cn()`
+- **Thin community `Community 1286`** (2 nodes): `ReportsSkuDetailView.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `useStableReportQuery.ts`, `useStableReportQuery()`
+- **Thin community `Community 1287`** (2 nodes): `useStableReportQuery.ts`, `useStableReportQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 1288`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1289`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1290`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1291`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
+- **Thin community `Community 1292`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1293`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `DemoNotice()`, `DemoNotice.tsx`
+- **Thin community `Community 1294`** (2 nodes): `DemoNotice()`, `DemoNotice.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
+- **Thin community `Community 1295`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `SharedDemoOwnerHome.tsx`, `SharedDemoOwnerHome()`
+- **Thin community `Community 1296`** (2 nodes): `SharedDemoOwnerHome.tsx`, `SharedDemoOwnerHome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
+- **Thin community `Community 1297`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
+- **Thin community `Community 1298`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
+- **Thin community `Community 1299`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
+- **Thin community `Community 1300`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
+- **Thin community `Community 1301`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
+- **Thin community `Community 1302`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
+- **Thin community `Community 1303`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
+- **Thin community `Community 1304`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
+- **Thin community `Community 1305`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 1306`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 1307`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 1308`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 1309`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 1310`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 1311`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 1312`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 1313`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 1314`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 1315`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 1316`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 1317`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 1318`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 1319`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 1320`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 1321`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 1322`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 1323`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 1324`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 1325`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1326`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1327`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1328`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
+- **Thin community `Community 1329`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1330`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1331`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1332`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1333`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1334`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1335`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1336`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1337`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1338`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1339`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1340`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1341`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1342`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1343`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1344`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1345`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `SessionOrderProbe()`, `OnlineOrderContext.test.tsx`
+- **Thin community `Community 1346`** (2 nodes): `SessionOrderProbe()`, `OnlineOrderContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
+- **Thin community `Community 1347`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1348`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1349`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1350`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1351`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1352`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1353`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1354`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1355`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1356`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1357`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1358`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1359`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1360`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1361`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1362`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1363`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1364`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1365`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1366`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1367`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1368`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1369`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1370`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1371`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1372`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1373`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1374`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1375`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1376`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1377`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1378`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1379`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1380`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1381`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1382`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1383`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1384`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
+- **Thin community `Community 1385`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1386`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1387`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1388`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1389`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1390`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1391`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1392`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
+- **Thin community `Community 1393`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
+- **Thin community `Community 1394`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
+- **Thin community `Community 1395`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
+- **Thin community `Community 1396`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
+- **Thin community `Community 1397`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
+- **Thin community `Community 1398`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
+- **Thin community `Community 1399`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
+- **Thin community `Community 1400`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
+- **Thin community `Community 1401`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1402`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1403`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
+- **Thin community `Community 1404`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1405`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1406`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
+- **Thin community `Community 1407`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `syncGapDiagnosis.ts`, `diagnoseHeldSyncBlocker()`
+- **Thin community `Community 1408`** (2 nodes): `syncGapDiagnosis.ts`, `diagnoseHeldSyncBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1409`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1410`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1411`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1412`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
+- **Thin community `Community 1413`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
+- **Thin community `Community 1414`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1415`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1416`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1417`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1418`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1419`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1420`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1421`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1422`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1423`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1424`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1425`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1426`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
+- **Thin community `Community 1427`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
+- **Thin community `Community 1428`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `-public-layout.tsx`, `onScroll()`
+- **Thin community `Community 1429`** (2 nodes): `-public-layout.tsx`, `onScroll()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1430`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1431`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1432`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1433`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1434`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (2 nodes): `InventoryImportRoute()`, `-inventory-import-route.tsx`
+- **Thin community `Community 1435`** (2 nodes): `InventoryImportRoute()`, `-inventory-import-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1436`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1437`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1438`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
+- **Thin community `Community 1439`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1440`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1441`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1442`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1443`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
+- **Thin community `Community 1444`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1445`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1446`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1447`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1448`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1449`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1450`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
+- **Thin community `Community 1451`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (2 nodes): `_authed.route.test.tsx`, `_authed.tsx`
+- **Thin community `Community 1452`** (2 nodes): `_authed.route.test.tsx`, `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1453`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1454`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1455`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1456`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1457`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1458`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1459`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1460`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1461`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1462`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1463`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1464`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1465`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (2 nodes): `wedAt()`, `dailyOperationsFixtures.ts`
+- **Thin community `Community 1466`** (2 nodes): `wedAt()`, `dailyOperationsFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (2 nodes): `wedAt()`, `openingHandoffFixtures.ts`
+- **Thin community `Community 1467`** (2 nodes): `wedAt()`, `openingHandoffFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (2 nodes): `momentAt()`, `operationsFixtureContext.ts`
+- **Thin community `Community 1468`** (2 nodes): `momentAt()`, `operationsFixtureContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (2 nodes): `posHubFixtures.ts`, `buildTrend()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 1469`** (2 nodes): `posHubFixtures.ts`, `buildTrend()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1470`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -99419,7 +99419,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_hooks_useprint_ts",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L249",
+      "source_location": "L255",
       "target": "useprint_getreceiptpageheightmm",
       "weight": 1
     },
@@ -99431,7 +99431,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_hooks_useprint_ts",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L265",
+      "source_location": "L271",
       "target": "useprint_setcontinuousreceiptpagesize",
       "weight": 1
     },
@@ -99443,7 +99443,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_src_hooks_useprint_ts",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L294",
+      "source_location": "L300",
       "target": "useprint_useprint",
       "weight": 1
     },
@@ -116069,13 +116069,25 @@
     },
     {
       "_src": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "_tgt": "useprint_test_emitprintwindowevent",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L26",
+      "target": "useprint_test_emitprintwindowevent",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "_tgt": "useprint_test_setwindowopenmock",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
       "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
-      "source_location": "L25",
+      "source_location": "L33",
       "target": "useprint_test_setwindowopenmock",
       "weight": 1
     },
@@ -159023,7 +159035,7 @@
       "relation": "calls",
       "source": "useprint_getreceiptpageheightmm",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L271",
+      "source_location": "L277",
       "target": "useprint_setcontinuousreceiptpagesize",
       "weight": 1
     },
@@ -163260,6 +163272,24 @@
     {
       "community": 1000,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
+      "label": "paymentAllocationAttribution.test.ts",
+      "norm_label": "paymentallocationattribution.test.ts",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1000,
+      "file_type": "code",
+      "id": "paymentallocationattribution_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
+      "source_location": "L12"
+    },
+    {
+      "community": 1001,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessions_test_ts",
       "label": "registerSessions.test.ts",
       "norm_label": "registersessions.test.ts",
@@ -163267,7 +163297,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1000,
+      "community": 1001,
       "file_type": "code",
       "id": "registersessions_test_gethandler",
       "label": "getHandler()",
@@ -163276,7 +163306,7 @@
       "source_location": "L32"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_stream_ts",
       "label": "stream.ts",
@@ -163285,7 +163315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1001,
+      "community": 1002,
       "file_type": "code",
       "id": "stream_getcloudflareconfig",
       "label": "getCloudflareConfig()",
@@ -163294,7 +163324,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "historicalstorefrontcontextimport_test_analyticsrow",
       "label": "analyticsRow()",
@@ -163303,7 +163333,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1002,
+      "community": 1003,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_historicalstorefrontcontextimport_test_ts",
       "label": "historicalStorefrontContextImport.test.ts",
@@ -163312,7 +163342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "historicalstorefrontcontextimportreport_buildhistoricalstorefrontcontextimportreport",
       "label": "buildHistoricalStorefrontContextImportReport()",
@@ -163321,7 +163351,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1003,
+      "community": 1004,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_historicalstorefrontcontextimportreport_ts",
       "label": "historicalStorefrontContextImportReport.ts",
@@ -163330,7 +163360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "legacystorefrontanalytics_test_analyticsrow",
       "label": "analyticsRow()",
@@ -163339,7 +163369,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1004,
+      "community": 1005,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_legacystorefrontanalytics_test_ts",
       "label": "legacyStorefrontAnalytics.test.ts",
@@ -163348,7 +163378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_policy_ts",
       "label": "policy.ts",
@@ -163357,7 +163387,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1005,
+      "community": 1006,
       "file_type": "code",
       "id": "policy_assertsupportedcustomermessagepolicy",
       "label": "assertSupportedCustomerMessagePolicy()",
@@ -163366,7 +163396,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_repository_test_ts",
       "label": "repository.test.ts",
@@ -163375,7 +163405,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1006,
+      "community": 1007,
       "file_type": "code",
       "id": "repository_test_queryresult",
       "label": "queryResult()",
@@ -163384,7 +163414,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_webhooksecurity_test_ts",
       "label": "webhookSecurity.test.ts",
@@ -163393,7 +163423,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1007,
+      "community": 1008,
       "file_type": "code",
       "id": "webhooksecurity_test_sign",
       "label": "sign()",
@@ -163402,7 +163432,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "dailymanagerreportbordered_dailymanagerreportbordered",
       "label": "DailyManagerReportBordered()",
@@ -163411,30 +163441,12 @@
       "source_location": "L5"
     },
     {
-      "community": 1008,
+      "community": 1009,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_dailymanagerreportbordered_tsx",
       "label": "DailyManagerReportBordered.tsx",
       "norm_label": "dailymanagerreportbordered.tsx",
       "source_file": "packages/athena-webapp/convex/emails/DailyManagerReportBordered.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "dailymanagerreportunbordered_dailymanagerreportunbordered",
-      "label": "DailyManagerReportUnbordered()",
-      "norm_label": "dailymanagerreportunbordered()",
-      "source_file": "packages/athena-webapp/convex/emails/DailyManagerReportUnbordered.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 1009,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_dailymanagerreportunbordered_tsx",
-      "label": "DailyManagerReportUnbordered.tsx",
-      "norm_label": "dailymanagerreportunbordered.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/DailyManagerReportUnbordered.tsx",
       "source_location": "L1"
     },
     {
@@ -163602,6 +163614,24 @@
     {
       "community": 1010,
       "file_type": "code",
+      "id": "dailymanagerreportunbordered_dailymanagerreportunbordered",
+      "label": "DailyManagerReportUnbordered()",
+      "norm_label": "dailymanagerreportunbordered()",
+      "source_file": "packages/athena-webapp/convex/emails/DailyManagerReportUnbordered.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 1010,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_dailymanagerreportunbordered_tsx",
+      "label": "DailyManagerReportUnbordered.tsx",
+      "norm_label": "dailymanagerreportunbordered.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/DailyManagerReportUnbordered.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1011,
+      "file_type": "code",
       "id": "orderemail_orderemailpreview",
       "label": "OrderEmailPreview()",
       "norm_label": "orderemailpreview()",
@@ -163609,7 +163639,7 @@
       "source_location": "L296"
     },
     {
-      "community": 1010,
+      "community": 1011,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_orderemail_tsx",
       "label": "OrderEmail.tsx",
@@ -163618,7 +163648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posterminalhealthalert_tsx",
       "label": "PosTerminalHealthAlert.tsx",
@@ -163627,7 +163657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1011,
+      "community": 1012,
       "file_type": "code",
       "id": "posterminalhealthalert_posterminalhealthalert",
       "label": "PosTerminalHealthAlert()",
@@ -163636,7 +163666,7 @@
       "source_location": "L32"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutmatchreportpreview_tsx",
       "label": "RegisterCloseoutMatchReportPreview.tsx",
@@ -163645,7 +163675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1012,
+      "community": 1013,
       "file_type": "code",
       "id": "registercloseoutmatchreportpreview_registercloseoutmatchreportpreview",
       "label": "RegisterCloseoutMatchReportPreview()",
@@ -163654,7 +163684,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealertpreview_tsx",
       "label": "RegisterCloseoutVarianceAlertPreview.tsx",
@@ -163663,7 +163693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1013,
+      "community": 1014,
       "file_type": "code",
       "id": "registercloseoutvariancealertpreview_registercloseoutvariancealertpreview",
       "label": "RegisterCloseoutVarianceAlertPreview()",
@@ -163672,7 +163702,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_verificationcode_tsx",
       "label": "VerificationCode.tsx",
@@ -163681,7 +163711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1014,
+      "community": 1015,
       "file_type": "code",
       "id": "verificationcode_verificationcode",
       "label": "VerificationCode()",
@@ -163690,7 +163720,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_walkthroughrequestnotification_tsx",
       "label": "WalkthroughRequestNotification.tsx",
@@ -163699,7 +163729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1015,
+      "community": 1016,
       "file_type": "code",
       "id": "walkthroughrequestnotification_delinkuntrustedemailtext",
       "label": "delinkUntrustedEmailText()",
@@ -163708,7 +163738,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "bannermessage_resolvepublicbannermessage",
       "label": "resolvePublicBannerMessage()",
@@ -163717,7 +163747,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1016,
+      "community": 1017,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -163726,7 +163756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "boundedbody_readboundedbody",
       "label": "readBoundedBody()",
@@ -163735,7 +163765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1017,
+      "community": 1018,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_boundedbody_ts",
       "label": "boundedBody.ts",
@@ -163744,7 +163774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
       "label": "subcategories.ts",
@@ -163753,31 +163783,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1018,
+      "community": 1019,
       "file_type": "code",
       "id": "subcategories_removestorefronthiddensubcategorylist",
       "label": "removeStorefrontHiddenSubcategoryList()",
       "norm_label": "removestorefronthiddensubcategorylist()",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/subcategories.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefrontcors_test_ts",
-      "label": "storefrontCors.test.ts",
-      "norm_label": "storefrontcors.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefrontCors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1019,
-      "file_type": "code",
-      "id": "storefrontcors_test_readroutefile",
-      "label": "readRouteFile()",
-      "norm_label": "readroutefile()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefrontCors.test.ts",
-      "source_location": "L6"
     },
     {
       "community": 102,
@@ -163944,6 +163956,24 @@
     {
       "community": 1020,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefrontcors_test_ts",
+      "label": "storefrontCors.test.ts",
+      "norm_label": "storefrontcors.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefrontCors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1020,
+      "file_type": "code",
+      "id": "storefrontcors_test_readroutefile",
+      "label": "readRouteFile()",
+      "norm_label": "readroutefile()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/storefrontCors.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 1021,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customermessaging_routes_whatsapp_ts",
       "label": "whatsapp.ts",
       "norm_label": "whatsapp.ts",
@@ -163951,7 +163981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1020,
+      "community": 1021,
       "file_type": "code",
       "id": "whatsapp_mapwebhookstatus",
       "label": "mapWebhookStatus()",
@@ -163960,7 +163990,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -163969,7 +163999,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1021,
+      "community": 1022,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -163978,7 +164008,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -163987,7 +164017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1022,
+      "community": 1023,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -163996,7 +164026,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "fake_createfakestructuredtextprovider",
       "label": "createFakeStructuredTextProvider()",
@@ -164005,7 +164035,7 @@
       "source_location": "L30"
     },
     {
-      "community": 1023,
+      "community": 1024,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_fake_ts",
       "label": "fake.ts",
@@ -164014,7 +164044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "athenauser_isexpiredshareddemosessionerror",
       "label": "isExpiredSharedDemoSessionError()",
@@ -164023,7 +164053,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1024,
+      "community": 1025,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -164032,7 +164062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "athenauseridentitywriters_test_source",
       "label": "source()",
@@ -164041,7 +164071,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1025,
+      "community": 1026,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauseridentitywriters_test_ts",
       "label": "athenaUserIdentityWriters.test.ts",
@@ -164050,7 +164080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -164059,7 +164089,7 @@
       "source_location": "L114"
     },
     {
-      "community": 1026,
+      "community": 1027,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
@@ -164068,7 +164098,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "bannermessage_test_gethandler",
       "label": "getHandler()",
@@ -164077,7 +164107,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1027,
+      "community": 1028,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bannermessage_test_ts",
       "label": "bannerMessage.test.ts",
@@ -164086,7 +164116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "bestseller_test_gethandler",
       "label": "getHandler()",
@@ -164095,30 +164125,12 @@
       "source_location": "L12"
     },
     {
-      "community": 1028,
+      "community": 1029,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
       "label": "bestSeller.test.ts",
       "norm_label": "bestseller.test.ts",
       "source_file": "packages/athena-webapp/convex/inventory/bestSeller.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "catalogsummary_test_createcatalogsummaryctx",
-      "label": "createCatalogSummaryCtx()",
-      "norm_label": "createcatalogsummaryctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/catalogSummary.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 1029,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_catalogsummary_test_ts",
-      "label": "catalogSummary.test.ts",
-      "norm_label": "catalogsummary.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/catalogSummary.test.ts",
       "source_location": "L1"
     },
     {
@@ -164286,6 +164298,24 @@
     {
       "community": 1030,
       "file_type": "code",
+      "id": "catalogsummary_test_createcatalogsummaryctx",
+      "label": "createCatalogSummaryCtx()",
+      "norm_label": "createcatalogsummaryctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/catalogSummary.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 1030,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_catalogsummary_test_ts",
+      "label": "catalogSummary.test.ts",
+      "norm_label": "catalogsummary.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/catalogSummary.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1031,
+      "file_type": "code",
       "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "label": "userErrorFromExpenseItemCommandFailure()",
       "norm_label": "usererrorfromexpenseitemcommandfailure()",
@@ -164293,7 +164323,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1030,
+      "community": 1031,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -164302,7 +164332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "expensetransactions_test_createfakemutationctx",
       "label": "createFakeMutationCtx()",
@@ -164311,7 +164341,7 @@
       "source_location": "L339"
     },
     {
-      "community": 1031,
+      "community": 1032,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
@@ -164320,7 +164350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "inventoryimportcostoverlaywork_test_createworkcontext",
       "label": "createWorkContext()",
@@ -164329,7 +164359,7 @@
       "source_location": "L65"
     },
     {
-      "community": 1032,
+      "community": 1033,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlaywork_test_ts",
       "label": "inventoryImportCostOverlayWork.test.ts",
@@ -164338,7 +164368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -164347,7 +164377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1033,
+      "community": 1034,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -164356,7 +164386,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -164365,7 +164395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1034,
+      "community": 1035,
       "file_type": "code",
       "id": "productsku_syncproductskusearchprojectionsbystore",
       "label": "syncProductSkuSearchProjectionsByStore()",
@@ -164374,7 +164404,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -164383,7 +164413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1035,
+      "community": 1036,
       "file_type": "code",
       "id": "productutil_buildallproductscachekey",
       "label": "buildAllProductsCacheKey()",
@@ -164392,7 +164422,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -164401,7 +164431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1036,
+      "community": 1037,
       "file_type": "code",
       "id": "promocode_calculateselectedproductpromodiscount",
       "label": "calculateSelectedProductPromoDiscount()",
@@ -164410,7 +164440,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_stores_ts",
       "label": "stores.ts",
@@ -164419,7 +164449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1037,
+      "community": 1038,
       "file_type": "code",
       "id": "stores_tov2onlyconfig",
       "label": "toV2OnlyConfig()",
@@ -164428,7 +164458,7 @@
       "source_location": "L35"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "commerceeffects_test_context",
       "label": "context()",
@@ -164437,31 +164467,13 @@
       "source_location": "L35"
     },
     {
-      "community": 1038,
+      "community": 1039,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_commerceeffects_test_ts",
       "label": "commerceEffects.test.ts",
       "norm_label": "commerceeffects.test.ts",
       "source_file": "packages/athena-webapp/convex/inventoryLedger/commerceEffects.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventoryledger_positionrevisions_ts",
-      "label": "positionRevisions.ts",
-      "norm_label": "positionrevisions.ts",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/positionRevisions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1039,
-      "file_type": "code",
-      "id": "positionrevisions_recordinventorypositionrevisionwithctx",
-      "label": "recordInventoryPositionRevisionWithCtx()",
-      "norm_label": "recordinventorypositionrevisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/positionRevisions.ts",
-      "source_location": "L4"
     },
     {
       "community": 104,
@@ -164628,6 +164640,24 @@
     {
       "community": 1040,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventoryledger_positionrevisions_ts",
+      "label": "positionRevisions.ts",
+      "norm_label": "positionrevisions.ts",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/positionRevisions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1040,
+      "file_type": "code",
+      "id": "positionrevisions_recordinventorypositionrevisionwithctx",
+      "label": "recordInventoryPositionRevisionWithCtx()",
+      "norm_label": "recordinventorypositionrevisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/positionRevisions.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 1041,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_schedulework_ts",
       "label": "scheduleWork.ts",
       "norm_label": "schedulework.ts",
@@ -164635,7 +164665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1040,
+      "community": 1041,
       "file_type": "code",
       "id": "schedulework_schedulereportingworkbesteffort",
       "label": "scheduleReportingWorkBestEffort()",
@@ -164644,7 +164674,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "athenauserauth_test_context",
       "label": "context()",
@@ -164653,7 +164683,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1041,
+      "community": 1042,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_athenauserauth_test_ts",
       "label": "athenaUserAuth.test.ts",
@@ -164662,7 +164692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -164671,7 +164701,7 @@
       "source_location": "L80"
     },
     {
-      "community": 1042,
+      "community": 1043,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -164680,7 +164710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_storememberaccess_ts",
       "label": "storeMemberAccess.ts",
@@ -164689,7 +164719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1043,
+      "community": 1044,
       "file_type": "code",
       "id": "storememberaccess_requirestorememberaccesswithctx",
       "label": "requireStoreMemberAccessWithCtx()",
@@ -164698,7 +164728,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -164707,7 +164737,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1044,
+      "community": 1045,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -164716,7 +164746,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -164725,7 +164755,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1045,
+      "community": 1046,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -164734,7 +164764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -164743,7 +164773,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1046,
+      "community": 1047,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -164752,7 +164782,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "landingfunnelretention_shouldexpirefunnelrecord",
       "label": "shouldExpireFunnelRecord()",
@@ -164761,7 +164791,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1047,
+      "community": 1048,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_landingfunnelretention_ts",
       "label": "landingFunnelRetention.ts",
@@ -164770,7 +164800,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughbudgets_ts",
       "label": "walkthroughBudgets.ts",
@@ -164779,31 +164809,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1048,
+      "community": 1049,
       "file_type": "code",
       "id": "walkthroughbudgets_consumewalkthroughbudget",
       "label": "consumeWalkthroughBudget()",
       "norm_label": "consumewalkthroughbudget()",
       "source_file": "packages/athena-webapp/convex/marketing/walkthroughBudgets.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_test_ts",
-      "label": "walkthroughRequestNotifications.test.ts",
-      "norm_label": "walkthroughrequestnotifications.test.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequestNotifications.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1049,
-      "file_type": "code",
-      "id": "walkthroughrequestnotifications_test_insertattempt",
-      "label": "insertAttempt()",
-      "norm_label": "insertattempt()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequestNotifications.test.ts",
-      "source_location": "L21"
     },
     {
       "community": 105,
@@ -164961,6 +164973,24 @@
     {
       "community": 1050,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_test_ts",
+      "label": "walkthroughRequestNotifications.test.ts",
+      "norm_label": "walkthroughrequestnotifications.test.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequestNotifications.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1050,
+      "file_type": "code",
+      "id": "walkthroughrequestnotifications_test_insertattempt",
+      "label": "insertAttempt()",
+      "norm_label": "insertattempt()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughRequestNotifications.test.ts",
+      "source_location": "L21"
+    },
+    {
+      "community": 1051,
+      "file_type": "code",
       "id": "backfillstoretimezoneauthority_test_createctx",
       "label": "createCtx()",
       "norm_label": "createctx()",
@@ -164968,7 +164998,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1050,
+      "community": 1051,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_test_ts",
       "label": "backfillStoreTimezoneAuthority.test.ts",
@@ -164977,7 +165007,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "migrateposamountstopesewas_test_createctx",
       "label": "createCtx()",
@@ -164986,7 +165016,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1051,
+      "community": 1052,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateposamountstopesewas_test_ts",
       "label": "migratePosAmountsToPesewas.test.ts",
@@ -164995,7 +165025,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -165004,7 +165034,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1052,
+      "community": 1053,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -165013,7 +165043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "emit_emitnotificationwithctx",
       "label": "emitNotificationWithCtx()",
@@ -165022,7 +165052,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1053,
+      "community": 1054,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_emit_ts",
       "label": "emit.ts",
@@ -165031,7 +165061,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_sweeper_ts",
       "label": "sweeper.ts",
@@ -165040,7 +165070,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1054,
+      "community": 1055,
       "file_type": "code",
       "id": "sweeper_terminalizeorphaneddelivery",
       "label": "terminalizeOrphanedDelivery()",
@@ -165049,7 +165079,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_transport_test_ts",
       "label": "transport.test.ts",
@@ -165058,7 +165088,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1055,
+      "community": 1056,
       "file_type": "code",
       "id": "transport_test_stubfetch",
       "label": "stubFetch()",
@@ -165067,7 +165097,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_transport_ts",
       "label": "transport.ts",
@@ -165076,7 +165106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1056,
+      "community": 1057,
       "file_type": "code",
       "id": "transport_sendnotificationemail",
       "label": "sendNotificationEmail()",
@@ -165085,7 +165115,7 @@
       "source_location": "L37"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "effects_declaresprotectedgateway",
       "label": "declaresProtectedGateway()",
@@ -165094,7 +165124,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1057,
+      "community": 1058,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_effects_ts",
       "label": "effects.ts",
@@ -165103,7 +165133,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_readadapters_test_ts",
       "label": "readAdapters.test.ts",
@@ -165112,31 +165142,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1058,
+      "community": 1059,
       "file_type": "code",
       "id": "readadapters_test_democtx",
       "label": "demoCtx()",
       "norm_label": "democtx()",
       "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.test.ts",
       "source_location": "L138"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_scopes_ts",
-      "label": "scopes.ts",
-      "norm_label": "scopes.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/scopes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1059,
-      "file_type": "code",
-      "id": "scopes_resolveoperationscope",
-      "label": "resolveOperationScope()",
-      "norm_label": "resolveoperationscope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/scopes.ts",
-      "source_location": "L9"
     },
     {
       "community": 106,
@@ -165294,6 +165306,24 @@
     {
       "community": 1060,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_scopes_ts",
+      "label": "scopes.ts",
+      "norm_label": "scopes.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/scopes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1060,
+      "file_type": "code",
+      "id": "scopes_resolveoperationscope",
+      "label": "resolveOperationScope()",
+      "norm_label": "resolveoperationscope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/scopes.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 1061,
+      "file_type": "code",
       "id": "approvalactions_consumecommandapprovalproofwithctx",
       "label": "consumeCommandApprovalProofWithCtx()",
       "norm_label": "consumecommandapprovalproofwithctx()",
@@ -165301,7 +165331,7 @@
       "source_location": "L62"
     },
     {
-      "community": 1060,
+      "community": 1061,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalactions_ts",
       "label": "approvalActions.ts",
@@ -165310,7 +165340,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "approvalauditevents_test_createoperationaleventctx",
       "label": "createOperationalEventCtx()",
@@ -165319,7 +165349,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1061,
+      "community": 1062,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_test_ts",
       "label": "approvalAuditEvents.test.ts",
@@ -165328,7 +165358,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "approvalproofs_test_createapprovalproofmutationctx",
       "label": "createApprovalProofMutationCtx()",
@@ -165337,7 +165367,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1062,
+      "community": 1063,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
       "label": "approvalProofs.test.ts",
@@ -165346,7 +165376,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "approvalrequesthelpers_buildapprovalrequest",
       "label": "buildApprovalRequest()",
@@ -165355,7 +165385,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1063,
+      "community": 1064,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesthelpers_ts",
       "label": "approvalRequestHelpers.ts",
@@ -165364,7 +165394,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -165373,7 +165403,7 @@
       "source_location": "L45"
     },
     {
-      "community": 1064,
+      "community": 1065,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -165382,7 +165412,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "inventorymovements_test_createinventorymovementctx",
       "label": "createInventoryMovementCtx()",
@@ -165391,7 +165421,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1065,
+      "community": 1066,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -165400,7 +165430,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "logicaloperationalwork_test_workitem",
       "label": "workItem()",
@@ -165409,7 +165439,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1066,
+      "community": 1067,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_logicaloperationalwork_test_ts",
       "label": "logicalOperationalWork.test.ts",
@@ -165418,7 +165448,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "operationalevents_test_createctx",
       "label": "createCtx()",
@@ -165427,7 +165457,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1067,
+      "community": 1068,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_test_ts",
       "label": "operationalEvents.test.ts",
@@ -165436,7 +165466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "oweddailyclosesweep_test_fullwindow",
       "label": "fullWindow()",
@@ -165445,31 +165475,13 @@
       "source_location": "L12"
     },
     {
-      "community": 1068,
+      "community": 1069,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_test_ts",
       "label": "owedDailyCloseSweep.test.ts",
       "norm_label": "oweddailyclosesweep.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocationcallers_test_ts",
-      "label": "paymentAllocationCallers.test.ts",
-      "norm_label": "paymentallocationcallers.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocationCallers.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1069,
-      "file_type": "code",
-      "id": "paymentallocationcallers_test_source",
-      "label": "source()",
-      "norm_label": "source()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocationCallers.test.ts",
-      "source_location": "L4"
     },
     {
       "community": 107,
@@ -165627,6 +165639,24 @@
     {
       "community": 1070,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocationcallers_test_ts",
+      "label": "paymentAllocationCallers.test.ts",
+      "norm_label": "paymentallocationcallers.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocationCallers.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1070,
+      "file_type": "code",
+      "id": "paymentallocationcallers_test_source",
+      "label": "source()",
+      "norm_label": "source()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocationCallers.test.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 1071,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymentallocations_test_ts",
       "label": "paymentAllocations.test.ts",
       "norm_label": "paymentallocations.test.ts",
@@ -165634,7 +165664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1070,
+      "community": 1071,
       "file_type": "code",
       "id": "paymentallocations_test_paymentcontext",
       "label": "paymentContext()",
@@ -165643,7 +165673,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registercloseoutvarianceemail_test_ts",
       "label": "registerCloseoutVarianceEmail.test.ts",
@@ -165652,7 +165682,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1071,
+      "community": 1072,
       "file_type": "code",
       "id": "registercloseoutvarianceemail_test_gethandler",
       "label": "getHandler()",
@@ -165661,7 +165691,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffmessages_ts",
       "label": "staffMessages.ts",
@@ -165670,7 +165700,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1072,
+      "community": 1073,
       "file_type": "code",
       "id": "staffmessages_requirestoremember",
       "label": "requireStoreMember()",
@@ -165679,7 +165709,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "createorreusependingcheckoutitem_test_creatependingcheckoutctx",
       "label": "createPendingCheckoutCtx()",
@@ -165688,7 +165718,7 @@
       "source_location": "L37"
     },
     {
-      "community": 1073,
+      "community": 1074,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_createorreusependingcheckoutitem_test_ts",
       "label": "createOrReusePendingCheckoutItem.test.ts",
@@ -165697,7 +165727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -165706,7 +165736,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1074,
+      "community": 1075,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -165715,7 +165745,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "correcttransactionpaymentmethod_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -165724,7 +165754,7 @@
       "source_location": "L87"
     },
     {
-      "community": 1075,
+      "community": 1076,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_correcttransactionpaymentmethod_test_ts",
       "label": "correctTransactionPaymentMethod.test.ts",
@@ -165733,7 +165763,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "correctionevents_buildcorrectionoperationalevent",
       "label": "buildCorrectionOperationalEvent()",
@@ -165742,7 +165772,7 @@
       "source_location": "L35"
     },
     {
-      "community": 1076,
+      "community": 1077,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
       "label": "correctionEvents.ts",
@@ -165751,7 +165781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "diagnosticredaction_redactsensitivediagnostictext",
       "label": "redactSensitiveDiagnosticText()",
@@ -165760,7 +165790,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1077,
+      "community": 1078,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_diagnosticredaction_ts",
       "label": "diagnosticRedaction.ts",
@@ -165769,7 +165799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
@@ -165778,30 +165808,12 @@
       "source_location": "L56"
     },
     {
-      "community": 1078,
+      "community": 1079,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
       "norm_label": "gettransactions.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/getTransactions.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "listregistercatalog_test_createregistercatalogctx",
-      "label": "createRegisterCatalogCtx()",
-      "norm_label": "createregistercatalogctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 1079,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
-      "label": "listRegisterCatalog.test.ts",
-      "norm_label": "listregistercatalog.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
       "source_location": "L1"
     },
     {
@@ -165960,6 +165972,24 @@
     {
       "community": 1080,
       "file_type": "code",
+      "id": "listregistercatalog_test_createregistercatalogctx",
+      "label": "createRegisterCatalogCtx()",
+      "norm_label": "createregistercatalogctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 1080,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
+      "label": "listRegisterCatalog.test.ts",
+      "norm_label": "listregistercatalog.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1081,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_projectionpolicies_test_ts",
       "label": "projectionPolicies.test.ts",
       "norm_label": "projectionpolicies.test.ts",
@@ -165967,7 +165997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1080,
+      "community": 1081,
       "file_type": "code",
       "id": "projectionpolicies_test_saleitem",
       "label": "saleItem()",
@@ -165976,7 +166006,7 @@
       "source_location": "L295"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_test_ts",
       "label": "registerCatalogRevision.test.ts",
@@ -165985,7 +166015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1081,
+      "community": 1082,
       "file_type": "code",
       "id": "registercatalogrevision_test_createrevisionctx",
       "label": "createRevisionCtx()",
@@ -165994,7 +166024,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_resolvelocalsyncreview_test_ts",
       "label": "resolveLocalSyncReview.test.ts",
@@ -166003,7 +166033,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1082,
+      "community": 1083,
       "file_type": "code",
       "id": "resolvelocalsyncreview_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -166012,7 +166042,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproofvalidation_ts",
       "label": "staffProofValidation.ts",
@@ -166021,7 +166051,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1083,
+      "community": 1084,
       "file_type": "code",
       "id": "staffproofvalidation_validateposlocalstaffproofwithctx",
       "label": "validatePosLocalStaffProofWithCtx()",
@@ -166030,7 +166060,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_transactionadjustmentplanner_test_ts",
       "label": "transactionAdjustmentPlanner.test.ts",
@@ -166039,7 +166069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1084,
+      "community": 1085,
       "file_type": "code",
       "id": "transactionadjustmentplanner_test_baseinput",
       "label": "baseInput()",
@@ -166048,7 +166078,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_poslifecyclejournal_test_ts",
       "label": "posLifecycleJournal.test.ts",
@@ -166057,7 +166087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1085,
+      "community": 1086,
       "file_type": "code",
       "id": "poslifecyclejournal_test_createctx",
       "label": "createCtx()",
@@ -166066,7 +166096,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_poslifecyclejournal_ts",
       "label": "posLifecycleJournal.ts",
@@ -166075,7 +166105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1086,
+      "community": 1087,
       "file_type": "code",
       "id": "poslifecyclejournal_appendposlifecyclejournalwithctx",
       "label": "appendPosLifecycleJournalWithCtx()",
@@ -166084,7 +166114,7 @@
       "source_location": "L58"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -166093,7 +166123,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1087,
+      "community": 1088,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -166102,7 +166132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "expensesessioncommandrepository_createexpensesessioncommandrepository",
       "label": "createExpenseSessionCommandRepository()",
@@ -166111,30 +166141,12 @@
       "source_location": "L72"
     },
     {
-      "community": 1088,
+      "community": 1089,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_expensesessioncommandrepository_ts",
       "label": "expenseSessionCommandRepository.ts",
       "norm_label": "expensesessioncommandrepository.ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/expenseSessionCommandRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "localsyncrepository_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 1089,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_localsyncrepository_test_ts",
-      "label": "localSyncRepository.test.ts",
-      "norm_label": "localsyncrepository.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts",
       "source_location": "L1"
     },
     {
@@ -166293,6 +166305,24 @@
     {
       "community": 1090,
       "file_type": "code",
+      "id": "localsyncrepository_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 1090,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_localsyncrepository_test_ts",
+      "label": "localSyncRepository.test.ts",
+      "norm_label": "localsyncrepository.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1091,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registerlifecycleauthorityrepository_ts",
       "label": "registerLifecycleAuthorityRepository.ts",
       "norm_label": "registerlifecycleauthorityrepository.ts",
@@ -166300,7 +166330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1090,
+      "community": 1091,
       "file_type": "code",
       "id": "registerlifecycleauthorityrepository_createregisterlifecycleauthorityrepository",
       "label": "createRegisterLifecycleAuthorityRepository()",
@@ -166309,7 +166339,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
@@ -166318,7 +166348,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1091,
+      "community": 1092,
       "file_type": "code",
       "id": "registersessionrepository_test_createregistersessionqueryctx",
       "label": "createRegisterSessionQueryCtx()",
@@ -166327,7 +166357,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -166336,7 +166366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1092,
+      "community": 1093,
       "file_type": "code",
       "id": "sessioncommandrepository_test_readprojectfile",
       "label": "readProjectFile()",
@@ -166345,7 +166375,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -166354,7 +166384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1093,
+      "community": 1094,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -166363,7 +166393,7 @@
       "source_location": "L88"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_posruntimeadapter_ts",
       "label": "posRuntimeAdapter.ts",
@@ -166372,7 +166402,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1094,
+      "community": 1095,
       "file_type": "code",
       "id": "posruntimeadapter_buildposremoteassistclientpresence",
       "label": "buildPosRemoteAssistClientPresence()",
@@ -166381,7 +166411,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistrepository_ts",
       "label": "remoteAssistRepository.ts",
@@ -166390,7 +166420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1095,
+      "community": 1096,
       "file_type": "code",
       "id": "remoteassistrepository_createremoteassistrepository",
       "label": "createRemoteAssistRepository()",
@@ -166399,7 +166429,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_test_buildcontext",
       "label": "buildContext()",
@@ -166408,7 +166438,7 @@
       "source_location": "L131"
     },
     {
-      "community": 1096,
+      "community": 1097,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_livekitremoteassisttransportprovider_test_ts",
       "label": "LiveKitRemoteAssistTransportProvider.test.ts",
@@ -166417,7 +166447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "createremoteassisttransportprovider_createremoteassisttransportprovider",
       "label": "createRemoteAssistTransportProvider()",
@@ -166426,7 +166456,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1097,
+      "community": 1098,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_createremoteassisttransportprovider_ts",
       "label": "createRemoteAssistTransportProvider.ts",
@@ -166435,7 +166465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_public_ts",
       "label": "public.ts",
@@ -166444,31 +166474,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1098,
+      "community": 1099,
       "file_type": "code",
       "id": "public_toremoteassistsessionreturn",
       "label": "toRemoteAssistSessionReturn()",
       "norm_label": "toremoteassistsessionreturn()",
       "source_file": "packages/athena-webapp/convex/remoteAssist/public.ts",
       "source_location": "L211"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_remoteassist_transport_ts",
-      "label": "transport.ts",
-      "norm_label": "transport.ts",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transport.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1099,
-      "file_type": "code",
-      "id": "transport_issuecredential",
-      "label": "issueCredential()",
-      "norm_label": "issuecredential()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/transport.ts",
-      "source_location": "L94"
     },
     {
       "community": 11,
@@ -167058,6 +167070,24 @@
     {
       "community": 1100,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_remoteassist_transport_ts",
+      "label": "transport.ts",
+      "norm_label": "transport.ts",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transport.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1100,
+      "file_type": "code",
+      "id": "transport_issuecredential",
+      "label": "issueCredential()",
+      "norm_label": "issuecredential()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/transport.ts",
+      "source_location": "L94"
+    },
+    {
+      "community": 1101,
+      "file_type": "code",
       "id": "access_test_context",
       "label": "context()",
       "norm_label": "context()",
@@ -167065,7 +167095,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1100,
+      "community": 1101,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_access_test_ts",
       "label": "access.test.ts",
@@ -167074,7 +167104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "access_requirereportsstoreaccess",
       "label": "requireReportsStoreAccess()",
@@ -167083,7 +167113,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1101,
+      "community": 1102,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_access_ts",
       "label": "access.ts",
@@ -167092,7 +167122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "fingerprint_test_fact",
       "label": "fact()",
@@ -167101,7 +167131,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1102,
+      "community": 1103,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_test_ts",
       "label": "fingerprint.test.ts",
@@ -167110,7 +167140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsynccontractvalidators_ts",
       "label": "posLocalSyncContractValidators.ts",
@@ -167119,7 +167149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1103,
+      "community": 1104,
       "file_type": "code",
       "id": "poslocalsynccontractvalidators_unionfromvalidators",
       "label": "unionFromValidators()",
@@ -167128,7 +167158,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "modulewiring_test_getsource",
       "label": "getSource()",
@@ -167137,7 +167167,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1104,
+      "community": 1105,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
       "label": "moduleWiring.test.ts",
@@ -167146,7 +167176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecasetracing_test_ts",
       "label": "serviceCaseTracing.test.ts",
@@ -167155,7 +167185,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1105,
+      "community": 1106,
       "file_type": "code",
       "id": "servicecasetracing_test_buildservicecase",
       "label": "buildServiceCase()",
@@ -167164,7 +167194,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "actor_test_contextfor",
       "label": "contextFor()",
@@ -167173,7 +167203,7 @@
       "source_location": "L99"
     },
     {
-      "community": 1106,
+      "community": 1107,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_actor_test_ts",
       "label": "actor.test.ts",
@@ -167182,7 +167212,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "enforcement_test_invoke",
       "label": "invoke()",
@@ -167191,7 +167221,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1107,
+      "community": 1108,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_enforcement_test_ts",
       "label": "enforcement.test.ts",
@@ -167200,7 +167230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "operationadapter_test_democtx",
       "label": "demoCtx()",
@@ -167209,31 +167239,13 @@
       "source_location": "L288"
     },
     {
-      "community": 1108,
+      "community": 1109,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_operationadapter_test_ts",
       "label": "operationAdapter.test.ts",
       "norm_label": "operationadapter.test.ts",
       "source_file": "packages/athena-webapp/convex/sharedDemo/operationAdapter.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_posstorereadaccesscoverage_test_ts",
-      "label": "posStoreReadAccessCoverage.test.ts",
-      "norm_label": "posstorereadaccesscoverage.test.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/posStoreReadAccessCoverage.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1109,
-      "file_type": "code",
-      "id": "posstorereadaccesscoverage_test_source",
-      "label": "source()",
-      "norm_label": "source()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/posStoreReadAccessCoverage.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 111,
@@ -167391,6 +167403,24 @@
     {
       "community": 1110,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_shareddemo_posstorereadaccesscoverage_test_ts",
+      "label": "posStoreReadAccessCoverage.test.ts",
+      "norm_label": "posstorereadaccesscoverage.test.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/posStoreReadAccessCoverage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1110,
+      "file_type": "code",
+      "id": "posstorereadaccesscoverage_test_source",
+      "label": "source()",
+      "norm_label": "source()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/posStoreReadAccessCoverage.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 1111,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_providerenforcement_test_ts",
       "label": "providerEnforcement.test.ts",
       "norm_label": "providerenforcement.test.ts",
@@ -167398,7 +167428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1110,
+      "community": 1111,
       "file_type": "code",
       "id": "providerenforcement_test_invoke",
       "label": "invoke()",
@@ -167407,7 +167437,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_provision_test_ts",
       "label": "provision.test.ts",
@@ -167416,7 +167446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1111,
+      "community": 1112,
       "file_type": "code",
       "id": "provision_test_seeddemoregisterfoundation",
       "label": "seedDemoRegisterFoundation()",
@@ -167425,7 +167455,7 @@
       "source_location": "L54"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_registerbaseline_test_ts",
       "label": "registerBaseline.test.ts",
@@ -167434,7 +167464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1112,
+      "community": 1113,
       "file_type": "code",
       "id": "registerbaseline_test_seedstorewithregister",
       "label": "seedStoreWithRegister()",
@@ -167443,7 +167473,7 @@
       "source_location": "L147"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_restore_test_ts",
       "label": "restore.test.ts",
@@ -167452,7 +167482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1113,
+      "community": 1114,
       "file_type": "code",
       "id": "restore_test_restorestatecontext",
       "label": "restoreStateContext()",
@@ -167461,7 +167491,7 @@
       "source_location": "L300"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
@@ -167470,7 +167500,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1114,
+      "community": 1115,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -167479,7 +167509,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -167488,7 +167518,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1115,
+      "community": 1116,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -167497,7 +167527,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseordertracing_test_ts",
       "label": "purchaseOrderTracing.test.ts",
@@ -167506,7 +167536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1116,
+      "community": 1117,
       "file_type": "code",
       "id": "purchaseordertracing_test_createworkflowtracectx",
       "label": "createWorkflowTraceCtx()",
@@ -167515,7 +167545,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -167524,7 +167554,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1117,
+      "community": 1118,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -167533,7 +167563,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -167542,30 +167572,12 @@
       "source_location": "L8"
     },
     {
-      "community": 1118,
+      "community": 1119,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
       "norm_label": "customerbehaviortimeline.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/customerBehaviorTimeline.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "customerobservabilitytimeline_test_createanalyticsevent",
-      "label": "createAnalyticsEvent()",
-      "norm_label": "createanalyticsevent()",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 1119,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
-      "label": "customerObservabilityTimeline.test.ts",
-      "norm_label": "customerobservabilitytimeline.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
       "source_location": "L1"
     },
     {
@@ -167724,6 +167736,24 @@
     {
       "community": 1120,
       "file_type": "code",
+      "id": "customerobservabilitytimeline_test_createanalyticsevent",
+      "label": "createAnalyticsEvent()",
+      "norm_label": "createanalyticsevent()",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 1120,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
+      "label": "customerObservabilityTimeline.test.ts",
+      "norm_label": "customerobservabilitytimeline.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/customerObservabilityTimeline.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1121,
+      "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
       "norm_label": "readprojectfile()",
@@ -167731,7 +167761,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1120,
+      "community": 1121,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -167740,7 +167770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -167749,7 +167779,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1121,
+      "community": 1122,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -167758,7 +167788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "homepagesnapshot_test_sku",
       "label": "sku()",
@@ -167767,7 +167797,7 @@
       "source_location": "L50"
     },
     {
-      "community": 1122,
+      "community": 1123,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_homepagesnapshot_test_ts",
       "label": "homepageSnapshot.test.ts",
@@ -167776,7 +167806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_payment_test_ts",
       "label": "payment.test.ts",
@@ -167785,7 +167815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1123,
+      "community": 1124,
       "file_type": "code",
       "id": "payment_test_gethandler",
       "label": "getHandler()",
@@ -167794,7 +167824,7 @@
       "source_location": "L38"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
@@ -167803,7 +167833,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1124,
+      "community": 1125,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -167812,7 +167842,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -167821,7 +167851,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1125,
+      "community": 1126,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -167830,7 +167860,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -167839,7 +167869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1126,
+      "community": 1127,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -167848,7 +167878,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -167857,7 +167887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1127,
+      "community": 1128,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -167866,7 +167896,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -167875,31 +167905,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1128,
+      "community": 1129,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
       "norm_label": "issyntheticmonitororigin()",
       "source_file": "packages/athena-webapp/convex/storeFront/syntheticMonitor.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
-      "label": "timeQueryRefactors.test.ts",
-      "norm_label": "timequeryrefactors.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1129,
-      "file_type": "code",
-      "id": "timequeryrefactors_test_readsource",
-      "label": "readSource()",
-      "norm_label": "readsource()",
-      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
-      "source_location": "L5"
     },
     {
       "community": 113,
@@ -168057,6 +168069,24 @@
     {
       "community": 1130,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
+      "label": "timeQueryRefactors.test.ts",
+      "norm_label": "timequeryrefactors.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1130,
+      "file_type": "code",
+      "id": "timequeryrefactors_test_readsource",
+      "label": "readSource()",
+      "norm_label": "readsource()",
+      "source_file": "packages/athena-webapp/convex/storeFront/timeQueryRefactors.test.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 1131,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
       "norm_label": "useroffers.ts",
@@ -168064,7 +168094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1130,
+      "community": 1131,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -168073,7 +168103,7 @@
       "source_location": "L30"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "ensuretimezoneauthority_test_createctx",
       "label": "createCtx()",
@@ -168082,7 +168112,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1131,
+      "community": 1132,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_ensuretimezoneauthority_test_ts",
       "label": "ensureTimezoneAuthority.test.ts",
@@ -168091,7 +168121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "operatingperiods_test_schedule",
       "label": "schedule()",
@@ -168100,7 +168130,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1132,
+      "community": 1133,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_operatingperiods_test_ts",
       "label": "operatingPeriods.test.ts",
@@ -168109,7 +168139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "expensesession_buildexpensesessiontraceseed",
       "label": "buildExpenseSessionTraceSeed()",
@@ -168118,7 +168148,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1133,
+      "community": 1134,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
       "label": "expenseSession.ts",
@@ -168127,7 +168157,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "onlineorder_test_buildorder",
       "label": "buildOrder()",
@@ -168136,7 +168166,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1134,
+      "community": 1135,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
@@ -168145,7 +168175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "orderreturnexchange_test_buildorder",
       "label": "buildOrder()",
@@ -168154,7 +168184,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1135,
+      "community": 1136,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_orderreturnexchange_test_ts",
       "label": "orderReturnExchange.test.ts",
@@ -168163,7 +168193,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -168172,7 +168202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1136,
+      "community": 1137,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -168181,7 +168211,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -168190,7 +168220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1137,
+      "community": 1138,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -168199,7 +168229,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -168208,31 +168238,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1138,
+      "community": 1139,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
       "norm_label": "gettableindexes()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/schemaIndexes.test.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "capabilitytypes_isathenaintelligencecapability",
-      "label": "isAthenaIntelligenceCapability()",
-      "norm_label": "isathenaintelligencecapability()",
-      "source_file": "packages/athena-webapp/shared/intelligence/capabilityTypes.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 1139,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_intelligence_capabilitytypes_ts",
-      "label": "capabilityTypes.ts",
-      "norm_label": "capabilitytypes.ts",
-      "source_file": "packages/athena-webapp/shared/intelligence/capabilityTypes.ts",
-      "source_location": "L1"
     },
     {
       "community": 114,
@@ -168381,6 +168393,24 @@
     {
       "community": 1140,
       "file_type": "code",
+      "id": "capabilitytypes_isathenaintelligencecapability",
+      "label": "isAthenaIntelligenceCapability()",
+      "norm_label": "isathenaintelligencecapability()",
+      "source_file": "packages/athena-webapp/shared/intelligence/capabilityTypes.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 1140,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_intelligence_capabilitytypes_ts",
+      "label": "capabilityTypes.ts",
+      "norm_label": "capabilitytypes.ts",
+      "source_file": "packages/athena-webapp/shared/intelligence/capabilityTypes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1141,
+      "file_type": "code",
       "id": "contexttracking_createcontexttracker",
       "label": "createContextTracker()",
       "norm_label": "createcontexttracker()",
@@ -168388,7 +168418,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1140,
+      "community": 1141,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contexttracking_ts",
       "label": "contextTracking.ts",
@@ -168397,7 +168427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_posterminalregistrationerror_ts",
       "label": "posTerminalRegistrationError.ts",
@@ -168406,7 +168436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1141,
+      "community": 1142,
       "file_type": "code",
       "id": "posterminalregistrationerror_isposregisternumberconflict",
       "label": "isPosRegisterNumberConflict()",
@@ -168415,7 +168445,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_reviewreasonformatter_ts",
       "label": "reviewReasonFormatter.ts",
@@ -168424,7 +168454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1142,
+      "community": 1143,
       "file_type": "code",
       "id": "reviewreasonformatter_formatstoredreviewreason",
       "label": "formatStoredReviewReason()",
@@ -168433,7 +168463,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
@@ -168442,7 +168472,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1143,
+      "community": 1144,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -168451,7 +168481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_shareddemoactionerror_ts",
       "label": "sharedDemoActionError.ts",
@@ -168460,7 +168490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1144,
+      "community": 1145,
       "file_type": "code",
       "id": "shareddemoactionerror_isshareddemoactiondenieddata",
       "label": "isSharedDemoActionDeniedData()",
@@ -168469,7 +168499,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_shareddemoregistererror_ts",
       "label": "sharedDemoRegisterError.ts",
@@ -168478,7 +168508,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1145,
+      "community": 1146,
       "file_type": "code",
       "id": "shareddemoregistererror_isshareddemoregisterunavailableerror",
       "label": "isSharedDemoRegisterUnavailableError()",
@@ -168487,7 +168517,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "convexauthurl_removeconvexauthcodeparamfromurl",
       "label": "removeConvexAuthCodeParamFromUrl()",
@@ -168496,7 +168526,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1146,
+      "community": 1147,
       "file_type": "code",
       "id": "packages_athena_webapp_src_auth_convexauthurl_ts",
       "label": "convexAuthUrl.ts",
@@ -168505,7 +168535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -168514,7 +168544,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1147,
+      "community": 1148,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -168523,7 +168553,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -168532,31 +168562,13 @@
       "source_location": "L12"
     },
     {
-      "community": 1148,
+      "community": 1149,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
       "norm_label": "organizationsview.tsx",
       "source_file": "packages/athena-webapp/src/components/OrganizationsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
-      "label": "PermissionGate.tsx",
-      "norm_label": "permissiongate.tsx",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1149,
-      "file_type": "code",
-      "id": "permissiongate_permissiongate",
-      "label": "PermissionGate()",
-      "norm_label": "permissiongate()",
-      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
-      "source_location": "L11"
     },
     {
       "community": 115,
@@ -168705,6 +168717,24 @@
     {
       "community": 1150,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_permissiongate_tsx",
+      "label": "PermissionGate.tsx",
+      "norm_label": "permissiongate.tsx",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1150,
+      "file_type": "code",
+      "id": "permissiongate_permissiongate",
+      "label": "PermissionGate()",
+      "norm_label": "permissiongate()",
+      "source_file": "packages/athena-webapp/src/components/PermissionGate.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 1151,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
       "norm_label": "protectedroute.tsx",
@@ -168712,7 +168742,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1150,
+      "community": 1151,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
@@ -168721,7 +168751,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_settingsview_tsx",
       "label": "SettingsView.tsx",
@@ -168730,7 +168760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1151,
+      "community": 1152,
       "file_type": "code",
       "id": "settingsview_settingsview",
       "label": "SettingsView()",
@@ -168739,7 +168769,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
@@ -168748,7 +168778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1152,
+      "community": 1153,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -168757,7 +168787,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -168766,7 +168796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1153,
+      "community": 1154,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -168775,7 +168805,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -168784,7 +168814,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1154,
+      "community": 1155,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -168793,7 +168823,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -168802,7 +168832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1155,
+      "community": 1156,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -168811,7 +168841,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -168820,7 +168850,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -168829,7 +168859,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -168838,7 +168868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -168847,7 +168877,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -168856,31 +168886,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
       "norm_label": "productavailabilitytogglegroup()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductAvailabilityToggleGroup.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
-      "label": "ProductDetails.tsx",
-      "norm_label": "productdetails.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "productdetails_handlenamechange",
-      "label": "handleNameChange()",
-      "norm_label": "handlenamechange()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
-      "source_location": "L9"
     },
     {
       "community": 116,
@@ -169029,6 +169041,24 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
+      "label": "ProductDetails.tsx",
+      "norm_label": "productdetails.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1160,
+      "file_type": "code",
+      "id": "productdetails_handlenamechange",
+      "label": "handleNameChange()",
+      "norm_label": "handlenamechange()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductDetails.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
       "norm_label": "productimages.tsx",
@@ -169036,7 +169066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1160,
+      "community": 1161,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
@@ -169045,7 +169075,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
       "label": "ProductPage.tsx",
@@ -169054,7 +169084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "productpage_productpage",
       "label": "ProductPage()",
@@ -169063,7 +169093,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "copyimagesview_buildcopyimagesskuupdate",
       "label": "buildCopyImagesSkuUpdate()",
@@ -169072,7 +169102,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -169081,7 +169111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -169090,7 +169120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -169099,7 +169129,7 @@
       "source_location": "L47"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_taxonomyselectlabels_ts",
       "label": "taxonomySelectLabels.ts",
@@ -169108,7 +169138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "taxonomyselectlabels_formattaxonomyselectoptionlabel",
       "label": "formatTaxonomySelectOptionLabel()",
@@ -169117,7 +169147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -169126,7 +169156,7 @@
       "source_location": "L151"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -169135,7 +169165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -169144,7 +169174,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -169153,7 +169183,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -169162,7 +169192,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -169171,7 +169201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -169180,30 +169210,12 @@
       "source_location": "L13"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
       "norm_label": "analyticsproducts.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsProducts.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "analyticsusers_analyticsusers",
-      "label": "AnalyticsUsers()",
-      "norm_label": "analyticsusers()",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
-      "label": "AnalyticsUsers.tsx",
-      "norm_label": "analyticsusers.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
       "source_location": "L1"
     },
     {
@@ -169353,6 +169365,24 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "analyticsusers_analyticsusers",
+      "label": "AnalyticsUsers()",
+      "norm_label": "analyticsusers()",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 1170,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
+      "label": "AnalyticsUsers.tsx",
+      "norm_label": "analyticsusers.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/AnalyticsUsers.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
       "norm_label": "getdaterangemilliseconds()",
@@ -169360,7 +169390,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1170,
+      "community": 1171,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
@@ -169369,7 +169399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_storeinsights_test_tsx",
       "label": "StoreInsights.test.tsx",
@@ -169378,7 +169408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "storeinsights_test_renderwithqueries",
       "label": "renderWithQueries()",
@@ -169387,7 +169417,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
@@ -169396,7 +169426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -169405,7 +169435,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "analyticsworkspaceefficiency_test_readsource",
       "label": "readSource()",
@@ -169414,7 +169444,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsworkspaceefficiency_test_ts",
       "label": "analyticsWorkspaceEfficiency.test.ts",
@@ -169423,7 +169453,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -169432,7 +169462,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -169441,7 +169471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -169450,7 +169480,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -169459,7 +169489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -169468,7 +169498,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -169477,7 +169507,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -169486,7 +169516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -169495,7 +169525,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "appmessagehost_cn",
       "label": "cn()",
@@ -169504,30 +169534,12 @@
       "source_location": "L99"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_messages_appmessagehost_tsx",
       "label": "AppMessageHost.tsx",
       "norm_label": "appmessagehost.tsx",
       "source_file": "packages/athena-webapp/src/components/app-messages/AppMessageHost.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "appsettingsview_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/app-settings/AppSettingsView.tsx",
-      "source_location": "L84"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_tsx",
-      "label": "AppSettingsView.tsx",
-      "norm_label": "appsettingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/app-settings/AppSettingsView.tsx",
       "source_location": "L1"
     },
     {
@@ -169677,6 +169689,24 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "appsettingsview_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/app-settings/AppSettingsView.tsx",
+      "source_location": "L84"
+    },
+    {
+      "community": 1180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_tsx",
+      "label": "AppSettingsView.tsx",
+      "norm_label": "appsettingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/app-settings/AppSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
       "norm_label": "auth()",
@@ -169684,7 +169714,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1180,
+      "community": 1181,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -169693,7 +169723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "inputotp_test_resolvesignin",
       "label": "resolveSignIn()",
@@ -169702,7 +169732,7 @@
       "source_location": "L123"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
@@ -169711,7 +169741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "loginform_isemailnotapprovederror",
       "label": "isEmailNotApprovedError()",
@@ -169720,7 +169750,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
       "label": "LoginForm.tsx",
@@ -169729,7 +169759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "index_test_expectpendingauthsyncredirect",
       "label": "expectPendingAuthSyncRedirect()",
@@ -169738,7 +169768,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_test_tsx",
       "label": "index.test.tsx",
@@ -169747,7 +169777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "data_table_column_header_datatablecolumnheader",
       "label": "DataTableColumnHeader()",
@@ -169756,7 +169786,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -169765,7 +169795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -169774,7 +169804,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -169783,7 +169813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -169792,7 +169822,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -169801,7 +169831,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -169810,7 +169840,7 @@
       "source_location": "L50"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -169819,7 +169849,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "formatreviewreason_formatreviewreason",
       "label": "formatReviewReason()",
@@ -169828,31 +169858,13 @@
       "source_location": "L4"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
       "label": "formatReviewReason.ts",
       "norm_label": "formatreviewreason.ts",
       "source_file": "packages/athena-webapp/src/components/cash-controls/formatReviewReason.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
-      "label": "registerSessionColumns.tsx",
-      "norm_label": "registersessioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/registerSessionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "registersessioncolumns_registersessionlink",
-      "label": "RegisterSessionLink()",
-      "norm_label": "registersessionlink()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/registerSessionColumns.tsx",
-      "source_location": "L33"
     },
     {
       "community": 119,
@@ -170001,6 +170013,24 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
+      "label": "registerSessionColumns.tsx",
+      "norm_label": "registersessioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/registerSessionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1190,
+      "file_type": "code",
+      "id": "registersessioncolumns_registersessionlink",
+      "label": "RegisterSessionLink()",
+      "norm_label": "registersessionlink()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/registerSessionColumns.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
       "norm_label": "checkoutsessionstable()",
@@ -170008,7 +170038,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1190,
+      "community": 1191,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -170017,7 +170047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -170026,7 +170056,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
@@ -170035,7 +170065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "animateddatastate_animateddatastate",
       "label": "AnimatedDataState()",
@@ -170044,7 +170074,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_animateddatastate_tsx",
       "label": "AnimatedDataState.tsx",
@@ -170053,7 +170083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "animatedheight_animatedheight",
       "label": "AnimatedHeight()",
@@ -170062,7 +170092,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_animatedheight_tsx",
       "label": "AnimatedHeight.tsx",
@@ -170071,7 +170101,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "financialvalue_financialvalue",
       "label": "FinancialValue()",
@@ -170080,7 +170110,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_financialvalue_tsx",
       "label": "FinancialValue.tsx",
@@ -170089,7 +170119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_registersessionidentity_tsx",
       "label": "RegisterSessionIdentity.tsx",
@@ -170098,7 +170128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "registersessionidentity_registersessionidentity",
       "label": "RegisterSessionIdentity()",
@@ -170107,7 +170137,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_registersessionidentitypresentation_ts",
       "label": "registerSessionIdentityPresentation.ts",
@@ -170116,7 +170146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "registersessionidentitypresentation_formatregisterheadername",
       "label": "formatRegisterHeaderName()",
@@ -170125,7 +170155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "expenseview_expenseview",
       "label": "ExpenseView()",
@@ -170134,7 +170164,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
       "label": "ExpenseView.tsx",
@@ -170143,7 +170173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "bestsellersdialog_bestsellersdialog",
       "label": "BestSellersDialog()",
@@ -170152,30 +170182,12 @@
       "source_location": "L7"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
       "norm_label": "bestsellersdialog.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/BestSellersDialog.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "featuredsectiondialog_featuredsectiondialog",
-      "label": "FeaturedSectionDialog()",
-      "norm_label": "featuredsectiondialog()",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
-      "label": "FeaturedSectionDialog.tsx",
-      "norm_label": "featuredsectiondialog.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
       "source_location": "L1"
     },
     {
@@ -170748,6 +170760,24 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "featuredsectiondialog_featuredsectiondialog",
+      "label": "FeaturedSectionDialog()",
+      "norm_label": "featuredsectiondialog()",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 1200,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
+      "label": "FeaturedSectionDialog.tsx",
+      "norm_label": "featuredsectiondialog.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSectionDialog.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
       "norm_label": "handleupdateconfig()",
@@ -170755,7 +170785,7 @@
       "source_location": "L83"
     },
     {
-      "community": 1200,
+      "community": 1201,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -170764,7 +170794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -170773,7 +170803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "shoplookdialog_shoplookdialog",
       "label": "ShopLookDialog()",
@@ -170782,7 +170812,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_intelligence_readoutsupport_tsx",
       "label": "ReadoutSupport.tsx",
@@ -170791,7 +170821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "readoutsupport_readouttrustmetadata",
       "label": "ReadoutTrustMetadata()",
@@ -170800,7 +170830,7 @@
       "source_location": "L90"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -170809,7 +170839,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -170818,7 +170848,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "landinggrain_landinggrain",
       "label": "LandingGrain()",
@@ -170827,7 +170857,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_landinggrain_tsx",
       "label": "LandingGrain.tsx",
@@ -170836,7 +170866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "automationrevealscene_automationrevealscene",
       "label": "AutomationRevealScene()",
@@ -170845,7 +170875,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_automationrevealscene_tsx",
       "label": "AutomationRevealScene.tsx",
@@ -170854,7 +170884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "cashcontrolsscene_cashcontrolsscene",
       "label": "CashControlsScene()",
@@ -170863,7 +170893,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_cashcontrolsscene_tsx",
       "label": "CashControlsScene.tsx",
@@ -170872,7 +170902,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_poshubroleswitcher_tsx",
       "label": "PosHubRoleSwitcher.tsx",
@@ -170881,7 +170911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "poshubroleswitcher_poshubroleswitcher",
       "label": "PosHubRoleSwitcher()",
@@ -170890,7 +170920,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_syncbridgescene_tsx",
       "label": "SyncBridgeScene.tsx",
@@ -170899,31 +170929,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "syncbridgescene_syncbridgescene",
       "label": "SyncBridgeScene()",
       "norm_label": "syncbridgescene()",
       "source_file": "packages/athena-webapp/src/components/landing/story/SyncBridgeScene.tsx",
       "source_location": "L21"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "demoday_formatdemomoney",
-      "label": "formatDemoMoney()",
-      "norm_label": "formatdemomoney()",
-      "source_file": "packages/athena-webapp/src/components/landing/story/demoDay.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_landing_story_demoday_ts",
-      "label": "demoDay.ts",
-      "norm_label": "demoday.ts",
-      "source_file": "packages/athena-webapp/src/components/landing/story/demoDay.ts",
-      "source_location": "L1"
     },
     {
       "community": 121,
@@ -171072,6 +171084,24 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "demoday_formatdemomoney",
+      "label": "formatDemoMoney()",
+      "norm_label": "formatdemomoney()",
+      "source_file": "packages/athena-webapp/src/components/landing/story/demoDay.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 1210,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_landing_story_demoday_ts",
+      "label": "demoDay.ts",
+      "norm_label": "demoday.ts",
+      "source_file": "packages/athena-webapp/src/components/landing/story/demoDay.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
       "id": "demodayfixtures_storytime",
       "label": "storyTime()",
       "norm_label": "storytime()",
@@ -171079,7 +171109,7 @@
       "source_location": "L47"
     },
     {
-      "community": 1210,
+      "community": 1211,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_demodayfixtures_ts",
       "label": "demoDayFixtures.ts",
@@ -171088,7 +171118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_uselandingtheme_ts",
       "label": "useLandingTheme.ts",
@@ -171097,7 +171127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "uselandingtheme_uselandingtheme",
       "label": "useLandingTheme()",
@@ -171106,7 +171136,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "inventorycostoverlayview_test_renderworkspace",
       "label": "renderWorkspace()",
@@ -171115,7 +171145,7 @@
       "source_location": "L226"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_inventorycostoverlayview_test_tsx",
       "label": "InventoryCostOverlayView.test.tsx",
@@ -171124,7 +171154,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "operationreviewitemcard_operationreviewitemcard",
       "label": "OperationReviewItemCard()",
@@ -171133,7 +171163,7 @@
       "source_location": "L33"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewitemcard_tsx",
       "label": "OperationReviewItemCard.tsx",
@@ -171142,7 +171172,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "operationssummarymetric_buildparams",
       "label": "buildParams()",
@@ -171151,7 +171181,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationssummarymetric_tsx",
       "label": "OperationsSummaryMetric.tsx",
@@ -171160,7 +171190,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "approvalrequesterbinding_toapprovalrequesterbindingarg",
       "label": "toApprovalRequesterBindingArg()",
@@ -171169,7 +171199,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_approvalrequesterbinding_ts",
       "label": "approvalRequesterBinding.ts",
@@ -171178,7 +171208,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "emailstatusview_handlesendorderemail",
       "label": "handleSendOrderEmail()",
@@ -171187,7 +171217,7 @@
       "source_location": "L40"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
       "label": "EmailStatusView.tsx",
@@ -171196,7 +171226,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
@@ -171205,7 +171235,7 @@
       "source_location": "L41"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -171214,7 +171244,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "orders_orders",
       "label": "Orders()",
@@ -171223,30 +171253,12 @@
       "source_location": "L13"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
       "norm_label": "orders.tsx",
       "source_file": "packages/athena-webapp/src/components/orders/Orders.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "ordersview_ordersview",
-      "label": "OrdersView()",
-      "norm_label": "ordersview()",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
-      "source_location": "L33"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
-      "label": "OrdersView.tsx",
-      "norm_label": "ordersview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
       "source_location": "L1"
     },
     {
@@ -171396,6 +171408,24 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "ordersview_ordersview",
+      "label": "OrdersView()",
+      "norm_label": "ordersview()",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L33"
+    },
+    {
+      "community": 1220,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
+      "label": "OrdersView.tsx",
+      "norm_label": "ordersview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/OrdersView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
       "norm_label": "refundsview.tsx",
@@ -171403,7 +171433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1220,
+      "community": 1221,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -171412,7 +171442,7 @@
       "source_location": "L81"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -171421,7 +171451,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -171430,7 +171460,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "ordercustomercell_ordercustomercell",
       "label": "OrderCustomerCell()",
@@ -171439,7 +171469,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercustomercell_tsx",
       "label": "OrderCustomerCell.tsx",
@@ -171448,7 +171478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -171457,7 +171487,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -171466,7 +171496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -171475,7 +171505,7 @@
       "source_location": "L87"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -171484,7 +171514,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "organization_switcher_organizationswitcher",
       "label": "OrganizationSwitcher()",
@@ -171493,7 +171523,7 @@
       "source_location": "L33"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
@@ -171502,7 +171532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "cartitems_test_buildserviceline",
       "label": "buildServiceLine()",
@@ -171511,7 +171541,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cartitems_test_tsx",
       "label": "CartItems.test.tsx",
@@ -171520,7 +171550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
@@ -171529,7 +171559,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -171538,7 +171568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -171547,31 +171577,13 @@
       "source_location": "L7"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
       "norm_label": "noresultsmessage.tsx",
       "source_file": "packages/athena-webapp/src/components/pos/NoResultsMessage.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
-      "label": "PinInput.tsx",
-      "norm_label": "pininput.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "pininput_pininput",
-      "label": "PinInput()",
-      "norm_label": "pininput()",
-      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
-      "source_location": "L14"
     },
     {
       "community": 123,
@@ -171720,6 +171732,24 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
+      "label": "PinInput.tsx",
+      "norm_label": "pininput.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1230,
+      "file_type": "code",
+      "id": "pininput_pininput",
+      "label": "PinInput()",
+      "norm_label": "pininput()",
+      "source_file": "packages/athena-webapp/src/components/pos/PinInput.tsx",
+      "source_location": "L14"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posclienttelemetryhost_tsx",
       "label": "PosClientTelemetryHost.tsx",
       "norm_label": "posclienttelemetryhost.tsx",
@@ -171727,7 +171757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1230,
+      "community": 1231,
       "file_type": "code",
       "id": "posclienttelemetryhost_posclienttelemetryhost",
       "label": "PosClientTelemetryHost()",
@@ -171736,7 +171766,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -171745,7 +171775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -171754,7 +171784,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
@@ -171763,7 +171793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -171772,7 +171802,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -171781,7 +171811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -171790,7 +171820,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "expensereportview_handleprintreceipt",
       "label": "handlePrintReceipt()",
@@ -171799,7 +171829,7 @@
       "source_location": "L95"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -171808,7 +171838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "expensereportrows_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -171817,7 +171847,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportrows_ts",
       "label": "expenseReportRows.ts",
@@ -171826,7 +171856,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "expensecompletionpanel_test_buildcheckout",
       "label": "buildCheckout()",
@@ -171835,7 +171865,7 @@
       "source_location": "L41"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_test_tsx",
       "label": "ExpenseCompletionPanel.test.tsx",
@@ -171844,7 +171874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
@@ -171853,7 +171883,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "posregisterview_test_pressdebugpanelshortcut",
       "label": "pressDebugPanelShortcut()",
@@ -171862,7 +171892,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -171871,31 +171901,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "registercheckoutpanel_registercheckoutpanel",
       "label": "RegisterCheckoutPanel()",
       "norm_label": "registercheckoutpanel()",
       "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx",
       "source_location": "L26"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
-      "label": "RegisterCustomerAttribution.test.tsx",
-      "norm_label": "registercustomerattribution.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "registercustomerattribution_test_makecustomer",
-      "label": "makeCustomer()",
-      "norm_label": "makecustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
-      "source_location": "L28"
     },
     {
       "community": 124,
@@ -172044,6 +172056,24 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
+      "label": "RegisterCustomerAttribution.test.tsx",
+      "norm_label": "registercustomerattribution.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1240,
+      "file_type": "code",
+      "id": "registercustomerattribution_test_makecustomer",
+      "label": "makeCustomer()",
+      "norm_label": "makecustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
       "norm_label": "registercustomerpanel.tsx",
@@ -172051,7 +172081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1240,
+      "community": 1241,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -172060,7 +172090,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
       "label": "RegisterDrawerGate.test.tsx",
@@ -172069,7 +172099,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "registerdrawergate_test_rendergate",
       "label": "renderGate()",
@@ -172078,7 +172108,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -172087,7 +172117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -172096,7 +172126,7 @@
       "source_location": "L70"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -172105,7 +172135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -172114,7 +172144,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sales_pulse_possalespulseview_tsx",
       "label": "POSSalesPulseView.tsx",
@@ -172123,7 +172153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "possalespulseview_posstorepulsesection",
       "label": "POSStorePulseSection()",
@@ -172132,7 +172162,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_posterminalhealthview_test_tsx",
       "label": "POSTerminalHealthView.test.tsx",
@@ -172141,7 +172171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "posterminalhealthview_test_basesummary_attentionreasons_source_terminal_runtime_summary_terminal_setup_needs_repair_before_this_checkout_station_can_record_new_sales_type_terminal_seed_missing_health_needs_attention_recovery_commandstatus_commandtype_repair_terminal_seed_label_terminal_setup_repair_status_completed_verificationstatus_verified_readiness_needs_terminal_action_terminalactions_commandcontext_expectedblockertype_terminal_seed_commandtype_repair_terminal_seed_expectedevidence_terminalintegritystatus_healthy_reason_terminal_setup_data_needs_repair",
       "label": "[\n          {\n            ...baseSummary,\n            attentionReasons: [\n              {\n                source: \"terminal_runtime\",\n                summary:\n                  \"Terminal setup needs repair before this checkout station can record new sales.\",\n                type: \"terminal_seed_missing\",\n              },\n            ],\n            health: \"needs_attention\",\n            recovery: {\n              commandStatus: {\n                commandType: \"repair_terminal_seed\",\n                label: \"Terminal setup repair\",\n                status: \"completed\",\n                verificationStatus: \"verified\",\n              },\n              readiness: \"needs_terminal_action\",\n              terminalActions: [\n                {\n                  commandContext: {\n                    expectedBlockerType: \"terminal_seed\",\n                  },\n                  commandType: \"repair_terminal_seed\",\n                  expectedEvidence: {\n                    terminalIntegrityStatus: \"healthy\",\n                  },\n                  reason: \"Terminal setup data needs repair.\",\n                },\n              ],\n            },\n          },\n        ]()",
@@ -172150,7 +172180,7 @@
       "source_location": "L608"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_posterminalhealthview_tsx",
       "label": "POSTerminalHealthView.tsx",
@@ -172159,7 +172189,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "posterminalhealthview_countmetric",
       "label": "CountMetric()",
@@ -172168,7 +172198,7 @@
       "source_location": "L77"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_posclienterrorspanel_test_tsx",
       "label": "PosClientErrorsPanel.test.tsx",
@@ -172177,7 +172207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "posclienterrorspanel_test_buildevent",
       "label": "buildEvent()",
@@ -172186,7 +172216,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -172195,31 +172225,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
       "norm_label": "rendertransactioncell()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.test.tsx",
       "source_location": "L34"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
-      "label": "transactionColumns.tsx",
-      "norm_label": "transactioncolumns.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "transactioncolumns_getpaymentmethodicon",
-      "label": "getPaymentMethodIcon()",
-      "norm_label": "getpaymentmethodicon()",
-      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
-      "source_location": "L30"
     },
     {
       "community": 125,
@@ -172368,6 +172380,24 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
+      "label": "transactionColumns.tsx",
+      "norm_label": "transactioncolumns.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1250,
+      "file_type": "code",
+      "id": "transactioncolumns_getpaymentmethodicon",
+      "label": "getPaymentMethodIcon()",
+      "norm_label": "getpaymentmethodicon()",
+      "source_file": "packages/athena-webapp/src/components/pos/transactions/transactionColumns.tsx",
+      "source_location": "L30"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
       "norm_label": "barcodeview()",
@@ -172375,7 +172405,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1250,
+      "community": 1251,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -172384,7 +172414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -172393,7 +172423,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -172402,7 +172432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -172411,7 +172441,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -172420,7 +172450,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -172429,7 +172459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "productdetailview_productdetailviewheader",
       "label": "ProductDetailViewHeader()",
@@ -172438,7 +172468,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -172447,7 +172477,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
@@ -172456,7 +172486,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstockpresentation_ts",
       "label": "productStockPresentation.ts",
@@ -172465,7 +172495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "productstockpresentation_productstocktextclass",
       "label": "productStockTextClass()",
@@ -172474,7 +172504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
@@ -172483,7 +172513,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "product_actions_usearchiveproduct",
       "label": "useArchiveProduct()",
@@ -172492,7 +172522,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "archivedproducts_archivedproductstoolbar",
       "label": "ArchivedProductsToolbar()",
@@ -172501,7 +172531,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_archivedproducts_tsx",
       "label": "ArchivedProducts.tsx",
@@ -172510,7 +172540,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "categorylistview_categorylistview",
       "label": "CategoryListView()",
@@ -172519,31 +172549,13 @@
       "source_location": "L5"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
       "norm_label": "categorylistview.tsx",
       "source_file": "packages/athena-webapp/src/components/products/CategoryListView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
-      "label": "ProductsView.tsx",
-      "norm_label": "productsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "productsview_productsview",
-      "label": "ProductsView()",
-      "norm_label": "productsview()",
-      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
-      "source_location": "L5"
     },
     {
       "community": 126,
@@ -172692,6 +172704,24 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_products_productsview_tsx",
+      "label": "ProductsView.tsx",
+      "norm_label": "productsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1260,
+      "file_type": "code",
+      "id": "productsview_productsview",
+      "label": "ProductsView()",
+      "norm_label": "productsview()",
+      "source_file": "packages/athena-webapp/src/components/products/ProductsView.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_producttaxonomycells_tsx",
       "label": "ProductTaxonomyCells.tsx",
       "norm_label": "producttaxonomycells.tsx",
@@ -172699,7 +172729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1260,
+      "community": 1261,
       "file_type": "code",
       "id": "producttaxonomycells_productcategorycell",
       "label": "ProductCategoryCell()",
@@ -172708,7 +172738,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -172717,7 +172747,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -172726,7 +172756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -172735,7 +172765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -172744,7 +172774,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -172753,7 +172783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -172762,7 +172792,7 @@
       "source_location": "L82"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -172771,7 +172801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
@@ -172780,7 +172810,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
       "label": "PromoCodePreview.tsx",
@@ -172789,7 +172819,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "promocodepreview_discount",
       "label": "Discount()",
@@ -172798,7 +172828,7 @@
       "source_location": "L37"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_test_tsx",
       "label": "PromoCodesView.test.tsx",
@@ -172807,7 +172837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "promocodesview_test_readsource",
       "label": "readSource()",
@@ -172816,7 +172846,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -172825,7 +172855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -172834,7 +172864,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -172843,31 +172873,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
       "norm_label": "toggle()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/SelectableCategories.tsx",
       "source_location": "L23"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "discounttypetogglegroup_discounttypetogglegroup",
-      "label": "DiscountTypeToggleGroup()",
-      "norm_label": "discounttypetogglegroup()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
-      "source_location": "L5"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
-      "label": "DiscountTypeToggleGroup.tsx",
-      "norm_label": "discounttypetogglegroup.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
-      "source_location": "L1"
     },
     {
       "community": 127,
@@ -173016,6 +173028,24 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "discounttypetogglegroup_discounttypetogglegroup",
+      "label": "DiscountTypeToggleGroup()",
+      "norm_label": "discounttypetogglegroup()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
+      "source_location": "L5"
+    },
+    {
+      "community": 1270,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
+      "label": "DiscountTypeToggleGroup.tsx",
+      "norm_label": "discounttypetogglegroup.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/add-promo-code/DiscountTypeToggleGroup.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
       "norm_label": "promocodespantogglegroup.tsx",
@@ -173023,7 +173053,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1270,
+      "community": 1271,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -173032,7 +173062,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -173041,7 +173071,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -173050,7 +173080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -173059,7 +173089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -173068,7 +173098,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistliveviewer_tsx",
       "label": "RemoteAssistLiveViewer.tsx",
@@ -173077,7 +173107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "remoteassistliveviewer_async",
       "label": "async()",
@@ -173086,7 +173116,7 @@
       "source_location": "L243"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistruntimeshell_tsx",
       "label": "RemoteAssistRuntimeShell.tsx",
@@ -173095,7 +173125,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "remoteassistruntimeshell_handledisconnect",
       "label": "handleDisconnect()",
@@ -173104,7 +173134,7 @@
       "source_location": "L38"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportbacklink_tsx",
       "label": "ReportBackLink.tsx",
@@ -173113,7 +173143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "reportbacklink_reportbacklink",
       "label": "ReportBackLink()",
@@ -173122,7 +173152,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportdayspanel_test_tsx",
       "label": "ReportDaysPanel.test.tsx",
@@ -173131,7 +173161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "reportdayspanel_test_constructor",
       "label": "constructor()",
@@ -173140,7 +173170,7 @@
       "source_location": "L676"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportfreshness_tsx",
       "label": "ReportFreshness.tsx",
@@ -173149,7 +173179,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "reportfreshness_reportfreshness",
       "label": "ReportFreshness()",
@@ -173158,7 +173188,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reporttrendchart_test_tsx",
       "label": "ReportTrendChart.test.tsx",
@@ -173167,31 +173197,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "reporttrendchart_test_labelformatter",
       "label": "labelFormatter()",
       "norm_label": "labelformatter()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportTrendChart.test.tsx",
       "source_location": "L51"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reporttruststrip_tsx",
-      "label": "ReportTrustStrip.tsx",
-      "norm_label": "reporttruststrip.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportTrustStrip.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "reporttruststrip_reporttruststrip",
-      "label": "ReportTrustStrip()",
-      "norm_label": "reporttruststrip()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportTrustStrip.tsx",
-      "source_location": "L9"
     },
     {
       "community": 128,
@@ -173340,6 +173352,24 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reporttruststrip_tsx",
+      "label": "ReportTrustStrip.tsx",
+      "norm_label": "reporttruststrip.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportTrustStrip.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1280,
+      "file_type": "code",
+      "id": "reporttruststrip_reporttruststrip",
+      "label": "ReportTrustStrip()",
+      "norm_label": "reporttruststrip()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportTrustStrip.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportscataloglookup_test_tsx",
       "label": "ReportsCatalogLookup.test.tsx",
       "norm_label": "reportscataloglookup.test.tsx",
@@ -173347,7 +173377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1280,
+      "community": 1281,
       "file_type": "code",
       "id": "reportscataloglookup_test_result",
       "label": "result()",
@@ -173356,7 +173386,7 @@
       "source_location": "L35"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsitemsperformance_tsx",
       "label": "ReportsItemsPerformance.tsx",
@@ -173365,7 +173395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "reportsitemsperformance_cn",
       "label": "cn()",
@@ -173374,7 +173404,7 @@
       "source_location": "L93"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsitemstable_tsx",
       "label": "ReportsItemsTable.tsx",
@@ -173383,7 +173413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "reportsitemstable_reportsitemstable",
       "label": "ReportsItemsTable()",
@@ -173392,7 +173422,7 @@
       "source_location": "L28"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsitemsview_tsx",
       "label": "ReportsItemsView.tsx",
@@ -173401,7 +173431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "reportsitemsview_handlepagechange",
       "label": "handlePageChange()",
@@ -173410,7 +173440,7 @@
       "source_location": "L62"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportslayout_tsx",
       "label": "ReportsLayout.tsx",
@@ -173419,7 +173449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "reportslayout_cn",
       "label": "cn()",
@@ -173428,7 +173458,7 @@
       "source_location": "L52"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsskudetailview_tsx",
       "label": "ReportsSkuDetailView.tsx",
@@ -173437,7 +173467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "reportsskudetailview_cn",
       "label": "cn()",
@@ -173446,7 +173476,7 @@
       "source_location": "L336"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_usestablereportquery_ts",
       "label": "useStableReportQuery.ts",
@@ -173455,7 +173485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "usestablereportquery_usestablereportquery",
       "label": "useStableReportQuery()",
@@ -173464,7 +173494,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -173473,7 +173503,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -173482,7 +173512,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -173491,31 +173521,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
       "norm_label": "chooseselectoption()",
       "source_file": "packages/athena-webapp/src/components/services/ServiceCasesView.test.tsx",
       "source_location": "L81"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
-      "label": "ServiceCatalogView.test.tsx",
-      "norm_label": "servicecatalogview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "servicecatalogview_test_chooseselectoption",
-      "label": "chooseSelectOption()",
-      "norm_label": "chooseselectoption()",
-      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
-      "source_location": "L60"
     },
     {
       "community": 129,
@@ -173664,6 +173676,24 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
+      "label": "ServiceCatalogView.test.tsx",
+      "norm_label": "servicecatalogview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1290,
+      "file_type": "code",
+      "id": "servicecatalogview_test_chooseselectoption",
+      "label": "chooseSelectOption()",
+      "norm_label": "chooseselectoption()",
+      "source_file": "packages/athena-webapp/src/components/services/ServiceCatalogView.test.tsx",
+      "source_location": "L60"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
       "norm_label": "serviceintakeview.auth.test.tsx",
@@ -173671,7 +173701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1290,
+      "community": 1291,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -173680,7 +173710,7 @@
       "source_location": "L66"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceworkspacedemonotice_tsx",
       "label": "ServiceWorkspaceDemoNotice.tsx",
@@ -173689,7 +173719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "serviceworkspacedemonotice_serviceworkspacedemonotice",
       "label": "ServiceWorkspaceDemoNotice()",
@@ -173698,7 +173728,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_test_tsx",
       "label": "ServicesWorkspaceView.test.tsx",
@@ -173707,7 +173737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "servicesworkspaceview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -173716,7 +173746,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "demonotice_demonotice",
       "label": "DemoNotice()",
@@ -173725,7 +173755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_demonotice_tsx",
       "label": "DemoNotice.tsx",
@@ -173734,7 +173764,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemomanagersigninguidance_tsx",
       "label": "SharedDemoManagerSignInGuidance.tsx",
@@ -173743,7 +173773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "shareddemomanagersigninguidance_shareddemomanagersigninguidance",
       "label": "SharedDemoManagerSignInGuidance()",
@@ -173752,7 +173782,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoownerhome_tsx",
       "label": "SharedDemoOwnerHome.tsx",
@@ -173761,7 +173791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "shareddemoownerhome_shareddemoownerhome",
       "label": "SharedDemoOwnerHome()",
@@ -173770,7 +173800,7 @@
       "source_location": "L57"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestrictedsurface_tsx",
       "label": "SharedDemoRestrictedSurface.tsx",
@@ -173779,7 +173809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "shareddemorestrictedsurface_shareddemorestrictedsurface",
       "label": "SharedDemoRestrictedSurface()",
@@ -173788,7 +173818,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoruntime_test_tsx",
       "label": "SharedDemoRuntime.test.tsx",
@@ -173797,7 +173827,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "shareddemoruntime_test_providerstatusprobe",
       "label": "ProviderStatusProbe()",
@@ -173806,7 +173836,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemostatusbar_tsx",
       "label": "SharedDemoStatusBar.tsx",
@@ -173815,30 +173845,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "shareddemostatusbar_normalizepathname",
       "label": "normalizePathname()",
       "norm_label": "normalizepathname()",
       "source_file": "packages/athena-webapp/src/components/shared-demo/SharedDemoStatusBar.tsx",
-      "source_location": "L8"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemoproviderstatus_ts",
-      "label": "sharedDemoProviderStatus.ts",
-      "norm_label": "shareddemoproviderstatus.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoProviderStatus.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "shareddemoproviderstatus_resolveshareddemoprovidedbootstrapstatus",
-      "label": "resolveSharedDemoProvidedBootstrapStatus()",
-      "norm_label": "resolveshareddemoprovidedbootstrapstatus()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoProviderStatus.ts",
       "source_location": "L8"
     },
     {
@@ -174402,6 +174414,24 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemoproviderstatus_ts",
+      "label": "sharedDemoProviderStatus.ts",
+      "norm_label": "shareddemoproviderstatus.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoProviderStatus.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1300,
+      "file_type": "code",
+      "id": "shareddemoproviderstatus_resolveshareddemoprovidedbootstrapstatus",
+      "label": "resolveSharedDemoProvidedBootstrapStatus()",
+      "norm_label": "resolveshareddemoprovidedbootstrapstatus()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoProviderStatus.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlaymodel_ts",
       "label": "sharedDemoRestoreOverlayModel.ts",
       "norm_label": "shareddemorestoreoverlaymodel.ts",
@@ -174409,7 +174439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1300,
+      "community": 1301,
       "file_type": "code",
       "id": "shareddemorestoreoverlaymodel_resolveshareddemorestoreoverlayphase",
       "label": "resolveSharedDemoRestoreOverlayPhase()",
@@ -174418,7 +174448,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestrictions_ts",
       "label": "sharedDemoRestrictions.ts",
@@ -174427,7 +174457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "shareddemorestrictions_isshareddemorestrictedpath",
       "label": "isSharedDemoRestrictedPath()",
@@ -174436,7 +174466,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoroutes_ts",
       "label": "sharedDemoRoutes.ts",
@@ -174445,7 +174475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "shareddemoroutes_getshareddemoroutes",
       "label": "getSharedDemoRoutes()",
@@ -174454,7 +174484,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoruntimecoordinator_test_ts",
       "label": "sharedDemoRuntimeCoordinator.test.ts",
@@ -174463,7 +174493,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "shareddemoruntimecoordinator_test_deferred",
       "label": "deferred()",
@@ -174472,7 +174502,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmessagesview_tsx",
       "label": "StaffMessagesView.tsx",
@@ -174481,7 +174511,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "staffmessagesview_submit",
       "label": "submit()",
@@ -174490,7 +174520,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffpinpolicy_ts",
       "label": "staffPinPolicy.ts",
@@ -174499,7 +174529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "staffpinpolicy_normalizestaffpin",
       "label": "normalizeStaffPin()",
@@ -174508,7 +174538,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -174517,7 +174547,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -174526,7 +174556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -174535,7 +174565,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -174544,7 +174574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -174553,30 +174583,12 @@
       "source_location": "L4"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
       "norm_label": "nopermissionview.tsx",
       "source_file": "packages/athena-webapp/src/components/states/no-permission/NoPermissionView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "notfoundview_notfoundview",
-      "label": "NotFoundView()",
-      "norm_label": "notfoundview()",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
-      "label": "NotFoundView.tsx",
-      "norm_label": "notfoundview.tsx",
-      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
       "source_location": "L1"
     },
     {
@@ -174717,6 +174729,24 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "notfoundview_notfoundview",
+      "label": "NotFoundView()",
+      "norm_label": "notfoundview()",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 1310,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
+      "label": "NotFoundView.tsx",
+      "norm_label": "notfoundview.tsx",
+      "source_file": "packages/athena-webapp/src/components/states/not-found/NotFoundView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
       "norm_label": "protectedadminsigninview.tsx",
@@ -174724,7 +174754,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1310,
+      "community": 1311,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -174733,7 +174763,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -174742,7 +174772,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -174751,7 +174781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -174760,7 +174790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
@@ -174769,7 +174799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "maintenanceview_maintenanceview",
       "label": "MaintenanceView()",
@@ -174778,7 +174808,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
       "label": "MaintenanceView.tsx",
@@ -174787,7 +174817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -174796,7 +174826,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -174805,7 +174835,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -174814,7 +174844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -174823,7 +174853,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestorescheduleupdate_ts",
       "label": "useStoreScheduleUpdate.ts",
@@ -174832,7 +174862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "usestorescheduleupdate_usestorescheduleupdate",
       "label": "useStoreScheduleUpdate()",
@@ -174841,7 +174871,7 @@
       "source_location": "L86"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -174850,7 +174880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -174859,7 +174889,7 @@
       "source_location": "L63"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -174868,30 +174898,12 @@
       "source_location": "L25"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
       "norm_label": "chart.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "copy_button_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "label": "copy-button.tsx",
-      "norm_label": "copy-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L1"
     },
     {
@@ -175032,6 +175044,24 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "copy_button_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 1320,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
+      "label": "copy-button.tsx",
+      "norm_label": "copy-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
       "norm_label": "handlecopy()",
@@ -175039,7 +175069,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1320,
+      "community": 1321,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -175048,7 +175078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -175057,7 +175087,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -175066,7 +175096,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -175075,7 +175105,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -175084,7 +175114,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -175093,7 +175123,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -175102,7 +175132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -175111,7 +175141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -175120,7 +175150,7 @@
       "source_location": "L63"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -175129,7 +175159,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -175138,7 +175168,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -175147,7 +175177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -175156,7 +175186,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
       "label": "select-native.tsx",
@@ -175165,7 +175195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "select_native_cn",
       "label": "cn()",
@@ -175174,7 +175204,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_test_tsx",
       "label": "sidebar.test.tsx",
@@ -175183,31 +175213,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "sidebar_test_sidebartoggleprobe",
       "label": "SidebarToggleProbe()",
       "norm_label": "sidebartoggleprobe()",
       "source_file": "packages/athena-webapp/src/components/ui/sidebar.test.tsx",
       "source_location": "L19"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
-      "label": "timeline-item.tsx",
-      "norm_label": "timeline-item.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "timeline_item_timelineitem",
-      "label": "TimelineItem()",
-      "norm_label": "timelineitem()",
-      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
-      "source_location": "L3"
     },
     {
       "community": 133,
@@ -175347,6 +175359,24 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
+      "label": "timeline-item.tsx",
+      "norm_label": "timeline-item.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1330,
+      "file_type": "code",
+      "id": "timeline_item_timelineitem",
+      "label": "TimelineItem()",
+      "norm_label": "timelineitem()",
+      "source_file": "packages/athena-webapp/src/components/ui/timeline-item.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
       "norm_label": "webp-image.tsx",
@@ -175354,7 +175384,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1330,
+      "community": 1331,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -175363,7 +175393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -175372,7 +175402,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -175381,7 +175411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -175390,7 +175420,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -175399,7 +175429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -175408,7 +175438,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -175417,7 +175447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -175426,7 +175456,7 @@
       "source_location": "L101"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -175435,7 +175465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -175444,7 +175474,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -175453,7 +175483,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -175462,7 +175492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
@@ -175471,7 +175501,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userinsightssection_test_tsx",
       "label": "UserInsightsSection.test.tsx",
@@ -175480,7 +175510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "userinsightssection_test_renderwithqueries",
       "label": "renderWithQueries()",
@@ -175489,7 +175519,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
@@ -175498,31 +175528,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
       "norm_label": "useronlineorders()",
       "source_file": "packages/athena-webapp/src/components/users/UserOnlineOrders.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
-      "label": "UserStatus.tsx",
-      "norm_label": "userstatus.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "userstatus_userstatus",
-      "label": "UserStatus()",
-      "norm_label": "userstatus()",
-      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
-      "source_location": "L7"
     },
     {
       "community": 134,
@@ -175662,6 +175674,24 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
+      "label": "UserStatus.tsx",
+      "norm_label": "userstatus.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1340,
+      "file_type": "code",
+      "id": "userstatus_userstatus",
+      "label": "UserStatus()",
+      "norm_label": "userstatus()",
+      "source_file": "packages/athena-webapp/src/components/users/UserStatus.tsx",
+      "source_location": "L7"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
       "norm_label": "userview.tsx",
@@ -175669,7 +175699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1340,
+      "community": 1341,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -175678,7 +175708,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -175687,7 +175717,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -175696,7 +175726,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -175705,7 +175735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "userbehaviorinsights_userbehaviorinsights",
       "label": "UserBehaviorInsights()",
@@ -175714,7 +175744,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "athenawebappcontextevents_buildathenawebappcontextevent",
       "label": "buildAthenaWebappContextEvent()",
@@ -175723,7 +175753,7 @@
       "source_location": "L28"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexttracking_athenawebappcontextevents_ts",
       "label": "athenaWebappContextEvents.ts",
@@ -175732,7 +175762,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "managerelevationcontext_test_wrapper",
       "label": "wrapper()",
@@ -175741,7 +175771,7 @@
       "source_location": "L64"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_test_tsx",
       "label": "ManagerElevationContext.test.tsx",
@@ -175750,7 +175780,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "onlineordercontext_test_sessionorderprobe",
       "label": "SessionOrderProbe()",
@@ -175759,7 +175789,7 @@
       "source_location": "L41"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_test_tsx",
       "label": "OnlineOrderContext.test.tsx",
@@ -175768,7 +175798,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_productcontext_test_tsx",
       "label": "ProductContext.test.tsx",
@@ -175777,7 +175807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "productcontext_test_buildproductsku",
       "label": "buildProductSku()",
@@ -175786,7 +175816,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -175795,7 +175825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -175804,7 +175834,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -175813,31 +175843,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
       "norm_label": "useismobile()",
       "source_file": "packages/athena-webapp/src/hooks/use-mobile.tsx",
       "source_location": "L5"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
-      "label": "use-navigate-back.ts",
-      "norm_label": "use-navigate-back.ts",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "use_navigate_back_usenavigateback",
-      "label": "useNavigateBack()",
-      "norm_label": "usenavigateback()",
-      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
-      "source_location": "L7"
     },
     {
       "community": 135,
@@ -175977,6 +175989,24 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
+      "label": "use-navigate-back.ts",
+      "norm_label": "use-navigate-back.ts",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1350,
+      "file_type": "code",
+      "id": "use_navigate_back_usenavigateback",
+      "label": "useNavigateBack()",
+      "norm_label": "usenavigateback()",
+      "source_file": "packages/athena-webapp/src/hooks/use-navigate-back.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
       "norm_label": "use-navigation-keyboard-shortcuts.ts",
@@ -175984,7 +176014,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1350,
+      "community": 1351,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -175993,7 +176023,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -176002,7 +176032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -176011,7 +176041,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -176020,7 +176050,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -176029,7 +176059,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -176038,7 +176068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -176047,7 +176077,7 @@
       "source_location": "L189"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -176056,7 +176086,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
@@ -176065,7 +176095,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
       "label": "useCopyText.ts",
@@ -176074,7 +176104,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "usecopytext_usecopytext",
       "label": "useCopyText()",
@@ -176083,7 +176113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
@@ -176092,7 +176122,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -176101,7 +176131,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -176110,7 +176140,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -176119,7 +176149,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -176128,31 +176158,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
       "norm_label": "usegetactiveproduct()",
       "source_file": "packages/athena-webapp/src/hooks/useGetActiveProduct.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
-      "label": "useGetAuthedUser.ts",
-      "norm_label": "usegetautheduser.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "usegetautheduser_usegetautheduser",
-      "label": "useGetAuthedUser()",
-      "norm_label": "usegetautheduser()",
-      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
-      "source_location": "L4"
     },
     {
       "community": 136,
@@ -176292,6 +176304,24 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
+      "label": "useGetAuthedUser.ts",
+      "norm_label": "usegetautheduser.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1360,
+      "file_type": "code",
+      "id": "usegetautheduser_usegetautheduser",
+      "label": "useGetAuthedUser()",
+      "norm_label": "usegetautheduser()",
+      "source_file": "packages/athena-webapp/src/hooks/useGetAuthedUser.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
       "norm_label": "usegetcategories.ts",
@@ -176299,7 +176329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1360,
+      "community": 1361,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -176308,7 +176338,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -176317,7 +176347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -176326,7 +176356,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -176335,7 +176365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -176344,7 +176374,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -176353,7 +176383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -176362,7 +176392,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -176371,7 +176401,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
@@ -176380,7 +176410,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
       "label": "useNewOrderNotification.ts",
@@ -176389,7 +176419,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "usenewordernotification_usenewordernotification",
       "label": "useNewOrderNotification()",
@@ -176398,7 +176428,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
@@ -176407,7 +176437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -176416,7 +176446,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -176425,7 +176455,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -176434,7 +176464,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -176443,30 +176473,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
       "norm_label": "useproductwithnoimagesnotification()",
       "source_file": "packages/athena-webapp/src/hooks/useProductWithNoImagesNotification.tsx",
-      "source_location": "L7"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
-      "label": "useProtectedAdminPageState.ts",
-      "norm_label": "useprotectedadminpagestate.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "useprotectedadminpagestate_useprotectedadminpagestate",
-      "label": "useProtectedAdminPageState()",
-      "norm_label": "useprotectedadminpagestate()",
-      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts",
       "source_location": "L7"
     },
     {
@@ -176607,6 +176619,24 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
+      "label": "useProtectedAdminPageState.ts",
+      "norm_label": "useprotectedadminpagestate.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1370,
+      "file_type": "code",
+      "id": "useprotectedadminpagestate_useprotectedadminpagestate",
+      "label": "useProtectedAdminPageState()",
+      "norm_label": "useprotectedadminpagestate()",
+      "source_file": "packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
       "norm_label": "useskusreservedincheckout.ts",
@@ -176614,7 +176644,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1370,
+      "community": 1371,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -176623,7 +176653,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -176632,7 +176662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -176641,7 +176671,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -176650,7 +176680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -176659,7 +176689,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_useappactionblocker_test_tsx",
       "label": "useAppActionBlocker.test.tsx",
@@ -176668,7 +176698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "useappactionblocker_test_wrapper",
       "label": "wrapper()",
@@ -176677,7 +176707,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecoordinatorprovider_tsx",
       "label": "UpdateCoordinatorProvider.tsx",
@@ -176686,7 +176716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "updatecoordinatorprovider_updatecoordinatorprovider",
       "label": "UpdateCoordinatorProvider()",
@@ -176695,7 +176725,7 @@
       "source_location": "L28"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "appupdatereload_test_createfakewindow",
       "label": "createFakeWindow()",
@@ -176704,7 +176734,7 @@
       "source_location": "L41"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_test_ts",
       "label": "appUpdateReload.test.ts",
@@ -176713,7 +176743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updateassetstaging_test_ts",
       "label": "updateAssetStaging.test.ts",
@@ -176722,7 +176752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "updateassetstaging_test_fakemessagechannel",
       "label": "FakeMessageChannel",
@@ -176731,7 +176761,7 @@
       "source_location": "L171"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecommunicationpreference_tsx",
       "label": "updateCommunicationPreference.tsx",
@@ -176740,7 +176770,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "updatecommunicationpreference_updatecommunicationpreferenceprovider",
       "label": "UpdateCommunicationPreferenceProvider()",
@@ -176749,7 +176779,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatedetectionsequencer_test_ts",
       "label": "updateDetectionSequencer.test.ts",
@@ -176758,31 +176788,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "updatedetectionsequencer_test_createdeferredstatus",
       "label": "createDeferredStatus()",
       "norm_label": "createdeferredstatus()",
       "source_file": "packages/athena-webapp/src/lib/app-update/updateDetectionSequencer.test.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_updatedetectionsequencer_ts",
-      "label": "updateDetectionSequencer.ts",
-      "norm_label": "updatedetectionsequencer.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateDetectionSequencer.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "updatedetectionsequencer_createupdatedetectionsequencer",
-      "label": "createUpdateDetectionSequencer()",
-      "norm_label": "createupdatedetectionsequencer()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/updateDetectionSequencer.ts",
-      "source_location": "L7"
     },
     {
       "community": 138,
@@ -176922,6 +176934,24 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_update_updatedetectionsequencer_ts",
+      "label": "updateDetectionSequencer.ts",
+      "norm_label": "updatedetectionsequencer.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateDetectionSequencer.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1380,
+      "file_type": "code",
+      "id": "updatedetectionsequencer_createupdatedetectionsequencer",
+      "label": "createUpdateDetectionSequencer()",
+      "norm_label": "createupdatedetectionsequencer()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/updateDetectionSequencer.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_useupdateapplyblocker_ts",
       "label": "useUpdateApplyBlocker.ts",
       "norm_label": "useupdateapplyblocker.ts",
@@ -176929,7 +176959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1380,
+      "community": 1381,
       "file_type": "code",
       "id": "useupdateapplyblocker_useupdateapplyblocker",
       "label": "useUpdateApplyBlocker()",
@@ -176938,7 +176968,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
@@ -176947,7 +176977,7 @@
       "source_location": "L52"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -176956,7 +176986,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -176965,7 +176995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -176974,7 +177004,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_navigation_storeentryroute_ts",
       "label": "storeEntryRoute.ts",
@@ -176983,7 +177013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "storeentryroute_getstoreentryrouteforrole",
       "label": "getStoreEntryRouteForRole()",
@@ -176992,7 +177022,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_poslocalstoretypes_ts",
       "label": "posLocalStoreTypes.ts",
@@ -177001,7 +177031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "poslocalstoretypes_canuploadposlocaleventtype",
       "label": "canUploadPosLocalEventType()",
@@ -177010,7 +177040,7 @@
       "source_location": "L51"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -177019,7 +177049,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -177028,7 +177058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -177037,7 +177067,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -177046,7 +177076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -177055,7 +177085,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -177064,7 +177094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -177073,31 +177103,13 @@
       "source_location": "L5"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
       "norm_label": "opendrawer.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/openDrawer.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
-      "label": "startSession.ts",
-      "norm_label": "startsession.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "startsession_startsession",
-      "label": "startSession()",
-      "norm_label": "startsession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
-      "source_location": "L5"
     },
     {
       "community": 139,
@@ -177237,6 +177249,24 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
+      "label": "startSession.ts",
+      "norm_label": "startsession.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1390,
+      "file_type": "code",
+      "id": "startsession_startsession",
+      "label": "startSession()",
+      "norm_label": "startsession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/application/useCases/startSession.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
       "norm_label": "calculatecarttotals()",
@@ -177244,7 +177274,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1390,
+      "community": 1391,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -177253,7 +177283,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "expenselocalcommandgateway_test_scope",
       "label": "scope()",
@@ -177262,7 +177292,7 @@
       "source_location": "L250"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_test_ts",
       "label": "expenseLocalCommandGateway.test.ts",
@@ -177271,7 +177301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalledgerpolicy_ts",
       "label": "posLocalLedgerPolicy.ts",
@@ -177280,7 +177310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "poslocalledgerpolicy_assessposlocalledgerretention",
       "label": "assessPosLocalLedgerRetention()",
@@ -177289,7 +177319,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageboundary_test_ts",
       "label": "posLocalStorageBoundary.test.ts",
@@ -177298,7 +177328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "poslocalstorageboundary_test_collectproductionsources",
       "label": "collectProductionSources()",
@@ -177307,7 +177337,7 @@
       "source_location": "L39"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageruntimecontext_test_tsx",
       "label": "posLocalStorageRuntimeContext.test.tsx",
@@ -177316,7 +177346,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "poslocalstorageruntimecontext_test_runtimestatus",
       "label": "RuntimeStatus()",
@@ -177325,7 +177355,7 @@
       "source_location": "L61"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreerrortaxonomy_test_ts",
       "label": "posLocalStoreErrorTaxonomy.test.ts",
@@ -177334,7 +177364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "poslocalstoreerrortaxonomy_test_failingadapter",
       "label": "failingAdapter()",
@@ -177343,7 +177373,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrationcoordinator_test_ts",
       "label": "posLocalStoreMigrationCoordinator.test.ts",
@@ -177352,7 +177382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "poslocalstoremigrationcoordinator_test_createlogicalfixtureengine",
       "label": "createLogicalFixtureEngine()",
@@ -177361,7 +177391,7 @@
       "source_location": "L176"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrationcoordinator_ts",
       "label": "posLocalStoreMigrationCoordinator.ts",
@@ -177370,7 +177400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "poslocalstoremigrationcoordinator_createtestonlyposlocalstoremigrationcoordinator",
       "label": "createTestOnlyPosLocalStoreMigrationCoordinator()",
@@ -177379,7 +177409,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrations_ts",
       "label": "posLocalStoreMigrations.ts",
@@ -177388,31 +177418,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "poslocalstoremigrations_runposlocalstoremigrations",
       "label": "runPosLocalStoreMigrations()",
       "norm_label": "runposlocalstoremigrations()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreMigrations.ts",
       "source_location": "L26"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoresnapshot_ts",
-      "label": "posLocalStoreSnapshot.ts",
-      "norm_label": "poslocalstoresnapshot.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreSnapshot.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "poslocalstoresnapshot_validateposlocalstoresnapshotshape",
-      "label": "validatePosLocalStoreSnapshotShape()",
-      "norm_label": "validateposlocalstoresnapshotshape()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreSnapshot.ts",
-      "source_location": "L33"
     },
     {
       "community": 14,
@@ -177948,6 +177960,24 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoresnapshot_ts",
+      "label": "posLocalStoreSnapshot.ts",
+      "norm_label": "poslocalstoresnapshot.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreSnapshot.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1400,
+      "file_type": "code",
+      "id": "poslocalstoresnapshot_validateposlocalstoresnapshotshape",
+      "label": "validatePosLocalStoreSnapshotShape()",
+      "norm_label": "validateposlocalstoresnapshotshape()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStoreSnapshot.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreversions_ts",
       "label": "posLocalStoreVersions.ts",
       "norm_label": "poslocalstoreversions.ts",
@@ -177955,7 +177985,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1400,
+      "community": 1401,
       "file_type": "code",
       "id": "poslocalstoreversions_compareposlocalstoreversion",
       "label": "comparePosLocalStoreVersion()",
@@ -177964,7 +177994,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registeravailabilitysnapshot_test_ts",
       "label": "registerAvailabilitySnapshot.test.ts",
@@ -177973,7 +178003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "registeravailabilitysnapshot_test_buildavailabilityrow",
       "label": "buildAvailabilityRow()",
@@ -177982,7 +178012,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registeravailabilitysnapshot_ts",
       "label": "registerAvailabilitySnapshot.ts",
@@ -177991,7 +178021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "registeravailabilitysnapshot_readregisteravailabilitysnapshotstate",
       "label": "readRegisterAvailabilitySnapshotState()",
@@ -178000,7 +178030,7 @@
       "source_location": "L33"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityreconciliation_test_ts",
       "label": "registerLifecycleAuthorityReconciliation.test.ts",
@@ -178009,7 +178039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "registerlifecycleauthorityreconciliation_test_versioned",
       "label": "versioned()",
@@ -178018,7 +178048,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerservicecatalogsnapshot_test_ts",
       "label": "registerServiceCatalogSnapshot.test.ts",
@@ -178027,7 +178057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "registerservicecatalogsnapshot_test_buildservicecatalogrow",
       "label": "buildServiceCatalogRow()",
@@ -178036,7 +178066,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerservicecatalogsnapshot_ts",
       "label": "registerServiceCatalogSnapshot.ts",
@@ -178045,7 +178075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "registerservicecatalogsnapshot_readregisterservicecatalogsnapshotstate",
       "label": "readRegisterServiceCatalogSnapshotState()",
@@ -178054,7 +178084,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registersessionauthoritybootstrap_ts",
       "label": "registerSessionAuthorityBootstrap.ts",
@@ -178063,7 +178093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "registersessionauthoritybootstrap_seedregistersessionauthoritybootstrap",
       "label": "seedRegisterSessionAuthorityBootstrap()",
@@ -178072,7 +178102,7 @@
       "source_location": "L32"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncgapdiagnosis_ts",
       "label": "syncGapDiagnosis.ts",
@@ -178081,7 +178111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "syncgapdiagnosis_diagnoseheldsyncblocker",
       "label": "diagnoseHeldSyncBlocker()",
@@ -178090,7 +178120,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncscheduler_test_ts",
       "label": "syncScheduler.test.ts",
@@ -178099,31 +178129,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "syncscheduler_test_baseevent",
       "label": "baseEvent()",
       "norm_label": "baseevent()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.test.ts",
       "source_location": "L8"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncstatus_test_ts",
-      "label": "syncStatus.test.ts",
-      "norm_label": "syncstatus.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "syncstatus_test_event",
-      "label": "event()",
-      "norm_label": "event()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts",
-      "source_location": "L9"
     },
     {
       "community": 141,
@@ -178263,6 +178275,24 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncstatus_test_ts",
+      "label": "syncStatus.test.ts",
+      "norm_label": "syncstatus.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1410,
+      "file_type": "code",
+      "id": "syncstatus_test_event",
+      "label": "event()",
+      "norm_label": "event()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalruntimestatus_test_ts",
       "label": "terminalRuntimeStatus.test.ts",
       "norm_label": "terminalruntimestatus.test.ts",
@@ -178270,7 +178300,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1410,
+      "community": 1411,
       "file_type": "code",
       "id": "terminalruntimestatus_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -178279,7 +178309,7 @@
       "source_location": "L1002"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalstaffauthorityrefresh_test_ts",
       "label": "terminalStaffAuthorityRefresh.test.ts",
@@ -178288,7 +178318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "terminalstaffauthorityrefresh_test_buildauthorityrecord",
       "label": "buildAuthorityRecord()",
@@ -178297,7 +178327,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "loggergateway_tometadatarecord",
       "label": "toMetadataRecord()",
@@ -178306,7 +178336,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
@@ -178315,7 +178345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_useposclienttelemetrydrain_ts",
       "label": "usePosClientTelemetryDrain.ts",
@@ -178324,7 +178354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "useposclienttelemetrydrain_useposclienttelemetrydrain",
       "label": "usePosClientTelemetryDrain()",
@@ -178333,7 +178363,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercatalogindex_ts",
       "label": "useRegisterCatalogIndex.ts",
@@ -178342,7 +178372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "useregistercatalogindex_useregistercatalogindex",
       "label": "useRegisterCatalogIndex()",
@@ -178351,7 +178381,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercheckoutdraftstate_ts",
       "label": "useRegisterCheckoutDraftState.ts",
@@ -178360,7 +178390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "useregistercheckoutdraftstate_useregistercheckoutdraftstate",
       "label": "useRegisterCheckoutDraftState()",
@@ -178369,7 +178399,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterlocalruntime_test_ts",
       "label": "useRegisterLocalRuntime.test.ts",
@@ -178378,7 +178408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "useregisterlocalruntime_test_renderruntime",
       "label": "renderRuntime()",
@@ -178387,7 +178417,7 @@
       "source_location": "L96"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_registersessioncode_ts",
       "label": "registerSessionCode.ts",
@@ -178396,7 +178426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "registersessioncode_formatregistersessioncode",
       "label": "formatRegisterSessionCode()",
@@ -178405,7 +178435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_remoteassistcobrowserecorder_test_ts",
       "label": "remoteAssistCobrowseRecorder.test.ts",
@@ -178414,31 +178444,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "remoteassistcobrowserecorder_test_setelementrect",
       "label": "setElementRect()",
       "norm_label": "setelementrect()",
       "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/remoteAssistCobrowseRecorder.test.ts",
       "source_location": "L395"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_test_ts",
-      "label": "runtime.test.ts",
-      "norm_label": "runtime.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "runtime_test_buildstate",
-      "label": "buildState()",
-      "norm_label": "buildstate()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime.test.ts",
-      "source_location": "L99"
     },
     {
       "community": 142,
@@ -178578,6 +178590,24 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_test_ts",
+      "label": "runtime.test.ts",
+      "norm_label": "runtime.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1420,
+      "file_type": "code",
+      "id": "runtime_test_buildstate",
+      "label": "buildState()",
+      "norm_label": "buildstate()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime.test.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_ts",
       "label": "runtime.ts",
       "norm_label": "runtime.ts",
@@ -178585,7 +178615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1420,
+      "community": 1421,
       "file_type": "code",
       "id": "runtime_getremoteassistconnectedstate",
       "label": "getRemoteAssistConnectedState()",
@@ -178594,7 +178624,7 @@
       "source_location": "L44"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_support_useremoteassistsupporttransport_ts",
       "label": "useRemoteAssistSupportTransport.ts",
@@ -178603,7 +178633,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "useremoteassistsupporttransport_useremoteassistsupporttransport",
       "label": "useRemoteAssistSupportTransport()",
@@ -178612,7 +178642,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_transport_remoteassistlivetransportclient_test_ts",
       "label": "RemoteAssistLiveTransportClient.test.ts",
@@ -178621,7 +178651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "remoteassistlivetransportclient_test_encode",
       "label": "encode()",
@@ -178630,7 +178660,7 @@
       "source_location": "L255"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
@@ -178639,7 +178669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -178648,7 +178678,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_test_ts",
       "label": "productSkuSearchAdapters.test.ts",
@@ -178657,7 +178687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "productskusearchadapters_test_buildresult",
       "label": "buildResult()",
@@ -178666,7 +178696,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_theme_test_ts",
       "label": "theme.test.ts",
@@ -178675,7 +178705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "theme_test_installmatchmedia",
       "label": "installMatchMedia()",
@@ -178684,7 +178714,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "authenticated_layout_authenticatedlayout",
       "label": "AuthenticatedLayout()",
@@ -178693,7 +178723,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authenticated_layout_tsx",
       "label": "-authenticated-layout.tsx",
@@ -178702,7 +178732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "demo_presentation_getshareddemoentrypresentation",
       "label": "getSharedDemoEntryPresentation()",
@@ -178711,7 +178741,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_presentation_ts",
       "label": "-demo-presentation.ts",
@@ -178720,7 +178750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_public_layout_tsx",
       "label": "-public-layout.tsx",
@@ -178729,31 +178759,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "public_layout_onscroll",
       "label": "onScroll()",
       "norm_label": "onscroll()",
       "source_file": "packages/athena-webapp/src/routes/-public-layout.tsx",
       "source_location": "L87"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "index_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 143,
@@ -178893,6 +178905,24 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "index_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 1430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
       "norm_label": "$sessionid.tsx",
@@ -178900,7 +178930,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1430,
+      "community": 1431,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -178909,7 +178939,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_activity_tsx",
       "label": "registers.$sessionId.activity.tsx",
@@ -178918,7 +178948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "registers_sessionid_activity_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -178927,7 +178957,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
@@ -178936,7 +178966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -178945,7 +178975,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -178954,7 +178984,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -178963,7 +178993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "inventory_import_route_inventoryimportroute",
       "label": "InventoryImportRoute()",
@@ -178972,7 +179002,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_route_tsx",
       "label": "-inventory-import-route.tsx",
@@ -178981,7 +179011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "approvals_approvalsroute",
       "label": "ApprovalsRoute()",
@@ -178990,7 +179020,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_approvals_tsx",
       "label": "approvals.tsx",
@@ -178999,7 +179029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "daily_close_history_dailyclosehistoryroute",
       "label": "DailyCloseHistoryRoute()",
@@ -179008,7 +179038,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_history_tsx",
       "label": "daily-close-history.tsx",
@@ -179017,7 +179047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "daily_close_dailycloseroute",
       "label": "DailyCloseRoute()",
@@ -179026,7 +179056,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_tsx",
       "label": "daily-close.tsx",
@@ -179035,7 +179065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "index_dailyoperationsroute",
       "label": "DailyOperationsRoute()",
@@ -179044,30 +179074,12 @@
       "source_location": "L21"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "open_work_openworkroute",
-      "label": "OpenWorkRoute()",
-      "norm_label": "openworkroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_open_work_tsx",
-      "label": "open-work.tsx",
-      "norm_label": "open-work.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work.tsx",
       "source_location": "L1"
     },
     {
@@ -179208,6 +179220,24 @@
     {
       "community": 1440,
       "file_type": "code",
+      "id": "open_work_openworkroute",
+      "label": "OpenWorkRoute()",
+      "norm_label": "openworkroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 1440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_open_work_tsx",
+      "label": "open-work.tsx",
+      "norm_label": "open-work.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/open-work.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
       "id": "opening_dailyopeningroute",
       "label": "DailyOpeningRoute()",
       "norm_label": "dailyopeningroute()",
@@ -179215,7 +179245,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1440,
+      "community": 1441,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_opening_tsx",
       "label": "opening.tsx",
@@ -179224,7 +179254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_stock_adjustments_tsx",
       "label": "stock-adjustments.tsx",
@@ -179233,7 +179263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1442,
       "file_type": "code",
       "id": "stock_adjustments_stockadjustmentsroute",
       "label": "StockAdjustmentsRoute()",
@@ -179242,7 +179272,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1442,
+      "community": 1443,
       "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
@@ -179251,7 +179281,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1442,
+      "community": 1443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -179260,7 +179290,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1443,
+      "community": 1444,
       "file_type": "code",
       "id": "index_pointofsaleroute",
       "label": "PointOfSaleRoute()",
@@ -179269,7 +179299,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1443,
+      "community": 1444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -179278,7 +179308,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -179287,7 +179317,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1445,
       "file_type": "code",
       "id": "settings_index_settingsnotfoundcomponent",
       "label": "SettingsNotFoundComponent()",
@@ -179296,7 +179326,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1445,
+      "community": 1446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_route_test_tsx",
       "label": "terminals.route.test.tsx",
@@ -179305,7 +179335,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1445,
+      "community": 1446,
       "file_type": "code",
       "id": "terminals_route_test_routebuilder",
       "label": "routeBuilder()",
@@ -179314,7 +179344,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1446,
+      "community": 1447,
       "file_type": "code",
       "id": "index_complimentaryproductsnotfoundcomponent",
       "label": "ComplimentaryProductsNotFoundComponent()",
@@ -179323,7 +179353,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1446,
+      "community": 1447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -179332,7 +179362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1447,
+      "community": 1448,
       "file_type": "code",
       "id": "index_productsnotfoundcomponent",
       "label": "ProductsNotFoundComponent()",
@@ -179341,7 +179371,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1447,
+      "community": 1448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -179350,7 +179380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1448,
+      "community": 1449,
       "file_type": "code",
       "id": "index_reportsitemsroute",
       "label": "ReportsItemsRoute()",
@@ -179359,31 +179389,13 @@
       "source_location": "L36"
     },
     {
-      "community": 1448,
+      "community": 1449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_index_tsx",
       "label": "index.tsx",
       "norm_label": "index.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reports/items/index.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
-      "label": "published.index.tsx",
-      "norm_label": "published.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "published_index_routecomponent",
-      "label": "RouteComponent()",
-      "norm_label": "routecomponent()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
-      "source_location": "L9"
     },
     {
       "community": 145,
@@ -179523,6 +179535,24 @@
     {
       "community": 1450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
+      "label": "published.index.tsx",
+      "norm_label": "published.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1450,
+      "file_type": "code",
+      "id": "published_index_routecomponent",
+      "label": "RouteComponent()",
+      "norm_label": "routecomponent()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/reviews/published.index.tsx",
+      "source_location": "L9"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_shared_demo_tsx",
       "label": "shared-demo.tsx",
       "norm_label": "shared-demo.tsx",
@@ -179530,7 +179560,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1450,
+      "community": 1451,
       "file_type": "code",
       "id": "shared_demo_shareddemohomeroute",
       "label": "SharedDemoHomeRoute()",
@@ -179539,7 +179569,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1451,
+      "community": 1452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_route_test_tsx",
       "label": "_authed.route.test.tsx",
@@ -179548,7 +179578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1451,
+      "community": 1452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_tsx",
       "label": "_authed.tsx",
@@ -179557,7 +179587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1452,
+      "community": 1453,
       "file_type": "code",
       "id": "login_ready_view_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -179566,7 +179596,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1452,
+      "community": 1453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_ready_view_tsx",
       "label": "-login-ready-view.tsx",
@@ -179575,7 +179605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1453,
+      "community": 1454,
       "file_type": "code",
       "id": "layout_test_activehandoff",
       "label": "activeHandoff()",
@@ -179584,7 +179614,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1453,
+      "community": 1454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -179593,7 +179623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1454,
+      "community": 1455,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -179602,7 +179632,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1454,
+      "community": 1455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -179611,7 +179641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1455,
+      "community": 1456,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -179620,7 +179650,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1455,
+      "community": 1456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -179629,7 +179659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_tsx",
       "label": "view-patterns.tsx",
@@ -179638,7 +179668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1457,
       "file_type": "code",
       "id": "view_patterns_cn",
       "label": "cn()",
@@ -179647,7 +179677,7 @@
       "source_location": "L142"
     },
     {
-      "community": 1457,
+      "community": 1458,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -179656,7 +179686,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1457,
+      "community": 1458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
@@ -179665,7 +179695,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1458,
+      "community": 1459,
       "file_type": "code",
       "id": "dialog_stories_dialogshowcase",
       "label": "DialogShowcase()",
@@ -179674,30 +179704,12 @@
       "source_location": "L15"
     },
     {
-      "community": 1458,
+      "community": 1459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
       "label": "Dialog.stories.tsx",
       "norm_label": "dialog.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "feedback_stories_feedbackshowcase",
-      "label": "FeedbackShowcase()",
-      "norm_label": "feedbackshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
-      "source_location": "L12"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
-      "label": "Feedback.stories.tsx",
-      "norm_label": "feedback.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -179838,6 +179850,24 @@
     {
       "community": 1460,
       "file_type": "code",
+      "id": "feedback_stories_feedbackshowcase",
+      "label": "FeedbackShowcase()",
+      "norm_label": "feedbackshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L12"
+    },
+    {
+      "community": 1460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
+      "label": "Feedback.stories.tsx",
+      "norm_label": "feedback.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Feedback.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1461,
+      "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
       "norm_label": "primitivesoverview()",
@@ -179845,7 +179875,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1460,
+      "community": 1461,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -179854,7 +179884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -179863,7 +179893,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1462,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -179872,7 +179902,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1462,
+      "community": 1463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -179881,7 +179911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1462,
+      "community": 1463,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -179890,7 +179920,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1463,
+      "community": 1464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -179899,7 +179929,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1463,
+      "community": 1464,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -179908,7 +179938,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1464,
+      "community": 1465,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -179917,7 +179947,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1464,
+      "community": 1465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -179926,7 +179956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1465,
+      "community": 1466,
       "file_type": "code",
       "id": "dailyoperationsfixtures_wedat",
       "label": "wedAt()",
@@ -179935,7 +179965,7 @@
       "source_location": "L550"
     },
     {
-      "community": 1465,
+      "community": 1466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_dailyoperationsfixtures_ts",
       "label": "dailyOperationsFixtures.ts",
@@ -179944,7 +179974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1467,
       "file_type": "code",
       "id": "openinghandofffixtures_wedat",
       "label": "wedAt()",
@@ -179953,7 +179983,7 @@
       "source_location": "L189"
     },
     {
-      "community": 1466,
+      "community": 1467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_openinghandofffixtures_ts",
       "label": "openingHandoffFixtures.ts",
@@ -179962,7 +179992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1467,
+      "community": 1468,
       "file_type": "code",
       "id": "operationsfixturecontext_momentat",
       "label": "momentAt()",
@@ -179971,7 +180001,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1467,
+      "community": 1468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_operationsfixturecontext_ts",
       "label": "operationsFixtureContext.ts",
@@ -179980,7 +180010,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1468,
+      "community": 1469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_poshubfixtures_ts",
       "label": "posHubFixtures.ts",
@@ -179989,31 +180019,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1468,
+      "community": 1469,
       "file_type": "code",
       "id": "poshubfixtures_buildtrend",
       "label": "buildTrend()",
       "norm_label": "buildtrend()",
       "source_file": "packages/athena-webapp/src/stories/operations/posHubFixtures.ts",
       "source_location": "L70"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
-      "label": "usePrint.test.ts",
-      "norm_label": "useprint.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "useprint_test_setwindowopenmock",
-      "label": "setWindowOpenMock()",
-      "norm_label": "setwindowopenmock()",
-      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
-      "source_location": "L25"
     },
     {
       "community": 147,
@@ -244138,7 +244150,7 @@
       "label": "getReceiptPageHeightMm()",
       "norm_label": "getreceiptpageheightmm()",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L249"
+      "source_location": "L255"
     },
     {
       "community": 695,
@@ -244147,7 +244159,7 @@
       "label": "setContinuousReceiptPageSize()",
       "norm_label": "setcontinuousreceiptpagesize()",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L265"
+      "source_location": "L271"
     },
     {
       "community": 695,
@@ -244156,7 +244168,7 @@
       "label": "usePrint()",
       "norm_label": "useprint()",
       "source_file": "packages/athena-webapp/src/hooks/usePrint.ts",
-      "source_location": "L294"
+      "source_location": "L300"
     },
     {
       "community": 696,
@@ -257895,6 +257907,33 @@
     {
       "community": 948,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_tests_pos_useprint_test_ts",
+      "label": "usePrint.test.ts",
+      "norm_label": "useprint.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 948,
+      "file_type": "code",
+      "id": "useprint_test_emitprintwindowevent",
+      "label": "emitPrintWindowEvent()",
+      "norm_label": "emitprintwindowevent()",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 948,
+      "file_type": "code",
+      "id": "useprint_test_setwindowopenmock",
+      "label": "setWindowOpenMock()",
+      "norm_label": "setwindowopenmock()",
+      "source_file": "packages/athena-webapp/src/tests/pos/usePrint.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 949,
+      "file_type": "code",
       "id": "index_hashpassword",
       "label": "hashPassword()",
       "norm_label": "hashpassword()",
@@ -257902,7 +257941,7 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_index_ts",
       "label": "index.ts",
@@ -257911,40 +257950,13 @@
       "source_location": "L1"
     },
     {
-      "community": 948,
+      "community": 949,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_index_ts",
       "label": "index.ts",
       "norm_label": "index.ts",
       "source_file": "packages/storefront-webapp/src/utils/index.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_test_ts",
-      "label": "versionChecker.test.ts",
-      "norm_label": "versionchecker.test.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "versionchecker_test_importversionchecker",
-      "label": "importVersionChecker()",
-      "norm_label": "importversionchecker()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 949,
-      "file_type": "code",
-      "id": "versionchecker_test_installinitialscript",
-      "label": "installInitialScript()",
-      "norm_label": "installinitialscript()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
-      "source_location": "L3"
     },
     {
       "community": 95,
@@ -258120,6 +258132,33 @@
     {
       "community": 950,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_test_ts",
+      "label": "versionChecker.test.ts",
+      "norm_label": "versionchecker.test.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 950,
+      "file_type": "code",
+      "id": "versionchecker_test_importversionchecker",
+      "label": "importVersionChecker()",
+      "norm_label": "importversionchecker()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 950,
+      "file_type": "code",
+      "id": "versionchecker_test_installinitialscript",
+      "label": "installInitialScript()",
+      "norm_label": "installinitialscript()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.test.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 951,
+      "file_type": "code",
       "id": "packages_athena_webapp_vite_config_ts",
       "label": "vite.config.ts",
       "norm_label": "vite.config.ts",
@@ -258127,7 +258166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 950,
+      "community": 951,
       "file_type": "code",
       "id": "packages_storefront_webapp_vite_config_ts",
       "label": "vite.config.ts",
@@ -258136,7 +258175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 950,
+      "community": 951,
       "file_type": "code",
       "id": "vite_config_manualchunks",
       "label": "manualChunks()",
@@ -258145,7 +258184,7 @@
       "source_location": "L26"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "auth_logout",
       "label": "logout()",
@@ -258154,7 +258193,7 @@
       "source_location": "L32"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "auth_verifyuseraccount",
       "label": "verifyUserAccount()",
@@ -258163,7 +258202,7 @@
       "source_location": "L3"
     },
     {
-      "community": 951,
+      "community": 952,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_auth_ts",
       "label": "auth.ts",
@@ -258172,7 +258211,7 @@
       "source_location": "L1"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "color_getallcolors",
       "label": "getAllColors()",
@@ -258181,7 +258220,7 @@
       "source_location": "L7"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "color_getbaseurl",
       "label": "getBaseUrl()",
@@ -258190,7 +258229,7 @@
       "source_location": "L5"
     },
     {
-      "community": 952,
+      "community": 953,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_color_ts",
       "label": "color.ts",
@@ -258199,7 +258238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "homepagesnapshot_gethomepagesnapshot",
       "label": "getHomepageSnapshot()",
@@ -258208,7 +258247,7 @@
       "source_location": "L96"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "homepagesnapshot_getstoredmarker",
       "label": "getStoredMarker()",
@@ -258217,7 +258256,7 @@
       "source_location": "L85"
     },
     {
-      "community": 953,
+      "community": 954,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_homepagesnapshot_ts",
       "label": "homepageSnapshot.ts",
@@ -258226,7 +258265,7 @@
       "source_location": "L1"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "organization_getallorganizations",
       "label": "getAllOrganizations()",
@@ -258235,7 +258274,7 @@
       "source_location": "L6"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "organization_getorganization",
       "label": "getOrganization()",
@@ -258244,7 +258283,7 @@
       "source_location": "L18"
     },
     {
-      "community": 954,
+      "community": 955,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_organization_ts",
       "label": "organization.ts",
@@ -258253,7 +258292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_upsells_ts",
       "label": "upsells.ts",
@@ -258262,7 +258301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "upsells_getbaseurl",
       "label": "getBaseUrl()",
@@ -258271,7 +258310,7 @@
       "source_location": "L3"
     },
     {
-      "community": 955,
+      "community": 956,
       "file_type": "code",
       "id": "upsells_getlastviewedproduct",
       "label": "getLastViewedProduct()",
@@ -258280,7 +258319,7 @@
       "source_location": "L5"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_useroffers_ts",
       "label": "userOffers.ts",
@@ -258289,7 +258328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "useroffers_getbaseurl",
       "label": "getBaseUrl()",
@@ -258298,7 +258337,7 @@
       "source_location": "L18"
     },
     {
-      "community": 956,
+      "community": 957,
       "file_type": "code",
       "id": "useroffers_getuserofferseligibility",
       "label": "getUserOffersEligibility()",
@@ -258307,7 +258346,7 @@
       "source_location": "L23"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productcard_tsx",
       "label": "ProductCard.tsx",
@@ -258316,7 +258355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "productcard_getpreferredcardsku",
       "label": "getPreferredCardSku()",
@@ -258325,7 +258364,7 @@
       "source_location": "L26"
     },
     {
-      "community": 957,
+      "community": 958,
       "file_type": "code",
       "id": "productcard_hassellableavailability",
       "label": "hasSellableAvailability()",
@@ -258334,7 +258373,7 @@
       "source_location": "L23"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "customerdetails_enteredcustomerdetails",
       "label": "EnteredCustomerDetails()",
@@ -258343,7 +258382,7 @@
       "source_location": "L22"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "customerdetails_onsubmit",
       "label": "onSubmit()",
@@ -258352,39 +258391,12 @@
       "source_location": "L55"
     },
     {
-      "community": 958,
+      "community": 959,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_customerdetails_tsx",
       "label": "CustomerDetails.tsx",
       "norm_label": "customerdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/CustomerDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_handlechange",
-      "label": "handleChange()",
-      "norm_label": "handlechange()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L77"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "deliveryoptionsselector_storeselector",
-      "label": "StoreSelector()",
-      "norm_label": "storeselector()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 959,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
-      "label": "DeliveryOptionsSelector.tsx",
-      "norm_label": "deliveryoptionsselector.tsx",
-      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
       "source_location": "L1"
     },
     {
@@ -258552,6 +258564,33 @@
     {
       "community": 960,
       "file_type": "code",
+      "id": "deliveryoptionsselector_handlechange",
+      "label": "handleChange()",
+      "norm_label": "handlechange()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 960,
+      "file_type": "code",
+      "id": "deliveryoptionsselector_storeselector",
+      "label": "StoreSelector()",
+      "norm_label": "storeselector()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 960,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliveryoptionsselector_tsx",
+      "label": "DeliveryOptionsSelector.tsx",
+      "norm_label": "deliveryoptionsselector.tsx",
+      "source_file": "packages/storefront-webapp/src/components/checkout/DeliveryDetails/DeliveryOptionsSelector.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 961,
+      "file_type": "code",
       "id": "deliverysection_deliverydetails",
       "label": "DeliveryDetails()",
       "norm_label": "deliverydetails()",
@@ -258559,7 +258598,7 @@
       "source_location": "L11"
     },
     {
-      "community": 960,
+      "community": 961,
       "file_type": "code",
       "id": "deliverysection_deliveryoptions",
       "label": "DeliveryOptions()",
@@ -258568,7 +258607,7 @@
       "source_location": "L22"
     },
     {
-      "community": 960,
+      "community": 961,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_deliverysection_tsx",
       "label": "DeliverySection.tsx",
@@ -258577,7 +258616,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliverydetails_pickupoptions_tsx",
       "label": "PickupOptions.tsx",
@@ -258586,7 +258625,7 @@
       "source_location": "L1"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "pickupoptions_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -258595,7 +258634,7 @@
       "source_location": "L165"
     },
     {
-      "community": 961,
+      "community": 962,
       "file_type": "code",
       "id": "pickupoptions_iswithinrestrictiontime",
       "label": "isWithinRestrictionTime()",
@@ -258604,7 +258643,7 @@
       "source_location": "L12"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "mobilebagsummary_handlekeydown",
       "label": "handleKeyDown()",
@@ -258613,7 +258652,7 @@
       "source_location": "L110"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "mobilebagsummary_handleredeempromocode",
       "label": "handleRedeemPromoCode()",
@@ -258622,7 +258661,7 @@
       "source_location": "L89"
     },
     {
-      "community": 962,
+      "community": 963,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_mobilebagsummary_tsx",
       "label": "MobileBagSummary.tsx",
@@ -258631,7 +258670,7 @@
       "source_location": "L1"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "checkoutstorage_loadcheckoutstate",
       "label": "loadCheckoutState()",
@@ -258640,7 +258679,7 @@
       "source_location": "L4"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "checkoutstorage_savecheckoutstate",
       "label": "saveCheckoutState()",
@@ -258649,7 +258688,7 @@
       "source_location": "L24"
     },
     {
-      "community": 963,
+      "community": 964,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutstorage_ts",
       "label": "checkoutStorage.ts",
@@ -258658,7 +258697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "footer_enablecategories",
       "label": "enableCategories()",
@@ -258667,7 +258706,7 @@
       "source_location": "L131"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "footer_linkgroup",
       "label": "LinkGroup()",
@@ -258676,7 +258715,7 @@
       "source_location": "L12"
     },
     {
-      "community": 964,
+      "community": 965,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_footer_tsx",
       "label": "Footer.tsx",
@@ -258685,7 +258724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "featuredproductssection_featuredproductssection",
       "label": "FeaturedProductsSection()",
@@ -258694,7 +258733,7 @@
       "source_location": "L35"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "featuredproductssection_featuredsection",
       "label": "FeaturedSection()",
@@ -258703,7 +258742,7 @@
       "source_location": "L61"
     },
     {
-      "community": 965,
+      "community": 966,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_featuredproductssection_tsx",
       "label": "FeaturedProductsSection.tsx",
@@ -258712,7 +258751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_promoalert_tsx",
       "label": "PromoAlert.tsx",
@@ -258721,7 +258760,7 @@
       "source_location": "L1"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "promoalert_getpromoalertcopy",
       "label": "getPromoAlertCopy()",
@@ -258730,7 +258769,7 @@
       "source_location": "L20"
     },
     {
-      "community": 966,
+      "community": 967,
       "file_type": "code",
       "id": "promoalert_promoalert",
       "label": "PromoAlert()",
@@ -258739,7 +258778,7 @@
       "source_location": "L59"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_rewardsalert_tsx",
       "label": "RewardsAlert.tsx",
@@ -258748,7 +258787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "rewardsalert_handleshopnow",
       "label": "handleShopNow()",
@@ -258757,7 +258796,7 @@
       "source_location": "L25"
     },
     {
-      "community": 967,
+      "community": 968,
       "file_type": "code",
       "id": "rewardsalert_onrewardsalertclose",
       "label": "onRewardsAlertClose()",
@@ -258766,7 +258805,7 @@
       "source_location": "L20"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "navigationbar_navigationbar",
       "label": "NavigationBar()",
@@ -258775,7 +258814,7 @@
       "source_location": "L30"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "navigationbar_storecategoriessubmenu",
       "label": "StoreCategoriesSubmenu()",
@@ -258784,40 +258823,13 @@
       "source_location": "L95"
     },
     {
-      "community": 968,
+      "community": 969,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_navigationbar_tsx",
       "label": "NavigationBar.tsx",
       "norm_label": "navigationbar.tsx",
       "source_file": "packages/storefront-webapp/src/components/navigation-bar/NavigationBar.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
-      "label": "ReviewEditor.tsx",
-      "norm_label": "revieweditor.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "revieweditor_handleformdatachange",
-      "label": "handleFormDataChange()",
-      "norm_label": "handleformdatachange()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L150"
-    },
-    {
-      "community": 969,
-      "file_type": "code",
-      "id": "revieweditor_handlesubmit",
-      "label": "handleSubmit()",
-      "norm_label": "handlesubmit()",
-      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
-      "source_location": "L157"
     },
     {
       "community": 97,
@@ -258984,6 +258996,33 @@
     {
       "community": 970,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_reviews_revieweditor_tsx",
+      "label": "ReviewEditor.tsx",
+      "norm_label": "revieweditor.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 970,
+      "file_type": "code",
+      "id": "revieweditor_handleformdatachange",
+      "label": "handleFormDataChange()",
+      "norm_label": "handleformdatachange()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L150"
+    },
+    {
+      "community": 970,
+      "file_type": "code",
+      "id": "revieweditor_handlesubmit",
+      "label": "handleSubmit()",
+      "norm_label": "handlesubmit()",
+      "source_file": "packages/storefront-webapp/src/components/product-reviews/ReviewEditor.tsx",
+      "source_location": "L157"
+    },
+    {
+      "community": 971,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodal_tsx",
       "label": "WelcomeBackModal.tsx",
       "norm_label": "welcomebackmodal.tsx",
@@ -258991,7 +259030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 970,
+      "community": 971,
       "file_type": "code",
       "id": "welcomebackmodal_handleclose",
       "label": "handleClose()",
@@ -259000,7 +259039,7 @@
       "source_location": "L63"
     },
     {
-      "community": 970,
+      "community": 971,
       "file_type": "code",
       "id": "welcomebackmodal_handlesuccess",
       "label": "handleSuccess()",
@@ -259009,7 +259048,7 @@
       "source_location": "L76"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalform_tsx",
       "label": "WelcomeBackModalForm.tsx",
@@ -259018,7 +259057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "welcomebackmodalform_handleinputchange",
       "label": "handleInputChange()",
@@ -259027,7 +259066,7 @@
       "source_location": "L51"
     },
     {
-      "community": 971,
+      "community": 972,
       "file_type": "code",
       "id": "welcomebackmodalform_handlesubmit",
       "label": "handleSubmit()",
@@ -259036,7 +259075,7 @@
       "source_location": "L36"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "navigationbarprovider_navigationbarprovider",
       "label": "NavigationBarProvider()",
@@ -259045,7 +259084,7 @@
       "source_location": "L16"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "navigationbarprovider_usenavigationbarcontext",
       "label": "useNavigationBarContext()",
@@ -259054,7 +259093,7 @@
       "source_location": "L39"
     },
     {
-      "community": 972,
+      "community": 973,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_navigationbarprovider_tsx",
       "label": "NavigationBarProvider.tsx",
@@ -259063,7 +259102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_storefrontobservabilityprovider_tsx",
       "label": "StorefrontObservabilityProvider.tsx",
@@ -259072,7 +259111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_storefrontobservabilityprovider",
       "label": "StorefrontObservabilityProvider()",
@@ -259081,7 +259120,7 @@
       "source_location": "L24"
     },
     {
-      "community": 973,
+      "community": 974,
       "file_type": "code",
       "id": "storefrontobservabilityprovider_usestorefrontobservability",
       "label": "useStorefrontObservability()",
@@ -259090,7 +259129,7 @@
       "source_location": "L74"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductdiscount_ts",
       "label": "useProductDiscount.ts",
@@ -259099,7 +259138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscount",
       "label": "useProductDiscount()",
@@ -259108,7 +259147,7 @@
       "source_location": "L107"
     },
     {
-      "community": 974,
+      "community": 975,
       "file_type": "code",
       "id": "useproductdiscount_useproductdiscounts",
       "label": "useProductDiscounts()",
@@ -259117,7 +259156,7 @@
       "source_location": "L25"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useshoppingbag_ts",
       "label": "useShoppingBag.ts",
@@ -259126,7 +259165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "useshoppingbag_isunavailableproductlist",
       "label": "isUnavailableProductList()",
@@ -259135,7 +259174,7 @@
       "source_location": "L556"
     },
     {
-      "community": 975,
+      "community": 976,
       "file_type": "code",
       "id": "useshoppingbag_useshoppingbag",
       "label": "useShoppingBag()",
@@ -259144,7 +259183,7 @@
       "source_location": "L52"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "index_getordermessage",
       "label": "getOrderMessage()",
@@ -259153,7 +259192,7 @@
       "source_location": "L431"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "index_getpaymenttext",
       "label": "getPaymentText()",
@@ -259162,7 +259201,7 @@
       "source_location": "L102"
     },
     {
-      "community": 976,
+      "community": 977,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_index_tsx",
       "label": "index.tsx",
@@ -259171,7 +259210,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_shop_orders_orderid_review_tsx",
       "label": "review.tsx",
@@ -259180,7 +259219,7 @@
       "source_location": "L1"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "review_getordermessage",
       "label": "getOrderMessage()",
@@ -259189,7 +259228,7 @@
       "source_location": "L257"
     },
     {
-      "community": 977,
+      "community": 978,
       "file_type": "code",
       "id": "review_ordernavigation",
       "label": "OrderNavigation()",
@@ -259198,7 +259237,7 @@
       "source_location": "L47"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "account_accountbeforeload",
       "label": "accountBeforeLoad()",
@@ -259207,7 +259246,7 @@
       "source_location": "L17"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "account_handleonsubmitform",
       "label": "handleOnSubmitForm()",
@@ -259216,39 +259255,12 @@
       "source_location": "L63"
     },
     {
-      "community": 978,
+      "community": 979,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_account_tsx",
       "label": "account.tsx",
       "norm_label": "account.tsx",
       "source_file": "packages/storefront-webapp/src/routes/_layout/account.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "login_loginbeforeload",
-      "label": "loginBeforeLoad()",
-      "norm_label": "loginbeforeload()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "login_onsubmit",
-      "label": "onSubmit()",
-      "norm_label": "onsubmit()",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
-      "source_location": "L141"
-    },
-    {
-      "community": 979,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_login_tsx",
-      "label": "login.tsx",
-      "norm_label": "login.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
       "source_location": "L1"
     },
     {
@@ -259416,6 +259428,33 @@
     {
       "community": 980,
       "file_type": "code",
+      "id": "login_loginbeforeload",
+      "label": "loginBeforeLoad()",
+      "norm_label": "loginbeforeload()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 980,
+      "file_type": "code",
+      "id": "login_onsubmit",
+      "label": "onSubmit()",
+      "norm_label": "onsubmit()",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L141"
+    },
+    {
+      "community": 980,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_login_tsx",
+      "label": "login.tsx",
+      "norm_label": "login.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/login.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 981,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_verify_index_tsx",
       "label": "verify.index.tsx",
       "norm_label": "verify.index.tsx",
@@ -259423,7 +259462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 980,
+      "community": 981,
       "file_type": "code",
       "id": "verify_index_verify",
       "label": "Verify()",
@@ -259432,7 +259471,7 @@
       "source_location": "L21"
     },
     {
-      "community": 980,
+      "community": 981,
       "file_type": "code",
       "id": "verify_index_verifycheckoutsessionpayment",
       "label": "VerifyCheckoutSessionPayment()",
@@ -259441,7 +259480,7 @@
       "source_location": "L107"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_signup_tsx",
       "label": "signup.tsx",
@@ -259450,7 +259489,7 @@
       "source_location": "L1"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "signup_onsubmit",
       "label": "onSubmit()",
@@ -259459,7 +259498,7 @@
       "source_location": "L161"
     },
     {
-      "community": 981,
+      "community": 982,
       "file_type": "code",
       "id": "signup_signupbeforeload",
       "label": "signupBeforeLoad()",
@@ -259468,7 +259507,7 @@
       "source_location": "L66"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "env_optionalnumberenv",
       "label": "optionalNumberEnv()",
@@ -259477,7 +259516,7 @@
       "source_location": "L11"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "env_requireenv",
       "label": "requireEnv()",
@@ -259486,7 +259525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 982,
+      "community": 983,
       "file_type": "code",
       "id": "packages_storefront_webapp_tests_e2e_helpers_env_ts",
       "label": "env.ts",
@@ -259495,7 +259534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "convex_operation_admission_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -259504,7 +259543,7 @@
       "source_location": "L13"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "convex_operation_admission_check_test_writefixture",
       "label": "writeFixture()",
@@ -259513,7 +259552,7 @@
       "source_location": "L22"
     },
     {
-      "community": 983,
+      "community": 984,
       "file_type": "code",
       "id": "scripts_convex_operation_admission_check_test_ts",
       "label": "convex-operation-admission-check.test.ts",
@@ -259522,7 +259561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "github_workflows_check_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -259531,7 +259570,7 @@
       "source_location": "L10"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "github_workflows_check_test_write",
       "label": "write()",
@@ -259540,7 +259579,7 @@
       "source_location": "L16"
     },
     {
-      "community": 984,
+      "community": 985,
       "file_type": "code",
       "id": "scripts_github_workflows_check_test_ts",
       "label": "github-workflows-check.test.ts",
@@ -259549,7 +259588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "github_workflows_check_collectworkflowfiles",
       "label": "collectWorkflowFiles()",
@@ -259558,7 +259597,7 @@
       "source_location": "L19"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "github_workflows_check_runworkflowcheck",
       "label": "runWorkflowCheck()",
@@ -259567,7 +259606,7 @@
       "source_location": "L29"
     },
     {
-      "community": 985,
+      "community": 986,
       "file_type": "code",
       "id": "scripts_github_workflows_check_ts",
       "label": "github-workflows-check.ts",
@@ -259576,7 +259615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "graphify_wiki_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -259585,7 +259624,7 @@
       "source_location": "L16"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "graphify_wiki_test_write",
       "label": "write()",
@@ -259594,7 +259633,7 @@
       "source_location": "L10"
     },
     {
-      "community": 986,
+      "community": 987,
       "file_type": "code",
       "id": "scripts_graphify_wiki_test_ts",
       "label": "graphify-wiki.test.ts",
@@ -259603,7 +259642,7 @@
       "source_location": "L1"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "harness_audit_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -259612,7 +259651,7 @@
       "source_location": "L17"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "harness_audit_test_write",
       "label": "write()",
@@ -259621,7 +259660,7 @@
       "source_location": "L11"
     },
     {
-      "community": 987,
+      "community": 988,
       "file_type": "code",
       "id": "scripts_harness_audit_test_ts",
       "label": "harness-audit.test.ts",
@@ -259630,7 +259669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "harness_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -259639,7 +259678,7 @@
       "source_location": "L48"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "harness_check_test_write",
       "label": "write()",
@@ -259648,39 +259687,12 @@
       "source_location": "L42"
     },
     {
-      "community": 988,
+      "community": 989,
       "file_type": "code",
       "id": "scripts_harness_check_test_ts",
       "label": "harness-check.test.ts",
       "norm_label": "harness-check.test.ts",
       "source_file": "scripts/harness-check.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "harness_generate_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "harness_generate_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-generate.test.ts",
-      "source_location": "L10"
-    },
-    {
-      "community": 989,
-      "file_type": "code",
-      "id": "scripts_harness_generate_test_ts",
-      "label": "harness-generate.test.ts",
-      "norm_label": "harness-generate.test.ts",
-      "source_file": "scripts/harness-generate.test.ts",
       "source_location": "L1"
     },
     {
@@ -259848,6 +259860,33 @@
     {
       "community": 990,
       "file_type": "code",
+      "id": "harness_generate_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 990,
+      "file_type": "code",
+      "id": "harness_generate_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 990,
+      "file_type": "code",
+      "id": "scripts_harness_generate_test_ts",
+      "label": "harness-generate.test.ts",
+      "norm_label": "harness-generate.test.ts",
+      "source_file": "scripts/harness-generate.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 991,
+      "file_type": "code",
       "id": "harness_self_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
       "norm_label": "createfixturerepo()",
@@ -259855,7 +259894,7 @@
       "source_location": "L16"
     },
     {
-      "community": 990,
+      "community": 991,
       "file_type": "code",
       "id": "harness_self_review_test_write",
       "label": "write()",
@@ -259864,7 +259903,7 @@
       "source_location": "L10"
     },
     {
-      "community": 990,
+      "community": 991,
       "file_type": "code",
       "id": "scripts_harness_self_review_test_ts",
       "label": "harness-self-review.test.ts",
@@ -259873,7 +259912,7 @@
       "source_location": "L1"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "harness_test_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -259882,7 +259921,7 @@
       "source_location": "L21"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "harness_test_test_write",
       "label": "write()",
@@ -259891,7 +259930,7 @@
       "source_location": "L15"
     },
     {
-      "community": 991,
+      "community": 992,
       "file_type": "code",
       "id": "scripts_harness_test_test_ts",
       "label": "harness-test.test.ts",
@@ -259900,7 +259939,7 @@
       "source_location": "L1"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "pr_athena_delivery_run_test_gitfixtureenv",
       "label": "gitFixtureEnv()",
@@ -259909,7 +259948,7 @@
       "source_location": "L28"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "pr_athena_delivery_run_test_rungit",
       "label": "runGit()",
@@ -259918,7 +259957,7 @@
       "source_location": "L14"
     },
     {
-      "community": 992,
+      "community": 993,
       "file_type": "code",
       "id": "scripts_pr_athena_delivery_run_test_ts",
       "label": "pr-athena-delivery-run.test.ts",
@@ -259927,7 +259966,7 @@
       "source_location": "L1"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "root_scripts_coverage_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -259936,7 +259975,7 @@
       "source_location": "L11"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "root_scripts_coverage_test_write",
       "label": "write()",
@@ -259945,7 +259984,7 @@
       "source_location": "L17"
     },
     {
-      "community": 993,
+      "community": 994,
       "file_type": "code",
       "id": "scripts_root_scripts_coverage_test_ts",
       "label": "root-scripts-coverage.test.ts",
@@ -259954,7 +259993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "root_scripts_coverage_collectrootscripttestfiles",
       "label": "collectRootScriptTestFiles()",
@@ -259963,7 +260002,7 @@
       "source_location": "L4"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "root_scripts_coverage_runrootscriptscoverage",
       "label": "runRootScriptsCoverage()",
@@ -259972,7 +260011,7 @@
       "source_location": "L13"
     },
     {
-      "community": 994,
+      "community": 995,
       "file_type": "code",
       "id": "scripts_root_scripts_coverage_ts",
       "label": "root-scripts-coverage.ts",
@@ -259981,7 +260020,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "scripts_worktree_bootstrap_check_test_ts",
       "label": "worktree-bootstrap-check.test.ts",
@@ -259990,7 +260029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "worktree_bootstrap_check_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -259999,7 +260038,7 @@
       "source_location": "L27"
     },
     {
-      "community": 995,
+      "community": 996,
       "file_type": "code",
       "id": "worktree_bootstrap_check_test_rungit",
       "label": "runGit()",
@@ -260008,7 +260047,7 @@
       "source_location": "L13"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_shareddemoticket_ts",
       "label": "SharedDemoTicket.ts",
@@ -260017,7 +260056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 996,
+      "community": 997,
       "file_type": "code",
       "id": "shareddemoticket_authorizeshareddemoticket",
       "label": "authorizeSharedDemoTicket()",
@@ -260026,7 +260065,7 @@
       "source_location": "L15"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "automationfoundation_test_createdb",
       "label": "createDb()",
@@ -260035,7 +260074,7 @@
       "source_location": "L18"
     },
     {
-      "community": 997,
+      "community": 998,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_automation_automationfoundation_test_ts",
       "label": "automationFoundation.test.ts",
@@ -260044,7 +260083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_automation_scheduledrunledger_test_ts",
       "label": "scheduledRunLedger.test.ts",
@@ -260053,31 +260092,13 @@
       "source_location": "L1"
     },
     {
-      "community": 998,
+      "community": 999,
       "file_type": "code",
       "id": "scheduledrunledger_test_createledgerctx",
       "label": "createLedgerCtx()",
       "norm_label": "createledgerctx()",
       "source_file": "packages/athena-webapp/convex/automation/scheduledRunLedger.test.ts",
       "source_location": "L11"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_test_ts",
-      "label": "paymentAllocationAttribution.test.ts",
-      "norm_label": "paymentallocationattribution.test.ts",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 999,
-      "file_type": "code",
-      "id": "paymentallocationattribution_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/cashControls/paymentAllocationAttribution.test.ts",
-      "source_location": "L12"
     }
   ]
 }

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2700
-- Graph nodes: 11013
-- Graph edges: 13413
+- Graph nodes: 11014
+- Graph edges: 13414
 - Communities: 2625
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/hooks/usePrint.ts
+++ b/packages/athena-webapp/src/hooks/usePrint.ts
@@ -4,6 +4,12 @@ const RECEIPT_PAGE_WIDTH_MM = 80;
 const RECEIPT_MIN_PAGE_HEIGHT_MM = 120;
 const RECEIPT_PAGE_HEIGHT_BUFFER_MM = 8;
 const CSS_PIXELS_PER_MM = 96 / 25.4;
+// Small breather after `afterprint` so the browser finishes unwinding the print
+// pipeline before the browsing context goes away.
+const AFTER_PRINT_CLOSE_DELAY_MS = 250;
+// Only for browsers that never fire `afterprint`. Long enough that it cannot
+// fire while a print dialog is still open on the terminal.
+const PRINT_FALLBACK_CLOSE_MS = 60_000;
 
 const receiptPrintStyles = `
             * {
@@ -323,9 +329,33 @@ export const usePrint = () => {
 
     // Set up close event handler to prevent reopening
     let isClosing = false;
+    let fallbackCloseTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const cancelFallbackClose = () => {
+      if (fallbackCloseTimer !== undefined) {
+        clearTimeout(fallbackCloseTimer);
+        fallbackCloseTimer = undefined;
+      }
+    };
+
     const handleClose = () => {
       if (!isClosing) {
         isClosing = true;
+        cancelFallbackClose();
+      }
+    };
+
+    const closeWindow = () => {
+      if (isClosing) return;
+      isClosing = true;
+      cancelFallbackClose();
+
+      try {
+        if (printWindow && !printWindow.closed) {
+          printWindow.close();
+        }
+      } catch (error) {
+        console.error("Error closing print window:", error);
       }
     };
 
@@ -353,22 +383,30 @@ ${receiptPrintStyles}
 
       printWindow.document.close();
 
-      const closeAfterDelay = () => {
-        setTimeout(() => {
-          if (printWindow && !printWindow.closed && !isClosing) {
-            isClosing = true;
-            printWindow.close();
-          }
-        }, 500);
+      // Tear the window down only once the browser says the print flow is
+      // over. Closing on a fixed delay discarded the browsing context while
+      // Blink was still running the print pipeline, and Chrome reports that as
+      // "Failed to execute 'print' on 'Window': The provided callback is no
+      // longer runnable" — raised asynchronously, so the try/catch around
+      // `print()` never sees it and it lands on the terminal as an unhandled
+      // rejection. `afterprint` fires once the dialog is dismissed (whether the
+      // job was sent or cancelled); the long fallback only covers browsers that
+      // never fire it, and must stay well clear of a dialog a cashier is still
+      // reading.
+      const closeAfterPrintCompletes = () => {
+        const handleAfterPrint = () => {
+          printWindow.removeEventListener("afterprint", handleAfterPrint);
+          setTimeout(closeWindow, AFTER_PRINT_CLOSE_DELAY_MS);
+        };
+
+        printWindow.addEventListener("afterprint", handleAfterPrint);
+        cancelFallbackClose();
+        fallbackCloseTimer = setTimeout(closeWindow, PRINT_FALLBACK_CLOSE_MS);
       };
 
-      // The print window is torn down on a timer while the browser may still
-      // be settling the print dialog, so `print()` can land on a context that
-      // is already being discarded — Chrome answers that with "The provided
-      // callback is no longer runnable". Never touch a window that is closed or
-      // closing, and only ever print once: the load handler and the slow-load
-      // fallback below both route through here, and re-entering would both
-      // double-print and print into a tearing-down window.
+      // Only ever print once: the load handler and the slow-load fallback below
+      // both route through here, and re-entering would both double-print and
+      // print into a tearing-down window.
       let hasPrinted = false;
       const runPrint = () => {
         if (hasPrinted || isClosing) return;
@@ -380,11 +418,13 @@ ${receiptPrintStyles}
           }
 
           setContinuousReceiptPageSize(printWindow);
+          // Registered before `print()` because the call is modal — the
+          // afterprint event can fire before it returns.
+          closeAfterPrintCompletes();
           printWindow.print();
-          closeAfterDelay();
         } catch (error) {
           console.error("Error during printing:", error);
-          closeAfterDelay();
+          closeWindow();
         }
       };
 
@@ -405,9 +445,7 @@ ${receiptPrintStyles}
       }, 1000);
     } catch (error) {
       console.error("Error preparing print window:", error);
-      if (!printWindow.closed) {
-        printWindow.close();
-      }
+      closeWindow();
     }
   }, []);
 

--- a/packages/athena-webapp/src/tests/pos/usePrint.test.ts
+++ b/packages/athena-webapp/src/tests/pos/usePrint.test.ts
@@ -22,6 +22,14 @@ const mockPrintWindow = {
   onload: null as null | (() => void),
 };
 
+/** Fire an event the hook registered on the print window via addEventListener. */
+function emitPrintWindowEvent(type: string) {
+  for (const [eventType, handler] of mockPrintWindow.addEventListener.mock
+    .calls as Array<[string, () => void]>) {
+    if (eventType === type) handler();
+  }
+}
+
 function setWindowOpenMock(returnValue: Window | null) {
   Object.defineProperty(window, "open", {
     configurable: true,
@@ -155,7 +163,7 @@ describe("usePrint Hook", () => {
       expect(mockPrintWindow.print).toHaveBeenCalled();
     });
 
-    it("should close window after printing with delay", () => {
+    it("closes the window once the browser reports the print finished", () => {
       vi.useFakeTimers();
       const { result } = renderHook(() => usePrint());
 
@@ -171,11 +179,40 @@ describe("usePrint Hook", () => {
       });
 
       act(() => {
-        vi.advanceTimersByTime(500);
+        emitPrintWindowEvent("afterprint");
+        vi.advanceTimersByTime(250);
       });
       vi.useRealTimers();
 
       expect(mockPrintWindow.close).toHaveBeenCalled();
+    });
+
+    it("keeps the window alive while the print dialog is still up", () => {
+      // The old fixed teardown timer discarded the browsing context mid-print,
+      // which is what produced "The provided callback is no longer runnable".
+      vi.useFakeTimers();
+      const { result } = renderHook(() => usePrint());
+
+      act(() => {
+        result.current.printReceipt("<div>Test</div>");
+      });
+      act(() => {
+        mockPrintWindow.onload?.();
+      });
+
+      // No afterprint yet: the dialog is still open.
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+      expect(mockPrintWindow.close).not.toHaveBeenCalled();
+
+      // A browser that never fires afterprint still gets cleaned up.
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+      vi.useRealTimers();
+
+      expect(mockPrintWindow.close).toHaveBeenCalledTimes(1);
     });
 
     it("should prevent multiple close attempts", () => {
@@ -197,7 +234,8 @@ describe("usePrint Hook", () => {
       mockPrintWindow.closed = true;
 
       act(() => {
-        vi.advanceTimersByTime(500);
+        emitPrintWindowEvent("afterprint");
+        vi.advanceTimersByTime(60_000);
       });
       vi.useRealTimers();
 
@@ -277,22 +315,39 @@ describe("usePrint Hook", () => {
       act(() => {
         result.current.printReceipt("<div>Test</div>");
       });
-      // Load, print, and let the teardown timer run.
-      act(() => {
-        mockPrintWindow.onload?.();
-      });
-      act(() => {
-        vi.advanceTimersByTime(500);
-      });
-      mockPrintWindow.print.mockClear();
 
-      // The slow-load fallback fires afterwards and must stay quiet.
+      // The operator dismisses the popup before it finished loading.
       act(() => {
-        vi.advanceTimersByTime(500);
+        emitPrintWindowEvent("unload");
+      });
+
+      // The slow-load fallback fires afterwards and must stay quiet rather than
+      // printing into a context that is already going away.
+      act(() => {
+        vi.advanceTimersByTime(1000);
       });
       vi.useRealTimers();
 
       expect(mockPrintWindow.print).not.toHaveBeenCalled();
+    });
+
+    it("does not close the window a second time after it unloads itself", () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => usePrint());
+
+      act(() => {
+        result.current.printReceipt("<div>Test</div>");
+      });
+      act(() => {
+        mockPrintWindow.onload?.();
+      });
+      act(() => {
+        emitPrintWindowEvent("unload");
+        vi.advanceTimersByTime(60_000);
+      });
+      vi.useRealTimers();
+
+      expect(mockPrintWindow.close).not.toHaveBeenCalled();
     });
 
     it("should handle blocked popup window", () => {


### PR DESCRIPTION
## Problem

The wigclub production terminal keeps reporting unhandled rejections from `usePrint`:

```
Failed to execute 'print' on 'Window': The provided callback is no longer runnable.
  at l (https://athena.wigclub.store/assets/usePrint-BOk7njdX.js:269:173)
flow: "unhandled" | message: "Unhandled promise rejection"
```

Six occurrences in `posClientEvent` for store `nn7byz68a3j4tfjvgdf9evpt3n78kk38`, all from one
terminal fingerprint, the most recent two on 2026-08-01. The deployed bundle already contains
the guards from #701, so that fix did not close the hole.

## Cause

#701 guarded the *entry* to `print()` (closed / closing / print-once) but left the teardown
timer untouched: `printReceipt` closed the popup 500ms after `print()` returned. That discards
the browsing context while the browser is still unwinding the print pipeline.

Chrome raises that failure asynchronously, which is why it lands as an unhandled *promise
rejection* on the parent window even though `print()` sits inside a `try/catch` — a synchronous
throw at that call site would have been caught and logged as "Error during printing:" instead.

The async-delivery mechanism is inferred from the error signature plus the call-site guards,
not from a live print-dialog repro.

## Fix

Close the print window on its own `afterprint` event (plus a short breather) rather than on a
fixed delay, so the context always outlives the print flow. A 60s fallback covers browsers that
never fire `afterprint`, and is long enough that it cannot fire while a cashier still has the
dialog open.

## Verification

- The two new tests fail against the previous implementation and pass against this one.
- All 26 tests in `src/tests/pos/usePrint.test.ts` pass.
- `typecheck` and `lint:frontend:changed` clean; `bun run pr:athena` passed with proof recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)