### PR TITLE
[V26-1155] Make the payment verification lane usable at production volume

### DIFF
--- a/docs/reports/2026-08-03-verify-payment-lane-capacity-report.html
+++ b/docs/reports/2026-08-03-verify-payment-lane-capacity-report.html
@@ -1,0 +1,422 @@
+<!doctype html>
+<html lang="en" data-athena-landed-change-report="v1" data-athena-report-diff-fingerprint="75b379367dc2942cfe9bc8d31ad843ea37227618487da43a773ead6b60855817" data-athena-report-base="origin/main" data-athena-report-head="codex/verify-payment-lane-capacity 8033dcce">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Making the payment verification lane usable at production volume</title>
+    <style>
+      :root {
+        --ink: #1f2933;
+        --muted: #596674;
+        --line: #d9e2ec;
+        --paper: #ffffff;
+        --soft: #f6f8fb;
+        --accent: #1d4ed8;
+        --accent-soft: #dbeafe;
+        --good: #166534;
+        --bad: #b91c1c;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--soft);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      main { max-width: 1120px; margin: 0 auto; padding: 48px 24px 72px; }
+      header { border-bottom: 1px solid var(--line); margin-bottom: 28px; padding-bottom: 28px; }
+      h1, h2, h3 { line-height: 1.18; letter-spacing: 0; }
+      h1 { font-size: 42px; max-width: 880px; margin: 0 0 16px; }
+      h2 { font-size: 28px; margin: 0 0 16px; }
+      h3 { font-size: 19px; margin: 22px 0 10px; }
+      p { margin: 0 0 14px; }
+      .lede { color: var(--muted); font-size: 18px; max-width: 880px; }
+      .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 20px; }
+      .pill { border: 1px solid var(--line); border-radius: 999px; background: var(--paper); color: var(--muted); font-size: 13px; padding: 6px 10px; }
+      .panel { background: var(--paper); border: 1px solid var(--line); border-radius: 8px; margin: 18px 0; padding: 22px; }
+      code { background: #eef2f7; border: 1px solid #d8dee8; border-radius: 5px; padding: 1px 5px; }
+      pre { overflow: auto; background: #111827; color: #e5e7eb; border-radius: 8px; padding: 16px; }
+      pre code { background: transparent; border: 0; color: inherit; padding: 0; }
+      .table-scroll { overflow-x: auto; }
+      table { width: 100%; border-collapse: collapse; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+      th, td { border-bottom: 1px solid var(--line); padding: 11px 12px; text-align: left; vertical-align: top; }
+      th { background: #eef2f7; color: var(--muted); font-size: 13px; text-transform: uppercase; }
+      tr:last-child td { border-bottom: 0; }
+      .quiz-question { border-top: 1px solid var(--line); padding: 18px 0; }
+      .quiz-question:first-child { border-top: 0; }
+      fieldset { border: 0; margin: 0; padding: 0; }
+      legend { font-weight: 700; margin-bottom: 10px; }
+      label { display: block; border: 1px solid var(--line); border-radius: 8px; background: #fbfdff; margin: 8px 0; padding: 10px 12px; cursor: pointer; }
+      @media (hover: hover) and (pointer: fine) {
+        label:hover { border-color: #b6c5d8; }
+      }
+      button {
+        appearance: none;
+        border: 0;
+        border-radius: 8px;
+        background: var(--accent);
+        color: #ffffff;
+        cursor: pointer;
+        font-weight: 700;
+        padding: 11px 16px;
+        transition: transform 140ms cubic-bezier(0.23, 1, 0.32, 1);
+      }
+      button:active { transform: scale(0.97); }
+      button.secondary { background: #475569; }
+      .quiz-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
+      #quizResult { font-weight: 700; }
+      .answer-detail { display: none; border-top: 1px dashed var(--line); color: var(--muted); margin-top: 10px; padding-top: 10px; }
+      .answer-detail.visible { display: block; }
+      .correct { border-color: #86efac !important; background: #f0fdf4 !important; }
+      .incorrect { border-color: #fecaca !important; background: #fef2f2 !important; }
+      @media (prefers-reduced-motion: reduce) { button { transition-duration: 0ms; } }
+      @media (max-width: 820px) { h1 { font-size: 32px; } main { padding: 32px 16px 56px; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Making the payment verification lane usable at production volume</h1>
+        <p class="lede">The report source verifier had a green test suite and could not return a verdict on a real store. When it did speak, it called GH&#8373;3,960 of untouched payment data a mismatch. Both defects were arithmetic against production row counts, and no test could have found either.</p>
+        <div class="meta"><span class="pill">Delivery candidate</span><span class="pill">Branch codex/verify-payment-lane-capacity</span><span class="pill">Commit 8033dcce</span><span class="pill">Base origin/main</span><span class="pill">Linear V26-1155</span><span class="pill">No PR opened</span><span class="pill">Merge gate pending</span><span class="pill">Production not mutated</span><span class="pill">Root alignment pending</span></div>
+      </header>
+
+      <section class="panel"><h2>Executive Summary</h2>
+        <p>Athena's report source verifier recomputes each day's metrics from primary tables and compares them against what the fold persisted. It was complete, it was tested, and the suite was green. Then it was <strong>run against production for the first time</strong>, and it failed in two ways at once.</p>
+        <p><strong>It could not return a verdict.</strong> <code>verifyCurrentWeekAgainstSources</code> on the production Wigclub store returned <code>{ outcome: "incomplete", reason: "source_cap_exceeded" }</code> &mdash; not a pass, not a mismatch, nothing. Every per-day run for 2026-07-27..08-02 returned the same. The payment allocation scan read a 90-day window under a 500-document cap; that window on production holds <strong>1,050 rows</strong>, about 12 allocations a day. One over-wide read was costing the entire lane.</p>
+        <p><strong>And when it did speak, it lied by omission.</strong> An incomplete lane fell back to an <code>expected</code> of <code>0</code>, and the diff builder dutifully compared that zero to the real folded total: <code>{ field: "paymentsCollectedMinor", expected: 0, actual: 396000 }</code> with <code>matches: false</code>. Monitoring output that reads as corrupted payment data when <em>nothing had been checked</em>. This is the more dangerous of the two bugs, because it makes a capacity limit and a genuine data discrepancy byte-identical &mdash; so a real finding would be dismissed as noise.</p>
+        <p>The fix is two independently bounded index reads with their ceiling arithmetic recorded beside the constants, and a third result state: <code>unverifiedFields</code>. Three files, 570 insertions against 52 deletions, one commit off <code>main</code>. The gate counts <strong>305 considerable source lines</strong> &mdash; tests excluded &mdash; against a 150-line solution-note threshold and a 300-line report threshold.</p>
+        <p>The sales lane, throughout all of this, was verifying clean on production on all seven days.</p>
+      </section>
+
+      <section class="panel"><h2>Problem and Context</h2>
+        <p>The verifier exists because a reporting pipeline that only checks itself proves nothing. Its rule, inherited from the read-optimized redesign, is <em>verify against sources, not against the pipeline</em>: recompute the day from <code>posTransaction</code>, <code>paymentAllocation</code>, adjustments, storefront orders and service cases, then diff that against the projection.</p>
+        <p>Every source scan is bounded, because an unbounded read in Convex is a production incident waiting for a busy store. The payment lane's bound had already been fixed once: an earlier change (<code>766bfe61</code>) introduced <code>PAYMENT_VOID_LOOKBACK_MS</code> and replaced a lifetime scan with the date-bounded window <code>[startAt - 90d, endAt]</code>. That was correct and necessary.</p>
+        <p>The 90 days are not arbitrary. <code>paymentAllocation</code> is indexed on <code>recordedAt</code> only, but a row contributes to a day at <em>two</em> instants: its original event at <code>recordedAt</code>, and &mdash; when voided with a server timestamp &mdash; its reversal at <code>voidedAt</code>. A row voided today may have been recorded months ago. To catch that, the scan reached back.</p>
+        <p><strong>Bounding a read is not the same as sizing it.</strong> A 90-day window under a 500-document ceiling is an unstated claim that the store does fewer than about 5.5 allocations a day. Nobody wrote that claim down, and nobody checked it. Production does twelve. So the lane went <code>incomplete</code> on day one of real use, on every day, permanently &mdash; even though the rows the period actually needed numbered in the dozens.</p>
+        <p>The second defect was waiting behind the first, and would have stayed invisible if the first had never fired. There was no way to say "unknown". The verifier had exactly two answers &mdash; agreed and differs &mdash; so an expectation that could not be established had nowhere to go but <code>differs</code>, against whatever the zero-value happened to be.</p>
+      </section>
+
+      <section class="panel"><h2>Mental Model</h2>
+        <p>Two ideas carry the change. The first is about reads:</p>
+        <p><strong>One read cannot answer two questions with different volumes.</strong> The old scan was asking two things at once:</p>
+        <pre><code>"What allocations belong to this period?"        ~30 rows   (common, essential)
+"Was an older allocation voided during it?"    ~1,050 rows (rare, cheap to lose)</code></pre>
+        <p>Under one ceiling, the rare question gets to veto the essential one. Split them and each gets a bound proportional to its own volume &mdash; and, more importantly, its own <em>failure mode</em>. Running out of in-period rows costs the day. Running out of lookback rows costs only the ability to spot a historical void.</p>
+        <p>The second idea is about outputs. A verifier needs three states, not two:</p>
+        <div class="table-scroll">
+        <table>
+          <thead><tr><th>State</th><th>Means</th><th>Where it appears</th></tr></thead>
+          <tbody>
+            <tr><td>agreed</td><td>Checked, and the source matched the projection</td><td>absent from <code>differences</code></td></tr>
+            <tr><td>differs</td><td>Checked, and they disagree</td><td><code>differences</code> / <code>paymentDifferences</code></td></tr>
+            <tr><td><strong>unverified</strong></td><td><strong>Not checked. No claim is made.</strong></td><td><code>unverifiedFields</code> &mdash; and nowhere else</td></tr>
+          </tbody>
+        </table>
+        </div>
+        <p>Collapsing the third into the second is what produced <code>expected: 0</code>. <code>matches</code> now means precisely <strong>"everything checked agreed"</strong>, so <code>matches: true</code> with a non-empty <code>unverifiedFields</code> is <em>partial</em> verification, not a clean bill of health. Alerting must read both.</p>
+      </section>
+
+      <section class="panel"><h2>Before and After</h2>
+        <ul>
+          <li>Before: one scan, <code>[startAt - 90d, endAt]</code>, ceiling <code>VERIFY_MAX_DOCS_PER_DOMAIN</code> (500). After: two half-open scans on <code>by_storeId_recordedAt</code> with ceilings of 5,000 and 3,000, derived from a measured rate and documented beside the constants.</li>
+          <li>Before: exhausting the read made the whole payment posture unreadable. After: exhausting the <em>lookback</em> ceiling degrades only reversal detection; the in-period posture still verifies.</li>
+          <li>Before: an incomplete lane produced <code>expected: 0</code> and a false difference. After: the affected fields are withdrawn from comparison and named on <code>unverifiedFields</code>.</li>
+          <li>Before: <code>matches</code> required <code>paymentPosture.outcome === "complete"</code>, so "we could not check" read as "it is wrong". After: <code>matches</code> is <code>!truncated &amp;&amp; differences.length === 0 &amp;&amp; paymentDifferences.length === 0</code>.</li>
+          <li>Before: one day with an incomplete payment lane returned <code>incomplete</code> for the entire week &mdash; six clean lanes discarded to say nothing about one. After: the week verifies and unions the withheld field names.</li>
+          <li>Before: weekly reasons included <code>payment_source_incomplete</code> and <code>invalid_payment_allocation</code>. After: both unreachable, and removed from the union. (Repo-wide grep: zero remaining references in source.)</li>
+          <li>Unchanged: the sales, adjustment, storefront and service lanes; <code>PAYMENT_VOID_LOOKBACK_MS</code> at 90 days and its documented blind spot; the persisted schema. Nothing in this commit is stored &mdash; <code>unverifiedFields</code> is a return-shape addition only.</li>
+        </ul>
+      </section>
+
+      <section class="panel"><h2>Layer-by-Layer Mechanics</h2>
+
+        <h3>1. The two reads</h3>
+        <pre><code>const inPeriodAllocations = await ctx.db
+  .query("paymentAllocation")
+  .withIndex("by_storeId_recordedAt", (q) =&gt;
+    q.eq("storeId", storeId).gte("recordedAt", startAt).lte("recordedAt", endAt),
+  )
+  .take(VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD + 1);   // 5_000
+
+const reversalLookbackProbe = await ctx.db
+  .query("paymentAllocation")
+  .withIndex("by_storeId_recordedAt", (q) =&gt;
+    q.eq("storeId", storeId)
+      .gte("recordedAt", startAt - PAYMENT_VOID_LOOKBACK_MS)
+      .lt("recordedAt", startAt),
+  )
+  .order("desc")
+  .take(VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS + 1);  // 3_000</code></pre>
+        <p>The lookback is <strong>newest-first</strong>. That is not a stylistic choice: a row voided during the period is far likelier to have been recorded recently, so when this read caps out, the rows it keeps are the ones most likely to matter. The two ranges are half-open against each other (<code>.lt("recordedAt", startAt)</code>), so nothing is counted twice. Rows from the lookback contribute <strong>only their reversal</strong> &mdash; their original event belongs to an earlier day by construction &mdash; so that loop opens with <code>if (allocation.status !== "voided") continue;</code>.</p>
+        <p>Only <code>inPeriodCapExceeded</code> sets <code>truncated</code>. Neither read collects.</p>
+
+        <h3>2. The ceiling arithmetic, written down</h3>
+        <p>The numbers are documented next to the constants, which is the part that would otherwise rot into folklore:</p>
+        <div class="table-scroll">
+        <table>
+          <thead><tr><th>Read</th><th>Expected volume</th><th>Ceiling</th><th>Headroom</th></tr></thead>
+          <tbody>
+            <tr><td>In-period</td><td>~30 rows (one operating day &plusmn;18h of slack &asymp; 2.5 days, at 12/day)</td><td>5,000</td><td>~2,000/day &mdash; ~165x measured, 10x the old 500 cap</td></tr>
+            <tr><td>Reversal lookback</td><td>~1,080 rows (90 days at 12/day)</td><td>3,000</td><td>~33/day &mdash; ~2.8x measured</td></tr>
+          </tbody>
+        </table>
+        </div>
+        <p>The lookback ceiling is deliberately the tighter of the two, because exhausting it is a soft degradation rather than a lost day. Worst-case read budget for the payment lane, per day: <code>(5,000 + 1) + (3,000 + 1)</code> index-backed documents. Measured in practice: about thirty.</p>
+
+        <h3>3. The seven fields, and why one of them survives</h3>
+        <p><code>VerifyUnverifiedField</code> names every field whose source-side expectation can be unknown rather than wrong. All seven are payment-side, because the payment lane is the only one that can be withheld while the rest of the day still verifies: three metrics (<code>paymentsCollectedMinor</code>, <code>paymentsRefundedMinor</code>, <code>paymentAllocatedMinor</code>) and four posture fields (<code>paymentUnsettledMinor</code>, <code>paymentAllocationCoverage</code>, <code>paymentAllocationOmittedMinor</code>, <code>paymentHasInvalidAllocation</code>).</p>
+        <pre><code>if (posture.outcome === "incomplete") {
+  return [...VERIFY_PAYMENT_METRIC_KEYS, ...VERIFY_PAYMENT_POSTURE_FIELDS];  // all 7
+}
+if (posture.reversalLookback.outcome === "incomplete") {
+  return [
+    ...VERIFY_PAYMENT_METRIC_KEYS.filter((f) =&gt; f !== "paymentsCollectedMinor"),
+    ...VERIFY_PAYMENT_POSTURE_FIELDS,
+  ];                                                                          // 6
+}
+return [];</code></pre>
+        <p>The two degradations are <strong>deliberately unequal</strong>, and the asymmetry is the most interesting line of reasoning in the change. <strong>In-period collection cannot be moved by an unseen historical void.</strong> A void of a pre-window row lands as a <em>reversal</em>: it adds to <code>paymentsRefundedMinor</code> and subtracts from <code>paymentAllocatedMinor</code>. It never touches what was collected inside the period. So an exhausted lookback withholds refunds, allocation and every posture field derived from them &mdash; but <code>paymentsCollectedMinor</code> stays verified. Withholding it too would have been the easy, symmetrical, and strictly less useful choice.</p>
+
+        <h3>4. Withheld before diffing, not filtered after</h3>
+        <pre><code>const unverifiedFields = unverifiedPaymentFields(paymentPosture);
+const unverified = new Set&lt;string&gt;(unverifiedFields);
+const differences = diffMetrics(expected, foldedMetrics(day)).filter(
+  (difference) =&gt; !unverified.has(difference.field),
+);</code></pre>
+        <p>A withheld field is never a candidate for disagreement. Six channels apply the filter: the day's <code>differences</code> and <code>paymentDifferences</code>; the weekly <code>includedDifferences</code>, <code>outsideScheduleDifferences</code> and the two payment equivalents; the accepted-baseline comparison; and the amendment comparison. That last one carries its own reasoning &mdash; an amendment is a claim that the week <em>moved</em>, and a field nobody checked has not moved.</p>
+
+        <h3>5. The week stops sinking</h3>
+        <p><code>verifyCurrentWeekWithCtx</code> used to <code>return</code> early with <code>incomplete</code> the moment any day's payment posture failed. It now keeps iterating all seven dates and unions the withheld names into one set, so <code>daysChecked: 7</code> with <code>outcome: "verified"</code> and a populated <code>unverifiedFields</code> is now reachable where the old code returned nothing usable.</p>
+
+        <h3>6. The deviation: pagination was not available</h3>
+        <p>The brief called for pagination on the in-period lane. <strong>Convex permits only one <code>.paginate()</code> per function execution</strong>, and this lane runs seven times inside a single <code>verifyCurrentWeekAgainstSources</code> &mdash; so pagination was structurally unavailable, not merely awkward. <code>convex-test</code> enforces the rule in the mock rather than letting it pass locally and fail in a deployed backend (<code>node_modules/convex-test/dist/index.js:951</code>):</p>
+        <pre><code>"Only a single paginated query (`.paginate()`) is allowed per function
+ execution. Calling `.paginate()` more than once in a single Convex function
+ fails at runtime in a deployed backend."</code></pre>
+        <p>A single bounded <code>.take(ceiling + 1)</code> is used instead. Anyone planning to paginate a per-day read inside a per-week aggregate in Convex will meet this wall; the workable answer is a well-sized bounded read with the arithmetic written down.</p>
+      </section>
+
+      <section class="panel"><h2>Failure Boundaries</h2>
+        <ul>
+          <li><strong>In-period allocations exceed 5,000.</strong> An honest <code>incomplete</code>: a partial in-period read is a lower bound, never a total that happens to agree. It sets <code>truncated</code>, which forces <code>matches: false</code>, and withholds all seven payment fields. Asserted by <em>refuses a period that exceeds the in-period allocation ceiling</em>.</li>
+          <li><strong>Pre-period allocations exceed 3,000.</strong> <code>reversalLookback = { outcome: "incomplete", reason: "lookback_cap_exceeded" }</code>. <code>truncated</code> stays false, the in-period posture still verifies, six of seven fields are withheld. Asserted by <em>degrades only reversal detection when the lookback bound is exhausted</em>.</li>
+          <li><strong>The boundary is narrower than the headline.</strong> It is the lookback <em>cap</em> that is isolated from the in-period posture, not the lookback lane as a whole. A pre-window row carrying <code>voided_refund_unsupported</code> or <code>legacy_void_missing_timestamp</code> still sets <code>paymentIncompleteReason</code> and so still degrades the in-period posture to <code>incomplete</code>. That is correct &mdash; those are unrepresentable facts, not a capacity limit &mdash; but worth knowing before reading the reversal lane as fully independent.</li>
+          <li><strong>A void older than 90 days.</strong> Still invisible, deliberately and unchanged. Documented in the module as a known blind spot: bounded staleness, not unbounded drift.</li>
+          <li><strong>A genuine payment mismatch.</strong> Still reported. When the lane completes, <code>unverifiedFields</code> is empty and nothing is filtered &mdash; asserted directly by <em>still reports a genuine payment mismatch when the lane completes</em>, which expects <code>expected: 9_000</code> against <code>actual: 396_000</code> and <code>matches: false</code>. Withholding must not become silencing, and only that test proves it does not.</li>
+          <li><strong><code>matches: true</code> read alone.</strong> This is the one boundary the code cannot close for you. It means "everything checked agreed", and with a non-empty <code>unverifiedFields</code> it is partial verification. The type carries the warning at the declaration site, but any consumer that ignores the list will draw a false conclusion.</li>
+          <li><strong>Nothing reads the new field yet.</strong> <code>unverifiedFields</code> has no consumer outside <code>verify.ts</code> and its two test files &mdash; no dashboard, alert, or UI branches on it. Until one does, the unchecked/wrong distinction lives in the return shape and not in anything an operator sees.</li>
+        </ul>
+      </section>
+
+      <section class="panel"><h2>What Intentionally Did Not Change</h2>
+        <ul>
+          <li><code>VERIFY_MAX_DOCS_PER_DOMAIN</code> is still 500, and still governs the completed-transaction, voided-transaction, adjustment, storefront-order and service-case scans. Raising it to cover the payment lane's worst case would have loosened four unrelated bounds to fix one. <strong>Those four bounds have not been measured against production either</strong> &mdash; they were not the lane that failed, which is not evidence they are sized right.</li>
+          <li><code>PAYMENT_VOID_LOOKBACK_MS</code> stays at 90 days. Only its <em>role</em> narrowed: it now governs the reversal read alone, and its doc comment was rewritten to say so.</li>
+          <li>The sales lane. It was already verifying clean against production, and the whole point of the split is that the payment lane's capacity problem was never the sales lane's problem.</li>
+          <li>The schema and the persisted contract. This commit touches three files and stores nothing new.</li>
+          <li>The posture-level <code>"invalid_allocation"</code> reason and the weekly-fold <code>"payment_invalid_allocation"</code>. Different enums from the two that were removed, and untouched.</li>
+        </ul>
+      </section>
+
+      <section class="panel">
+        <h2>Key Files</h2>
+        <div class="table-scroll">
+        <table>
+          <thead><tr><th>File</th><th>Why It Matters</th></tr></thead>
+          <tbody>
+            <tr><td><code>convex/reports/verify.ts</code></td><td>305 changed lines &mdash; the entire source diff. Both ceilings and their arithmetic, the split reads, <code>VerifyUnverifiedField</code>, <code>unverifiedPaymentFields</code>, the six difference-channel filters, the new <code>matches</code> definition, and the weekly union that replaced the early return. Also holds the weekly verifier: there is no <code>weeklyVerify.ts</code>.</td></tr>
+            <tr><td><code>convex/reports/verify.test.ts</code></td><td>282 changed lines. Three large-fixture ceiling tests at <code>60_000</code>, the void-lands-in-period test, and the <em>unverified is not mismatched</em> block &mdash; including the paired test that proves a real mismatch still reports.</td></tr>
+            <tr><td><code>convex/reports/weeklyVerify.test.ts</code></td><td>35 changed lines, one test. <em>keeps the weekly gate incomplete for an untimed legacy payment void</em> became <em>withholds payment fields for an untimed legacy void, keeping the rest verified</em> &mdash; the rename is the behavior change in one line.</td></tr>
+          </tbody>
+        </table>
+        </div>
+      </section>
+
+      <section class="panel"><h2>Validation and Review Evidence</h2>
+        <p><strong>Re-executed while writing this report.</strong> <code>convex/reports/verify.test.ts</code> (22 tests) and <code>convex/reports/weeklyVerify.test.ts</code> (15 tests) &mdash; <strong>2 files, 37 tests, 0 failures</strong> in 8.79s. The <code>delivery:documentation-check</code> gate was falsified in both directions: it fails with these two artifacts absent (naming both the 150-line solution-note threshold and the 300-line report threshold against 305 changed source lines) and exits 0 with them in place.</p>
+        <p><strong>Recorded in the delivery session</strong> (attributed rather than restated as this report's own evidence): a full local run of 674 files / 7,535 tests. A full run also shows 1&ndash;2 failures in <code>usePosLocalSyncRuntime.test.ts</code> at around 5000ms. These are the <strong>known load flake</strong>, not a regression from this change: the file passes 96/96 in isolation, and different tests within it fail on different runs. The same load pressure is why the three new ceiling tests carry explicit <code>60_000</code> timeouts &mdash; they seed thousands of allocations to exercise the real bounds and outran vitest's 5s default under full-suite contention.</p>
+        <p><strong>Falsifications performed in the delivery session.</strong> Each was an executed perturbation, not a prediction:</p>
+        <ul>
+          <li>Restoring the in-period scan to the 90-day window under the 500 ceiling fails <em>verifies a day whose in-period allocations exceed the old 500 cap</em>.</li>
+          <li>Making <code>unverifiedPaymentFields</code> return <code>[]</code> for an incomplete posture fails <em>withholds payment fields rather than diffing them against a fallback 0</em>.</li>
+        </ul>
+        <p><strong>Production evidence</strong> (deployment <code>prod:colorless-cardinal-870</code>, store Wigclub, 2026-08-02). <code>verifyCurrentWeekAgainstSources</code> returned <code>incomplete/source_cap_exceeded</code>; per-day verification for 2026-07-27..08-02 returned the same on all seven days. The <strong>sales lane verified clean on every one of those days</strong> &mdash; zero differences in net, gross, units or refunds (Jul 27 GH&#8373;4,240/36u, Jul 28 GH&#8373;6,225/118u, Jul 29 GH&#8373;1,295/20u, Jul 30 GH&#8373;5,905/82u, Jul 31 GH&#8373;2,425/57u, Aug 1 GH&#8373;3,960/77u, Aug 2 zero). That run independently re-confirmed that the 106-day mass refold changed no values. Measured 1,050 allocations in the 90-day window, oldest 2026-05-12, newest 2026-08-01. These figures come from the production run itself and could not be re-executed while writing this report.</p>
+        <p><strong>Status.</strong> Delivery candidate on <code>codex/verify-payment-lane-capacity</code> at commit <code>8033dcce</code>, one commit off <code>main</code>, clean working tree apart from these two documentation artifacts. No PR opened. Not merged. The full <code>bun run pr:athena</code> merge gate is pending. Production was not mutated by this change &mdash; the production activity was read-only verifier invocation. Root/local alignment is pending. Linear V26-1155 is not claimed as Done.</p>
+      </section>
+
+      <section class="panel"><h2>Next-Time Guidance</h2>
+        <ul>
+          <li><strong>A green test suite does not establish that a tool works at production scale. Run it against production.</strong> Both defects here were arithmetic against real row counts, and every test passed the entire time. For any read-bounded tool, a production dry run is a delivery step, not a follow-up.</li>
+          <li>Never choose a cap without measuring the volume it must clear, and record the measurement, the date, the store and the derivation beside the constant. A cap with no recorded arithmetic is indistinguishable from a guess.</li>
+          <li>Treat a window and a ceiling as one decision. <code>[startAt - 90d, endAt]</code> under 500 docs is a claim about allocations per day; write that claim down and check it. Widening a range means re-deriving the ceiling, and vice versa.</li>
+          <li>A verifier whose failure mode is indistinguishable from a finding is worse than no verifier. The cost is not the false alarm &mdash; it is that the next genuine mismatch arrives in the same shape and gets dismissed.</li>
+          <li>Never fall back to a sentinel in a comparison path. <code>expected: 0</code> is an assertion that the source side is zero. If a value cannot be computed, withhold the field; do not invent one and compare it.</li>
+          <li>Withhold before comparing, not after. Filtering a computed difference list leaves every future channel free to reintroduce the bug &mdash; six needed the filter here, and a seventh added later must not have to remember.</li>
+          <li>When one lane of a multi-lane check degrades, degrade that lane. Discarding six clean results to say nothing about one is a worse answer than a partial result with named gaps.</li>
+          <li>Ask what a degradation can actually move. The unequal withholding came from reasoning about causality, not from picking the safe symmetrical answer. Symmetry is often a sign nobody worked it out.</li>
+          <li>Size a regression test like the defect. A ceiling test that seeds ten rows tests nothing about the ceiling; if that means a 60s timeout, set one and say why in the file.</li>
+          <li>To extend this area: the next honest step is a consumer that renders <code>unverifiedFields</code> distinctly from <code>differences</code>, and a production measurement of the five domains still reading under the unexamined 500 cap.</li>
+        </ul>
+      </section>
+
+      <section class="panel">
+        <h2>Subagent Evidence</h2>
+        <ul>
+          <li><strong>Delivered-diff subagent (read-only codebase researcher):</strong> Mapped <code>git show 8033dcce</code> against the files at HEAD across all three changed files. Contributed the verbatim ceiling-arithmetic comment and confirmation that its <code>&plusmn;18h</code> / 2.5-day claim matches <code>OPERATING_DAY_SLACK_MS</code> and the actual candidate window; the exact seven-field split and its correspondence to the four <code>diffPaymentPosture</code> emitters; confirmation of both query shapes as <code>.take</code>-bounded and half-open with no <code>.paginate()</code> or <code>.collect()</code>; verification that all six difference channels filter; a repo-wide grep proving <code>payment_source_incomplete</code> and <code>invalid_payment_allocation</code> have zero remaining source references while the distinct <code>invalid_allocation</code> and <code>payment_invalid_allocation</code> enums are untouched; and the test inventory with the three <code>60_000</code> timeouts. It also produced two findings that corrected the framing of this report: that the lookback lane is isolated from the in-period posture only on the <em>cap</em> path, and that <code>unverifiedFields</code> currently has no consumer anywhere in the codebase.</li>
+          <li><strong>Session and documentation context subagent (read-only):</strong> Established the lineage used in the companion solution note &mdash; the read-optimized redesign and its "verify against sources, not against the pipeline" rule, the implementation plan defining Slice F, the schedule-day-driven weekly lifecycle, the 2026-08-02 fold-version/refold note whose output this run cross-checked, and the Convex read-amplification prior art. It identified commit <code>766bfe61</code> (squash of <code>90d2823a</code>) as the earlier date-bounding fix that introduced <code>PAYMENT_VOID_LOOKBACK_MS</code>, confirmed that no existing note covers read caps or payment allocation posture, recovered the production-run figures and the deployment identifier from session history, and recommended <code>logic-errors/</code> over <code>architecture-patterns/</code> on the grounds that no boundary design changed &mdash; only the honesty and capacity of one lane.</li>
+          <li><strong>Report review:</strong> No separate reviewer subagent was dispatched. Instead every executable claim here was re-run by the orchestrator: both verify suites, the documentation gate falsified in both directions, the <code>convex-test</code> pagination error quoted from the installed package, and the removed reason codes grepped. Claims that could not be re-executed &mdash; the production figures, the full-suite counts, the load flake, and the two perturbation runs &mdash; are attributed above to the delivery session rather than restated as this report's own evidence.</li>
+        </ul>
+      </section>
+
+      <section id="quiz" class="panel">
+        <h2>Quiz: Pass Required</h2>
+        <p>You must score at least 8 out of 10 to pass.</p>
+        <form id="changeQuiz" data-threshold="8">
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>1. The payment allocation scan was already date-bounded by an earlier fix. Why did it still fail on production?</legend>
+    <label><input type="radio" name="q1" value="0" /> The index <code>by_storeId_recordedAt</code> was missing, so the read fell back to a table scan</label>
+    <label><input type="radio" name="q1" value="1" /> The bound was applied to <code>voidedAt</code> rather than <code>recordedAt</code></label>
+    <label><input type="radio" name="q1" value="2" /> A 90-day window under a 500-document ceiling is an unstated claim that the store does under ~5.5 allocations a day; production does ~12, so the window held 1,050 rows</label>
+  </fieldset>
+  <div class="answer-detail">Bounding a read is not the same as sizing it. The window and the ceiling are one decision, and nobody had checked the claim the pair was making.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>2. Why two new ceilings instead of simply raising <code>VERIFY_MAX_DOCS_PER_DOMAIN</code>?</legend>
+    <label><input type="radio" name="q2" value="0" /> Convex enforces a hard per-query document limit that 500 was already near</label>
+    <label><input type="radio" name="q2" value="1" /> One read was answering two questions with very different volumes and very different costs on failure; the shared cap would also have loosened four unrelated scans</label>
+    <label><input type="radio" name="q2" value="2" /> The per-domain constant is generated and cannot be edited by hand</label>
+  </fieldset>
+  <div class="answer-detail">In-period is ~30 rows and essential; the lookback is ~1,080 rows and rare. Under one ceiling the rare question vetoes the essential one.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>3. Why is the reversal lookback read newest-first (<code>.order("desc")</code>)?</legend>
+    <label><input type="radio" name="q3" value="0" /> A row voided during the period is far likelier to be recent, so if the read caps out it keeps the rows most likely to matter</label>
+    <label><input type="radio" name="q3" value="1" /> Descending index reads are cheaper in Convex than ascending ones</label>
+    <label><input type="radio" name="q3" value="2" /> It guarantees the lookback and in-period ranges cannot overlap</label>
+  </fieldset>
+  <div class="answer-detail">Non-overlap comes from the half-open bound <code>.lt("recordedAt", startAt)</code>, not from the ordering. The ordering is about which rows survive truncation.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>4. An exhausted reversal lookback withholds six of the seven payment fields, keeping <code>paymentsCollectedMinor</code> verified. Why that one?</legend>
+    <label><input type="radio" name="q4" value="0" /> It is the only field the weekly projection persists, so it must always be comparable</label>
+    <label><input type="radio" name="q4" value="1" /> It is derived from <code>posTransaction</code> rather than from <code>paymentAllocation</code>, so the lookback is irrelevant to it</label>
+    <label><input type="radio" name="q4" value="2" /> A void of a pre-window row lands as a reversal &mdash; it moves refunds and allocation but can never change what was collected inside the period</label>
+  </fieldset>
+  <div class="answer-detail">The asymmetry comes from reasoning about causality rather than choosing the safe symmetrical answer. Symmetry here would have been strictly less useful.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>5. What does <code>matches: true</code> with a non-empty <code>unverifiedFields</code> mean?</legend>
+    <label><input type="radio" name="q5" value="0" /> The day verified cleanly; <code>unverifiedFields</code> is advisory metadata about read cost</label>
+    <label><input type="radio" name="q5" value="1" /> Partial verification &mdash; everything <em>checked</em> agreed, but the named fields were never compared, and alerting must read both</label>
+    <label><input type="radio" name="q5" value="2" /> An internal inconsistency that should never occur and indicates a verifier bug</label>
+  </fieldset>
+  <div class="answer-detail">This is the one boundary the code cannot close for you. The type carries the warning at its declaration, but a consumer that reads <code>matches</code> alone will draw a false conclusion.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>6. The old output was <code>{ field: "paymentsCollectedMinor", expected: 0, actual: 396000 }</code> with <code>matches: false</code>. Why was this called the more dangerous of the two defects?</legend>
+    <label><input type="radio" name="q6" value="0" /> Nothing had been checked, yet the output was byte-identical to a genuine discrepancy &mdash; so a real finding would later be dismissed as a known false alarm</label>
+    <label><input type="radio" name="q6" value="1" /> The fallback zero was written back into the projection, corrupting the stored day</label>
+    <label><input type="radio" name="q6" value="2" /> It masked the capacity problem, delaying discovery of the cap</label>
+  </fieldset>
+  <div class="answer-detail">A verifier whose failure mode is indistinguishable from a finding is worse than no verifier. The cost is the credibility of every future alert, not the single false one.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>7. The brief asked for pagination on the in-period lane. Why was a bounded <code>.take(ceiling + 1)</code> used instead?</legend>
+    <label><input type="radio" name="q7" value="0" /> Pagination cursors cannot be used inside a <code>QueryCtx</code> helper function</label>
+    <label><input type="radio" name="q7" value="1" /> Pagination would have been correct but was deferred to a follow-up for time</label>
+    <label><input type="radio" name="q7" value="2" /> Convex allows only one <code>.paginate()</code> per function execution, and this lane runs seven times inside one <code>verifyCurrentWeekAgainstSources</code></label>
+  </fieldset>
+  <div class="answer-detail"><code>convex-test</code> enforces the rule in the mock rather than letting it pass locally and fail in a deployed backend. Anyone paginating a per-day read inside a per-week aggregate will hit this.</div>
+</div>
+
+<div class="quiz-question" data-answer="1">
+  <fieldset>
+    <legend>8. Which pair of tests, taken together, proves the withholding mechanism is safe?</legend>
+    <label><input type="radio" name="q8" value="0" /> The two ceiling tests &mdash; one for the in-period bound, one for the lookback bound</label>
+    <label><input type="radio" name="q8" value="1" /> <em>withholds payment fields rather than diffing them against a fallback 0</em> together with <em>still reports a genuine payment mismatch when the lane completes</em></label>
+    <label><input type="radio" name="q8" value="2" /> The weekly rename test together with <em>detects a void landing in-period against an older allocation</em></label>
+  </fieldset>
+  <div class="answer-detail">The first shows unchecked fields are withheld; the second shows withholding did not become silencing. Either alone would be consistent with a broken verifier.</div>
+</div>
+
+<div class="quiz-question" data-answer="0">
+  <fieldset>
+    <legend>9. A full local suite run shows 1&ndash;2 failures in <code>usePosLocalSyncRuntime.test.ts</code> at around 5000ms. How should this be read?</legend>
+    <label><input type="radio" name="q9" value="0" /> The known load flake &mdash; the file passes 96/96 in isolation and different tests fail on different runs; separately, the three new ceiling tests carry explicit <code>60_000</code> timeouts for the same load reason</label>
+    <label><input type="radio" name="q9" value="1" /> A regression introduced by the new large allocation fixtures competing for the same workers</label>
+    <label><input type="radio" name="q9" value="2" /> Proof the 60s timeouts were set too high and are starving other suites</label>
+  </fieldset>
+  <div class="answer-detail">The 60s timeouts exist because the ceiling tests seed thousands of allocations to exercise the real bounds and outran the 5s default under contention. A ceiling test that seeds ten rows tests nothing about the ceiling.</div>
+</div>
+
+<div class="quiz-question" data-answer="2">
+  <fieldset>
+    <legend>10. What is honestly still open after this change, and what is its delivery status?</legend>
+    <label><input type="radio" name="q10" value="0" /> Nothing &mdash; the lane is fully verified end to end, and the change is merged and deployed</label>
+    <label><input type="radio" name="q10" value="1" /> Only the 90-day blind spot remains, and it is scheduled for removal in the next slice</label>
+    <label><input type="radio" name="q10" value="2" /> No consumer reads <code>unverifiedFields</code> yet, and five other source domains still read under the unmeasured 500 cap &mdash; and the change is a delivery candidate at <code>8033dcce</code>, not merged, not deployed</label>
+  </fieldset>
+  <div class="answer-detail">Until something renders unchecked differently from wrong, the distinction lives in the return shape and not in anything an operator sees. And the four untouched bounds were not the lane that failed, which is not evidence they are sized right.</div>
+</div>
+
+          <div class="quiz-actions">
+            <button type="button" id="gradeQuiz">Grade quiz</button>
+            <button type="button" class="secondary" id="resetQuiz">Reset</button>
+            <span id="quizResult" aria-live="polite"></span>
+          </div>
+        </form>
+      </section>
+
+    </main>
+    <script>
+      const questions = Array.from(document.querySelectorAll(".quiz-question"));
+      const result = document.getElementById("quizResult");
+      const form = document.getElementById("changeQuiz");
+      const threshold = Number(form.dataset.threshold || 0);
+      function clearGrades() {
+        questions.forEach((question) => {
+          question.classList.remove("correct", "incorrect");
+          question.querySelector(".answer-detail").classList.remove("visible");
+        });
+        result.textContent = "";
+        result.style.color = "";
+      }
+      document.getElementById("gradeQuiz").addEventListener("click", () => {
+        clearGrades();
+        let score = 0;
+        questions.forEach((question, index) => {
+          const selected = document.querySelector(`input[name="q${index + 1}"]:checked`);
+          const isCorrect = selected && Number(selected.value) === Number(question.dataset.answer);
+          if (isCorrect) score += 1;
+          question.classList.add(isCorrect ? "correct" : "incorrect");
+          question.querySelector(".answer-detail").classList.add("visible");
+        });
+        const passed = score >= threshold;
+        result.textContent = passed
+          ? `Passed: ${score}/${questions.length}.`
+          : `Not passed: ${score}/${questions.length}. Review the report and try again.`;
+        result.style.color = passed ? "var(--good)" : "var(--bad)";
+      });
+      document.getElementById("resetQuiz").addEventListener("click", () => {
+        form.reset();
+        clearGrades();
+      });
+    </script>
+  </body>
+</html>

--- a/docs/solutions/logic-errors/athena-verifier-payment-lane-capacity-and-unverified-is-not-mismatched-2026-08-03.md
+++ b/docs/solutions/logic-errors/athena-verifier-payment-lane-capacity-and-unverified-is-not-mismatched-2026-08-03.md
@@ -1,0 +1,397 @@
+---
+title: A Verifier Must Be Sized Against Production and Must Never Report Unchecked as Wrong
+date: 2026-08-03
+category: logic-errors
+module: Athena Reports / Source Verification
+problem_type: logic_error
+component: payments
+symptoms:
+  - "`verifyCurrentWeekAgainstSources` on production returned `{ outcome: \"incomplete\", reason: \"source_cap_exceeded\" }` — no verdict for any day"
+  - "Every per-day run for 2026-07-27..08-02 hit the same payment cap while the sales lane verified clean"
+  - "The diff builder emitted `paymentsCollectedMinor` expected 0 against actual 396,000 with `matches: false` for a lane that had checked nothing"
+  - "A capped read and a genuine data discrepancy produced byte-identical output"
+  - "The full test suite was green throughout — 674 files, 7,535 tests"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - "payment-allocation-scan"
+  - "weekly-source-verification"
+  - "convex-index-range-reads"
+  - "monitoring-output"
+tags:
+  - source-verification
+  - read-caps
+  - production-volume
+  - unverified-not-mismatched
+  - partial-verification
+  - convex-pagination-limit
+  - payment-allocation
+  - observability
+delivery_diff_fingerprint: 75b379367dc2942cfe9bc8d31ad843ea37227618487da43a773ead6b60855817
+---
+
+# A Verifier Must Be Sized Against Production and Must Never Report Unchecked as Wrong
+
+## Problem
+
+Athena's report source verifier recomputes each day's metrics from primary
+sources and compares them to what the fold persisted. It had a complete test
+suite and it was green. Then it was **run against production** for the first
+time, and both of its defects appeared at once — neither of which any test could
+have surfaced, because both are functions of real data volume.
+
+`verifyCurrentWeekAgainstSources` on the production Wigclub store returned
+`{ outcome: "incomplete", reason: "source_cap_exceeded" }`. Not a mismatch, not a
+pass — **no verdict at all**, for the whole week. Running the per-day verifier
+across 2026-07-27..08-02 gave the same answer on all seven days.
+
+Worse, the per-day output did not say "unknown". It said this:
+
+```
+{ field: "paymentsCollectedMinor", expected: 0, actual: 396000 }   matches: false
+```
+
+An incomplete payment lane fell back to an `expected` of `0`, and `buildDifferences`
+then diffed that zero against the real folded total. Production monitoring output
+looked like GH₵3,960 of corrupted payment data when in fact **nothing had been
+checked**. That is the worst output a verifier can produce: a cap and a genuine
+discrepancy are indistinguishable, so a real finding would have been dismissed as
+noise and this non-finding demanded an investigation.
+
+The two defects have one shared cause — the verifier was built and tested at
+fixture scale and never run at production scale until this branch.
+
+## Symptoms
+
+- `verifyCurrentWeekAgainstSources` returned `incomplete/source_cap_exceeded` on
+  production; the weekly gate could not produce a verdict.
+- All seven per-day runs for 2026-07-27..08-02 returned the same payment cap
+  outcome. The **sales lane verified clean on every one of those days** — zero
+  differences in net sales, gross, units, or refunds (Jul 27 GH₵4,240/36u,
+  Jul 28 GH₵6,225/118u, Jul 29 GH₵1,295/20u, Jul 30 GH₵5,905/82u, Jul 31
+  GH₵2,425/57u, Aug 1 GH₵3,960/77u, Aug 2 zero). Only payments were affected,
+  and that run independently re-confirmed that the 106-day mass refold changed
+  no values.
+- A withheld field surfaced as a difference with `expected: 0`.
+- The whole failure was invisible locally. The test suite passed.
+
+## What Didn't Work
+
+- **The date-bounding fix alone.** An earlier change had already bounded the
+  allocation scan to the verified period rather than the store's lifetime,
+  replacing an unbounded read. That was correct and necessary and it was still
+  not enough: the window it settled on was `[startAt - 90d, endAt]`, and 90 days
+  against a 500-document ceiling is arithmetically unusable for any store doing
+  more than ~5.5 allocations a day. Production does ~12. Bounding a read is not
+  the same as *sizing* it.
+- **Raising `VERIFY_MAX_DOCS_PER_DOMAIN`.** The per-domain cap is shared by five
+  other source scans. Raising it to cover the payment lane's worst case would
+  have loosened four unrelated bounds to fix one, and would still have left one
+  over-wide read answering two different questions under one ceiling.
+- **Pagination on the in-period lane.** This was the shape the brief asked for
+  and it is unavailable here — see the deviation recorded below.
+
+## Solution
+
+### 1. Two reads, bounded independently, failing differently
+
+The single scan over `[startAt - 90d, endAt]` was doing two unrelated jobs. The
+90-day lookback exists only because `paymentAllocation` is indexed on
+`recordedAt`: a row **recorded long ago but voided during the verified period**
+must still be found, since a void contributes its reversal at `voidedAt`. That
+is a real case, but a rare one — and it was costing the entire lane.
+
+It is now two `.take`-bounded range scans on `by_storeId_recordedAt`:
+
+```ts
+const inPeriodAllocations = await ctx.db
+  .query("paymentAllocation")
+  .withIndex("by_storeId_recordedAt", (q) =>
+    q.eq("storeId", storeId).gte("recordedAt", startAt).lte("recordedAt", endAt),
+  )
+  .take(VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD + 1);   // 5_000
+
+// Newest-first: a row voided during the period is far likelier to be recent,
+// so when this read caps out the rows it keeps are the ones that matter.
+const reversalLookbackProbe = await ctx.db
+  .query("paymentAllocation")
+  .withIndex("by_storeId_recordedAt", (q) =>
+    q
+      .eq("storeId", storeId)
+      .gte("recordedAt", startAt - PAYMENT_VOID_LOOKBACK_MS)
+      .lt("recordedAt", startAt),
+  )
+  .order("desc")
+  .take(VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS + 1);  // 3_000
+```
+
+Rows from the lookback contribute **only their reversal** — their original
+event belongs to an earlier day by construction, so the loop over them starts
+`if (allocation.status !== "voided") continue;`.
+
+The two lanes now fail differently, which is the whole point:
+
+| Read | Ceiling | Exhausting it costs |
+|---|---|---|
+| In-period (`startAt..endAt`) | `VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD = 5_000` | The day. A partial in-period read is a lower bound, never a total, so it sets `truncated` like any capped domain scan. |
+| Reversal lookback (`[startAt - 90d, startAt)`) | `VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS = 3_000` | Only reversal detection: `paymentPosture.reversalLookback = { outcome: "incomplete", reason: "lookback_cap_exceeded" }`. The in-period posture still verifies. |
+
+The ranges are half-open against each other (`.lt("recordedAt", startAt)`), so no
+row is counted twice. Only `inPeriodCapExceeded` sets `truncated`.
+
+**One boundary is narrower than it first reads, and it is worth knowing.** It is
+the lookback *cap* that is isolated from the in-period posture, not the lookback
+lane as a whole. A pre-window row carrying a `voided_refund_unsupported` or
+`legacy_void_missing_timestamp` condition still sets `paymentIncompleteReason`
+and therefore still degrades the in-period posture to `incomplete`. That is
+correct — those are unrepresentable facts, not a capacity limit — but "exhausting
+the lookback degrades only reversal detection" is a statement about the ceiling
+and nothing else.
+
+**The ceiling arithmetic is recorded beside the constants**, which is the part
+that would otherwise rot:
+
+- The candidate window is one operating day plus `OPERATING_DAY_SLACK_MS` of
+  ±18h — roughly 2.5 days, so ~30 rows at the measured 12/day. The in-period
+  ceiling of 5,000 is ~2,000 allocations/day: **~165x the measured rate and 10x
+  the old 500 cap.**
+- 90 days at 12/day is ~1,080 rows. The lookback ceiling of 3,000 is ~33/day,
+  **~2.8x measured** — deliberately tighter, because exhausting it is a soft
+  degradation rather than a lost day.
+- Worst-case read budget for the payment lane, per day: `(5,000 + 1) + (3,000 + 1)`
+  index-backed documents. Measured in practice: ~30. Neither read collects.
+
+The 90-day `PAYMENT_VOID_LOOKBACK_MS` and its documented blind spot (a reversal
+of a row recorded more than 90 days ago is invisible — bounded staleness, not
+unbounded drift) are unchanged. What changed is that the window now governs
+*only* the reversal read.
+
+### 2. Unverified is a third state, and it is not a difference
+
+`VerifyUnverifiedField` names every field whose source-side expectation can be
+**unknown rather than wrong**. All of them are payment-side, because the payment
+lane is the only one that can be withheld while the rest of the day still
+verifies. There are seven:
+
+```ts
+export const VERIFY_PAYMENT_METRIC_KEYS = [
+  "paymentsCollectedMinor", "paymentsRefundedMinor", "paymentAllocatedMinor",
+] as const;
+
+export const VERIFY_PAYMENT_POSTURE_FIELDS = [
+  "paymentUnsettledMinor", "paymentAllocationCoverage",
+  "paymentAllocationOmittedMinor", "paymentHasInvalidAllocation",
+] as const;
+```
+
+`unverifiedPaymentFields(posture)` maps a posture to the fields it declines to
+make a claim about, and the two degradations are **deliberately unequal**:
+
+```ts
+if (posture.outcome === "incomplete") {
+  return [...VERIFY_PAYMENT_METRIC_KEYS, ...VERIFY_PAYMENT_POSTURE_FIELDS];  // all seven
+}
+if (posture.reversalLookback.outcome === "incomplete") {
+  return [
+    ...VERIFY_PAYMENT_METRIC_KEYS.filter((f) => f !== "paymentsCollectedMinor"),
+    ...VERIFY_PAYMENT_POSTURE_FIELDS,
+  ];                                                                          // six
+}
+return [];
+```
+
+The asymmetry is the interesting part and it is not cosmetic. **In-period
+collection cannot be moved by an unseen historical void.** A void of a row
+recorded before the window lands as a *reversal* — it adds to
+`paymentsRefundedMinor` and subtracts from `paymentAllocatedMinor` — and it
+never touches what was collected inside the period. So an exhausted lookback
+withholds refunds, allocation, and every posture field derived from them, but
+keeps `paymentsCollectedMinor` verified. Withholding it too would have been the
+easy, symmetrical, and less useful choice.
+
+Withheld fields are removed **before diffing, not filtered after**, and from
+every channel:
+
+- `differences` and `paymentDifferences` on `VerifyDayResult`
+- the weekly `includedDifferences` and `outsideScheduleDifferences`
+- the weekly `includedPaymentDifferences` and `outsideSchedulePaymentDifferences`
+- the accepted-baseline comparison
+- the amendment comparison — because an amendment is a claim that the week
+  *moved*, and a field nobody checked has not moved
+
+The weekly result unions the withheld fields across the frame's days onto
+`unverifiedFields`, and a day with an incomplete payment lane **no longer sinks
+the whole week**. `payment_source_incomplete` and `invalid_payment_allocation`
+became unreachable as weekly reasons and were deleted from the union.
+
+### 3. What `matches` now means
+
+`matches` means **"everything checked agreed."** `matches: true` alongside a
+non-empty `unverifiedFields` is **partial verification, not a clean bill of
+health**, and alerting has to read the two together. The types say so at the
+declaration site rather than in a wiki:
+
+```ts
+/**
+ * Fields no comparison was made on, because the source side could not be
+ * established. These NEVER appear in `differences` or `paymentDifferences`
+ * and never flip `matches` — "we could not check payments" must not be
+ * readable as "payments are wrong".
+ */
+unverifiedFields: VerifyUnverifiedField[];
+```
+
+A capped in-period read still sets `truncated`, and `truncated` still forces
+`matches: false`. A lower bound is never blessed as a total.
+
+### 4. Deviation: pagination was unavailable
+
+The brief called for pagination on the in-period lane. **Convex permits only one
+`.paginate()` per function execution**, and this lane runs seven times inside a
+single `verifyCurrentWeekAgainstSources` — so pagination was structurally
+unavailable, not merely inconvenient. `convex-test` enforces the rule in the mock
+rather than letting it pass locally and fail in a deployed backend
+(`node_modules/convex-test/dist/index.js:951`):
+
+> "Only a single paginated query (`.paginate()`) is allowed per function
+> execution. Calling `.paginate()` more than once in a single Convex function
+> fails at runtime in a deployed backend."
+
+A single bounded `.take(ceiling + 1)` is used instead. **Anyone planning to
+paginate a per-day read inside a per-week aggregate in Convex will hit this**,
+and the honest answer is a well-sized bounded read with the arithmetic written
+down.
+
+## Why This Works
+
+The capacity fix works because it stops making one read answer two questions
+under one ceiling. The in-period rows and the pre-period rows have completely
+different volumes (~30 vs ~1,080), completely different purposes, and completely
+different costs when they run out. Giving them one bound meant the rare, cheap
+question — "was an old allocation voided today?" — got to veto the common,
+essential one. Splitting them lets the expensive lookback degrade without taking
+the posture with it.
+
+The reporting fix works because it introduces the state that was actually
+missing. The verifier only ever had two answers, `agreed` and `differs`, so an
+unestablished expectation had nowhere to go but `differs` with a fallback value.
+Once `unverified` exists as a first-class output, `expected: 0` stops being
+something the code has to invent, and `matches` recovers a meaning you can
+actually alert on.
+
+## Prevention
+
+- **A green test suite does not establish that a tool works at production scale.
+  Run it against production.** Both defects here were arithmetic against real row
+  counts. Every test passed, at every stage, the entire time. For any read-bounded
+  tool, a production dry run is a delivery step, not a follow-up.
+- **Never choose a cap without measuring the volume it has to clear.** Record the
+  measurement, the date, the store, and the derivation next to the constant — as
+  `VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD` now does — so the next person can
+  tell a considered headroom multiple from a round number someone liked. A cap
+  with no recorded arithmetic is indistinguishable from a guess.
+- **A window and a ceiling are one decision, not two.** `[startAt - 90d, endAt]`
+  under 500 docs is a statement that the store does under ~5.5 allocations a day.
+  Nobody wrote that down or checked it. Whenever you widen a range read, re-derive
+  the ceiling; whenever you tighten a ceiling, re-derive the range.
+- **A verifier whose failure mode is indistinguishable from a finding is worse
+  than no verifier.** It cries wolf, and the cost is not the false alarm — it is
+  that the next *genuine* mismatch arrives in the same shape and gets dismissed.
+  "Could not check" and "checked, and it is wrong" must be different outputs.
+- **Never fall back to a sentinel value in a comparison path.** `expected: 0` for
+  an unestablished expectation is an assertion that the source side is zero. If a
+  value cannot be computed, withhold the field; do not invent one and compare it.
+- **Withhold before comparing, not after.** Filtering a difference list after the
+  fact leaves every future channel — a new report, an amendment check, an
+  accepted-baseline diff — free to reintroduce the bug. Six channels needed the
+  filter here; a seventh added later must not have to remember.
+- **When one lane of a multi-lane check degrades, degrade that lane.** The old
+  weekly gate discarded six clean lanes to say nothing about one. Partial results
+  with named gaps beat a global `incomplete`.
+- **Ask what a degradation can actually move.** The unequal withholding —
+  six fields for an exhausted lookback, seven for an incomplete lane — came from
+  reasoning about causality (an unseen historical void cannot alter in-period
+  collection), not from picking the safe symmetrical answer. Symmetry is usually
+  a sign nobody worked it out.
+- **A new output field is not delivered until something reads it.**
+  `unverifiedFields` currently has no consumer outside `verify.ts` and its two
+  test files — no dashboard, alert, or UI branches on it yet. Until one does, the
+  distinction between "unchecked" and "wrong" exists in the return shape and not
+  in anything an operator sees. Whoever adds that surface must render the two
+  states differently, or the fix is only half landed.
+- **Residual risk, recorded honestly:** the other five source domains
+  (completed transactions, voided transactions, adjustments, storefront orders,
+  service cases) still read under `VERIFY_MAX_DOCS_PER_DOMAIN = 500`, and none of
+  those bounds has been checked against production volume. They were not the lane
+  that failed; that is not evidence they are sized right.
+- **Regression tests must be sized like the defect.** The three new large-fixture
+  tests seed thousands of allocations to exercise the real ceilings, and each
+  carries an explicit `60_000` timeout because they outran vitest's 5s default
+  under full-suite load. A ceiling test that only seeds ten rows tests nothing
+  about the ceiling.
+
+## Examples
+
+**Before — one read, one ceiling, two jobs:**
+
+```ts
+const allocations = await ctx.db
+  .query("paymentAllocation")
+  .withIndex("by_storeId_recordedAt", (q) =>
+    q.eq("storeId", storeId)
+      .gte("recordedAt", startAt - PAYMENT_VOID_LOOKBACK_MS)  // 90 days
+      .lte("recordedAt", endAt),
+  )
+  .take(VERIFY_MAX_DOCS_PER_DOMAIN + 1);                      // 500
+// Production: 1,050 rows in that window → incomplete, every day, forever.
+```
+
+**Before — the fallback that turned unknown into wrong:**
+
+```ts
+const differences = diffMetrics(expected, foldedMetrics(day));
+// expected.paymentsCollectedMinor is 0 because the lane never completed.
+// → { field: "paymentsCollectedMinor", expected: 0, actual: 396000 }
+matches: !truncated
+  && differences.length === 0
+  && paymentDifferences.length === 0
+  && paymentPosture.outcome === "complete",   // any incomplete lane = "wrong"
+```
+
+**After — withheld before the comparison exists:**
+
+```ts
+const unverifiedFields = unverifiedPaymentFields(paymentPosture);
+const unverified = new Set<string>(unverifiedFields);
+const differences = diffMetrics(expected, foldedMetrics(day)).filter(
+  (difference) => !unverified.has(difference.field),
+);
+matches: !truncated && differences.length === 0 && paymentDifferences.length === 0,
+```
+
+**The two behaviours, as asserted:**
+
+```ts
+it("withholds payment fields rather than diffing them against a fallback 0", ...)
+  // posture incomplete → differences [] , paymentDifferences [] ,
+  // all seven fields on unverifiedFields, matches true (PARTIAL)
+
+it("still reports a genuine payment mismatch when the lane completes", ...)
+  // posture complete → unverifiedFields [] ,
+  // differences [{ expected: 9_000, actual: 396_000, ... }] , matches false
+```
+
+The pair matters more than either test alone: withholding must not silence a
+real mismatch, and only the second test proves it does not.
+
+## Related Issues
+
+- [Athena reporting read-optimized redesign](../architecture/athena-reporting-read-optimized-redesign-2026-07-28.md) — the direct design ancestor, and the source of the rule this branch is an application of: *verify against sources, not against the pipeline*.
+- [Athena reporting read-optimized implementation plan](../architecture/athena-reporting-read-optimized-implementation-plan-2026-07-28.md) — defines Slice F (`convex/reports/verify.ts`) and makes independent verification the cutover gate; the gate this payment lane was blocking.
+- [Athena weekly reports use a schedule-day-driven projection lifecycle](../architecture-patterns/athena-schedule-day-driven-weekly-report-projection-lifecycle-2026-08-01.md) — the accepted-baseline and amendment semantics whose comparisons now also filter withheld fields.
+- [A declared fold version with no producer made every report change non-retroactive](./athena-reports-fold-version-refold-and-store-currency-source-2026-08-02.md) — the 106-day mass refold whose output this production verifier run was cross-checking, and which it re-confirmed as value-neutral.
+- [Athena reporting fact/projection boundary](../architecture/athena-reporting-fact-projection-boundary-2026-07-09.md) — why an independent recompute from sources is meaningful in the first place.
+- [Athena Convex read amplification](../performance/athena-convex-read-amplification-2026-06-29.md) — the closest prior art on bounded Convex reads and read caps.
+- [Athena register closeout pending-void policy](./athena-register-closeout-pending-void-policy-2026-06-25.md) — the void semantics behind `voidedAt` reversal handling.
+- Commit `766bfe61` (squash of `90d2823a`), *[V26-1142..V26-1152] Close EOW report audit gaps and total the weekly headline* — introduced `PAYMENT_VOID_LOOKBACK_MS` and the date-bounded window. That is the "earlier fix" this branch sizes correctly.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 11383 nodes · 13957 edges · 2675 communities detected
+- 11385 nodes · 13960 edges · 2675 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2954,47 +2954,47 @@ Nodes (5): listCompletedTransactionsForDay(), listCompletedTransactionsForRange(
 
 ### Community 60 - "Community 60"
 Cohesion: 0.17
-Nodes (23): buildHomepageSnapshotV1(), getHomepageSnapshotWithCtx(), hydrateCategory(), hydrateFeaturedItem(), hydrateHomepageRowsUntil(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts() (+15 more)
+Nodes (24): accumulatePayment(), addMetrics(), candidateWindow(), computeExpectedDay(), diffMetrics(), diffPaymentPosture(), foldedMetrics(), inventoryAttentionAgrees() (+16 more)
 
 ### Community 61 - "Community 61"
+Cohesion: 0.17
+Nodes (23): buildHomepageSnapshotV1(), getHomepageSnapshotWithCtx(), hydrateCategory(), hydrateFeaturedItem(), hydrateHomepageRowsUntil(), hydrateProduct(), hydrateSubcategory(), hydrateTargetProducts() (+15 more)
+
+### Community 62 - "Community 62"
 Cohesion: 0.15
 Nodes (20): addColumnSamples(), appendJsonProperty(), buildInventoryImportSourceRowIdentity(), completeProjection(), detectInventoryImportSourceFormat(), emptyProjection(), extractJsonSourceRows(), flattenJsonSourceRows() (+12 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.16
 Nodes (20): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getRuntimeReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady() (+12 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.21
 Nodes (23): buildCartChange(), buildLegacyContextPayload(), buildLegacyProductId(), compactPayload(), compileLegacyStorefrontAnalyticsRow(), compileLegacyStorefrontAnalyticsRows(), compileLegacyStorefrontAnalyticsRowsWithReport(), containsSensitiveText() (+15 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.17
 Nodes (20): actorForDirection(), applyCostOverlayRowWithCtx(), classifyCostOverlayUndoRowWithCtx(), costOverlayPreparedImpact(), finishOrContinue(), getPosition(), isExpectedValuationDomainError(), lineageDigest() (+12 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.13
 Nodes (15): buildProductSkuSearchProjection(), buildSearchText(), hydrateCanonicalProjection(), isRegisterCatalogProjectionIncluded(), normalizeAttributes(), normalizeLookup(), projectionsEqual(), refreshProductSkuSearchForProduct() (+7 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.2
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.14
 Nodes (18): findCurrentStoreDayOpening(), findLatestStoreDayOpening(), getTodaySummary(), getTransactionById(), isActivePosSummaryOpeningAt(), isValidPosSummaryWindowRange(), listMixedServiceLinesForTransaction(), listStaffNames() (+10 more)
-
-### Community 70 - "Community 70"
-Cohesion: 0.18
-Nodes (23): accumulatePayment(), addMetrics(), candidateWindow(), computeExpectedDay(), diffMetrics(), diffPaymentPosture(), foldedMetrics(), inventoryAttentionAgrees() (+15 more)
 
 ### Community 71 - "Community 71"
 Cohesion: 0.12
@@ -3618,47 +3618,47 @@ Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 227 - "Community 227"
-Cohesion: 0.33
 Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
 
-### Community 228 - "Community 228"
+### Community 227 - "Community 227"
 Cohesion: 0.36
 Nodes (8): costOverlayStoreWriteOperation(), cycleCountDraftStoreWriteOperation(), defineOperation(), inventoryImportReviewPayloadWriteOperation(), notificationSubscriptionRowWriteOperation(), orderStoreWriteOperation(), storeWriteOperation(), transactionStoreWriteOperation()
 
-### Community 229 - "Community 229"
+### Community 228 - "Community 228"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 230 - "Community 230"
+### Community 229 - "Community 229"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 231 - "Community 231"
+### Community 230 - "Community 230"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 232 - "Community 232"
+### Community 231 - "Community 231"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 233 - "Community 233"
+### Community 232 - "Community 232"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 234 - "Community 234"
+### Community 233 - "Community 233"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 235 - "Community 235"
+### Community 234 - "Community 234"
 Cohesion: 0.27
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
-### Community 236 - "Community 236"
+### Community 235 - "Community 235"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
+
+### Community 236 - "Community 236"
+Cohesion: 0.33
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 237 - "Community 237"
 Cohesion: 0.31
@@ -3849,28 +3849,28 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 284 - "Community 284"
-Cohesion: 0.42
-Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
-
-### Community 285 - "Community 285"
-Cohesion: 0.36
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
-
-### Community 286 - "Community 286"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 287 - "Community 287"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
-### Community 288 - "Community 288"
 Cohesion: 0.31
 Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
-### Community 289 - "Community 289"
+### Community 285 - "Community 285"
+Cohesion: 0.42
+Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
+
+### Community 286 - "Community 286"
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
+### Community 287 - "Community 287"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 288 - "Community 288"
 Cohesion: 0.39
 Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
+
+### Community 289 - "Community 289"
+Cohesion: 0.31
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 290 - "Community 290"
 Cohesion: 0.22
@@ -4393,388 +4393,388 @@ Cohesion: 0.4
 Nodes (2): at(), seedFullDay()
 
 ### Community 420 - "Community 420"
+Cohesion: 0.4
+Nodes (2): at(), seedVerifiableDay()
+
+### Community 421 - "Community 421"
 Cohesion: 0.47
 Nodes (3): projectFrozenWeeklyInventoryAttention(), projectLiveWeeklyInventoryAttention(), summarizeWeeklyInventoryAttention()
 
-### Community 421 - "Community 421"
+### Community 422 - "Community 422"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 422 - "Community 422"
+### Community 423 - "Community 423"
 Cohesion: 0.6
 Nodes (5): getSharedDemoActorWithCtx(), requireReadySharedDemoStoreCapabilityIfApplicable(), requireSharedDemoActorWithCtx(), requireSharedDemoCapabilityIfApplicable(), requireSharedDemoStoreCapabilityIfApplicable()
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.53
 Nodes (4): buildOnlineOrderReportedReturns(), buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.4
 Nodes (2): localDate(), resolveStoreTimeAuthority()
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 430 - "Community 430"
+### Community 431 - "Community 431"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 431 - "Community 431"
+### Community 432 - "Community 432"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 432 - "Community 432"
+### Community 433 - "Community 433"
 Cohesion: 0.47
 Nodes (3): canUploadPosLocalSyncLocalEventType(), getPosLocalSyncEventContractForLocalEventType(), getPosLocalSyncEventTypeForLocalEventType()
 
-### Community 433 - "Community 433"
+### Community 434 - "Community 434"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 434 - "Community 434"
+### Community 435 - "Community 435"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 435 - "Community 435"
+### Community 436 - "Community 436"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 436 - "Community 436"
+### Community 437 - "Community 437"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 437 - "Community 437"
+### Community 438 - "Community 438"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
-
-### Community 438 - "Community 438"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 439 - "Community 439"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 440 - "Community 440"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 442 - "Community 442"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
 
 ### Community 443 - "Community 443"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
-
-### Community 444 - "Community 444"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 444 - "Community 444"
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 446 - "Community 446"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 447 - "Community 447"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 447 - "Community 447"
+### Community 448 - "Community 448"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 448 - "Community 448"
+### Community 449 - "Community 449"
 Cohesion: 0.47
 Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
 
-### Community 449 - "Community 449"
+### Community 450 - "Community 450"
 Cohesion: 0.4
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 450 - "Community 450"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 451 - "Community 451"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 452 - "Community 452"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 453 - "Community 453"
 Cohesion: 0.4
 Nodes (2): isSelectedDay(), selectDay()
 
-### Community 453 - "Community 453"
+### Community 454 - "Community 454"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 454 - "Community 454"
-Cohesion: 0.4
-Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.4
-Nodes (2): addDaysToDate(), isoWeekStart()
+Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
 ### Community 456 - "Community 456"
+Cohesion: 0.4
+Nodes (2): addDaysToDate(), isoWeekStart()
+
+### Community 457 - "Community 457"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 457 - "Community 457"
+### Community 458 - "Community 458"
 Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
-### Community 458 - "Community 458"
+### Community 459 - "Community 459"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 459 - "Community 459"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 460 - "Community 460"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 461 - "Community 461"
-Cohesion: 0.73
-Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
-
-### Community 462 - "Community 462"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 462 - "Community 462"
+Cohesion: 0.73
+Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
 ### Community 463 - "Community 463"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 464 - "Community 464"
-Cohesion: 0.4
-Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 465 - "Community 465"
 Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 466 - "Community 466"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 467 - "Community 467"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 468 - "Community 468"
-Cohesion: 0.47
-Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
-
-### Community 469 - "Community 469"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 470 - "Community 470"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 471 - "Community 471"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
-### Community 472 - "Community 472"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 473 - "Community 473"
+### Community 469 - "Community 469"
 Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
+
+### Community 470 - "Community 470"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 471 - "Community 471"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
+### Community 472 - "Community 472"
+Cohesion: 0.33
+Nodes (1): MemoryCache
+
+### Community 473 - "Community 473"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 474 - "Community 474"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 476 - "Community 476"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 477 - "Community 477"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 477 - "Community 477"
+### Community 478 - "Community 478"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 478 - "Community 478"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 479 - "Community 479"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 480 - "Community 480"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 482 - "Community 482"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
-
-### Community 483 - "Community 483"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 483 - "Community 483"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
 ### Community 484 - "Community 484"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 485 - "Community 485"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 487 - "Community 487"
+### Community 488 - "Community 488"
 Cohesion: 0.47
 Nodes (3): assertDeliveryDocumentationCheck(), findingsFrom(), isPolicyFailure()
 
-### Community 488 - "Community 488"
+### Community 489 - "Community 489"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 489 - "Community 489"
+### Community 490 - "Community 490"
 Cohesion: 0.47
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 490 - "Community 490"
+### Community 491 - "Community 491"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 491 - "Community 491"
+### Community 492 - "Community 492"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 492 - "Community 492"
+### Community 493 - "Community 493"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 494 - "Community 494"
-Cohesion: 0.6
-Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 495 - "Community 495"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 497 - "Community 497"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 498 - "Community 498"
 Cohesion: 0.7
 Nodes (3): ApprovalRequestPending(), buildApprovalRequestPendingSubject(), getApprovalRequestDescriptor()
 
-### Community 498 - "Community 498"
+### Community 499 - "Community 499"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 499 - "Community 499"
-Cohesion: 0.6
-Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.6
-Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+Nodes (3): isDisplayableMarker(), presentSnapshotAtRequestTime(), resolveHomepageSnapshotBootstrap()
 
 ### Community 501 - "Community 501"
+Cohesion: 0.6
+Nodes (4): assertArtifactTransition(), assertRunTransition(), canTransitionArtifact(), canTransitionRun()
+
+### Community 502 - "Community 502"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 502 - "Community 502"
+### Community 503 - "Community 503"
 Cohesion: 0.5
 Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
-### Community 503 - "Community 503"
+### Community 504 - "Community 504"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 504 - "Community 504"
+### Community 505 - "Community 505"
 Cohesion: 0.6
 Nodes (4): applyCommerceInventoryEffectWithCtx(), outboundBasisFromEffect(), reportingLineCostFromEffect(), uncostedOutboundBasis()
 
-### Community 505 - "Community 505"
+### Community 506 - "Community 506"
 Cohesion: 0.5
 Nodes (2): historicalCostLane(), materializeDeferredAdjustmentWithCtx()
 
-### Community 506 - "Community 506"
+### Community 507 - "Community 507"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 507 - "Community 507"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 508 - "Community 508"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 509 - "Community 509"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 510 - "Community 510"
 Cohesion: 0.7
 Nodes (4): backfillStoreTimezoneAuthorityWithCtx(), buildRow(), listSchedulesForStore(), normalizeLimit()
 
-### Community 510 - "Community 510"
+### Community 511 - "Community 511"
 Cohesion: 0.5
 Nodes (2): recordNotificationFailureEventWithCtx(), recordTerminalDeliveryFailureEvent()
 
-### Community 511 - "Community 511"
+### Community 512 - "Community 512"
 Cohesion: 0.6
 Nodes (4): dedupeKey(), keyFor(), prepare(), stubCtx()
 
-### Community 512 - "Community 512"
+### Community 513 - "Community 513"
 Cohesion: 0.7
 Nodes (4): createNormalUserOperationAdapter(), createPublicOperationAdapter(), isAdmitted(), resolveOperationAdmission()
 
-### Community 513 - "Community 513"
+### Community 514 - "Community 514"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 514 - "Community 514"
+### Community 515 - "Community 515"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 515 - "Community 515"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 0.4
@@ -4785,72 +4785,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 518 - "Community 518"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 519 - "Community 519"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.5
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 520 - "Community 520"
+### Community 521 - "Community 521"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 521 - "Community 521"
-Cohesion: 0.7
-Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 522 - "Community 522"
 Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
 ### Community 523 - "Community 523"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 524 - "Community 524"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 524 - "Community 524"
+### Community 525 - "Community 525"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 525 - "Community 525"
+### Community 526 - "Community 526"
 Cohesion: 0.6
 Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
-### Community 526 - "Community 526"
+### Community 527 - "Community 527"
 Cohesion: 0.6
 Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
-
-### Community 527 - "Community 527"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 528 - "Community 528"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 529 - "Community 529"
-Cohesion: 0.5
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
-
-### Community 530 - "Community 530"
-Cohesion: 0.6
-Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
-
-### Community 531 - "Community 531"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 530 - "Community 530"
+Cohesion: 0.5
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+
+### Community 531 - "Community 531"
+Cohesion: 0.6
+Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
+
 ### Community 532 - "Community 532"
-Cohesion: 0.7
-Nodes (4): factFingerprint(), fingerprintPayload(), matchesStoredFingerprint(), stableStringHash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 533 - "Community 533"
 Cohesion: 0.7
-Nodes (4): boundedLimit(), countStaleFoldVersionDaysWithCtx(), dayPage(), markStaleFoldVersionDaysWithCtx()
+Nodes (4): factFingerprint(), fingerprintPayload(), matchesStoredFingerprint(), stableStringHash()
 
 ### Community 534 - "Community 534"
-Cohesion: 0.5
-Nodes (2): at(), seedVerifiableDay()
+Cohesion: 0.7
+Nodes (4): boundedLimit(), countStaleFoldVersionDaysWithCtx(), dayPage(), markStaleFoldVersionDaysWithCtx()
 
 ### Community 535 - "Community 535"
 Cohesion: 0.4
@@ -5289,40 +5289,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 644 - "Community 644"
-Cohesion: 0.5
-Nodes (1): buildCtx()
-
-### Community 645 - "Community 645"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 646 - "Community 646"
+### Community 645 - "Community 645"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 647 - "Community 647"
+### Community 646 - "Community 646"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 648 - "Community 648"
+### Community 647 - "Community 647"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 649 - "Community 649"
+### Community 648 - "Community 648"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 650 - "Community 650"
+### Community 649 - "Community 649"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 651 - "Community 651"
+### Community 650 - "Community 650"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 652 - "Community 652"
+### Community 651 - "Community 651"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 652 - "Community 652"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 653 - "Community 653"
 Cohesion: 0.5
@@ -5334,7 +5334,7 @@ Nodes (0):
 
 ### Community 655 - "Community 655"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 656 - "Community 656"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -71099,7 +71099,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L33",
+      "source_location": "L35",
       "target": "verify_test_at",
       "weight": 1
     },
@@ -71111,7 +71111,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L55",
+      "source_location": "L57",
       "target": "verify_test_folddirtydays",
       "weight": 1
     },
@@ -71123,8 +71123,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L42",
+      "source_location": "L44",
       "target": "verify_test_runreseed",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_reports_verify_test_ts",
+      "_tgt": "verify_test_seedfoldedpaymentday",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_verify_test_ts",
+      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
+      "source_location": "L883",
+      "target": "verify_test_seedfoldedpaymentday",
       "weight": 1
     },
     {
@@ -71135,7 +71147,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L98",
+      "source_location": "L100",
       "target": "verify_test_seedverifiableday",
       "weight": 1
     },
@@ -71147,7 +71159,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1253",
+      "source_location": "L1459",
       "target": "verify_accumulatepayment",
       "weight": 1
     },
@@ -71159,7 +71171,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L276",
+      "source_location": "L414",
       "target": "verify_addmetrics",
       "weight": 1
     },
@@ -71171,7 +71183,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L287",
+      "source_location": "L425",
       "target": "verify_candidatewindow",
       "weight": 1
     },
@@ -71183,7 +71195,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L309",
+      "source_location": "L447",
       "target": "verify_computeexpectedday",
       "weight": 1
     },
@@ -71195,7 +71207,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L636",
+      "source_location": "L832",
       "target": "verify_diffmetrics",
       "weight": 1
     },
@@ -71207,7 +71219,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L665",
+      "source_location": "L861",
       "target": "verify_diffpaymentposture",
       "weight": 1
     },
@@ -71219,7 +71231,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L711",
+      "source_location": "L907",
       "target": "verify_foldedmetrics",
       "weight": 1
     },
@@ -71231,7 +71243,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1132",
+      "source_location": "L1338",
       "target": "verify_inventoryattentionagrees",
       "weight": 1
     },
@@ -71243,7 +71255,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L857",
+      "source_location": "L1063",
       "target": "verify_isoweekday",
       "weight": 1
     },
@@ -71255,7 +71267,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1198",
+      "source_location": "L1404",
       "target": "verify_recomputeverifiedvariance",
       "weight": 1
     },
@@ -71267,7 +71279,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1058",
+      "source_location": "L1264",
       "target": "verify_recountopeninventoryreviewgroups",
       "weight": 1
     },
@@ -71279,7 +71291,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L911",
+      "source_location": "L1117",
       "target": "verify_resolveverifiedframe",
       "weight": 1
     },
@@ -71291,7 +71303,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L869",
+      "source_location": "L1075",
       "target": "verify_schedulegoverning",
       "weight": 1
     },
@@ -71303,7 +71315,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L894",
+      "source_location": "L1100",
       "target": "verify_scheduleincludesdate",
       "weight": 1
     },
@@ -71315,7 +71327,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L862",
+      "source_location": "L1068",
       "target": "verify_shiftlocaldate",
       "weight": 1
     },
@@ -71327,8 +71339,20 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1283",
+      "source_location": "L1489",
       "target": "verify_storedweeklypayment",
+      "weight": 1
+    },
+    {
+      "_src": "packages_athena_webapp_convex_reports_verify_ts",
+      "_tgt": "verify_unverifiedpaymentfields",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_reports_verify_ts",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L297",
+      "target": "verify_unverifiedpaymentfields",
       "weight": 1
     },
     {
@@ -71339,7 +71363,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L966",
+      "source_location": "L1172",
       "target": "verify_verifyacceptedcloseposture",
       "weight": 1
     },
@@ -71351,7 +71375,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1301",
+      "source_location": "L1507",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -71363,7 +71387,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L740",
+      "source_location": "L936",
       "target": "verify_verifydaywithctx",
       "weight": 1
     },
@@ -71375,7 +71399,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L807",
+      "source_location": "L1013",
       "target": "verify_verifystoresummarywithctx",
       "weight": 1
     },
@@ -71387,7 +71411,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L725",
+      "source_location": "L921",
       "target": "verify_weeklyverifiedmetrics",
       "weight": 1
     },
@@ -71399,7 +71423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L263",
+      "source_location": "L401",
       "target": "verify_zerometrics",
       "weight": 1
     },
@@ -71411,7 +71435,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_verify_ts",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1273",
+      "source_location": "L1479",
       "target": "verify_zeropaymentcomparable",
       "weight": 1
     },
@@ -72263,7 +72287,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_weeklyverify_test_ts",
       "source_file": "packages/athena-webapp/convex/reports/weeklyVerify.test.ts",
-      "source_location": "L638",
+      "source_location": "L659",
       "target": "weeklyverify_test_seedsettledpaymentweek",
       "weight": 1
     },
@@ -165827,7 +165851,7 @@
       "relation": "calls",
       "source": "verify_candidatewindow",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L319",
+      "source_location": "L457",
       "target": "verify_computeexpectedday",
       "weight": 1
     },
@@ -165839,7 +165863,7 @@
       "relation": "calls",
       "source": "verify_zerometrics",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L318",
+      "source_location": "L456",
       "target": "verify_computeexpectedday",
       "weight": 1
     },
@@ -165851,7 +165875,7 @@
       "relation": "calls",
       "source": "verify_zerometrics",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L712",
+      "source_location": "L908",
       "target": "verify_foldedmetrics",
       "weight": 1
     },
@@ -165863,7 +165887,7 @@
       "relation": "calls",
       "source": "verify_isoweekday",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L927",
+      "source_location": "L1133",
       "target": "verify_resolveverifiedframe",
       "weight": 1
     },
@@ -165875,7 +165899,7 @@
       "relation": "calls",
       "source": "verify_schedulegoverning",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L917",
+      "source_location": "L1123",
       "target": "verify_resolveverifiedframe",
       "weight": 1
     },
@@ -165887,7 +165911,7 @@
       "relation": "calls",
       "source": "verify_scheduleincludesdate",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L936",
+      "source_location": "L1142",
       "target": "verify_resolveverifiedframe",
       "weight": 1
     },
@@ -165899,7 +165923,7 @@
       "relation": "calls",
       "source": "verify_shiftlocaldate",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L925",
+      "source_location": "L1131",
       "target": "verify_resolveverifiedframe",
       "weight": 1
     },
@@ -165911,7 +165935,7 @@
       "relation": "calls",
       "source": "verify_isoweekday",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L901",
+      "source_location": "L1107",
       "target": "verify_scheduleincludesdate",
       "weight": 1
     },
@@ -165923,7 +165947,7 @@
       "relation": "calls",
       "source": "verify_test_at",
       "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L102",
+      "source_location": "L104",
       "target": "verify_test_seedverifiableday",
       "weight": 1
     },
@@ -165935,7 +165959,7 @@
       "relation": "calls",
       "source": "verify_accumulatepayment",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1386",
+      "source_location": "L1588",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -165947,7 +165971,7 @@
       "relation": "calls",
       "source": "verify_addmetrics",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1369",
+      "source_location": "L1579",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -165959,19 +165983,7 @@
       "relation": "calls",
       "source": "verify_computeexpectedday",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1359",
-      "target": "verify_verifycurrentweekwithctx",
-      "weight": 1
-    },
-    {
-      "_src": "verify_verifycurrentweekwithctx",
-      "_tgt": "verify_diffmetrics",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "verify_diffmetrics",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1400",
+      "source_location": "L1569",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -165983,7 +165995,7 @@
       "relation": "calls",
       "source": "verify_diffpaymentposture",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1408",
+      "source_location": "L1622",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -165995,7 +166007,7 @@
       "relation": "calls",
       "source": "verify_inventoryattentionagrees",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1510",
+      "source_location": "L1724",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166007,7 +166019,7 @@
       "relation": "calls",
       "source": "verify_recomputeverifiedvariance",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1447",
+      "source_location": "L1661",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166019,7 +166031,7 @@
       "relation": "calls",
       "source": "verify_recountopeninventoryreviewgroups",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1487",
+      "source_location": "L1701",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166031,7 +166043,7 @@
       "relation": "calls",
       "source": "verify_resolveverifiedframe",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1346",
+      "source_location": "L1552",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166043,7 +166055,19 @@
       "relation": "calls",
       "source": "verify_storedweeklypayment",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1410",
+      "source_location": "L1624",
+      "target": "verify_verifycurrentweekwithctx",
+      "weight": 1
+    },
+    {
+      "_src": "verify_verifycurrentweekwithctx",
+      "_tgt": "verify_unverifiedpaymentfields",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "verify_unverifiedpaymentfields",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1584",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166055,7 +166079,7 @@
       "relation": "calls",
       "source": "verify_verifyacceptedcloseposture",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1519",
+      "source_location": "L1733",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166067,7 +166091,7 @@
       "relation": "calls",
       "source": "verify_weeklyverifiedmetrics",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1398",
+      "source_location": "L1600",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166079,7 +166103,7 @@
       "relation": "calls",
       "source": "verify_zerometrics",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1353",
+      "source_location": "L1559",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166091,7 +166115,7 @@
       "relation": "calls",
       "source": "verify_zeropaymentcomparable",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1355",
+      "source_location": "L1561",
       "target": "verify_verifycurrentweekwithctx",
       "weight": 1
     },
@@ -166103,7 +166127,7 @@
       "relation": "calls",
       "source": "verify_computeexpectedday",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L752",
+      "source_location": "L948",
       "target": "verify_verifydaywithctx",
       "weight": 1
     },
@@ -166115,7 +166139,7 @@
       "relation": "calls",
       "source": "verify_diffmetrics",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L757",
+      "source_location": "L957",
       "target": "verify_verifydaywithctx",
       "weight": 1
     },
@@ -166127,7 +166151,7 @@
       "relation": "calls",
       "source": "verify_diffpaymentposture",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L758",
+      "source_location": "L960",
       "target": "verify_verifydaywithctx",
       "weight": 1
     },
@@ -166139,7 +166163,19 @@
       "relation": "calls",
       "source": "verify_foldedmetrics",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L757",
+      "source_location": "L957",
+      "target": "verify_verifydaywithctx",
+      "weight": 1
+    },
+    {
+      "_src": "verify_verifydaywithctx",
+      "_tgt": "verify_unverifiedpaymentfields",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "verify_unverifiedpaymentfields",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L955",
       "target": "verify_verifydaywithctx",
       "weight": 1
     },
@@ -166151,7 +166187,7 @@
       "relation": "calls",
       "source": "verify_verifydaywithctx",
       "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L823",
+      "source_location": "L1029",
       "target": "verify_verifystoresummarywithctx",
       "weight": 1
     },
@@ -208362,92 +208398,92 @@
     {
       "community": 226,
       "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L373"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 226,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
     },
     {
       "community": 226,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 226,
+      "file_type": "code",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 2260,
@@ -208542,92 +208578,92 @@
     {
       "community": 227,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "definitions_costoverlaystorewriteoperation",
+      "label": "costOverlayStoreWriteOperation()",
+      "norm_label": "costoverlaystorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L486"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "definitions_cyclecountdraftstorewriteoperation",
+      "label": "cycleCountDraftStoreWriteOperation()",
+      "norm_label": "cyclecountdraftstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L375"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "definitions_defineoperation",
+      "label": "defineOperation()",
+      "norm_label": "defineoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
+      "label": "inventoryImportReviewPayloadWriteOperation()",
+      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L461"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "definitions_notificationsubscriptionrowwriteoperation",
+      "label": "notificationSubscriptionRowWriteOperation()",
+      "norm_label": "notificationsubscriptionrowwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L546"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "definitions_orderstorewriteoperation",
+      "label": "orderStoreWriteOperation()",
+      "norm_label": "orderstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "definitions_storewriteoperation",
+      "label": "storeWriteOperation()",
+      "norm_label": "storewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "definitions_transactionstorewriteoperation",
+      "label": "transactionStoreWriteOperation()",
+      "norm_label": "transactionstorewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "definitions_validateoperationdefinition",
+      "label": "validateOperationDefinition()",
+      "norm_label": "validateoperationdefinition()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "source_location": "L635"
+    },
+    {
+      "community": 227,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
+      "label": "definitions.ts",
+      "norm_label": "definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 227,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
     },
     {
       "community": 2270,
@@ -208722,91 +208758,91 @@
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_costoverlaystorewriteoperation",
-      "label": "costOverlayStoreWriteOperation()",
-      "norm_label": "costoverlaystorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L486"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_cyclecountdraftstorewriteoperation",
-      "label": "cycleCountDraftStoreWriteOperation()",
-      "norm_label": "cyclecountdraftstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L375"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_defineoperation",
-      "label": "defineOperation()",
-      "norm_label": "defineoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L11"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_inventoryimportreviewpayloadwriteoperation",
-      "label": "inventoryImportReviewPayloadWriteOperation()",
-      "norm_label": "inventoryimportreviewpayloadwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L461"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_notificationsubscriptionrowwriteoperation",
-      "label": "notificationSubscriptionRowWriteOperation()",
-      "norm_label": "notificationsubscriptionrowwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L546"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_orderstorewriteoperation",
-      "label": "orderStoreWriteOperation()",
-      "norm_label": "orderstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L155"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_storewriteoperation",
-      "label": "storeWriteOperation()",
-      "norm_label": "storewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L108"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_transactionstorewriteoperation",
-      "label": "transactionStoreWriteOperation()",
-      "norm_label": "transactionstorewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L128"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "definitions_validateoperationdefinition",
-      "label": "validateOperationDefinition()",
-      "norm_label": "validateoperationdefinition()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
-      "source_location": "L635"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 228,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
-      "label": "definitions.ts",
-      "norm_label": "definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/definitions.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -208902,91 +208938,91 @@
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 229,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -209433,91 +209469,91 @@
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "operationalevents_buildoperationalevent",
+      "label": "buildOperationalEvent()",
+      "norm_label": "buildoperationalevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L43"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "operationalevents_buildtracemetadata",
+      "label": "buildTraceMetadata()",
+      "norm_label": "buildtracemetadata()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L96"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "operationalevents_isrecord",
+      "label": "isRecord()",
+      "norm_label": "isrecord()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L145"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "operationalevents_listproductoperationaltimelinewithctx",
+      "label": "listProductOperationalTimelineWithCtx()",
+      "norm_label": "listproductoperationaltimelinewithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L246"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "operationalevents_matchesexistingevent",
+      "label": "matchesExistingEvent()",
+      "norm_label": "matchesexistingevent()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L149"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "operationalevents_metadatadedupekeysmatch",
+      "label": "metadataDedupeKeysMatch()",
+      "norm_label": "metadatadedupekeysmatch()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L205"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "operationalevents_normalizeoperationaleventtracefields",
+      "label": "normalizeOperationalEventTraceFields()",
+      "norm_label": "normalizeoperationaleventtracefields()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L60"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "operationalevents_recordoperationaleventwithctx",
+      "label": "recordOperationalEventWithCtx()",
+      "norm_label": "recordoperationaleventwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L215"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "operationalevents_shouldnormalizepostrace",
+      "label": "shouldNormalizePosTrace()",
+      "norm_label": "shouldnormalizepostrace()",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "source_location": "L118"
     },
     {
       "community": 230,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
+      "label": "operationalEvents.ts",
+      "norm_label": "operationalevents.ts",
+      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
       "source_location": "L1"
     },
     {
@@ -209613,91 +209649,91 @@
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_buildoperationalevent",
-      "label": "buildOperationalEvent()",
-      "norm_label": "buildoperationalevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L43"
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_buildtracemetadata",
-      "label": "buildTraceMetadata()",
-      "norm_label": "buildtracemetadata()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L96"
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_isrecord",
-      "label": "isRecord()",
-      "norm_label": "isrecord()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L145"
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_listproductoperationaltimelinewithctx",
-      "label": "listProductOperationalTimelineWithCtx()",
-      "norm_label": "listproductoperationaltimelinewithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L246"
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_matchesexistingevent",
-      "label": "matchesExistingEvent()",
-      "norm_label": "matchesexistingevent()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L149"
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_metadatadedupekeysmatch",
-      "label": "metadataDedupeKeysMatch()",
-      "norm_label": "metadatadedupekeysmatch()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L205"
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_normalizeoperationaleventtracefields",
-      "label": "normalizeOperationalEventTraceFields()",
-      "norm_label": "normalizeoperationaleventtracefields()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L60"
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_recordoperationaleventwithctx",
-      "label": "recordOperationalEventWithCtx()",
-      "norm_label": "recordoperationaleventwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L215"
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "operationalevents_shouldnormalizepostrace",
-      "label": "shouldNormalizePosTrace()",
-      "norm_label": "shouldnormalizepostrace()",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
-      "source_location": "L118"
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
     },
     {
       "community": 231,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_operationalevents_ts",
-      "label": "operationalEvents.ts",
-      "norm_label": "operationalevents.ts",
-      "source_file": "packages/athena-webapp/convex/operations/operationalEvents.ts",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
     },
     {
@@ -209793,92 +209829,92 @@
     {
       "community": 232,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 232,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 232,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L92"
     },
     {
       "community": 2320,
@@ -209973,92 +210009,92 @@
     {
       "community": 233,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
+    },
+    {
+      "community": 233,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L161"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L146"
-    },
-    {
-      "community": 233,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L92"
     },
     {
       "community": 2330,
@@ -210153,92 +210189,92 @@
     {
       "community": 234,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
+      "label": "terminalRecoveryRepository.ts",
+      "norm_label": "terminalrecoveryrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
+      "label": "createTerminalRecoveryCommandReadRepository()",
+      "norm_label": "createterminalrecoverycommandreadrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
+      "label": "createTerminalRecoveryCommandRepository()",
+      "norm_label": "createterminalrecoverycommandrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
+      "label": "dedupeRecoveryCommandsById()",
+      "norm_label": "deduperecoverycommandsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
+      "label": "dedupeRecoveryConflictsById()",
+      "norm_label": "deduperecoveryconflictsbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L193"
+    },
+    {
+      "community": 234,
+      "file_type": "code",
+      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
+      "label": "getTerminalRecoverySourceEvent()",
+      "norm_label": "getterminalrecoverysourceevent()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
       "source_location": "L222"
     },
     {
       "community": 234,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
+      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
+      "label": "isCurrentTerminalRecoveryConflict()",
+      "norm_label": "iscurrentterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L206"
     },
     {
       "community": 234,
       "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
+      "label": "listTerminalRecoveryConflictsForRepair()",
+      "norm_label": "listterminalrecoveryconflictsforrepair()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L141"
     },
     {
       "community": 234,
       "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
+      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
+      "label": "listTerminalRecoveryConflictSources()",
+      "norm_label": "listterminalrecoveryconflictsources()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L162"
     },
     {
       "community": 234,
       "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 234,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L1"
+      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
+      "label": "patchTerminalRecoveryConflict()",
+      "norm_label": "patchterminalrecoveryconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "source_location": "L241"
     },
     {
       "community": 2340,
@@ -210333,92 +210369,92 @@
     {
       "community": 235,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_ts",
-      "label": "terminalRecoveryRepository.ts",
-      "norm_label": "terminalrecoveryrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L189"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L58"
+    },
+    {
+      "community": 235,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandreadrepository",
-      "label": "createTerminalRecoveryCommandReadRepository()",
-      "norm_label": "createterminalrecoverycommandreadrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_createterminalrecoverycommandrepository",
-      "label": "createTerminalRecoveryCommandRepository()",
-      "norm_label": "createterminalrecoverycommandrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoverycommandsbyid",
-      "label": "dedupeRecoveryCommandsById()",
-      "norm_label": "deduperecoverycommandsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_deduperecoveryconflictsbyid",
-      "label": "dedupeRecoveryConflictsById()",
-      "norm_label": "deduperecoveryconflictsbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_getterminalrecoverysourceevent",
-      "label": "getTerminalRecoverySourceEvent()",
-      "norm_label": "getterminalrecoverysourceevent()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_iscurrentterminalrecoveryconflict",
-      "label": "isCurrentTerminalRecoveryConflict()",
-      "norm_label": "iscurrentterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L206"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsforrepair",
-      "label": "listTerminalRecoveryConflictsForRepair()",
-      "norm_label": "listterminalrecoveryconflictsforrepair()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_listterminalrecoveryconflictsources",
-      "label": "listTerminalRecoveryConflictSources()",
-      "norm_label": "listterminalrecoveryconflictsources()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 235,
-      "file_type": "code",
-      "id": "terminalrecoveryrepository_patchterminalrecoveryconflict",
-      "label": "patchTerminalRecoveryConflict()",
-      "norm_label": "patchterminalrecoveryconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.ts",
-      "source_location": "L241"
     },
     {
       "community": 2350,
@@ -210513,91 +210549,91 @@
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L217"
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L253"
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L373"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L84"
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L52"
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L35"
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L112"
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L189"
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L46"
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L58"
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 236,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
       "source_location": "L1"
     },
     {
@@ -219108,330 +219144,6 @@
     {
       "community": 284,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
-      "label": "applyAcceptedControlResult()",
-      "norm_label": "applyacceptedcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applykeyevent",
-      "label": "applyKeyEvent()",
-      "norm_label": "applykeyevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applypointerevent",
-      "label": "applyPointerEvent()",
-      "norm_label": "applypointerevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
-      "label": "applyRemoteAssistControlIntent()",
-      "norm_label": "applyremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
-      "label": "getRecentControlResult()",
-      "norm_label": "getrecentcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
-      "label": "getRemoteAssistControlTarget()",
-      "norm_label": "getremoteassistcontroltarget()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
-      "label": "prepareRemoteAssistControlIntent()",
-      "norm_label": "prepareremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_remembercontrolresult",
-      "label": "rememberControlResult()",
-      "norm_label": "remembercontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 284,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
-      "label": "applyRemoteAssistControlIntent.ts",
-      "norm_label": "applyremoteassistcontrolintent.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 285,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L222"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L283"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "foundations_content_detailviewrolecard",
-      "label": "DetailViewRoleCard()",
-      "norm_label": "detailviewrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L214"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L265"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L218"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L246"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "versionchecker_buildidfromscripts",
-      "label": "buildIdFromScripts()",
-      "norm_label": "buildidfromscripts()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L192"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "versionchecker_createversionchecker",
-      "label": "createVersionChecker()",
-      "norm_label": "createversionchecker()",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "versionchecker_getinitialdeploybuildid",
-      "label": "getInitialDeployBuildId()",
-      "norm_label": "getinitialdeploybuildid()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "versionchecker_readdeploybuildid",
-      "label": "readDeployBuildId()",
-      "norm_label": "readdeploybuildid()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "versionchecker_readdocumentscriptsources",
-      "label": "readDocumentScriptSources()",
-      "norm_label": "readdocumentscriptsources()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "versionchecker_readentryhtmlscripts",
-      "label": "readEntryHtmlScripts()",
-      "norm_label": "readentryhtmlscripts()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "versionchecker_readscriptsources",
-      "label": "readScriptSources()",
-      "norm_label": "readscriptsources()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
       "norm_label": "productutils.ts",
@@ -219439,7 +219151,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 284,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -219448,7 +219160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 288,
+      "community": 284,
       "file_type": "code",
       "id": "productutils_getpreferredsku",
       "label": "getPreferredSku()",
@@ -219457,7 +219169,7 @@
       "source_location": "L78"
     },
     {
-      "community": 288,
+      "community": 284,
       "file_type": "code",
       "id": "productutils_getproductname",
       "label": "getProductName()",
@@ -219466,7 +219178,7 @@
       "source_location": "L18"
     },
     {
-      "community": 288,
+      "community": 284,
       "file_type": "code",
       "id": "productutils_haslowstock",
       "label": "hasLowStock()",
@@ -219475,7 +219187,7 @@
       "source_location": "L52"
     },
     {
-      "community": 288,
+      "community": 284,
       "file_type": "code",
       "id": "productutils_issoldout",
       "label": "isSoldOut()",
@@ -219484,7 +219196,7 @@
       "source_location": "L45"
     },
     {
-      "community": 288,
+      "community": 284,
       "file_type": "code",
       "id": "productutils_sortproduct",
       "label": "sortProduct()",
@@ -219493,7 +219205,7 @@
       "source_location": "L82"
     },
     {
-      "community": 288,
+      "community": 284,
       "file_type": "code",
       "id": "productutils_sortskusbyavailabilitythenlength",
       "label": "sortSkusByAvailabilityThenLength()",
@@ -219502,7 +219214,7 @@
       "source_location": "L63"
     },
     {
-      "community": 288,
+      "community": 284,
       "file_type": "code",
       "id": "productutils_sortskusbylength",
       "label": "sortSkusByLength()",
@@ -219511,7 +219223,250 @@
       "source_location": "L59"
     },
     {
-      "community": 289,
+      "community": 285,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
+      "label": "applyAcceptedControlResult()",
+      "norm_label": "applyacceptedcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applykeyevent",
+      "label": "applyKeyEvent()",
+      "norm_label": "applykeyevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applypointerevent",
+      "label": "applyPointerEvent()",
+      "norm_label": "applypointerevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
+      "label": "applyRemoteAssistControlIntent()",
+      "norm_label": "applyremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
+      "label": "getRecentControlResult()",
+      "norm_label": "getrecentcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
+      "label": "getRemoteAssistControlTarget()",
+      "norm_label": "getremoteassistcontroltarget()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
+      "label": "prepareRemoteAssistControlIntent()",
+      "norm_label": "prepareremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_remembercontrolresult",
+      "label": "rememberControlResult()",
+      "norm_label": "remembercontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 285,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
+      "label": "applyRemoteAssistControlIntent.ts",
+      "norm_label": "applyremoteassistcontrolintent.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L222"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L283"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "foundations_content_detailviewrolecard",
+      "label": "DetailViewRoleCard()",
+      "norm_label": "detailviewrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L363"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L214"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L265"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L218"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L246"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 288,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
       "label": "storefrontObservability.ts",
@@ -219520,7 +219475,7 @@
       "source_location": "L1"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "storefrontobservability_createstorefrontobservabilitycontext",
       "label": "createStorefrontObservabilityContext()",
@@ -219529,7 +219484,7 @@
       "source_location": "L182"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "storefrontobservability_createstorefrontobservabilitypayload",
       "label": "createStorefrontObservabilityPayload()",
@@ -219538,7 +219493,7 @@
       "source_location": "L229"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
       "label": "getOrCreateStorefrontObservabilitySessionId()",
@@ -219547,7 +219502,7 @@
       "source_location": "L157"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "storefrontobservability_isbrowserautomationcontext",
       "label": "isBrowserAutomationContext()",
@@ -219556,7 +219511,7 @@
       "source_location": "L125"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "storefrontobservability_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -219565,7 +219520,7 @@
       "source_location": "L121"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
       "label": "resolveStorefrontAnalyticsOrigin()",
@@ -219574,7 +219529,7 @@
       "source_location": "L135"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "storefrontobservability_resolveviewportbucket",
       "label": "resolveViewportBucket()",
@@ -219583,13 +219538,94 @@
       "source_location": "L211"
     },
     {
-      "community": 289,
+      "community": 288,
       "file_type": "code",
       "id": "storefrontobservability_trackstorefrontevent",
       "label": "trackStorefrontEvent()",
       "norm_label": "trackstorefrontevent()",
       "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
       "source_location": "L265"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "versionchecker_buildidfromscripts",
+      "label": "buildIdFromScripts()",
+      "norm_label": "buildidfromscripts()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L192"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "versionchecker_createversionchecker",
+      "label": "createVersionChecker()",
+      "norm_label": "createversionchecker()",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "versionchecker_getinitialdeploybuildid",
+      "label": "getInitialDeployBuildId()",
+      "norm_label": "getinitialdeploybuildid()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "versionchecker_readdeploybuildid",
+      "label": "readDeployBuildId()",
+      "norm_label": "readdeploybuildid()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "versionchecker_readdocumentscriptsources",
+      "label": "readDocumentScriptSources()",
+      "norm_label": "readdocumentscriptsources()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "versionchecker_readentryhtmlscripts",
+      "label": "readEntryHtmlScripts()",
+      "norm_label": "readentryhtmlscripts()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 289,
+      "file_type": "code",
+      "id": "versionchecker_readscriptsources",
+      "label": "readScriptSources()",
+      "norm_label": "readscriptsources()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L182"
     },
     {
       "community": 29,
@@ -233517,6 +233553,60 @@
     {
       "community": 420,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_verify_test_ts",
+      "label": "verify.test.ts",
+      "norm_label": "verify.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "verify_test_at",
+      "label": "at()",
+      "norm_label": "at()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "verify_test_folddirtydays",
+      "label": "foldDirtyDays()",
+      "norm_label": "folddirtydays()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
+      "source_location": "L57"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "verify_test_runreseed",
+      "label": "runReseed()",
+      "norm_label": "runreseed()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "verify_test_seedfoldedpaymentday",
+      "label": "seedFoldedPaymentDay()",
+      "norm_label": "seedfoldedpaymentday()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
+      "source_location": "L883"
+    },
+    {
+      "community": 420,
+      "file_type": "code",
+      "id": "verify_test_seedverifiableday",
+      "label": "seedVerifiableDay()",
+      "norm_label": "seedverifiableday()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 421,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyinventory_ts",
       "label": "weeklyInventory.ts",
       "norm_label": "weeklyinventory.ts",
@@ -233524,7 +233614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "weeklyinventory_classifyweeklyinventorygroup",
       "label": "classifyWeeklyInventoryGroup()",
@@ -233533,7 +233623,7 @@
       "source_location": "L56"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "weeklyinventory_issyncedsaleinventoryreviewgroup",
       "label": "isSyncedSaleInventoryReviewGroup()",
@@ -233542,7 +233632,7 @@
       "source_location": "L101"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "weeklyinventory_projectfrozenweeklyinventoryattention",
       "label": "projectFrozenWeeklyInventoryAttention()",
@@ -233551,7 +233641,7 @@
       "source_location": "L144"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "weeklyinventory_projectliveweeklyinventoryattention",
       "label": "projectLiveWeeklyInventoryAttention()",
@@ -233560,7 +233650,7 @@
       "source_location": "L110"
     },
     {
-      "community": 420,
+      "community": 421,
       "file_type": "code",
       "id": "weeklyinventory_summarizeweeklyinventoryattention",
       "label": "summarizeWeeklyInventoryAttention()",
@@ -233569,7 +233659,7 @@
       "source_location": "L82"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "orderemailservice_buildorderstatusmessage",
       "label": "buildOrderStatusMessage()",
@@ -233578,7 +233668,7 @@
       "source_location": "L49"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "orderemailservice_buildpickupdetails",
       "label": "buildPickupDetails()",
@@ -233587,7 +233677,7 @@
       "source_location": "L77"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "orderemailservice_sendpaymentverificationemails",
       "label": "sendPaymentVerificationEmails()",
@@ -233596,7 +233686,7 @@
       "source_location": "L217"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "orderemailservice_sendpodorderemails",
       "label": "sendPODOrderEmails()",
@@ -233605,7 +233695,7 @@
       "source_location": "L96"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "orderemailservice_shouldsendtoadmins",
       "label": "shouldSendToAdmins()",
@@ -233614,7 +233704,7 @@
       "source_location": "L42"
     },
     {
-      "community": 421,
+      "community": 422,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
       "label": "orderEmailService.ts",
@@ -233623,7 +233713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "actor_getshareddemoactorwithctx",
       "label": "getSharedDemoActorWithCtx()",
@@ -233632,7 +233722,7 @@
       "source_location": "L14"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "actor_requirereadyshareddemostorecapabilityifapplicable",
       "label": "requireReadySharedDemoStoreCapabilityIfApplicable()",
@@ -233641,7 +233731,7 @@
       "source_location": "L92"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "actor_requireshareddemoactorwithctx",
       "label": "requireSharedDemoActorWithCtx()",
@@ -233650,7 +233740,7 @@
       "source_location": "L57"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "actor_requireshareddemocapabilityifapplicable",
       "label": "requireSharedDemoCapabilityIfApplicable()",
@@ -233659,7 +233749,7 @@
       "source_location": "L66"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "actor_requireshareddemostorecapabilityifapplicable",
       "label": "requireSharedDemoStoreCapabilityIfApplicable()",
@@ -233668,7 +233758,7 @@
       "source_location": "L78"
     },
     {
-      "community": 422,
+      "community": 423,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_actor_ts",
       "label": "actor.ts",
@@ -233677,7 +233767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -233686,7 +233776,7 @@
       "source_location": "L305"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "adjustments_test_createinventorysnapshotqueryctx",
       "label": "createInventorySnapshotQueryCtx()",
@@ -233695,7 +233785,7 @@
       "source_location": "L57"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -233704,7 +233794,7 @@
       "source_location": "L506"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "adjustments_test_gethandler",
       "label": "getHandler()",
@@ -233713,7 +233803,7 @@
       "source_location": "L53"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -233722,7 +233812,7 @@
       "source_location": "L49"
     },
     {
-      "community": 423,
+      "community": 424,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -233731,7 +233821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_vendors_ts",
       "label": "vendors.ts",
@@ -233740,7 +233830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "vendors_createvendorcommandwithctx",
       "label": "createVendorCommandWithCtx()",
@@ -233749,7 +233839,7 @@
       "source_location": "L124"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "vendors_createvendorwithctx",
       "label": "createVendorWithCtx()",
@@ -233758,7 +233848,7 @@
       "source_location": "L75"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "vendors_mapcreatevendorerror",
       "label": "mapCreateVendorError()",
@@ -233767,7 +233857,7 @@
       "source_location": "L46"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "vendors_normalizevendorlookupkey",
       "label": "normalizeVendorLookupKey()",
@@ -233776,7 +233866,7 @@
       "source_location": "L38"
     },
     {
-      "community": 424,
+      "community": 425,
       "file_type": "code",
       "id": "vendors_trimoptional",
       "label": "trimOptional()",
@@ -233785,7 +233875,7 @@
       "source_location": "L33"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
@@ -233794,7 +233884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreportedreturns",
       "label": "buildOnlineOrderReportedReturns()",
@@ -233803,7 +233893,7 @@
       "source_location": "L73"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -233812,7 +233902,7 @@
       "source_location": "L137"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -233821,7 +233911,7 @@
       "source_location": "L112"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -233830,7 +233920,7 @@
       "source_location": "L96"
     },
     {
-      "community": 425,
+      "community": 426,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -233839,7 +233929,7 @@
       "source_location": "L92"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "onlineorder_test_createunauthorizednormalorderctx",
       "label": "createUnauthorizedNormalOrderCtx()",
@@ -233848,7 +233938,7 @@
       "source_location": "L164"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "onlineorder_test_gethandler",
       "label": "getHandler()",
@@ -233857,7 +233947,7 @@
       "source_location": "L160"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "onlineorder_test_getsource",
       "label": "getSource()",
@@ -233866,7 +233956,7 @@
       "source_location": "L156"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "onlineorder_test_readstorefrontfacts",
       "label": "readStorefrontFacts()",
@@ -233875,7 +233965,7 @@
       "source_location": "L150"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "onlineorder_test_seedfulfillableorder",
       "label": "seedFulfillableOrder()",
@@ -233884,7 +233974,7 @@
       "source_location": "L29"
     },
     {
-      "community": 426,
+      "community": 427,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
@@ -233893,7 +233983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_storetimeauthority_ts",
       "label": "storeTimeAuthority.ts",
@@ -233902,7 +233992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "storetimeauthority_assertstoretimezoneversioncanbeinserted",
       "label": "assertStoreTimezoneVersionCanBeInserted()",
@@ -233911,7 +234001,7 @@
       "source_location": "L50"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "storetimeauthority_includesoccurrence",
       "label": "includesOccurrence()",
@@ -233920,7 +234010,7 @@
       "source_location": "L18"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "storetimeauthority_intervalsoverlap",
       "label": "intervalsOverlap()",
@@ -233929,7 +234019,7 @@
       "source_location": "L41"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "storetimeauthority_localdate",
       "label": "localDate()",
@@ -233938,7 +234028,7 @@
       "source_location": "L28"
     },
     {
-      "community": 427,
+      "community": 428,
       "file_type": "code",
       "id": "storetimeauthority_resolvestoretimeauthority",
       "label": "resolveStoreTimeAuthority()",
@@ -233947,7 +234037,7 @@
       "source_location": "L84"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -233956,7 +234046,7 @@
       "source_location": "L1"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "purchaseorder_buildpurchaseorderreceivinglookup",
       "label": "buildPurchaseOrderReceivingLookup()",
@@ -233965,7 +234055,7 @@
       "source_location": "L162"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "purchaseorder_buildpurchaseordertraceseed",
       "label": "buildPurchaseOrderTraceSeed()",
@@ -233974,7 +234064,7 @@
       "source_location": "L82"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "purchaseorder_compactdetails",
       "label": "compactDetails()",
@@ -233983,7 +234073,7 @@
       "source_location": "L74"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "purchaseorder_formatpurchaseorderlabel",
       "label": "formatPurchaseOrderLabel()",
@@ -233992,67 +234082,13 @@
       "source_location": "L45"
     },
     {
-      "community": 428,
+      "community": 429,
       "file_type": "code",
       "id": "purchaseorder_normalizelookup",
       "label": "normalizeLookup()",
       "norm_label": "normalizelookup()",
       "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/purchaseOrder.ts",
       "source_location": "L53"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_find_block_end",
-      "label": "find_block_end()",
-      "norm_label": "find_block_end()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L123"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_list_convex_files",
-      "label": "list_convex_files()",
-      "norm_label": "list_convex_files()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L187"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_main",
-      "label": "main()",
-      "norm_label": "main()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L207"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_scan_file",
-      "label": "scan_file()",
-      "norm_label": "scan_file()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L137"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "convexpaginationantipatterncheck_strip_code",
-      "label": "strip_code()",
-      "norm_label": "strip_code()",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L9"
-    },
-    {
-      "community": 429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
-      "label": "convexPaginationAntiPatternCheck.py",
-      "norm_label": "convexpaginationantipatterncheck.py",
-      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
-      "source_location": "L1"
     },
     {
       "community": 43,
@@ -234327,6 +234363,60 @@
     {
       "community": 430,
       "file_type": "code",
+      "id": "convexpaginationantipatterncheck_find_block_end",
+      "label": "find_block_end()",
+      "norm_label": "find_block_end()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L123"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_list_convex_files",
+      "label": "list_convex_files()",
+      "norm_label": "list_convex_files()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L187"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_main",
+      "label": "main()",
+      "norm_label": "main()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L207"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_scan_file",
+      "label": "scan_file()",
+      "norm_label": "scan_file()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L137"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "convexpaginationantipatterncheck_strip_code",
+      "label": "strip_code()",
+      "norm_label": "strip_code()",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L9"
+    },
+    {
+      "community": 430,
+      "file_type": "code",
+      "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
+      "label": "convexPaginationAntiPatternCheck.py",
+      "norm_label": "convexpaginationantipatterncheck.py",
+      "source_file": "packages/athena-webapp/scripts/convexPaginationAntiPatternCheck.py",
+      "source_location": "L1"
+    },
+    {
+      "community": 431,
+      "file_type": "code",
       "id": "commandresult_approvalrequired",
       "label": "approvalRequired()",
       "norm_label": "approvalrequired()",
@@ -234334,7 +234424,7 @@
       "source_location": "L62"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "commandresult_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -234343,7 +234433,7 @@
       "source_location": "L77"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
@@ -234352,7 +234442,7 @@
       "source_location": "L71"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -234361,7 +234451,7 @@
       "source_location": "L48"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -234370,7 +234460,7 @@
       "source_location": "L55"
     },
     {
-      "community": 430,
+      "community": 431,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -234379,7 +234469,7 @@
       "source_location": "L1"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "homepageranking_comparehomepagerankeditems",
       "label": "compareHomepageRankedItems()",
@@ -234388,7 +234478,7 @@
       "source_location": "L22"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "homepageranking_gethomepagesortrank",
       "label": "getHomepageSortRank()",
@@ -234397,7 +234487,7 @@
       "source_location": "L9"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "homepageranking_getnexthomepagerank",
       "label": "getNextHomepageRank()",
@@ -234406,7 +234496,7 @@
       "source_location": "L40"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "homepageranking_getpresentedhomepagerank",
       "label": "getPresentedHomepageRank()",
@@ -234415,7 +234505,7 @@
       "source_location": "L15"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "homepageranking_sorthomepagerankeditems",
       "label": "sortHomepageRankedItems()",
@@ -234424,7 +234514,7 @@
       "source_location": "L36"
     },
     {
-      "community": 431,
+      "community": 432,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_homepageranking_ts",
       "label": "homepageRanking.ts",
@@ -234433,7 +234523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_poslocalsynccontract_ts",
       "label": "posLocalSyncContract.ts",
@@ -234442,7 +234532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "poslocalsynccontract_canuploadposlocalsynclocaleventtype",
       "label": "canUploadPosLocalSyncLocalEventType()",
@@ -234451,7 +234541,7 @@
       "source_location": "L143"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "poslocalsynccontract_eventtypesfromcontract",
       "label": "eventTypesFromContract()",
@@ -234460,7 +234550,7 @@
       "source_location": "L60"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "poslocalsynccontract_getposlocalsynceventcontractforlocaleventtype",
       "label": "getPosLocalSyncEventContractForLocalEventType()",
@@ -234469,7 +234559,7 @@
       "source_location": "L123"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "poslocalsynccontract_getposlocalsynceventtypeforlocaleventtype",
       "label": "getPosLocalSyncEventTypeForLocalEventType()",
@@ -234478,7 +234568,7 @@
       "source_location": "L136"
     },
     {
-      "community": 432,
+      "community": 433,
       "file_type": "code",
       "id": "poslocalsynccontract_isposlocalsynceventtype",
       "label": "isPosLocalSyncEventType()",
@@ -234487,7 +234577,7 @@
       "source_location": "L117"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_registersessionstatus_ts",
       "label": "registerSessionStatus.ts",
@@ -234496,7 +234586,7 @@
       "source_location": "L1"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "registersessionstatus_includesregistersessionstatus",
       "label": "includesRegisterSessionStatus()",
@@ -234505,7 +234595,7 @@
       "source_location": "L38"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
       "label": "isCashControlVisibleRegisterSessionStatus()",
@@ -234514,7 +234604,7 @@
       "source_location": "L62"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "registersessionstatus_isposusableregistersessionstatus",
       "label": "isPosUsableRegisterSessionStatus()",
@@ -234523,7 +234613,7 @@
       "source_location": "L48"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "registersessionstatus_isregistersessionconflictblockingstatus",
       "label": "isRegisterSessionConflictBlockingStatus()",
@@ -234532,7 +234622,7 @@
       "source_location": "L55"
     },
     {
-      "community": 433,
+      "community": 434,
       "file_type": "code",
       "id": "registersessionstatus_isregistersessionstatus",
       "label": "isRegisterSessionStatus()",
@@ -234541,7 +234631,7 @@
       "source_location": "L29"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
@@ -234550,7 +234640,7 @@
       "source_location": "L1"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "workflowtrace_assertobjectkeysareminimized",
       "label": "assertObjectKeysAreMinimized()",
@@ -234559,7 +234649,7 @@
       "source_location": "L44"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "workflowtrace_assertworkflowtracedetailsareminimized",
       "label": "assertWorkflowTraceDetailsAreMinimized()",
@@ -234568,7 +234658,7 @@
       "source_location": "L67"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -234577,7 +234667,7 @@
       "source_location": "L93"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtraceeventkey",
       "label": "normalizeWorkflowTraceEventKey()",
@@ -234586,7 +234676,7 @@
       "source_location": "L83"
     },
     {
-      "community": 434,
+      "community": 435,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -234595,7 +234685,7 @@
       "source_location": "L73"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -234604,7 +234694,7 @@
       "source_location": "L1"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -234613,7 +234703,7 @@
       "source_location": "L327"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -234622,7 +234712,7 @@
       "source_location": "L234"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "productcategorization_handleproductposvisibility",
       "label": "handleProductPosVisibility()",
@@ -234631,7 +234721,7 @@
       "source_location": "L284"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -234640,7 +234730,7 @@
       "source_location": "L274"
     },
     {
-      "community": 435,
+      "community": 436,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
@@ -234649,7 +234739,7 @@
       "source_location": "L261"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "data_table_toolbar_datatabletoolbar",
       "label": "DataTableToolbar()",
@@ -234658,7 +234748,7 @@
       "source_location": "L23"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -234667,7 +234757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -234676,7 +234766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -234685,7 +234775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -234694,7 +234784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 436,
+      "community": 437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -234703,7 +234793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -234712,7 +234802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -234721,7 +234811,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -234730,7 +234820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -234739,7 +234829,7 @@
       "source_location": "L1"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "selectable_data_provider_selectedproductsprovider",
       "label": "SelectedProductsProvider()",
@@ -234748,7 +234838,7 @@
       "source_location": "L16"
     },
     {
-      "community": 437,
+      "community": 438,
       "file_type": "code",
       "id": "selectable_data_provider_useselectedproducts",
       "label": "useSelectedProducts()",
@@ -234757,7 +234847,7 @@
       "source_location": "L37"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "flipnumber_defaultformatvalue",
       "label": "defaultFormatValue()",
@@ -234766,7 +234856,7 @@
       "source_location": "L20"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "flipnumber_flipnumber",
       "label": "FlipNumber()",
@@ -234775,7 +234865,7 @@
       "source_location": "L232"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "flipnumber_fliptext",
       "label": "FlipText()",
@@ -234784,7 +234874,7 @@
       "source_location": "L47"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "flipnumber_renderflipglyphs",
       "label": "renderFlipGlyphs()",
@@ -234793,7 +234883,7 @@
       "source_location": "L24"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "flipnumber_renderfliptext",
       "label": "renderFlipText()",
@@ -234802,66 +234892,12 @@
       "source_location": "L37"
     },
     {
-      "community": 438,
+      "community": 439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_flipnumber_tsx",
       "label": "FlipNumber.tsx",
       "norm_label": "flipnumber.tsx",
       "source_file": "packages/athena-webapp/src/components/common/FlipNumber.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "bannermessageeditor_getcountdownstatus",
-      "label": "getCountdownStatus()",
-      "norm_label": "getcountdownstatus()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L130"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleactivetoggle",
-      "label": "handleActiveToggle()",
-      "norm_label": "handleactivetoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L90"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "bannermessageeditor_handleclear",
-      "label": "handleClear()",
-      "norm_label": "handleclear()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlecountdownchange",
-      "label": "handleCountdownChange()",
-      "norm_label": "handlecountdownchange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L120"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "bannermessageeditor_handlesave",
-      "label": "handleSave()",
-      "norm_label": "handlesave()",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
-      "source_location": "L45"
-    },
-    {
-      "community": 439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
-      "label": "BannerMessageEditor.tsx",
-      "norm_label": "bannermessageeditor.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
       "source_location": "L1"
     },
     {
@@ -235137,6 +235173,60 @@
     {
       "community": 440,
       "file_type": "code",
+      "id": "bannermessageeditor_getcountdownstatus",
+      "label": "getCountdownStatus()",
+      "norm_label": "getcountdownstatus()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L130"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleactivetoggle",
+      "label": "handleActiveToggle()",
+      "norm_label": "handleactivetoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L90"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "bannermessageeditor_handleclear",
+      "label": "handleClear()",
+      "norm_label": "handleclear()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlecountdownchange",
+      "label": "handleCountdownChange()",
+      "norm_label": "handlecountdownchange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L120"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "bannermessageeditor_handlesave",
+      "label": "handleSave()",
+      "norm_label": "handlesave()",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L45"
+    },
+    {
+      "community": 440,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
+      "label": "BannerMessageEditor.tsx",
+      "norm_label": "bannermessageeditor.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/BannerMessageEditor.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 441,
+      "file_type": "code",
       "id": "bestsellers_bestsellers",
       "label": "bestSellers()",
       "norm_label": "bestsellers()",
@@ -235144,7 +235234,7 @@
       "source_location": "L157"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -235153,7 +235243,7 @@
       "source_location": "L66"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "bestsellers_movebestseller",
       "label": "moveBestSeller()",
@@ -235162,7 +235252,7 @@
       "source_location": "L126"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -235171,7 +235261,7 @@
       "source_location": "L76"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "bestsellers_saveorder",
       "label": "saveOrder()",
@@ -235180,7 +235270,7 @@
       "source_location": "L104"
     },
     {
-      "community": 440,
+      "community": 441,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -235189,7 +235279,7 @@
       "source_location": "L1"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "featuredsection_formatstoredcurrencyamount",
       "label": "formatStoredCurrencyAmount()",
@@ -235198,7 +235288,7 @@
       "source_location": "L215"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -235207,7 +235297,7 @@
       "source_location": "L66"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "featuredsection_movefeatureditem",
       "label": "moveFeaturedItem()",
@@ -235216,7 +235306,7 @@
       "source_location": "L128"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -235225,7 +235315,7 @@
       "source_location": "L78"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "featuredsection_saveorder",
       "label": "saveOrder()",
@@ -235234,7 +235324,7 @@
       "source_location": "L106"
     },
     {
-      "community": 441,
+      "community": 442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
@@ -235243,7 +235333,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_scenechrome_tsx",
       "label": "SceneChrome.tsx",
@@ -235252,7 +235342,7 @@
       "source_location": "L1"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "scenechrome_appshellexhibit",
       "label": "AppShellExhibit()",
@@ -235261,7 +235351,7 @@
       "source_location": "L131"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "scenechrome_automationbeat",
       "label": "AutomationBeat()",
@@ -235270,7 +235360,7 @@
       "source_location": "L272"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "scenechrome_possyncbadge",
       "label": "PosSyncBadge()",
@@ -235279,7 +235369,7 @@
       "source_location": "L248"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "scenechrome_workspaceexhibit",
       "label": "WorkspaceExhibit()",
@@ -235288,7 +235378,7 @@
       "source_location": "L80"
     },
     {
-      "community": 442,
+      "community": 443,
       "file_type": "code",
       "id": "scenechrome_workspaceframe",
       "label": "WorkspaceFrame()",
@@ -235297,7 +235387,7 @@
       "source_location": "L39"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_historyrecord",
       "label": "historyRecord()",
@@ -235306,7 +235396,7 @@
       "source_location": "L190"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockprotectedstate",
       "label": "mockProtectedState()",
@@ -235315,7 +235405,7 @@
       "source_location": "L241"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockqueries",
       "label": "mockQueries()",
@@ -235324,7 +235414,7 @@
       "source_location": "L255"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_snapshot",
       "label": "snapshot()",
@@ -235333,7 +235423,7 @@
       "source_location": "L104"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_storedreportsnapshot",
       "label": "storedReportSnapshot()",
@@ -235342,7 +235432,7 @@
       "source_location": "L171"
     },
     {
-      "community": 443,
+      "community": 444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_test_tsx",
       "label": "DailyCloseHistoryView.test.tsx",
@@ -235351,7 +235441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "dailyopeningview_test_async",
       "label": "async()",
@@ -235360,7 +235450,7 @@
       "source_location": "L124"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "dailyopeningview_test_disconnect",
       "label": "disconnect()",
@@ -235369,7 +235459,7 @@
       "source_location": "L359"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "dailyopeningview_test_formatexpectedtimestamp",
       "label": "formatExpectedTimestamp()",
@@ -235378,7 +235468,7 @@
       "source_location": "L258"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "dailyopeningview_test_observe",
       "label": "observe()",
@@ -235387,7 +235477,7 @@
       "source_location": "L360"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "dailyopeningview_test_unobserve",
       "label": "unobserve()",
@@ -235396,7 +235486,7 @@
       "source_location": "L361"
     },
     {
-      "community": 444,
+      "community": 445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "label": "DailyOpeningView.test.tsx",
@@ -235405,7 +235495,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsales_tsx",
       "label": "SkuActivityUntrustedSales.tsx",
@@ -235414,7 +235504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_cn",
       "label": "cn()",
@@ -235423,7 +235513,7 @@
       "source_location": "L207"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_formatcountlabel",
       "label": "formatCountLabel()",
@@ -235432,7 +235522,7 @@
       "source_location": "L139"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_handlesourcepagechange",
       "label": "handleSourcePageChange()",
@@ -235441,7 +235531,7 @@
       "source_location": "L932"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_sourcematchesevidencequery",
       "label": "sourceMatchesEvidenceQuery()",
@@ -235450,7 +235540,7 @@
       "source_location": "L147"
     },
     {
-      "community": 445,
+      "community": 446,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_usedetailstickyposition",
       "label": "useDetailStickyPosition()",
@@ -235459,7 +235549,7 @@
       "source_location": "L83"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -235468,7 +235558,7 @@
       "source_location": "L1"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "useapprovedcommand_buildapprovalretryargs",
       "label": "buildApprovalRetryArgs()",
@@ -235477,7 +235567,7 @@
       "source_location": "L90"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "useapprovedcommand_getasyncapprovalrequestid",
       "label": "getAsyncApprovalRequestId()",
@@ -235486,7 +235576,7 @@
       "source_location": "L78"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -235495,7 +235585,7 @@
       "source_location": "L72"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -235504,7 +235594,7 @@
       "source_location": "L66"
     },
     {
-      "community": 446,
+      "community": 447,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -235513,7 +235603,7 @@
       "source_location": "L102"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -235522,7 +235612,7 @@
       "source_location": "L1"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "paymentsaddedlist_test_deferred",
       "label": "deferred()",
@@ -235531,7 +235621,7 @@
       "source_location": "L46"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -235540,7 +235630,7 @@
       "source_location": "L28"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -235549,7 +235639,7 @@
       "source_location": "L19"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -235558,7 +235648,7 @@
       "source_location": "L41"
     },
     {
-      "community": 447,
+      "community": 448,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -235567,7 +235657,7 @@
       "source_location": "L15"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -235576,7 +235666,7 @@
       "source_location": "L1"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "pointofsaleview_formatnextopeninglabel",
       "label": "formatNextOpeningLabel()",
@@ -235585,7 +235675,7 @@
       "source_location": "L131"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "pointofsaleview_formatstorehourstimelabel",
       "label": "formatStoreHoursTimeLabel()",
@@ -235594,7 +235684,7 @@
       "source_location": "L100"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "pointofsaleview_formatstorelocaldatelabel",
       "label": "formatStoreLocalDateLabel()",
@@ -235603,7 +235693,7 @@
       "source_location": "L116"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "pointofsaleview_formatstorelocaldatetime",
       "label": "formatStoreLocalDateTime()",
@@ -235612,67 +235702,13 @@
       "source_location": "L79"
     },
     {
-      "community": 448,
+      "community": 449,
       "file_type": "code",
       "id": "pointofsaleview_useminutenow",
       "label": "useMinuteNow()",
       "norm_label": "useminutenow()",
       "source_file": "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
       "source_location": "L144"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
-      "label": "POSRegisterOpeningGuard.tsx",
-      "norm_label": "posregisteropeningguard.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "posregisteropeningguard_getlocaloperatingdate",
-      "label": "getLocalOperatingDate()",
-      "norm_label": "getlocaloperatingdate()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L65"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "posregisteropeningguard_getlocaloperatingdaterange",
-      "label": "getLocalOperatingDateRange()",
-      "norm_label": "getlocaloperatingdaterange()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L73"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "posregisteropeningguard_if",
-      "label": "if()",
-      "norm_label": "if()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L689"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "posregisteropeningguard_isbrowseroffline",
-      "label": "isBrowserOffline()",
-      "norm_label": "isbrowseroffline()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L92"
-    },
-    {
-      "community": 449,
-      "file_type": "code",
-      "id": "posregisteropeningguard_posregisteropeningguard",
-      "label": "POSRegisterOpeningGuard()",
-      "norm_label": "posregisteropeningguard()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
-      "source_location": "L96"
     },
     {
       "community": 45,
@@ -235938,6 +235974,60 @@
     {
       "community": 450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
+      "label": "POSRegisterOpeningGuard.tsx",
+      "norm_label": "posregisteropeningguard.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "posregisteropeningguard_getlocaloperatingdate",
+      "label": "getLocalOperatingDate()",
+      "norm_label": "getlocaloperatingdate()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
+      "source_location": "L65"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "posregisteropeningguard_getlocaloperatingdaterange",
+      "label": "getLocalOperatingDateRange()",
+      "norm_label": "getlocaloperatingdaterange()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
+      "source_location": "L73"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "posregisteropeningguard_if",
+      "label": "if()",
+      "norm_label": "if()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
+      "source_location": "L689"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "posregisteropeningguard_isbrowseroffline",
+      "label": "isBrowserOffline()",
+      "norm_label": "isbrowseroffline()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
+      "source_location": "L92"
+    },
+    {
+      "community": 450,
+      "file_type": "code",
+      "id": "posregisteropeningguard_posregisteropeningguard",
+      "label": "POSRegisterOpeningGuard()",
+      "norm_label": "posregisteropeningguard()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx",
+      "source_location": "L96"
+    },
+    {
+      "community": 451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
       "norm_label": "transactionview.test.tsx",
@@ -235945,7 +236035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -235954,7 +236044,7 @@
       "source_location": "L199"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "transactionview_test_deferred",
       "label": "deferred()",
@@ -235963,7 +236053,7 @@
       "source_location": "L15"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -235972,7 +236062,7 @@
       "source_location": "L554"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -235981,7 +236071,7 @@
       "source_location": "L473"
     },
     {
-      "community": 450,
+      "community": 451,
       "file_type": "code",
       "id": "transactionview_test_voidapprovalrequirement",
       "label": "voidApprovalRequirement()",
@@ -235990,7 +236080,7 @@
       "source_location": "L506"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
       "label": "ProcurementView.test.tsx",
@@ -235999,7 +236089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "procurementview_test_choosedraftvendor",
       "label": "chooseDraftVendor()",
@@ -236008,7 +236098,7 @@
       "source_location": "L367"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "procurementview_test_chooseprocurementmode",
       "label": "chooseProcurementMode()",
@@ -236017,7 +236107,7 @@
       "source_location": "L357"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "procurementview_test_installmutationmocks",
       "label": "installMutationMocks()",
@@ -236026,7 +236116,7 @@
       "source_location": "L323"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "procurementview_test_makeproductskusearchresult",
       "label": "makeProductSkuSearchResult()",
@@ -236035,7 +236125,7 @@
       "source_location": "L294"
     },
     {
-      "community": 451,
+      "community": 452,
       "file_type": "code",
       "id": "procurementview_test_makerecommendation",
       "label": "makeRecommendation()",
@@ -236044,7 +236134,7 @@
       "source_location": "L285"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportdayspanel_tsx",
       "label": "ReportDaysPanel.tsx",
@@ -236053,7 +236143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "reportdayspanel_cn",
       "label": "cn()",
@@ -236062,7 +236152,7 @@
       "source_location": "L254"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "reportdayspanel_isinselectedrange",
       "label": "isInSelectedRange()",
@@ -236071,7 +236161,7 @@
       "source_location": "L166"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "reportdayspanel_isselectedday",
       "label": "isSelectedDay()",
@@ -236080,7 +236170,7 @@
       "source_location": "L164"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "reportdayspanel_pagecontainingdate",
       "label": "pageContainingDate()",
@@ -236089,7 +236179,7 @@
       "source_location": "L36"
     },
     {
-      "community": 452,
+      "community": 453,
       "file_type": "code",
       "id": "reportdayspanel_selectday",
       "label": "selectDay()",
@@ -236098,7 +236188,7 @@
       "source_location": "L168"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
       "label": "ReviewsView.tsx",
@@ -236107,7 +236197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "reviewsview_handleapprove",
       "label": "handleApprove()",
@@ -236116,7 +236206,7 @@
       "source_location": "L44"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "reviewsview_handlepublish",
       "label": "handlePublish()",
@@ -236125,7 +236215,7 @@
       "source_location": "L80"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "reviewsview_handlereject",
       "label": "handleReject()",
@@ -236134,7 +236224,7 @@
       "source_location": "L62"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "reviewsview_handleunpublish",
       "label": "handleUnpublish()",
@@ -236143,7 +236233,7 @@
       "source_location": "L98"
     },
     {
-      "community": 453,
+      "community": 454,
       "file_type": "code",
       "id": "reviewsview_header",
       "label": "Header()",
@@ -236152,7 +236242,7 @@
       "source_location": "L15"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogform_ts",
       "label": "serviceCatalogForm.ts",
@@ -236161,7 +236251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "servicecatalogform_formatservicecatalogname",
       "label": "formatServiceCatalogName()",
@@ -236170,7 +236260,7 @@
       "source_location": "L92"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "servicecatalogform_itemtoservicecatalogformstate",
       "label": "itemToServiceCatalogFormState()",
@@ -236179,7 +236269,7 @@
       "source_location": "L154"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "servicecatalogform_parseservicecatalogcreateform",
       "label": "parseServiceCatalogCreateForm()",
@@ -236188,7 +236278,7 @@
       "source_location": "L178"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "servicecatalogform_parseservicecatalogupdateform",
       "label": "parseServiceCatalogUpdateForm()",
@@ -236197,7 +236287,7 @@
       "source_location": "L203"
     },
     {
-      "community": 454,
+      "community": 455,
       "file_type": "code",
       "id": "servicecatalogform_validateservicecatalogform",
       "label": "validateServiceCatalogForm()",
@@ -236206,7 +236296,7 @@
       "source_location": "L102"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoreportsfixture_test_ts",
       "label": "sharedDemoReportsFixture.test.ts",
@@ -236215,7 +236305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_adddaystodate",
       "label": "addDaysToDate()",
@@ -236224,7 +236314,7 @@
       "source_location": "L37"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_expectfinitenumbers",
       "label": "expectFiniteNumbers()",
@@ -236233,7 +236323,7 @@
       "source_location": "L59"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_historydates",
       "label": "historyDates()",
@@ -236242,7 +236332,7 @@
       "source_location": "L52"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_isoweekstart",
       "label": "isoWeekStart()",
@@ -236251,7 +236341,7 @@
       "source_location": "L43"
     },
     {
-      "community": 455,
+      "community": 456,
       "file_type": "code",
       "id": "shareddemoreportsfixture_test_skuidfor",
       "label": "skuIdFor()",
@@ -236260,7 +236350,7 @@
       "source_location": "L48"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "feesview_formatdeliveryfeeinput",
       "label": "formatDeliveryFeeInput()",
@@ -236269,7 +236359,7 @@
       "source_location": "L31"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -236278,7 +236368,7 @@
       "source_location": "L162"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -236287,7 +236377,7 @@
       "source_location": "L88"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "feesview_parsedeliveryfeeinputs",
       "label": "parseDeliveryFeeInputs()",
@@ -236296,7 +236386,7 @@
       "source_location": "L45"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "feesview_parseoptionaldeliveryfeeinput",
       "label": "parseOptionalDeliveryFeeInput()",
@@ -236305,7 +236395,7 @@
       "source_location": "L35"
     },
     {
-      "community": 456,
+      "community": 457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -236314,7 +236404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usenotificationsubscriptions_ts",
       "label": "useNotificationSubscriptions.ts",
@@ -236323,7 +236413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "usenotificationsubscriptions_derivecategorystate",
       "label": "deriveCategoryState()",
@@ -236332,7 +236422,7 @@
       "source_location": "L113"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "usenotificationsubscriptions_isvalidrecipientemail",
       "label": "isValidRecipientEmail()",
@@ -236341,7 +236431,7 @@
       "source_location": "L104"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "usenotificationsubscriptions_normalizerecipientemailinput",
       "label": "normalizeRecipientEmailInput()",
@@ -236350,7 +236440,7 @@
       "source_location": "L100"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "usenotificationsubscriptions_sortrecipientcandidates",
       "label": "sortRecipientCandidates()",
@@ -236359,7 +236449,7 @@
       "source_location": "L127"
     },
     {
-      "community": 457,
+      "community": 458,
       "file_type": "code",
       "id": "usenotificationsubscriptions_usenotificationsubscriptions",
       "label": "useNotificationSubscriptions()",
@@ -236368,7 +236458,7 @@
       "source_location": "L138"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "image_uploader_ondragend",
       "label": "onDragEnd()",
@@ -236377,7 +236467,7 @@
       "source_location": "L101"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "image_uploader_ondrop",
       "label": "onDrop()",
@@ -236386,7 +236476,7 @@
       "source_location": "L20"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "image_uploader_removeimage",
       "label": "removeImage()",
@@ -236395,7 +236485,7 @@
       "source_location": "L31"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "image_uploader_unmarkfordeletion",
       "label": "unmarkForDeletion()",
@@ -236404,7 +236494,7 @@
       "source_location": "L46"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -236413,66 +236503,12 @@
       "source_location": "L1"
     },
     {
-      "community": 458,
+      "community": 459,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
       "norm_label": "image-uploader.tsx",
       "source_file": "packages/storefront-webapp/src/components/ui/image-uploader.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "managerelevationcontext_getstaffdisplayname",
-      "label": "getStaffDisplayName()",
-      "norm_label": "getstaffdisplayname()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L64"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "managerelevationcontext_managerelevationprovider",
-      "label": "ManagerElevationProvider()",
-      "norm_label": "managerelevationprovider()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L87"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "managerelevationcontext_tostaffauthenticationresult",
-      "label": "toStaffAuthenticationResult()",
-      "norm_label": "tostaffauthenticationresult()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L74"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "managerelevationcontext_usemanagerelevation",
-      "label": "useManagerElevation()",
-      "norm_label": "usemanagerelevation()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L242"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "managerelevationcontext_useoptionalmanagerelevation",
-      "label": "useOptionalManagerElevation()",
-      "norm_label": "useoptionalmanagerelevation()",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
-      "source_location": "L251"
-    },
-    {
-      "community": 459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
-      "label": "ManagerElevationContext.tsx",
-      "norm_label": "managerelevationcontext.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
       "source_location": "L1"
     },
     {
@@ -236739,6 +236775,60 @@
     {
       "community": 460,
       "file_type": "code",
+      "id": "managerelevationcontext_getstaffdisplayname",
+      "label": "getStaffDisplayName()",
+      "norm_label": "getstaffdisplayname()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L64"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "managerelevationcontext_managerelevationprovider",
+      "label": "ManagerElevationProvider()",
+      "norm_label": "managerelevationprovider()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L87"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "managerelevationcontext_tostaffauthenticationresult",
+      "label": "toStaffAuthenticationResult()",
+      "norm_label": "tostaffauthenticationresult()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L74"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "managerelevationcontext_usemanagerelevation",
+      "label": "useManagerElevation()",
+      "norm_label": "usemanagerelevation()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L242"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "managerelevationcontext_useoptionalmanagerelevation",
+      "label": "useOptionalManagerElevation()",
+      "norm_label": "useoptionalmanagerelevation()",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L251"
+    },
+    {
+      "community": 460,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
+      "label": "ManagerElevationContext.tsx",
+      "norm_label": "managerelevationcontext.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ManagerElevationContext.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
       "norm_label": "useexpensesessions.ts",
@@ -236746,7 +236836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -236755,7 +236845,7 @@
       "source_location": "L42"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -236764,7 +236854,7 @@
       "source_location": "L32"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -236773,7 +236863,7 @@
       "source_location": "L62"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -236782,7 +236872,7 @@
       "source_location": "L101"
     },
     {
-      "community": 460,
+      "community": 461,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -236791,7 +236881,7 @@
       "source_location": "L10"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
@@ -236800,7 +236890,7 @@
       "source_location": "L54"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -236809,7 +236899,7 @@
       "source_location": "L41"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -236818,7 +236908,7 @@
       "source_location": "L47"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -236827,7 +236917,7 @@
       "source_location": "L61"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -236836,7 +236926,7 @@
       "source_location": "L68"
     },
     {
-      "community": 461,
+      "community": 462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
@@ -236845,7 +236935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -236854,7 +236944,7 @@
       "source_location": "L173"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -236863,7 +236953,7 @@
       "source_location": "L71"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -236872,7 +236962,7 @@
       "source_location": "L251"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -236881,7 +236971,7 @@
       "source_location": "L36"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -236890,7 +236980,7 @@
       "source_location": "L277"
     },
     {
-      "community": 462,
+      "community": 463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -236899,7 +236989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -236908,7 +236998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -236917,7 +237007,7 @@
       "source_location": "L134"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -236926,7 +237016,7 @@
       "source_location": "L69"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -236935,7 +237025,7 @@
       "source_location": "L86"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -236944,7 +237034,7 @@
       "source_location": "L52"
     },
     {
-      "community": 463,
+      "community": 464,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -236953,7 +237043,7 @@
       "source_location": "L103"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -236962,7 +237052,7 @@
       "source_location": "L1"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -236971,7 +237061,7 @@
       "source_location": "L45"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -236980,7 +237070,7 @@
       "source_location": "L220"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -236989,7 +237079,7 @@
       "source_location": "L167"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -236998,7 +237088,7 @@
       "source_location": "L182"
     },
     {
-      "community": 464,
+      "community": 465,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
@@ -237007,7 +237097,7 @@
       "source_location": "L194"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
       "label": "usePosLocalSyncRuntime.test.ts",
@@ -237016,7 +237106,7 @@
       "source_location": "L1"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -237025,7 +237115,7 @@
       "source_location": "L7332"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommand",
       "label": "buildRecoveryCommand()",
@@ -237034,7 +237124,7 @@
       "source_location": "L7355"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
       "label": "buildRecoveryCommandStore()",
@@ -237043,7 +237133,7 @@
       "source_location": "L7374"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_deferred",
       "label": "deferred()",
@@ -237052,7 +237142,7 @@
       "source_location": "L103"
     },
     {
-      "community": 465,
+      "community": 466,
       "file_type": "code",
       "id": "useposlocalsyncruntime_test_storefactory",
       "label": "storeFactory()",
@@ -237061,7 +237151,7 @@
       "source_location": "L347"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
@@ -237070,7 +237160,7 @@
       "source_location": "L1"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -237079,7 +237169,7 @@
       "source_location": "L28"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -237088,7 +237178,7 @@
       "source_location": "L37"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -237097,7 +237187,7 @@
       "source_location": "L12"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -237106,7 +237196,7 @@
       "source_location": "L6"
     },
     {
-      "community": 466,
+      "community": 467,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -237115,7 +237205,7 @@
       "source_location": "L49"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -237124,7 +237214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -237133,7 +237223,7 @@
       "source_location": "L171"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -237142,7 +237232,7 @@
       "source_location": "L302"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -237151,7 +237241,7 @@
       "source_location": "L319"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -237160,7 +237250,7 @@
       "source_location": "L312"
     },
     {
-      "community": 467,
+      "community": 468,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -237169,7 +237259,7 @@
       "source_location": "L293"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
       "label": "productSkuSearchAdapters.ts",
@@ -237178,7 +237268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoption",
       "label": "buildAdminSkuSearchOption()",
@@ -237187,7 +237277,7 @@
       "source_location": "L80"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoptions",
       "label": "buildAdminSkuSearchOptions()",
@@ -237196,7 +237286,7 @@
       "source_location": "L132"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "productskusearchadapters_compactjoin",
       "label": "compactJoin()",
@@ -237205,7 +237295,7 @@
       "source_location": "L73"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
       "label": "groupAdminSkuSearchOptionsByProduct()",
@@ -237214,67 +237304,13 @@
       "source_location": "L138"
     },
     {
-      "community": 468,
+      "community": 469,
       "file_type": "code",
       "id": "productskusearchadapters_presentationtext",
       "label": "presentationText()",
       "norm_label": "presentationtext()",
       "source_file": "packages/athena-webapp/src/lib/skuSearch/productSkuSearchAdapters.ts",
       "source_location": "L66"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
-      "label": "skuSearch.ts",
-      "norm_label": "skusearch.ts",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "skusearch_isbarcodeshapedsearchquery",
-      "label": "isBarcodeShapedSearchQuery()",
-      "norm_label": "isbarcodeshapedsearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "skusearch_matchesskusearchterms",
-      "label": "matchesSkuSearchTerms()",
-      "norm_label": "matchesskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "skusearch_normalizeidentifier",
-      "label": "normalizeIdentifier()",
-      "norm_label": "normalizeidentifier()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "skusearch_normalizeskusearchquery",
-      "label": "normalizeSkuSearchQuery()",
-      "norm_label": "normalizeskusearchquery()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 469,
-      "file_type": "code",
-      "id": "skusearch_scoreskusearchterms",
-      "label": "scoreSkuSearchTerms()",
-      "norm_label": "scoreskusearchterms()",
-      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
-      "source_location": "L18"
     },
     {
       "community": 47,
@@ -237540,6 +237576,60 @@
     {
       "community": 470,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
+      "label": "skuSearch.ts",
+      "norm_label": "skusearch.ts",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "skusearch_isbarcodeshapedsearchquery",
+      "label": "isBarcodeShapedSearchQuery()",
+      "norm_label": "isbarcodeshapedsearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "skusearch_matchesskusearchterms",
+      "label": "matchesSkuSearchTerms()",
+      "norm_label": "matchesskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "skusearch_normalizeidentifier",
+      "label": "normalizeIdentifier()",
+      "norm_label": "normalizeidentifier()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "skusearch_normalizeskusearchquery",
+      "label": "normalizeSkuSearchQuery()",
+      "norm_label": "normalizeskusearchquery()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 470,
+      "file_type": "code",
+      "id": "skusearch_scoreskusearchterms",
+      "label": "scoreSkuSearchTerms()",
+      "norm_label": "scoreskusearchterms()",
+      "source_file": "packages/athena-webapp/src/lib/stockOps/skuSearch.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 471,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
       "norm_label": "posappshellroutes.ts",
@@ -237547,7 +237637,7 @@
       "source_location": "L1"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -237556,7 +237646,7 @@
       "source_location": "L53"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -237565,7 +237655,7 @@
       "source_location": "L71"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -237574,7 +237664,7 @@
       "source_location": "L48"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -237583,7 +237673,7 @@
       "source_location": "L88"
     },
     {
-      "community": 470,
+      "community": 471,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
@@ -237592,7 +237682,7 @@
       "source_location": "L107"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
       "label": "posAppShellServiceWorkerStaging.test.ts",
@@ -237601,7 +237691,7 @@
       "source_location": "L1"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
       "label": "createServiceWorkerFixture()",
@@ -237610,7 +237700,7 @@
       "source_location": "L32"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache",
       "label": "MemoryCache",
@@ -237619,7 +237709,7 @@
       "source_location": "L14"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_keys",
       "label": ".keys()",
@@ -237628,7 +237718,7 @@
       "source_location": "L27"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_match",
       "label": ".match()",
@@ -237637,7 +237727,7 @@
       "source_location": "L17"
     },
     {
-      "community": 471,
+      "community": 472,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_put",
       "label": ".put()",
@@ -237646,7 +237736,7 @@
       "source_location": "L22"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
       "label": "procurement.index.tsx",
@@ -237655,7 +237745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementmodesearch",
       "label": "getNextProcurementModeSearch()",
@@ -237664,7 +237754,7 @@
       "source_location": "L19"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementpagesearch",
       "label": "getNextProcurementPageSearch()",
@@ -237673,7 +237763,7 @@
       "source_location": "L37"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementquerysearch",
       "label": "getNextProcurementQuerySearch()",
@@ -237682,7 +237772,7 @@
       "source_location": "L47"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "procurement_index_getnextprocurementselectedskusearch",
       "label": "getNextProcurementSelectedSkuSearch()",
@@ -237691,7 +237781,7 @@
       "source_location": "L62"
     },
     {
-      "community": 472,
+      "community": 473,
       "file_type": "code",
       "id": "procurement_index_procurementroute",
       "label": "ProcurementRoute()",
@@ -237700,7 +237790,7 @@
       "source_location": "L88"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -237709,7 +237799,7 @@
       "source_location": "L145"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -237718,7 +237808,7 @@
       "source_location": "L95"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -237727,7 +237817,7 @@
       "source_location": "L33"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -237736,7 +237826,7 @@
       "source_location": "L29"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -237745,7 +237835,7 @@
       "source_location": "L45"
     },
     {
-      "community": 473,
+      "community": 474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -237754,7 +237844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -237763,7 +237853,7 @@
       "source_location": "L155"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -237772,7 +237862,7 @@
       "source_location": "L197"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -237781,7 +237871,7 @@
       "source_location": "L104"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -237790,7 +237880,7 @@
       "source_location": "L25"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -237799,7 +237889,7 @@
       "source_location": "L72"
     },
     {
-      "community": 474,
+      "community": 475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -237808,7 +237898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -237817,7 +237907,7 @@
       "source_location": "L1"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -237826,7 +237916,7 @@
       "source_location": "L231"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -237835,7 +237925,7 @@
       "source_location": "L167"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -237844,7 +237934,7 @@
       "source_location": "L116"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -237853,7 +237943,7 @@
       "source_location": "L83"
     },
     {
-      "community": 475,
+      "community": 476,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -237862,7 +237952,7 @@
       "source_location": "L29"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyclosefixture",
       "label": "useDailyCloseFixture()",
@@ -237871,7 +237961,7 @@
       "source_location": "L102"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyopeningfixture",
       "label": "useDailyOpeningFixture()",
@@ -237880,7 +237970,7 @@
       "source_location": "L96"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyoperationsfixture",
       "label": "useDailyOperationsFixture()",
@@ -237889,7 +237979,7 @@
       "source_location": "L90"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "devfixtureactivation_useposhubfixture",
       "label": "usePosHubFixture()",
@@ -237898,7 +237988,7 @@
       "source_location": "L108"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "devfixtureactivation_useworkspacefixture",
       "label": "useWorkspaceFixture()",
@@ -237907,7 +237997,7 @@
       "source_location": "L46"
     },
     {
-      "community": 476,
+      "community": 477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
       "label": "devFixtureActivation.ts",
@@ -237916,7 +238006,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -237925,7 +238015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -237934,7 +238024,7 @@
       "source_location": "L76"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -237943,7 +238033,7 @@
       "source_location": "L55"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -237952,7 +238042,7 @@
       "source_location": "L88"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -237961,7 +238051,7 @@
       "source_location": "L34"
     },
     {
-      "community": 477,
+      "community": 478,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -237970,7 +238060,7 @@
       "source_location": "L13"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -237979,7 +238069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -237988,7 +238078,7 @@
       "source_location": "L69"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -237997,7 +238087,7 @@
       "source_location": "L57"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -238006,7 +238096,7 @@
       "source_location": "L90"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -238015,67 +238105,13 @@
       "source_location": "L59"
     },
     {
-      "community": 478,
+      "community": 479,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
       "norm_label": ".constructor()",
       "source_file": "packages/storefront-webapp/src/api/posTransaction.ts",
       "source_location": "L62"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_promocodes_ts",
-      "label": "promoCodes.ts",
-      "norm_label": "promocodes.ts",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "promocodes_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "promocodes_getpromocodeitems",
-      "label": "getPromoCodeItems()",
-      "norm_label": "getpromocodeitems()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "promocodes_getpromocodes",
-      "label": "getPromoCodes()",
-      "norm_label": "getpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "promocodes_getredeemedpromocodes",
-      "label": "getRedeemedPromoCodes()",
-      "norm_label": "getredeemedpromocodes()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 479,
-      "file_type": "code",
-      "id": "promocodes_redeempromocode",
-      "label": "redeemPromoCode()",
-      "norm_label": "redeempromocode()",
-      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
-      "source_location": "L6"
     },
     {
       "community": 48,
@@ -238341,6 +238377,60 @@
     {
       "community": 480,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_promocodes_ts",
+      "label": "promoCodes.ts",
+      "norm_label": "promocodes.ts",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "promocodes_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "promocodes_getpromocodeitems",
+      "label": "getPromoCodeItems()",
+      "norm_label": "getpromocodeitems()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "promocodes_getpromocodes",
+      "label": "getPromoCodes()",
+      "norm_label": "getpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "promocodes_getredeemedpromocodes",
+      "label": "getRedeemedPromoCodes()",
+      "norm_label": "getredeemedpromocodes()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 480,
+      "file_type": "code",
+      "id": "promocodes_redeempromocode",
+      "label": "redeemPromoCode()",
+      "norm_label": "redeempromocode()",
+      "source_file": "packages/storefront-webapp/src/api/promoCodes.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 481,
+      "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
       "norm_label": "clearform()",
@@ -238348,7 +238438,7 @@
       "source_location": "L173"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -238357,7 +238447,7 @@
       "source_location": "L102"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -238366,7 +238456,7 @@
       "source_location": "L201"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -238375,7 +238465,7 @@
       "source_location": "L150"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -238384,7 +238474,7 @@
       "source_location": "L155"
     },
     {
-      "community": 480,
+      "community": 481,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
@@ -238393,7 +238483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "homehero_test_attachmedia",
       "label": "attachMedia()",
@@ -238402,7 +238492,7 @@
       "source_location": "L22"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "homehero_test_destroy",
       "label": "destroy()",
@@ -238411,7 +238501,7 @@
       "source_location": "L24"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "homehero_test_issupported",
       "label": "isSupported()",
@@ -238420,7 +238510,7 @@
       "source_location": "L18"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "homehero_test_loadsource",
       "label": "loadSource()",
@@ -238429,7 +238519,7 @@
       "source_location": "L21"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "homehero_test_on",
       "label": "on()",
@@ -238438,7 +238528,7 @@
       "source_location": "L23"
     },
     {
-      "community": 481,
+      "community": 482,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
       "label": "HomeHero.test.tsx",
@@ -238447,7 +238537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
@@ -238456,7 +238546,7 @@
       "source_location": "L76"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -238465,7 +238555,7 @@
       "source_location": "L120"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -238474,7 +238564,7 @@
       "source_location": "L129"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -238483,7 +238573,7 @@
       "source_location": "L133"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -238492,7 +238582,7 @@
       "source_location": "L44"
     },
     {
-      "community": 482,
+      "community": 483,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -238501,7 +238591,7 @@
       "source_location": "L1"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -238510,7 +238600,7 @@
       "source_location": "L9"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -238519,7 +238609,7 @@
       "source_location": "L73"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -238528,7 +238618,7 @@
       "source_location": "L54"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -238537,7 +238627,7 @@
       "source_location": "L98"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -238546,7 +238636,7 @@
       "source_location": "L33"
     },
     {
-      "community": 483,
+      "community": 484,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -238555,7 +238645,7 @@
       "source_location": "L1"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
@@ -238564,7 +238654,7 @@
       "source_location": "L138"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -238573,7 +238663,7 @@
       "source_location": "L100"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -238582,7 +238672,7 @@
       "source_location": "L74"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -238591,7 +238681,7 @@
       "source_location": "L34"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -238600,7 +238690,7 @@
       "source_location": "L17"
     },
     {
-      "community": 484,
+      "community": 485,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
@@ -238609,7 +238699,7 @@
       "source_location": "L1"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
@@ -238618,7 +238708,7 @@
       "source_location": "L149"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -238627,7 +238717,7 @@
       "source_location": "L156"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -238636,7 +238726,7 @@
       "source_location": "L201"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -238645,7 +238735,7 @@
       "source_location": "L93"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -238654,7 +238744,7 @@
       "source_location": "L282"
     },
     {
-      "community": 485,
+      "community": 486,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
@@ -238663,7 +238753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "coverage_summary_test_coveragesummary",
       "label": "coverageSummary()",
@@ -238672,7 +238762,7 @@
       "source_location": "L27"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "coverage_summary_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -238681,7 +238771,7 @@
       "source_location": "L15"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "coverage_summary_test_write",
       "label": "write()",
@@ -238690,7 +238780,7 @@
       "source_location": "L21"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "coverage_summary_test_writepackagesummaries",
       "label": "writePackageSummaries()",
@@ -238699,7 +238789,7 @@
       "source_location": "L38"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "coverage_summary_test_writerealbaselinesummaries",
       "label": "writeRealBaselineSummaries()",
@@ -238708,7 +238798,7 @@
       "source_location": "L54"
     },
     {
-      "community": 486,
+      "community": 487,
       "file_type": "code",
       "id": "scripts_coverage_summary_test_ts",
       "label": "coverage-summary.test.ts",
@@ -238717,7 +238807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "delivery_documentation_check_assertdeliverydocumentationcheck",
       "label": "assertDeliveryDocumentationCheck()",
@@ -238726,7 +238816,7 @@
       "source_location": "L29"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "delivery_documentation_check_changedfiles",
       "label": "changedFiles()",
@@ -238735,7 +238825,7 @@
       "source_location": "L102"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "delivery_documentation_check_findingsfrom",
       "label": "findingsFrom()",
@@ -238744,7 +238834,7 @@
       "source_location": "L22"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "delivery_documentation_check_ispolicyfailure",
       "label": "isPolicyFailure()",
@@ -238753,7 +238843,7 @@
       "source_location": "L70"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "delivery_documentation_check_parseargs",
       "label": "parseArgs()",
@@ -238762,7 +238852,7 @@
       "source_location": "L74"
     },
     {
-      "community": 487,
+      "community": 488,
       "file_type": "code",
       "id": "scripts_delivery_documentation_check_ts",
       "label": "delivery-documentation-check.ts",
@@ -238771,7 +238861,7 @@
       "source_location": "L1"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
@@ -238780,7 +238870,7 @@
       "source_location": "L73"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -238789,7 +238879,7 @@
       "source_location": "L125"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -238798,7 +238888,7 @@
       "source_location": "L107"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -238807,7 +238897,7 @@
       "source_location": "L64"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -238816,66 +238906,12 @@
       "source_location": "L152"
     },
     {
-      "community": 488,
+      "community": 489,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
       "norm_label": "graphify-check.ts",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_commitfixturerepo",
-      "label": "commitFixtureRepo()",
-      "norm_label": "commitfixturerepo()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L169"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_createfixturerepo",
-      "label": "createFixtureRepo()",
-      "norm_label": "createfixturerepo()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_gitfixtureenv",
-      "label": "gitFixtureEnv()",
-      "norm_label": "gitfixtureenv()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_runfixturecommand",
-      "label": "runFixtureCommand()",
-      "norm_label": "runfixturecommand()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L22"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "harness_inferential_review_test_write",
-      "label": "write()",
-      "norm_label": "write()",
-      "source_file": "scripts/harness-inferential-review.test.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 489,
-      "file_type": "code",
-      "id": "scripts_harness_inferential_review_test_ts",
-      "label": "harness-inferential-review.test.ts",
-      "norm_label": "harness-inferential-review.test.ts",
-      "source_file": "scripts/harness-inferential-review.test.ts",
       "source_location": "L1"
     },
     {
@@ -239142,6 +239178,60 @@
     {
       "community": 490,
       "file_type": "code",
+      "id": "harness_inferential_review_test_commitfixturerepo",
+      "label": "commitFixtureRepo()",
+      "norm_label": "commitfixturerepo()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L169"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_createfixturerepo",
+      "label": "createFixtureRepo()",
+      "norm_label": "createfixturerepo()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_gitfixtureenv",
+      "label": "gitFixtureEnv()",
+      "norm_label": "gitfixtureenv()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_runfixturecommand",
+      "label": "runFixtureCommand()",
+      "norm_label": "runfixturecommand()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L22"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "harness_inferential_review_test_write",
+      "label": "write()",
+      "norm_label": "write()",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 490,
+      "file_type": "code",
+      "id": "scripts_harness_inferential_review_test_ts",
+      "label": "harness-inferential-review.test.ts",
+      "norm_label": "harness-inferential-review.test.ts",
+      "source_file": "scripts/harness-inferential-review.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 491,
+      "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationcapabilities",
       "label": "collectHarnessRepoValidationCapabilities()",
       "norm_label": "collectharnessrepovalidationcapabilities()",
@@ -239149,7 +239239,7 @@
       "source_location": "L73"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -239158,7 +239248,7 @@
       "source_location": "L50"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -239167,7 +239257,7 @@
       "source_location": "L42"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -239176,7 +239266,7 @@
       "source_location": "L32"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -239185,7 +239275,7 @@
       "source_location": "L36"
     },
     {
-      "community": 490,
+      "community": 491,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
@@ -239194,7 +239284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -239203,7 +239293,7 @@
       "source_location": "L20"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createspawn",
       "label": "createSpawn()",
@@ -239212,7 +239302,7 @@
       "source_location": "L63"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_log",
       "label": "log()",
@@ -239221,7 +239311,7 @@
       "source_location": "L147"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_warn",
       "label": "warn()",
@@ -239230,7 +239320,7 @@
       "source_location": "L287"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_write",
       "label": "write()",
@@ -239239,7 +239329,7 @@
       "source_location": "L14"
     },
     {
-      "community": 491,
+      "community": 492,
       "file_type": "code",
       "id": "scripts_pre_push_validation_proof_test_ts",
       "label": "pre-push-validation-proof.test.ts",
@@ -239248,7 +239338,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "scripts_validate_plan_html_ts",
       "label": "validate-plan-html.ts",
@@ -239257,7 +239347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "validate_plan_html_collectdefaultplanhtmlfiles",
       "label": "collectDefaultPlanHtmlFiles()",
@@ -239266,7 +239356,7 @@
       "source_location": "L16"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "validate_plan_html_collectplanhtmlfindings",
       "label": "collectPlanHtmlFindings()",
@@ -239275,7 +239365,7 @@
       "source_location": "L31"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "validate_plan_html_hasremotereference",
       "label": "hasRemoteReference()",
@@ -239284,7 +239374,7 @@
       "source_location": "L27"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "validate_plan_html_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -239293,7 +239383,7 @@
       "source_location": "L12"
     },
     {
-      "community": 492,
+      "community": 493,
       "file_type": "code",
       "id": "validate_plan_html_runplanhtmlvalidation",
       "label": "runPlanHtmlValidation()",
@@ -239302,7 +239392,7 @@
       "source_location": "L119"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "closeouts_test_createcloseoutmappingholdctx",
       "label": "createCloseoutMappingHoldCtx()",
@@ -239311,7 +239401,7 @@
       "source_location": "L32"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "closeouts_test_creatependingitemadjustmentapprovalctx",
       "label": "createPendingItemAdjustmentApprovalCtx()",
@@ -239320,7 +239410,7 @@
       "source_location": "L184"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "closeouts_test_gethandler",
       "label": "getHandler()",
@@ -239329,7 +239419,7 @@
       "source_location": "L28"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "closeouts_test_getsource",
       "label": "getSource()",
@@ -239338,7 +239428,7 @@
       "source_location": "L24"
     },
     {
-      "community": 493,
+      "community": 494,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_closeouts_test_ts",
       "label": "closeouts.test.ts",
@@ -239347,7 +239437,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_paymentallocationattribution_ts",
       "label": "paymentAllocationAttribution.ts",
@@ -239356,7 +239446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "paymentallocationattribution_buildinstorepaymentallocations",
       "label": "buildInStorePaymentAllocations()",
@@ -239365,7 +239455,7 @@
       "source_location": "L46"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "paymentallocationattribution_normalizeinstorepayments",
       "label": "normalizeInStorePayments()",
@@ -239374,7 +239464,7 @@
       "source_location": "L22"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "paymentallocationattribution_resolveregistersessionforinstorecollectionwithctx",
       "label": "resolveRegisterSessionForInStoreCollectionWithCtx()",
@@ -239383,7 +239473,7 @@
       "source_location": "L124"
     },
     {
-      "community": 494,
+      "community": 495,
       "file_type": "code",
       "id": "paymentallocationattribution_selectregistersessionforattribution",
       "label": "selectRegisterSessionForAttribution()",
@@ -239392,7 +239482,7 @@
       "source_location": "L87"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessionactivity_test_ts",
       "label": "registerSessionActivity.test.ts",
@@ -239401,7 +239491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "registersessionactivity_test_admissionawareauthimplementation",
       "label": "admissionAwareAuthImplementation()",
@@ -239410,7 +239500,7 @@
       "source_location": "L218"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "registersessionactivity_test_baseevent",
       "label": "baseEvent()",
@@ -239419,7 +239509,7 @@
       "source_location": "L27"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "registersessionactivity_test_basemapping",
       "label": "baseMapping()",
@@ -239428,7 +239518,7 @@
       "source_location": "L58"
     },
     {
-      "community": 495,
+      "community": 496,
       "file_type": "code",
       "id": "registersessionactivity_test_gethandler",
       "label": "getHandler()",
@@ -239437,7 +239527,7 @@
       "source_location": "L22"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_registersessiontracelifecycle_test_ts",
       "label": "registerSessionTraceLifecycle.test.ts",
@@ -239446,7 +239536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildapprovalproof",
       "label": "buildApprovalProof()",
@@ -239455,7 +239545,7 @@
       "source_location": "L382"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -239464,7 +239554,7 @@
       "source_location": "L106"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -239473,7 +239563,7 @@
       "source_location": "L122"
     },
     {
-      "community": 496,
+      "community": 497,
       "file_type": "code",
       "id": "registersessiontracelifecycle_test_gethandler",
       "label": "getHandler()",
@@ -239482,7 +239572,7 @@
       "source_location": "L401"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "approvalrequestpending_approvalrequestpending",
       "label": "ApprovalRequestPending()",
@@ -239491,7 +239581,7 @@
       "source_location": "L194"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "approvalrequestpending_buildapprovalrequestpendingsubject",
       "label": "buildApprovalRequestPendingSubject()",
@@ -239500,7 +239590,7 @@
       "source_location": "L167"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "approvalrequestpending_getapprovalrequestdescriptor",
       "label": "getApprovalRequestDescriptor()",
@@ -239509,7 +239599,7 @@
       "source_location": "L153"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "approvalrequestpending_sectionheading",
       "label": "SectionHeading()",
@@ -239518,7 +239608,7 @@
       "source_location": "L281"
     },
     {
-      "community": 497,
+      "community": 498,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_approvalrequestpending_tsx",
       "label": "ApprovalRequestPending.tsx",
@@ -239527,7 +239617,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealert_tsx",
       "label": "RegisterCloseoutVarianceAlert.tsx",
@@ -239536,7 +239626,7 @@
       "source_location": "L1"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealert",
       "label": "RegisterCloseoutVarianceAlert()",
@@ -239545,7 +239635,7 @@
       "source_location": "L59"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "registercloseoutvariancealert_sectionheading",
       "label": "SectionHeading()",
@@ -239554,7 +239644,7 @@
       "source_location": "L186"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "registercloseoutvariancealert_statusbadge",
       "label": "StatusBadge()",
@@ -239563,58 +239653,13 @@
       "source_location": "L196"
     },
     {
-      "community": 498,
+      "community": 499,
       "file_type": "code",
       "id": "registercloseoutvariancealert_summaryvaluestylefor",
       "label": "summaryValueStyleFor()",
       "norm_label": "summaryvaluestylefor()",
       "source_file": "packages/athena-webapp/convex/emails/RegisterCloseoutVarianceAlert.tsx",
       "source_location": "L224"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "homepagesnapshot_isdisplayablemarker",
-      "label": "isDisplayableMarker()",
-      "norm_label": "isdisplayablemarker()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "homepagesnapshot_presentsnapshotatrequesttime",
-      "label": "presentSnapshotAtRequestTime()",
-      "norm_label": "presentsnapshotatrequesttime()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "homepagesnapshot_resolvehomepagesnapshotbootstrap",
-      "label": "resolveHomepageSnapshotBootstrap()",
-      "norm_label": "resolvehomepagesnapshotbootstrap()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L53"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "homepagesnapshot_setbootstrapcookie",
-      "label": "setBootstrapCookie()",
-      "norm_label": "setbootstrapcookie()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_ts",
-      "label": "homepageSnapshot.ts",
-      "norm_label": "homepagesnapshot.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
-      "source_location": "L1"
     },
     {
       "community": 5,
@@ -240555,6 +240600,51 @@
     {
       "community": 500,
       "file_type": "code",
+      "id": "homepagesnapshot_isdisplayablemarker",
+      "label": "isDisplayableMarker()",
+      "norm_label": "isdisplayablemarker()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "homepagesnapshot_presentsnapshotatrequesttime",
+      "label": "presentSnapshotAtRequestTime()",
+      "norm_label": "presentsnapshotatrequesttime()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "homepagesnapshot_resolvehomepagesnapshotbootstrap",
+      "label": "resolveHomepageSnapshotBootstrap()",
+      "norm_label": "resolvehomepagesnapshotbootstrap()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L53"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "homepagesnapshot_setbootstrapcookie",
+      "label": "setBootstrapCookie()",
+      "norm_label": "setbootstrapcookie()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 500,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_homepagesnapshot_ts",
+      "label": "homepageSnapshot.ts",
+      "norm_label": "homepagesnapshot.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/homepageSnapshot.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 501,
+      "file_type": "code",
       "id": "lifecycle_assertartifacttransition",
       "label": "assertArtifactTransition()",
       "norm_label": "assertartifacttransition()",
@@ -240562,7 +240652,7 @@
       "source_location": "L59"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "lifecycle_assertruntransition",
       "label": "assertRunTransition()",
@@ -240571,7 +240661,7 @@
       "source_location": "L43"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "lifecycle_cantransitionartifact",
       "label": "canTransitionArtifact()",
@@ -240580,7 +240670,7 @@
       "source_location": "L52"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "lifecycle_cantransitionrun",
       "label": "canTransitionRun()",
@@ -240589,7 +240679,7 @@
       "source_location": "L36"
     },
     {
-      "community": 500,
+      "community": 501,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_lifecycle_ts",
       "label": "lifecycle.ts",
@@ -240598,7 +240688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_tanstack_ts",
       "label": "tanstack.ts",
@@ -240607,7 +240697,7 @@
       "source_location": "L1"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "tanstack_createtanstackstructuredtextprovider",
       "label": "createTanStackStructuredTextProvider()",
@@ -240616,7 +240706,7 @@
       "source_location": "L41"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "tanstack_extractstructuredoutput",
       "label": "extractStructuredOutput()",
@@ -240625,7 +240715,7 @@
       "source_location": "L134"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "tanstack_loadopenaiadapter",
       "label": "loadOpenAiAdapter()",
@@ -240634,7 +240724,7 @@
       "source_location": "L147"
     },
     {
-      "community": 501,
+      "community": 502,
       "file_type": "code",
       "id": "tanstack_loadtanstackai",
       "label": "loadTanStackAi()",
@@ -240643,7 +240733,7 @@
       "source_location": "L143"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "featureditem_countfeaturedtargets",
       "label": "countFeaturedTargets()",
@@ -240652,7 +240742,7 @@
       "source_location": "L43"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "featureditem_getnextfeatureditemrank",
       "label": "getNextFeaturedItemRank()",
@@ -240661,7 +240751,7 @@
       "source_location": "L103"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "featureditem_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -240670,7 +240760,7 @@
       "source_location": "L23"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "featureditem_validatefeaturedplacement",
       "label": "validateFeaturedPlacement()",
@@ -240679,7 +240769,7 @@
       "source_location": "L52"
     },
     {
-      "community": 502,
+      "community": 503,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -240688,7 +240778,7 @@
       "source_location": "L1"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpenseitembelongstosession",
       "label": "validateExpenseItemBelongsToSession()",
@@ -240697,7 +240787,7 @@
       "source_location": "L114"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionactive",
       "label": "validateExpenseSessionActive()",
@@ -240706,7 +240796,7 @@
       "source_location": "L39"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionexists",
       "label": "validateExpenseSessionExists()",
@@ -240715,7 +240805,7 @@
       "source_location": "L19"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "expensesessionvalidation_validateexpensesessionmodifiable",
       "label": "validateExpenseSessionModifiable()",
@@ -240724,7 +240814,7 @@
       "source_location": "L81"
     },
     {
-      "community": 503,
+      "community": 504,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_helpers_expensesessionvalidation_ts",
       "label": "expenseSessionValidation.ts",
@@ -240733,7 +240823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "commerceeffects_applycommerceinventoryeffectwithctx",
       "label": "applyCommerceInventoryEffectWithCtx()",
@@ -240742,7 +240832,7 @@
       "source_location": "L152"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "commerceeffects_outboundbasisfromeffect",
       "label": "outboundBasisFromEffect()",
@@ -240751,7 +240841,7 @@
       "source_location": "L79"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "commerceeffects_reportinglinecostfromeffect",
       "label": "reportingLineCostFromEffect()",
@@ -240760,7 +240850,7 @@
       "source_location": "L116"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "commerceeffects_uncostedoutboundbasis",
       "label": "uncostedOutboundBasis()",
@@ -240769,7 +240859,7 @@
       "source_location": "L64"
     },
     {
-      "community": 504,
+      "community": 505,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_commerceeffects_ts",
       "label": "commerceEffects.ts",
@@ -240778,7 +240868,7 @@
       "source_location": "L1"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "deficitresolutionwork_allocatedeferreddeficitcost",
       "label": "allocateDeferredDeficitCost()",
@@ -240787,7 +240877,7 @@
       "source_location": "L25"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "deficitresolutionwork_enqueuedeficitresolutionworkwithctx",
       "label": "enqueueDeficitResolutionWorkWithCtx()",
@@ -240796,7 +240886,7 @@
       "source_location": "L46"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "deficitresolutionwork_historicalcostlane",
       "label": "historicalCostLane()",
@@ -240805,7 +240895,7 @@
       "source_location": "L19"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "deficitresolutionwork_materializedeferredadjustmentwithctx",
       "label": "materializeDeferredAdjustmentWithCtx()",
@@ -240814,7 +240904,7 @@
       "source_location": "L107"
     },
     {
-      "community": 505,
+      "community": 506,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_deficitresolutionwork_ts",
       "label": "deficitResolutionWork.ts",
@@ -240823,7 +240913,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "currency_formatstoredamount",
       "label": "formatStoredAmount()",
@@ -240832,7 +240922,7 @@
       "source_location": "L9"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "currency_todisplayamount",
       "label": "toDisplayAmount()",
@@ -240841,7 +240931,7 @@
       "source_location": "L5"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "currency_topesewas",
       "label": "toPesewas()",
@@ -240850,7 +240940,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_currency_ts",
       "label": "currency.ts",
@@ -240859,7 +240949,7 @@
       "source_location": "L1"
     },
     {
-      "community": 506,
+      "community": 507,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_currency_ts",
       "label": "currency.ts",
@@ -240868,7 +240958,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_ts",
       "label": "walkthroughRequestNotifications.ts",
@@ -240877,7 +240967,7 @@
       "source_location": "L1"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -240886,7 +240976,7 @@
       "source_location": "L27"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_classifydeliveryresult",
       "label": "classifyDeliveryResult()",
@@ -240895,7 +240985,7 @@
       "source_location": "L13"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_isdeliberateretryeligible",
       "label": "isDeliberateRetryEligible()",
@@ -240904,7 +240994,7 @@
       "source_location": "L20"
     },
     {
-      "community": 507,
+      "community": 508,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_nextbackoffms",
       "label": "nextBackoffMs()",
@@ -240913,7 +241003,7 @@
       "source_location": "L12"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createctx",
       "label": "createCtx()",
@@ -240922,7 +241012,7 @@
       "source_location": "L80"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -240931,7 +241021,7 @@
       "source_location": "L29"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishbackfill",
       "label": "finishBackfill()",
@@ -240940,7 +241030,7 @@
       "source_location": "L118"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishverification",
       "label": "finishVerification()",
@@ -240949,57 +241039,12 @@
       "source_location": "L139"
     },
     {
-      "community": 508,
+      "community": 509,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_test_ts",
       "label": "backfillReportingCycleStart.test.ts",
       "norm_label": "backfillreportingcyclestart.test.ts",
       "source_file": "packages/athena-webapp/convex/migrations/backfillReportingCycleStart.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
-      "label": "backfillStoreTimezoneAuthorityWithCtx()",
-      "norm_label": "backfillstoretimezoneauthoritywithctx()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "backfillstoretimezoneauthority_buildrow",
-      "label": "buildRow()",
-      "norm_label": "buildrow()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "backfillstoretimezoneauthority_listschedulesforstore",
-      "label": "listSchedulesForStore()",
-      "norm_label": "listschedulesforstore()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "backfillstoretimezoneauthority_normalizelimit",
-      "label": "normalizeLimit()",
-      "norm_label": "normalizelimit()",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
-      "label": "backfillStoreTimezoneAuthority.ts",
-      "norm_label": "backfillstoretimezoneauthority.ts",
-      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
       "source_location": "L1"
     },
     {
@@ -241248,6 +241293,51 @@
     {
       "community": 510,
       "file_type": "code",
+      "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
+      "label": "backfillStoreTimezoneAuthorityWithCtx()",
+      "norm_label": "backfillstoretimezoneauthoritywithctx()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "backfillstoretimezoneauthority_buildrow",
+      "label": "buildRow()",
+      "norm_label": "buildrow()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "backfillstoretimezoneauthority_listschedulesforstore",
+      "label": "listSchedulesForStore()",
+      "norm_label": "listschedulesforstore()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "backfillstoretimezoneauthority_normalizelimit",
+      "label": "normalizeLimit()",
+      "norm_label": "normalizelimit()",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 510,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
+      "label": "backfillStoreTimezoneAuthority.ts",
+      "norm_label": "backfillstoretimezoneauthority.ts",
+      "source_file": "packages/athena-webapp/convex/migrations/backfillStoreTimezoneAuthority.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 511,
+      "file_type": "code",
       "id": "dispatch_recordnotificationfailureeventwithctx",
       "label": "recordNotificationFailureEventWithCtx()",
       "norm_label": "recordnotificationfailureeventwithctx()",
@@ -241255,7 +241345,7 @@
       "source_location": "L400"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "dispatch_recordterminaldeliveryfailureevent",
       "label": "recordTerminalDeliveryFailureEvent()",
@@ -241264,7 +241354,7 @@
       "source_location": "L427"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "dispatch_resolverecipients",
       "label": "resolveRecipients()",
@@ -241273,7 +241363,7 @@
       "source_location": "L53"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "dispatch_suppressintentwithctx",
       "label": "suppressIntentWithCtx()",
@@ -241282,7 +241372,7 @@
       "source_location": "L85"
     },
     {
-      "community": 510,
+      "community": 511,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
       "label": "dispatch.ts",
@@ -241291,7 +241381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "label": "registry.test.ts",
@@ -241300,7 +241390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registry_test_dedupekey",
       "label": "dedupeKey()",
@@ -241309,7 +241399,7 @@
       "source_location": "L386"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registry_test_keyfor",
       "label": "keyFor()",
@@ -241318,7 +241408,7 @@
       "source_location": "L457"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registry_test_prepare",
       "label": "prepare()",
@@ -241327,7 +241417,7 @@
       "source_location": "L42"
     },
     {
-      "community": 511,
+      "community": 512,
       "file_type": "code",
       "id": "registry_test_stubctx",
       "label": "stubCtx()",
@@ -241336,7 +241426,7 @@
       "source_location": "L26"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "adapters_createnormaluseroperationadapter",
       "label": "createNormalUserOperationAdapter()",
@@ -241345,7 +241435,7 @@
       "source_location": "L13"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "adapters_createpublicoperationadapter",
       "label": "createPublicOperationAdapter()",
@@ -241354,7 +241444,7 @@
       "source_location": "L41"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "adapters_isadmitted",
       "label": "isAdmitted()",
@@ -241363,7 +241453,7 @@
       "source_location": "L115"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "adapters_resolveoperationadmission",
       "label": "resolveOperationAdmission()",
@@ -241372,7 +241462,7 @@
       "source_location": "L59"
     },
     {
-      "community": 512,
+      "community": 513,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_adapters_ts",
       "label": "adapters.ts",
@@ -241381,7 +241471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "approvalrequesterchallenges_consumeapprovalrequesterchallengewithctx",
       "label": "consumeApprovalRequesterChallengeWithCtx()",
@@ -241390,7 +241480,7 @@
       "source_location": "L97"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "approvalrequesterchallenges_createapprovalrequesterchallengewithctx",
       "label": "createApprovalRequesterChallengeWithCtx()",
@@ -241399,7 +241489,7 @@
       "source_location": "L55"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "approvalrequesterchallenges_invalidapprovalrequesterchallengeresult",
       "label": "invalidApprovalRequesterChallengeResult()",
@@ -241408,7 +241498,7 @@
       "source_location": "L37"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "approvalrequesterchallenges_torequesterbinding",
       "label": "toRequesterBinding()",
@@ -241417,7 +241507,7 @@
       "source_location": "L44"
     },
     {
-      "community": 513,
+      "community": 514,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesterchallenges_ts",
       "label": "approvalRequesterChallenges.ts",
@@ -241426,7 +241516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -241435,7 +241525,7 @@
       "source_location": "L24"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -241444,7 +241534,7 @@
       "source_location": "L207"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -241453,7 +241543,7 @@
       "source_location": "L45"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -241462,7 +241552,7 @@
       "source_location": "L30"
     },
     {
-      "community": 514,
+      "community": 515,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -241471,7 +241561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "dailymanagerreportemail_test_ask",
       "label": "ask()",
@@ -241480,7 +241570,7 @@
       "source_location": "L322"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "dailymanagerreportemail_test_insertlegacydelivery",
       "label": "insertLegacyDelivery()",
@@ -241489,7 +241579,7 @@
       "source_location": "L293"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "dailymanagerreportemail_test_money",
       "label": "money()",
@@ -241498,7 +241588,7 @@
       "source_location": "L75"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "dailymanagerreportemail_test_seedstoreandrun",
       "label": "seedStoreAndRun()",
@@ -241507,7 +241597,7 @@
       "source_location": "L255"
     },
     {
-      "community": 515,
+      "community": 516,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailymanagerreportemail_test_ts",
       "label": "dailyManagerReportEmail.test.ts",
@@ -241516,7 +241606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "operationalworkitems_test_approvalrequest",
       "label": "approvalRequest()",
@@ -241525,7 +241615,7 @@
       "source_location": "L46"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "operationalworkitems_test_createqueuecontext",
       "label": "createQueueContext()",
@@ -241534,7 +241624,7 @@
       "source_location": "L59"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "operationalworkitems_test_gethandler",
       "label": "getHandler()",
@@ -241543,7 +241633,7 @@
       "source_location": "L25"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "operationalworkitems_test_workitem",
       "label": "workItem()",
@@ -241552,7 +241642,7 @@
       "source_location": "L31"
     },
     {
-      "community": 516,
+      "community": 517,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_test_ts",
       "label": "operationalWorkItems.test.ts",
@@ -241561,7 +241651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "oweddailyclosesweep_completedoperatingdatesforstore",
       "label": "completedOperatingDatesForStore()",
@@ -241570,7 +241660,7 @@
       "source_location": "L149"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "oweddailyclosesweep_daysbetweenoperatingdates",
       "label": "daysBetweenOperatingDates()",
@@ -241579,7 +241669,7 @@
       "source_location": "L354"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "oweddailyclosesweep_listenabledeodpolicies",
       "label": "listEnabledEodPolicies()",
@@ -241588,7 +241678,7 @@
       "source_location": "L135"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "oweddailyclosesweep_selectoweddailyclosedates",
       "label": "selectOwedDailyCloseDates()",
@@ -241597,7 +241687,7 @@
       "source_location": "L84"
     },
     {
-      "community": 517,
+      "community": 518,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_ts",
       "label": "owedDailyCloseSweep.ts",
@@ -241606,7 +241696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymenttotals_ts",
       "label": "paymentTotals.ts",
@@ -241615,7 +241705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "paymenttotals_buildpaymenttotals",
       "label": "buildPaymentTotals()",
@@ -241624,7 +241714,7 @@
       "source_location": "L50"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "paymenttotals_listtransactionpayments",
       "label": "listTransactionPayments()",
@@ -241633,7 +241723,7 @@
       "source_location": "L11"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "paymenttotals_transactioncashdelta",
       "label": "transactionCashDelta()",
@@ -241642,58 +241732,13 @@
       "source_location": "L81"
     },
     {
-      "community": 518,
+      "community": 519,
       "file_type": "code",
       "id": "paymenttotals_transactionpaymenttotals",
       "label": "transactionPaymentTotals()",
       "norm_label": "transactionpaymenttotals()",
       "source_file": "packages/athena-webapp/convex/operations/paymentTotals.ts",
       "source_location": "L25"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
-      "label": "staffCredentials.test.ts",
-      "norm_label": "staffcredentials.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "staffcredentials_test_admissionawareauth",
-      "label": "admissionAwareAuth()",
-      "norm_label": "admissionawareauth()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "staffcredentials_test_createrestoredproofvalidationctx",
-      "label": "createRestoredProofValidationCtx()",
-      "norm_label": "createrestoredproofvalidationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L271"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "staffcredentials_test_createstaffcredentialsmutationctx",
-      "label": "createStaffCredentialsMutationCtx()",
-      "norm_label": "createstaffcredentialsmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 519,
-      "file_type": "code",
-      "id": "staffcredentials_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
-      "source_location": "L267"
     },
     {
       "community": 52,
@@ -241941,6 +241986,51 @@
     {
       "community": 520,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
+      "label": "staffCredentials.test.ts",
+      "norm_label": "staffcredentials.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "staffcredentials_test_admissionawareauth",
+      "label": "admissionAwareAuth()",
+      "norm_label": "admissionawareauth()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "staffcredentials_test_createrestoredproofvalidationctx",
+      "label": "createRestoredProofValidationCtx()",
+      "norm_label": "createrestoredproofvalidationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L271"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "staffcredentials_test_createstaffcredentialsmutationctx",
+      "label": "createStaffCredentialsMutationCtx()",
+      "norm_label": "createstaffcredentialsmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 520,
+      "file_type": "code",
+      "id": "staffcredentials_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/staffCredentials.test.ts",
+      "source_location": "L267"
+    },
+    {
+      "community": 521,
+      "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
       "norm_label": "customerprofile()",
@@ -241948,7 +242038,7 @@
       "source_location": "L319"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -241957,7 +242047,7 @@
       "source_location": "L346"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -241966,7 +242056,7 @@
       "source_location": "L303"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -241975,7 +242065,7 @@
       "source_location": "L333"
     },
     {
-      "community": 520,
+      "community": 521,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
@@ -241984,7 +242074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
       "label": "registerLifecycleAuthority.ts",
@@ -241993,7 +242083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
       "label": "acknowledgeRegisterLifecycleAuthority()",
@@ -242002,7 +242092,7 @@
       "source_location": "L46"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "registerlifecycleauthority_equivalentacknowledgement",
       "label": "equivalentAcknowledgement()",
@@ -242011,7 +242101,7 @@
       "source_location": "L124"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "registerlifecycleauthority_isrevision",
       "label": "isRevision()",
@@ -242020,7 +242110,7 @@
       "source_location": "L153"
     },
     {
-      "community": 521,
+      "community": 522,
       "file_type": "code",
       "id": "registerlifecycleauthority_normalizesafemetadata",
       "label": "normalizeSafeMetadata()",
@@ -242029,7 +242119,7 @@
       "source_location": "L145"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
@@ -242038,7 +242128,7 @@
       "source_location": "L107"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -242047,7 +242137,7 @@
       "source_location": "L117"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -242056,7 +242146,7 @@
       "source_location": "L91"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -242065,7 +242155,7 @@
       "source_location": "L99"
     },
     {
-      "community": 522,
+      "community": 523,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -242074,7 +242164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_reconcilesequencegaps_ts",
       "label": "reconcileSequenceGaps.ts",
@@ -242083,7 +242173,7 @@
       "source_location": "L1"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "reconcilesequencegaps_collectterminalevidence",
       "label": "collectTerminalEvidence()",
@@ -242092,7 +242182,7 @@
       "source_location": "L185"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "reconcilesequencegaps_issuegapprobe",
       "label": "issueGapProbe()",
@@ -242101,7 +242191,7 @@
       "source_location": "L249"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "reconcilesequencegaps_listheldeventsforcursor",
       "label": "listHeldEventsForCursor()",
@@ -242110,7 +242200,7 @@
       "source_location": "L156"
     },
     {
-      "community": 523,
+      "community": 524,
       "file_type": "code",
       "id": "reconcilesequencegaps_skipsequencegap",
       "label": "skipSequenceGap()",
@@ -242119,7 +242209,7 @@
       "source_location": "L295"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_policy_test_ts",
       "label": "policy.test.ts",
@@ -242128,7 +242218,7 @@
       "source_location": "L1"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "policy_test_baseinput",
       "label": "baseInput()",
@@ -242137,7 +242227,7 @@
       "source_location": "L1225"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "policy_test_buildregistersession",
       "label": "buildRegisterSession()",
@@ -242146,7 +242236,7 @@
       "source_location": "L1329"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "policy_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -242155,7 +242245,7 @@
       "source_location": "L1287"
     },
     {
-      "community": 524,
+      "community": 525,
       "file_type": "code",
       "id": "policy_test_emptysyncevidence",
       "label": "emptySyncEvidence()",
@@ -242164,7 +242254,7 @@
       "source_location": "L1267"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_test_ts",
       "label": "terminalRecoveryRepository.test.ts",
@@ -242173,7 +242263,7 @@
       "source_location": "L1"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildctx",
       "label": "buildCtx()",
@@ -242182,7 +242272,7 @@
       "source_location": "L381"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildqueryctx",
       "label": "buildQueryCtx()",
@@ -242191,7 +242281,7 @@
       "source_location": "L469"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_filterrows",
       "label": "filterRows()",
@@ -242200,7 +242290,7 @@
       "source_location": "L483"
     },
     {
-      "community": 525,
+      "community": 526,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_orderedrows",
       "label": "orderedRows()",
@@ -242209,7 +242299,7 @@
       "source_location": "L492"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "customers_requireposcustomeraccessbyid",
       "label": "requirePosCustomerAccessById()",
@@ -242218,7 +242308,7 @@
       "source_location": "L76"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "customers_requireposcustomerreadaccessbyid",
       "label": "requirePosCustomerReadAccessById()",
@@ -242227,7 +242317,7 @@
       "source_location": "L123"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "customers_requireposcustomerstoreaccess",
       "label": "requirePosCustomerStoreAccess()",
@@ -242236,7 +242326,7 @@
       "source_location": "L53"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "customers_requireposcustomerstorereadaccess",
       "label": "requirePosCustomerStoreReadAccess()",
@@ -242245,7 +242335,7 @@
       "source_location": "L99"
     },
     {
-      "community": 526,
+      "community": 527,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -242254,7 +242344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_posrecoverycodes_test_ts",
       "label": "posRecoveryCodes.test.ts",
@@ -242263,7 +242353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "posrecoverycodes_test_buildctx",
       "label": "buildCtx()",
@@ -242272,7 +242362,7 @@
       "source_location": "L565"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "posrecoverycodes_test_createfilter",
       "label": "createFilter()",
@@ -242281,7 +242371,7 @@
       "source_location": "L669"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "posrecoverycodes_test_createquery",
       "label": "createQuery()",
@@ -242290,7 +242380,7 @@
       "source_location": "L642"
     },
     {
-      "community": 527,
+      "community": 528,
       "file_type": "code",
       "id": "posrecoverycodes_test_gethandler",
       "label": "getHandler()",
@@ -242299,7 +242389,7 @@
       "source_location": "L25"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
@@ -242308,7 +242398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -242317,7 +242407,7 @@
       "source_location": "L106"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -242326,7 +242416,7 @@
       "source_location": "L34"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -242335,58 +242425,13 @@
       "source_location": "L24"
     },
     {
-      "community": 528,
+      "community": 529,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
       "norm_label": "storedevent()",
       "source_file": "packages/athena-webapp/convex/pos/public/telemetry.test.ts",
       "source_location": "L371"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
-      "label": "transactions.ts",
-      "norm_label": "transactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "transactions_mapcorrectionerror",
-      "label": "mapCorrectionError()",
-      "norm_label": "mapcorrectionerror()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "transactions_redactpospulsesummary",
-      "label": "redactPosPulseSummary()",
-      "norm_label": "redactpospulsesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
-      "source_location": "L307"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "transactions_requirepostransactionaccess",
-      "label": "requirePosTransactionAccess()",
-      "norm_label": "requirepostransactionaccess()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
-      "source_location": "L93"
-    },
-    {
-      "community": 529,
-      "file_type": "code",
-      "id": "transactions_requirepostransactionstoreaccess",
-      "label": "requirePosTransactionStoreAccess()",
-      "norm_label": "requirepostransactionstoreaccess()",
-      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
-      "source_location": "L64"
     },
     {
       "community": 53,
@@ -242634,6 +242679,51 @@
     {
       "community": 530,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
+      "label": "transactions.ts",
+      "norm_label": "transactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "transactions_mapcorrectionerror",
+      "label": "mapCorrectionError()",
+      "norm_label": "mapcorrectionerror()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
+      "source_location": "L339"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "transactions_redactpospulsesummary",
+      "label": "redactPosPulseSummary()",
+      "norm_label": "redactpospulsesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "transactions_requirepostransactionaccess",
+      "label": "requirePosTransactionAccess()",
+      "norm_label": "requirepostransactionaccess()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 530,
+      "file_type": "code",
+      "id": "transactions_requirepostransactionstoreaccess",
+      "label": "requirePosTransactionStoreAccess()",
+      "norm_label": "requirepostransactionstoreaccess()",
+      "source_file": "packages/athena-webapp/convex/pos/public/transactions.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 531,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_policy_ts",
       "label": "policy.ts",
       "norm_label": "policy.ts",
@@ -242641,7 +242731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "policy_denied",
       "label": "denied()",
@@ -242650,7 +242740,7 @@
       "source_location": "L96"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "policy_evaluateremoteassistpolicy",
       "label": "evaluateRemoteAssistPolicy()",
@@ -242659,7 +242749,7 @@
       "source_location": "L31"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "policy_isclientfresh",
       "label": "isClientFresh()",
@@ -242668,7 +242758,7 @@
       "source_location": "L88"
     },
     {
-      "community": 530,
+      "community": 531,
       "file_type": "code",
       "id": "policy_policydecisiontocommandresult",
       "label": "policyDecisionToCommandResult()",
@@ -242677,7 +242767,7 @@
       "source_location": "L76"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
       "label": "remoteAssistReadRepository.ts",
@@ -242686,7 +242776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
       "label": "compareRemoteAssistSessionForSupportView()",
@@ -242695,7 +242785,7 @@
       "source_location": "L88"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "remoteassistreadrepository_createremoteassistreadrepository",
       "label": "createRemoteAssistReadRepository()",
@@ -242704,7 +242794,7 @@
       "source_location": "L10"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "remoteassistreadrepository_toremoteassistclient",
       "label": "toRemoteAssistClient()",
@@ -242713,7 +242803,7 @@
       "source_location": "L108"
     },
     {
-      "community": 531,
+      "community": 532,
       "file_type": "code",
       "id": "remoteassistreadrepository_toremoteassistsession",
       "label": "toRemoteAssistSession()",
@@ -242722,7 +242812,7 @@
       "source_location": "L121"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "fingerprint_factfingerprint",
       "label": "factFingerprint()",
@@ -242731,7 +242821,7 @@
       "source_location": "L69"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "fingerprint_fingerprintpayload",
       "label": "fingerprintPayload()",
@@ -242740,7 +242830,7 @@
       "source_location": "L26"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "fingerprint_matchesstoredfingerprint",
       "label": "matchesStoredFingerprint()",
@@ -242749,7 +242839,7 @@
       "source_location": "L86"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "fingerprint_stablestringhash",
       "label": "stableStringHash()",
@@ -242758,7 +242848,7 @@
       "source_location": "L55"
     },
     {
-      "community": 532,
+      "community": 533,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -242767,7 +242857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "foldversionrepair_boundedlimit",
       "label": "boundedLimit()",
@@ -242776,7 +242866,7 @@
       "source_location": "L43"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "foldversionrepair_countstalefoldversiondayswithctx",
       "label": "countStaleFoldVersionDaysWithCtx()",
@@ -242785,7 +242875,7 @@
       "source_location": "L164"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "foldversionrepair_daypage",
       "label": "dayPage()",
@@ -242794,7 +242884,7 @@
       "source_location": "L57"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "foldversionrepair_markstalefoldversiondayswithctx",
       "label": "markStaleFoldVersionDaysWithCtx()",
@@ -242803,58 +242893,13 @@
       "source_location": "L70"
     },
     {
-      "community": 533,
+      "community": 534,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldversionrepair_ts",
       "label": "foldVersionRepair.ts",
       "norm_label": "foldversionrepair.ts",
       "source_file": "packages/athena-webapp/convex/reports/foldVersionRepair.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 534,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verify_test_ts",
-      "label": "verify.test.ts",
-      "norm_label": "verify.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 534,
-      "file_type": "code",
-      "id": "verify_test_at",
-      "label": "at()",
-      "norm_label": "at()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 534,
-      "file_type": "code",
-      "id": "verify_test_folddirtydays",
-      "label": "foldDirtyDays()",
-      "norm_label": "folddirtydays()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 534,
-      "file_type": "code",
-      "id": "verify_test_runreseed",
-      "label": "runReseed()",
-      "norm_label": "runreseed()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 534,
-      "file_type": "code",
-      "id": "verify_test_seedverifiableday",
-      "label": "seedVerifiableDay()",
-      "norm_label": "seedverifiableday()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.test.ts",
-      "source_location": "L98"
     },
     {
       "community": 535,
@@ -242899,7 +242944,7 @@
       "label": "seedSettledPaymentWeek()",
       "norm_label": "seedsettledpaymentweek()",
       "source_file": "packages/athena-webapp/convex/reports/weeklyVerify.test.ts",
-      "source_location": "L638"
+      "source_location": "L659"
     },
     {
       "community": 536,
@@ -247836,227 +247881,227 @@
     {
       "community": 60,
       "file_type": "code",
-      "id": "homepagesnapshot_buildhomepagesnapshotv1",
-      "label": "buildHomepageSnapshotV1()",
-      "norm_label": "buildhomepagesnapshotv1()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L380"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_gethomepagesnapshotwithctx",
-      "label": "getHomepageSnapshotWithCtx()",
-      "norm_label": "gethomepagesnapshotwithctx()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L629"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_hydratebestseller",
-      "label": "hydrateBestSeller()",
-      "norm_label": "hydratebestseller()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L556"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_hydratecategory",
-      "label": "hydrateCategory()",
-      "norm_label": "hydratecategory()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L520"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_hydratefeatureditem",
-      "label": "hydrateFeaturedItem()",
-      "norm_label": "hydratefeatureditem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L594"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_hydratehomepagerowsuntil",
-      "label": "hydrateHomepageRowsUntil()",
-      "norm_label": "hydratehomepagerowsuntil()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_hydrateproduct",
-      "label": "hydrateProduct()",
-      "norm_label": "hydrateproduct()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L460"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_hydratesubcategory",
-      "label": "hydrateSubcategory()",
-      "norm_label": "hydratesubcategory()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L536"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_hydratetargetproducts",
-      "label": "hydrateTargetProducts()",
-      "norm_label": "hydratetargetproducts()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L482"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_iscustomervisibleproduct",
-      "label": "isCustomerVisibleProduct()",
-      "norm_label": "iscustomervisibleproduct()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_iscustomervisiblesku",
-      "label": "isCustomerVisibleSku()",
-      "norm_label": "iscustomervisiblesku()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_issellablesku",
-      "label": "isSellableSku()",
-      "norm_label": "issellablesku()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_numberornull",
-      "label": "numberOrNull()",
-      "norm_label": "numberornull()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L138"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_presentcategory",
-      "label": "presentCategory()",
-      "norm_label": "presentcategory()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L266"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_presentfeatureditem",
-      "label": "presentFeaturedItem()",
-      "norm_label": "presentfeatureditem()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L322"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_presentproduct",
-      "label": "presentProduct()",
-      "norm_label": "presentproduct()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L238"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_presentproductsku",
-      "label": "presentProductSku()",
-      "norm_label": "presentproductsku()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L193"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_presentsubcategory",
-      "label": "presentSubcategory()",
-      "norm_label": "presentsubcategory()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L291"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_quantityavailableof",
-      "label": "quantityAvailableOf()",
-      "norm_label": "quantityavailableof()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L175"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_rowid",
-      "label": "rowId()",
-      "norm_label": "rowid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L142"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_skusfromproduct",
-      "label": "skusFromProduct()",
-      "norm_label": "skusfromproduct()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L234"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_sortbyrankthenid",
-      "label": "sortByRankThenId()",
-      "norm_label": "sortbyrankthenid()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_sortskusforpublicdisplay",
-      "label": "sortSkusForPublicDisplay()",
-      "norm_label": "sortskusforpublicdisplay()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "homepagesnapshot_stringornull",
-      "label": "stringOrNull()",
-      "norm_label": "stringornull()",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
-      "source_location": "L134"
-    },
-    {
-      "community": 60,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_homepagesnapshot_ts",
-      "label": "homepageSnapshot.ts",
-      "norm_label": "homepagesnapshot.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "id": "packages_athena_webapp_convex_reports_verify_ts",
+      "label": "verify.ts",
+      "norm_label": "verify.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_accumulatepayment",
+      "label": "accumulatePayment()",
+      "norm_label": "accumulatepayment()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1459"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_addmetrics",
+      "label": "addMetrics()",
+      "norm_label": "addmetrics()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L414"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_candidatewindow",
+      "label": "candidateWindow()",
+      "norm_label": "candidatewindow()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L425"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_computeexpectedday",
+      "label": "computeExpectedDay()",
+      "norm_label": "computeexpectedday()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L447"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_diffmetrics",
+      "label": "diffMetrics()",
+      "norm_label": "diffmetrics()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L832"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_diffpaymentposture",
+      "label": "diffPaymentPosture()",
+      "norm_label": "diffpaymentposture()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L861"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_foldedmetrics",
+      "label": "foldedMetrics()",
+      "norm_label": "foldedmetrics()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L907"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_inventoryattentionagrees",
+      "label": "inventoryAttentionAgrees()",
+      "norm_label": "inventoryattentionagrees()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1338"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_isoweekday",
+      "label": "isoWeekday()",
+      "norm_label": "isoweekday()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1063"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_recomputeverifiedvariance",
+      "label": "recomputeVerifiedVariance()",
+      "norm_label": "recomputeverifiedvariance()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1404"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_recountopeninventoryreviewgroups",
+      "label": "recountOpenInventoryReviewGroups()",
+      "norm_label": "recountopeninventoryreviewgroups()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1264"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_resolveverifiedframe",
+      "label": "resolveVerifiedFrame()",
+      "norm_label": "resolveverifiedframe()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1117"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_schedulegoverning",
+      "label": "scheduleGoverning()",
+      "norm_label": "schedulegoverning()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1075"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_scheduleincludesdate",
+      "label": "scheduleIncludesDate()",
+      "norm_label": "scheduleincludesdate()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1100"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_shiftlocaldate",
+      "label": "shiftLocalDate()",
+      "norm_label": "shiftlocaldate()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1068"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_storedweeklypayment",
+      "label": "storedWeeklyPayment()",
+      "norm_label": "storedweeklypayment()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1489"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_unverifiedpaymentfields",
+      "label": "unverifiedPaymentFields()",
+      "norm_label": "unverifiedpaymentfields()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L297"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_verifyacceptedcloseposture",
+      "label": "verifyAcceptedClosePosture()",
+      "norm_label": "verifyacceptedcloseposture()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1172"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_verifycurrentweekwithctx",
+      "label": "verifyCurrentWeekWithCtx()",
+      "norm_label": "verifycurrentweekwithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1507"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_verifydaywithctx",
+      "label": "verifyDayWithCtx()",
+      "norm_label": "verifydaywithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L936"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_verifystoresummarywithctx",
+      "label": "verifyStoreSummaryWithCtx()",
+      "norm_label": "verifystoresummarywithctx()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1013"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_weeklyverifiedmetrics",
+      "label": "weeklyVerifiedMetrics()",
+      "norm_label": "weeklyverifiedmetrics()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L921"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_zerometrics",
+      "label": "zeroMetrics()",
+      "norm_label": "zerometrics()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L401"
+    },
+    {
+      "community": 60,
+      "file_type": "code",
+      "id": "verify_zeropaymentcomparable",
+      "label": "zeroPaymentComparable()",
+      "norm_label": "zeropaymentcomparable()",
+      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "source_location": "L1479"
     },
     {
       "community": 600,
@@ -248430,226 +248475,226 @@
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_addcolumnsamples",
-      "label": "addColumnSamples()",
-      "norm_label": "addcolumnsamples()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L490"
+      "id": "homepagesnapshot_buildhomepagesnapshotv1",
+      "label": "buildHomepageSnapshotV1()",
+      "norm_label": "buildhomepagesnapshotv1()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L380"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_appendjsonproperty",
-      "label": "appendJsonProperty()",
-      "norm_label": "appendjsonproperty()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L484"
+      "id": "homepagesnapshot_gethomepagesnapshotwithctx",
+      "label": "getHomepageSnapshotWithCtx()",
+      "norm_label": "gethomepagesnapshotwithctx()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L629"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_boundinventoryimportsourcecolumns",
-      "label": "boundInventoryImportSourceColumns()",
-      "norm_label": "boundinventoryimportsourcecolumns()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L36"
+      "id": "homepagesnapshot_hydratebestseller",
+      "label": "hydrateBestSeller()",
+      "norm_label": "hydratebestseller()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L556"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_buildinventoryimportsourcerowidentity",
-      "label": "buildInventoryImportSourceRowIdentity()",
-      "norm_label": "buildinventoryimportsourcerowidentity()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L146"
+      "id": "homepagesnapshot_hydratecategory",
+      "label": "hydrateCategory()",
+      "norm_label": "hydratecategory()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L520"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_completeprojection",
-      "label": "completeProjection()",
-      "norm_label": "completeprojection()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L593"
+      "id": "homepagesnapshot_hydratefeatureditem",
+      "label": "hydrateFeaturedItem()",
+      "norm_label": "hydratefeatureditem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L594"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_detectinventoryimportsourceformat",
-      "label": "detectInventoryImportSourceFormat()",
-      "norm_label": "detectinventoryimportsourceformat()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L561"
+      "id": "homepagesnapshot_hydratehomepagerowsuntil",
+      "label": "hydrateHomepageRowsUntil()",
+      "norm_label": "hydratehomepagerowsuntil()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L28"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_emptyprojection",
-      "label": "emptyProjection()",
-      "norm_label": "emptyprojection()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L607"
+      "id": "homepagesnapshot_hydrateproduct",
+      "label": "hydrateProduct()",
+      "norm_label": "hydrateproduct()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L460"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_extractjsonsourcerows",
-      "label": "extractJsonSourceRows()",
-      "norm_label": "extractjsonsourcerows()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L408"
+      "id": "homepagesnapshot_hydratesubcategory",
+      "label": "hydrateSubcategory()",
+      "norm_label": "hydratesubcategory()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L536"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_flattenjsonsourcerows",
-      "label": "flattenJsonSourceRows()",
-      "norm_label": "flattenjsonsourcerows()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L428"
+      "id": "homepagesnapshot_hydratetargetproducts",
+      "label": "hydrateTargetProducts()",
+      "norm_label": "hydratetargetproducts()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L482"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_inferinventoryimportidentityname",
-      "label": "inferInventoryImportIdentityName()",
-      "norm_label": "inferinventoryimportidentityname()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L218"
+      "id": "homepagesnapshot_iscustomervisibleproduct",
+      "label": "isCustomerVisibleProduct()",
+      "norm_label": "iscustomervisibleproduct()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L148"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_interpretinventoryimportcost",
-      "label": "interpretInventoryImportCost()",
-      "norm_label": "interpretinventoryimportcost()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L246"
+      "id": "homepagesnapshot_iscustomervisiblesku",
+      "label": "isCustomerVisibleSku()",
+      "norm_label": "iscustomervisiblesku()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L160"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_inventoryimportsourcerowtorecord",
-      "label": "inventoryImportSourceRowToRecord()",
-      "norm_label": "inventoryimportsourcerowtorecord()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L129"
+      "id": "homepagesnapshot_issellablesku",
+      "label": "isSellableSku()",
+      "norm_label": "issellablesku()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L179"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_isinventoryimportsourcevalue",
-      "label": "isInventoryImportSourceValue()",
-      "norm_label": "isinventoryimportsourcevalue()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L578"
+      "id": "homepagesnapshot_numberornull",
+      "label": "numberOrNull()",
+      "norm_label": "numberornull()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L138"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_isjsonrecord",
-      "label": "isJsonRecord()",
-      "norm_label": "isjsonrecord()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L589"
+      "id": "homepagesnapshot_presentcategory",
+      "label": "presentCategory()",
+      "norm_label": "presentcategory()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L266"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_lookslikeinventoryimportlabel",
-      "label": "looksLikeInventoryImportLabel()",
-      "norm_label": "lookslikeinventoryimportlabel()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L242"
+      "id": "homepagesnapshot_presentfeatureditem",
+      "label": "presentFeaturedItem()",
+      "norm_label": "presentfeatureditem()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L322"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_normalizeinventoryimportsourcekey",
-      "label": "normalizeInventoryImportSourceKey()",
-      "norm_label": "normalizeinventoryimportsourcekey()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L571"
+      "id": "homepagesnapshot_presentproduct",
+      "label": "presentProduct()",
+      "norm_label": "presentproduct()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L238"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_parsecsv",
-      "label": "parseCsv()",
-      "norm_label": "parsecsv()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L516"
+      "id": "homepagesnapshot_presentproductsku",
+      "label": "presentProductSku()",
+      "norm_label": "presentproductsku()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L193"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_projectcsvsource",
-      "label": "projectCsvSource()",
-      "norm_label": "projectcsvsource()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L309"
+      "id": "homepagesnapshot_presentsubcategory",
+      "label": "presentSubcategory()",
+      "norm_label": "presentsubcategory()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L291"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_projectinventoryimportsource",
-      "label": "projectInventoryImportSource()",
-      "norm_label": "projectinventoryimportsource()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L107"
+      "id": "homepagesnapshot_quantityavailableof",
+      "label": "quantityAvailableOf()",
+      "norm_label": "quantityavailableof()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L175"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_projectjsonsource",
-      "label": "projectJsonSource()",
-      "norm_label": "projectjsonsource()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L358"
+      "id": "homepagesnapshot_rowid",
+      "label": "rowId()",
+      "norm_label": "rowid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L142"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_readinventoryimportidentitylabel",
-      "label": "readInventoryImportIdentityLabel()",
-      "norm_label": "readinventoryimportidentitylabel()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L207"
+      "id": "homepagesnapshot_skusfromproduct",
+      "label": "skusFromProduct()",
+      "norm_label": "skusfromproduct()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L234"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_readinventoryimportidentitystring",
-      "label": "readInventoryImportIdentityString()",
-      "norm_label": "readinventoryimportidentitystring()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L199"
+      "id": "homepagesnapshot_sortbyrankthenid",
+      "label": "sortByRankThenId()",
+      "norm_label": "sortbyrankthenid()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L144"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_readinventoryimportidentityvalue",
-      "label": "readInventoryImportIdentityValue()",
-      "norm_label": "readinventoryimportidentityvalue()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L180"
+      "id": "homepagesnapshot_sortskusforpublicdisplay",
+      "label": "sortSkusForPublicDisplay()",
+      "norm_label": "sortskusforpublicdisplay()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L183"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "inventoryimportsource_scalarjsonfields",
-      "label": "scalarJsonFields()",
-      "norm_label": "scalarjsonfields()",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
-      "source_location": "L468"
+      "id": "homepagesnapshot_stringornull",
+      "label": "stringOrNull()",
+      "norm_label": "stringornull()",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
+      "source_location": "L134"
     },
     {
       "community": 61,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_inventoryimportsource_ts",
-      "label": "inventoryImportSource.ts",
-      "norm_label": "inventoryimportsource.ts",
-      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "id": "packages_athena_webapp_convex_storefront_homepagesnapshot_ts",
+      "label": "homepageSnapshot.ts",
+      "norm_label": "homepagesnapshot.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.ts",
       "source_location": "L1"
     },
     {
@@ -249015,226 +249060,226 @@
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_ancestorchain",
-      "label": "ancestorChain()",
-      "norm_label": "ancestorchain()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L167"
+      "id": "inventoryimportsource_addcolumnsamples",
+      "label": "addColumnSamples()",
+      "norm_label": "addcolumnsamples()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L490"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectconvexmoneyboundaryfindingsfromsource",
-      "label": "collectConvexMoneyBoundaryFindingsFromSource()",
-      "norm_label": "collectconvexmoneyboundaryfindingsfromsource()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L456"
+      "id": "inventoryimportsource_appendjsonproperty",
+      "label": "appendJsonProperty()",
+      "norm_label": "appendjsonproperty()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L484"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectdirectmoneyformatsfromsource",
-      "label": "collectDirectMoneyFormatsFromSource()",
-      "norm_label": "collectdirectmoneyformatsfromsource()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L394"
+      "id": "inventoryimportsource_boundinventoryimportsourcecolumns",
+      "label": "boundInventoryImportSourceColumns()",
+      "norm_label": "boundinventoryimportsourcecolumns()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L36"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparses",
-      "label": "collectRawMoneyParses()",
-      "norm_label": "collectrawmoneyparses()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L364"
+      "id": "inventoryimportsource_buildinventoryimportsourcerowidentity",
+      "label": "buildInventoryImportSourceRowIdentity()",
+      "norm_label": "buildinventoryimportsourcerowidentity()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L146"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
-      "label": "collectRawMoneyParsesFromSource()",
-      "norm_label": "collectrawmoneyparsesfromsource()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L291"
+      "id": "inventoryimportsource_completeprojection",
+      "label": "completeProjection()",
+      "norm_label": "completeprojection()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L593"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
-      "label": "collectRawNumericHelperNames()",
-      "norm_label": "collectrawnumerichelpernames()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L265"
+      "id": "inventoryimportsource_detectinventoryimportsourceformat",
+      "label": "detectInventoryImportSourceFormat()",
+      "norm_label": "detectinventoryimportsourceformat()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L561"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectsourcefiles",
-      "label": "collectSourceFiles()",
-      "norm_label": "collectsourcefiles()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L75"
+      "id": "inventoryimportsource_emptyprojection",
+      "label": "emptyProjection()",
+      "norm_label": "emptyprojection()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L607"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_collectstorefrontdirectmoneyformats",
-      "label": "collectStorefrontDirectMoneyFormats()",
-      "norm_label": "collectstorefrontdirectmoneyformats()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L441"
+      "id": "inventoryimportsource_extractjsonsourcerows",
+      "label": "extractJsonSourceRows()",
+      "norm_label": "extractjsonsourcerows()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L408"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
-      "label": "containsDisallowedRawNumericParse()",
-      "norm_label": "containsdisallowedrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L230"
+      "id": "inventoryimportsource_flattenjsonsourcerows",
+      "label": "flattenJsonSourceRows()",
+      "norm_label": "flattenjsonsourcerows()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L428"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_containsterm",
-      "label": "containsTerm()",
-      "norm_label": "containsterm()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L119"
+      "id": "inventoryimportsource_inferinventoryimportidentityname",
+      "label": "inferInventoryImportIdentityName()",
+      "norm_label": "inferinventoryimportidentityname()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L218"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isalloweddisplayconversion",
-      "label": "isAllowedDisplayConversion()",
-      "norm_label": "isalloweddisplayconversion()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L209"
+      "id": "inventoryimportsource_interpretinventoryimportcost",
+      "label": "interpretInventoryImportCost()",
+      "norm_label": "interpretinventoryimportcost()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L246"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowedmoneyformatconversion",
-      "label": "isAllowedMoneyFormatConversion()",
-      "norm_label": "isallowedmoneyformatconversion()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L370"
+      "id": "inventoryimportsource_inventoryimportsourcerowtorecord",
+      "label": "inventoryImportSourceRowToRecord()",
+      "norm_label": "inventoryimportsourcerowtorecord()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L129"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowednumericrounding",
-      "label": "isAllowedNumericRounding()",
-      "norm_label": "isallowednumericrounding()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L219"
+      "id": "inventoryimportsource_isinventoryimportsourcevalue",
+      "label": "isInventoryImportSourceValue()",
+      "norm_label": "isinventoryimportsourcevalue()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L578"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isallowedpercentagebranch",
-      "label": "isAllowedPercentageBranch()",
-      "norm_label": "isallowedpercentagebranch()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L195"
+      "id": "inventoryimportsource_isjsonrecord",
+      "label": "isJsonRecord()",
+      "norm_label": "isjsonrecord()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L589"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_isformatterformatcall",
-      "label": "isFormatterFormatCall()",
-      "norm_label": "isformatterformatcall()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L382"
+      "id": "inventoryimportsource_lookslikeinventoryimportlabel",
+      "label": "looksLikeInventoryImportLabel()",
+      "norm_label": "lookslikeinventoryimportlabel()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L242"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_israwnumericparse",
-      "label": "isRawNumericParse()",
-      "norm_label": "israwnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L98"
+      "id": "inventoryimportsource_normalizeinventoryimportsourcekey",
+      "label": "normalizeInventoryImportSourceKey()",
+      "norm_label": "normalizeinventoryimportsourcekey()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L571"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_nearestcontextnode",
-      "label": "nearestContextNode()",
-      "norm_label": "nearestcontextnode()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L179"
+      "id": "inventoryimportsource_parsecsv",
+      "label": "parseCsv()",
+      "norm_label": "parsecsv()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L516"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_nodeline",
-      "label": "nodeLine()",
-      "norm_label": "nodeline()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L156"
+      "id": "inventoryimportsource_projectcsvsource",
+      "label": "projectCsvSource()",
+      "norm_label": "projectcsvsource()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L309"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_readfilefromroot",
-      "label": "readFileFromRoot()",
-      "norm_label": "readfilefromroot()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L67"
+      "id": "inventoryimportsource_projectinventoryimportsource",
+      "label": "projectInventoryImportSource()",
+      "norm_label": "projectinventoryimportsource()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L107"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_readwebappfile",
-      "label": "readWebappFile()",
-      "norm_label": "readwebappfile()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L71"
+      "id": "inventoryimportsource_projectjsonsource",
+      "label": "projectJsonSource()",
+      "norm_label": "projectjsonsource()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L358"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_referencesmoney",
-      "label": "referencesMoney()",
-      "norm_label": "referencesmoney()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L124"
+      "id": "inventoryimportsource_readinventoryimportidentitylabel",
+      "label": "readInventoryImportIdentityLabel()",
+      "norm_label": "readinventoryimportidentitylabel()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L207"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
-      "label": "referencesOnlyNonMoneyNumericContext()",
-      "norm_label": "referencesonlynonmoneynumericcontext()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L138"
+      "id": "inventoryimportsource_readinventoryimportidentitystring",
+      "label": "readInventoryImportIdentityString()",
+      "norm_label": "readinventoryimportidentitystring()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L199"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_returnsrawnumericparse",
-      "label": "returnsRawNumericParse()",
-      "norm_label": "returnsrawnumericparse()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L245"
+      "id": "inventoryimportsource_readinventoryimportidentityvalue",
+      "label": "readInventoryImportIdentityValue()",
+      "norm_label": "readinventoryimportidentityvalue()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L180"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "moneyentryaudit_test_reviewedreason",
-      "label": "reviewedReason()",
-      "norm_label": "reviewedreason()",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
-      "source_location": "L142"
+      "id": "inventoryimportsource_scalarjsonfields",
+      "label": "scalarJsonFields()",
+      "norm_label": "scalarjsonfields()",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
+      "source_location": "L468"
     },
     {
       "community": 62,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
-      "label": "moneyEntryAudit.test.ts",
-      "norm_label": "moneyentryaudit.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "id": "packages_athena_webapp_shared_inventoryimportsource_ts",
+      "label": "inventoryImportSource.ts",
+      "norm_label": "inventoryimportsource.ts",
+      "source_file": "packages/athena-webapp/shared/inventoryImportSource.ts",
       "source_location": "L1"
     },
     {
@@ -249600,227 +249645,227 @@
     {
       "community": 63,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalruntimestatus_ts",
-      "label": "terminalRuntimeStatus.ts",
-      "norm_label": "terminalruntimestatus.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "id": "moneyentryaudit_test_ancestorchain",
+      "label": "ancestorChain()",
+      "norm_label": "ancestorchain()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectconvexmoneyboundaryfindingsfromsource",
+      "label": "collectConvexMoneyBoundaryFindingsFromSource()",
+      "norm_label": "collectconvexmoneyboundaryfindingsfromsource()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L456"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectdirectmoneyformatsfromsource",
+      "label": "collectDirectMoneyFormatsFromSource()",
+      "norm_label": "collectdirectmoneyformatsfromsource()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L394"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawmoneyparses",
+      "label": "collectRawMoneyParses()",
+      "norm_label": "collectrawmoneyparses()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L364"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawmoneyparsesfromsource",
+      "label": "collectRawMoneyParsesFromSource()",
+      "norm_label": "collectrawmoneyparsesfromsource()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L291"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectrawnumerichelpernames",
+      "label": "collectRawNumericHelperNames()",
+      "norm_label": "collectrawnumerichelpernames()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectsourcefiles",
+      "label": "collectSourceFiles()",
+      "norm_label": "collectsourcefiles()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L75"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_collectstorefrontdirectmoneyformats",
+      "label": "collectStorefrontDirectMoneyFormats()",
+      "norm_label": "collectstorefrontdirectmoneyformats()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L441"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_containsdisallowedrawnumericparse",
+      "label": "containsDisallowedRawNumericParse()",
+      "norm_label": "containsdisallowedrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L230"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_containsterm",
+      "label": "containsTerm()",
+      "norm_label": "containsterm()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isalloweddisplayconversion",
+      "label": "isAllowedDisplayConversion()",
+      "norm_label": "isalloweddisplayconversion()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L209"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowedmoneyformatconversion",
+      "label": "isAllowedMoneyFormatConversion()",
+      "norm_label": "isallowedmoneyformatconversion()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L370"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowednumericrounding",
+      "label": "isAllowedNumericRounding()",
+      "norm_label": "isallowednumericrounding()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L219"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isallowedpercentagebranch",
+      "label": "isAllowedPercentageBranch()",
+      "norm_label": "isallowedpercentagebranch()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L195"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_isformatterformatcall",
+      "label": "isFormatterFormatCall()",
+      "norm_label": "isformatterformatcall()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L382"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_israwnumericparse",
+      "label": "isRawNumericParse()",
+      "norm_label": "israwnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_nearestcontextnode",
+      "label": "nearestContextNode()",
+      "norm_label": "nearestcontextnode()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_nodeline",
+      "label": "nodeLine()",
+      "norm_label": "nodeline()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L156"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_readfilefromroot",
+      "label": "readFileFromRoot()",
+      "norm_label": "readfilefromroot()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_readwebappfile",
+      "label": "readWebappFile()",
+      "norm_label": "readwebappfile()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_referencesmoney",
+      "label": "referencesMoney()",
+      "norm_label": "referencesmoney()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_referencesonlynonmoneynumericcontext",
+      "label": "referencesOnlyNonMoneyNumericContext()",
+      "norm_label": "referencesonlynonmoneynumericcontext()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_returnsrawnumericparse",
+      "label": "returnsRawNumericParse()",
+      "norm_label": "returnsrawnumericparse()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "moneyentryaudit_test_reviewedreason",
+      "label": "reviewedReason()",
+      "norm_label": "reviewedreason()",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
+      "source_location": "L142"
+    },
+    {
+      "community": 63,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_moneyentryaudit_test_ts",
+      "label": "moneyEntryAudit.test.ts",
+      "norm_label": "moneyentryaudit.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/moneyEntryAudit.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_buildposterminalruntimecopydiagnostics",
-      "label": "buildPosTerminalRuntimeCopyDiagnostics()",
-      "norm_label": "buildposterminalruntimecopydiagnostics()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L568"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_buildposterminalruntimestatus",
-      "label": "buildPosTerminalRuntimeStatus()",
-      "norm_label": "buildposterminalruntimestatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L367"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_buildsyncmetrics",
-      "label": "buildSyncMetrics()",
-      "norm_label": "buildsyncmetrics()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L731"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_buildvalidationmetadatametrics",
-      "label": "buildValidationMetadataMetrics()",
-      "norm_label": "buildvalidationmetadatametrics()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L711"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_compareuploadableeventorder",
-      "label": "compareUploadableEventOrder()",
-      "norm_label": "compareuploadableeventorder()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L1054"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_getreviewdiagnosticsevents",
-      "label": "getReviewDiagnosticsEvents()",
-      "norm_label": "getreviewdiagnosticsevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L1005"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_getruntimereviewdiagnosticsevents",
-      "label": "getRuntimeReviewDiagnosticsEvents()",
-      "norm_label": "getruntimereviewdiagnosticsevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L1016"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_getterminalintegritylabel",
-      "label": "getTerminalIntegrityLabel()",
-      "norm_label": "getterminalintegritylabel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L829"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_issaleauthorityready",
-      "label": "isSaleAuthorityReady()",
-      "norm_label": "issaleauthorityready()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L556"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_mapsyncstatus",
-      "label": "mapSyncStatus()",
-      "norm_label": "mapsyncstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L799"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_normalizestaffauthoritystatus",
-      "label": "normalizeStaffAuthorityStatus()",
-      "norm_label": "normalizestaffauthoritystatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L820"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_omitundefined",
-      "label": "omitUndefined()",
-      "norm_label": "omitundefined()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L1082"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_positiveruntimecount",
-      "label": "positiveRuntimeCount()",
-      "norm_label": "positiveruntimecount()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L930"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_positiveruntimetimestamp",
-      "label": "positiveRuntimeTimestamp()",
-      "norm_label": "positiveruntimetimestamp()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L924"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_snapshotages",
-      "label": "snapshotAges()",
-      "norm_label": "snapshotages()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L946"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_toposterminalruntimediagnosticsevent",
-      "label": "toPosTerminalRuntimeDiagnosticsEvent()",
-      "norm_label": "toposterminalruntimediagnosticsevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L981"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_toreportableposterminalruntimestatus",
-      "label": "toReportablePosTerminalRuntimeStatus()",
-      "norm_label": "toreportableposterminalruntimestatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L725"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_tosafeappsessionrecoverydiagnostics",
-      "label": "toSafeAppSessionRecoveryDiagnostics()",
-      "norm_label": "tosafeappsessionrecoverydiagnostics()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L838"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_tosafeappsessionrecoverylabel",
-      "label": "toSafeAppSessionRecoveryLabel()",
-      "norm_label": "tosafeappsessionrecoverylabel()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L846"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_tosafeappupdatediagnostics",
-      "label": "toSafeAppUpdateDiagnostics()",
-      "norm_label": "tosafeappupdatediagnostics()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L871"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_tosafebuildid",
-      "label": "toSafeBuildId()",
-      "norm_label": "tosafebuildid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L936"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_tosafefailuremessage",
-      "label": "toSafeFailureMessage()",
-      "norm_label": "tosafefailuremessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L1067"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_tosaferuntimediagnosticsevent",
-      "label": "toSafeRuntimeDiagnosticsEvent()",
-      "norm_label": "tosaferuntimediagnosticsevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L1032"
-    },
-    {
-      "community": 63,
-      "file_type": "code",
-      "id": "terminalruntimestatus_tosaferuntimestring",
-      "label": "toSafeRuntimeString()",
-      "norm_label": "tosaferuntimestring()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
-      "source_location": "L940"
     },
     {
       "community": 630,
@@ -250185,227 +250230,227 @@
     {
       "community": 64,
       "file_type": "code",
-      "id": "harness_self_review_appendlistsection",
-      "label": "appendListSection()",
-      "norm_label": "appendlistsection()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L609"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_buildmarkdownbundle",
-      "label": "buildMarkdownBundle()",
-      "norm_label": "buildmarkdownbundle()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L628"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_collectcoverage",
-      "label": "collectCoverage()",
-      "norm_label": "collectcoverage()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L398"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_evaluategraphifyfreshness",
-      "label": "evaluateGraphifyFreshness()",
-      "norm_label": "evaluategraphifyfreshness()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L532"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_fileexists",
-      "label": "fileExists()",
-      "norm_label": "fileexists()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_formatvalidationcommand",
-      "label": "formatValidationCommand()",
-      "norm_label": "formatvalidationcommand()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L132"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_getchangedfilesfromgit",
-      "label": "getChangedFilesFromGit()",
-      "norm_label": "getchangedfilesfromgit()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_islikelycodeorconfig",
-      "label": "isLikelyCodeOrConfig()",
-      "norm_label": "islikelycodeorconfig()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L493"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_islocalgeneratedartifactpath",
-      "label": "isLocalGeneratedArtifactPath()",
-      "norm_label": "islocalgeneratedartifactpath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L523"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_isworktreemetadatapath",
-      "label": "isWorktreeMetadataPath()",
-      "norm_label": "isworktreemetadatapath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L514"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_loadselfreviewtarget",
-      "label": "loadSelfReviewTarget()",
-      "norm_label": "loadselfreviewtarget()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L247"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_loadselfreviewtargets",
-      "label": "loadSelfReviewTargets()",
-      "norm_label": "loadselfreviewtargets()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L379"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_matchespathprefix",
-      "label": "matchesPathPrefix()",
-      "norm_label": "matchespathprefix()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L106"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_normalizebehaviorscenarioname",
-      "label": "normalizeBehaviorScenarioName()",
-      "norm_label": "normalizebehaviorscenarioname()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_normalizerepopath",
-      "label": "normalizeRepoPath()",
-      "norm_label": "normalizerepopath()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L96"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_normalizevalidationcommand",
-      "label": "normalizeValidationCommand()",
-      "norm_label": "normalizevalidationcommand()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_parsecliarguments",
-      "label": "parseCliArguments()",
-      "norm_label": "parsecliarguments()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L801"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_parseruntimescenarios",
-      "label": "parseRuntimeScenarios()",
-      "norm_label": "parseruntimescenarios()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L241"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_quotecode",
-      "label": "quoteCode()",
-      "norm_label": "quotecode()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L140"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_readjsonfile",
-      "label": "readJsonFile()",
-      "norm_label": "readjsonfile()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_runharnessselfreview",
-      "label": "runHarnessSelfReview()",
-      "norm_label": "runharnessselfreview()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L850"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_runquietharnesscheck",
-      "label": "runQuietHarnessCheck()",
-      "norm_label": "runquietharnesscheck()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L600"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "harness_self_review_sortuniquepaths",
-      "label": "sortUniquePaths()",
-      "norm_label": "sortuniquepaths()",
-      "source_file": "scripts/harness-self-review.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 64,
-      "file_type": "code",
-      "id": "scripts_harness_self_review_ts",
-      "label": "harness-self-review.ts",
-      "norm_label": "harness-self-review.ts",
-      "source_file": "scripts/harness-self-review.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalruntimestatus_ts",
+      "label": "terminalRuntimeStatus.ts",
+      "norm_label": "terminalruntimestatus.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_buildposterminalruntimecopydiagnostics",
+      "label": "buildPosTerminalRuntimeCopyDiagnostics()",
+      "norm_label": "buildposterminalruntimecopydiagnostics()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L568"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_buildposterminalruntimestatus",
+      "label": "buildPosTerminalRuntimeStatus()",
+      "norm_label": "buildposterminalruntimestatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L367"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_buildsyncmetrics",
+      "label": "buildSyncMetrics()",
+      "norm_label": "buildsyncmetrics()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L731"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_buildvalidationmetadatametrics",
+      "label": "buildValidationMetadataMetrics()",
+      "norm_label": "buildvalidationmetadatametrics()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L711"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_compareuploadableeventorder",
+      "label": "compareUploadableEventOrder()",
+      "norm_label": "compareuploadableeventorder()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L1054"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_getreviewdiagnosticsevents",
+      "label": "getReviewDiagnosticsEvents()",
+      "norm_label": "getreviewdiagnosticsevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L1005"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_getruntimereviewdiagnosticsevents",
+      "label": "getRuntimeReviewDiagnosticsEvents()",
+      "norm_label": "getruntimereviewdiagnosticsevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L1016"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_getterminalintegritylabel",
+      "label": "getTerminalIntegrityLabel()",
+      "norm_label": "getterminalintegritylabel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L829"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_issaleauthorityready",
+      "label": "isSaleAuthorityReady()",
+      "norm_label": "issaleauthorityready()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L556"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_mapsyncstatus",
+      "label": "mapSyncStatus()",
+      "norm_label": "mapsyncstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L799"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_normalizestaffauthoritystatus",
+      "label": "normalizeStaffAuthorityStatus()",
+      "norm_label": "normalizestaffauthoritystatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L820"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_omitundefined",
+      "label": "omitUndefined()",
+      "norm_label": "omitundefined()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L1082"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_positiveruntimecount",
+      "label": "positiveRuntimeCount()",
+      "norm_label": "positiveruntimecount()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L930"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_positiveruntimetimestamp",
+      "label": "positiveRuntimeTimestamp()",
+      "norm_label": "positiveruntimetimestamp()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L924"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_snapshotages",
+      "label": "snapshotAges()",
+      "norm_label": "snapshotages()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L946"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_toposterminalruntimediagnosticsevent",
+      "label": "toPosTerminalRuntimeDiagnosticsEvent()",
+      "norm_label": "toposterminalruntimediagnosticsevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L981"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_toreportableposterminalruntimestatus",
+      "label": "toReportablePosTerminalRuntimeStatus()",
+      "norm_label": "toreportableposterminalruntimestatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L725"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_tosafeappsessionrecoverydiagnostics",
+      "label": "toSafeAppSessionRecoveryDiagnostics()",
+      "norm_label": "tosafeappsessionrecoverydiagnostics()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L838"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_tosafeappsessionrecoverylabel",
+      "label": "toSafeAppSessionRecoveryLabel()",
+      "norm_label": "tosafeappsessionrecoverylabel()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L846"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_tosafeappupdatediagnostics",
+      "label": "toSafeAppUpdateDiagnostics()",
+      "norm_label": "tosafeappupdatediagnostics()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L871"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_tosafebuildid",
+      "label": "toSafeBuildId()",
+      "norm_label": "tosafebuildid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L936"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_tosafefailuremessage",
+      "label": "toSafeFailureMessage()",
+      "norm_label": "tosafefailuremessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L1067"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_tosaferuntimediagnosticsevent",
+      "label": "toSafeRuntimeDiagnosticsEvent()",
+      "norm_label": "tosaferuntimediagnosticsevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L1032"
+    },
+    {
+      "community": 64,
+      "file_type": "code",
+      "id": "terminalruntimestatus_tosaferuntimestring",
+      "label": "toSafeRuntimeString()",
+      "norm_label": "tosaferuntimestring()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts",
+      "source_location": "L940"
     },
     {
       "community": 640,
@@ -250554,42 +250599,6 @@
     {
       "community": 644,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 644,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 644,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 644,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 645,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -250597,7 +250606,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 644,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -250606,7 +250615,7 @@
       "source_location": "L34"
     },
     {
-      "community": 645,
+      "community": 644,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -250615,7 +250624,7 @@
       "source_location": "L29"
     },
     {
-      "community": 645,
+      "community": 644,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -250624,7 +250633,7 @@
       "source_location": "L56"
     },
     {
-      "community": 646,
+      "community": 645,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -250633,7 +250642,7 @@
       "source_location": "L39"
     },
     {
-      "community": 646,
+      "community": 645,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -250642,7 +250651,7 @@
       "source_location": "L99"
     },
     {
-      "community": 646,
+      "community": 645,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -250651,7 +250660,7 @@
       "source_location": "L74"
     },
     {
-      "community": 646,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -250660,7 +250669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 646,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -250669,7 +250678,7 @@
       "source_location": "L21"
     },
     {
-      "community": 647,
+      "community": 646,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -250678,7 +250687,7 @@
       "source_location": "L42"
     },
     {
-      "community": 647,
+      "community": 646,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -250687,7 +250696,7 @@
       "source_location": "L80"
     },
     {
-      "community": 647,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -250696,7 +250705,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -250705,7 +250714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 647,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -250714,7 +250723,7 @@
       "source_location": "L12"
     },
     {
-      "community": 648,
+      "community": 647,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -250723,7 +250732,7 @@
       "source_location": "L127"
     },
     {
-      "community": 648,
+      "community": 647,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
@@ -250732,7 +250741,7 @@
       "source_location": "L99"
     },
     {
-      "community": 649,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
       "label": "posRegisterSessionActivity.test.ts",
@@ -250741,7 +250750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 649,
+      "community": 648,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildactivity",
       "label": "buildActivity()",
@@ -250750,7 +250759,7 @@
       "source_location": "L457"
     },
     {
-      "community": 649,
+      "community": 648,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildreport",
       "label": "buildReport()",
@@ -250759,7 +250768,7 @@
       "source_location": "L436"
     },
     {
-      "community": 649,
+      "community": 648,
       "file_type": "code",
       "id": "posregistersessionactivity_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -250768,223 +250777,7 @@
       "source_location": "L476"
     },
     {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_buildcartchange",
-      "label": "buildCartChange()",
-      "norm_label": "buildcartchange()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L239"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_buildlegacycontextpayload",
-      "label": "buildLegacyContextPayload()",
-      "norm_label": "buildlegacycontextpayload()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_buildlegacyproductid",
-      "label": "buildLegacyProductId()",
-      "norm_label": "buildlegacyproductid()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_compactpayload",
-      "label": "compactPayload()",
-      "norm_label": "compactpayload()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_compilelegacystorefrontanalyticsrow",
-      "label": "compileLegacyStorefrontAnalyticsRow()",
-      "norm_label": "compilelegacystorefrontanalyticsrow()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_compilelegacystorefrontanalyticsrows",
-      "label": "compileLegacyStorefrontAnalyticsRows()",
-      "norm_label": "compilelegacystorefrontanalyticsrows()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_compilelegacystorefrontanalyticsrowswithreport",
-      "label": "compileLegacyStorefrontAnalyticsRowsWithReport()",
-      "norm_label": "compilelegacystorefrontanalyticsrowswithreport()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_containssensitivetext",
-      "label": "containsSensitiveText()",
-      "norm_label": "containssensitivetext()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_ismissingrequiredpayload",
-      "label": "isMissingRequiredPayload()",
-      "norm_label": "ismissingrequiredpayload()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L224"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readcheckoutblocker",
-      "label": "readCheckoutBlocker()",
-      "norm_label": "readcheckoutblocker()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L305"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readcheckoutstate",
-      "label": "readCheckoutState()",
-      "norm_label": "readcheckoutstate()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L300"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readnumber",
-      "label": "readNumber()",
-      "norm_label": "readnumber()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L276"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readrawstring",
-      "label": "readRawString()",
-      "norm_label": "readrawstring()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readreferrerorigin",
-      "label": "readReferrerOrigin()",
-      "norm_label": "readreferrerorigin()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L322"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readroutepath",
-      "label": "readRoutePath()",
-      "norm_label": "readroutepath()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L310"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readsafecampaign",
-      "label": "readSafeCampaign()",
-      "norm_label": "readsafecampaign()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readsafeid",
-      "label": "readSafeId()",
-      "norm_label": "readsafeid()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L280"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readsafeslug",
-      "label": "readSafeSlug()",
-      "norm_label": "readsafeslug()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L285"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readsafestatus",
-      "label": "readSafeStatus()",
-      "norm_label": "readsafestatus()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_readstring",
-      "label": "readString()",
-      "norm_label": "readstring()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_resolveobservabilitycontexteventid",
-      "label": "resolveObservabilityContextEventId()",
-      "norm_label": "resolveobservabilitycontexteventid()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L158"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_resolvestorefrontcontexteventid",
-      "label": "resolveStorefrontContextEventId()",
-      "norm_label": "resolvestorefrontcontexteventid()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "legacystorefrontanalytics_sanitizepathname",
-      "label": "sanitizePathname()",
-      "norm_label": "sanitizepathname()",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L350"
-    },
-    {
-      "community": 65,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_contexttracking_legacystorefrontanalytics_ts",
-      "label": "legacyStorefrontAnalytics.ts",
-      "norm_label": "legacystorefrontanalytics.ts",
-      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 650,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
@@ -250993,7 +250786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 649,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -251002,7 +250795,7 @@
       "source_location": "L24"
     },
     {
-      "community": 650,
+      "community": 649,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -251011,7 +250804,7 @@
       "source_location": "L16"
     },
     {
-      "community": 650,
+      "community": 649,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -251020,7 +250813,232 @@
       "source_location": "L6"
     },
     {
-      "community": 651,
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_appendlistsection",
+      "label": "appendListSection()",
+      "norm_label": "appendlistsection()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L609"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_buildmarkdownbundle",
+      "label": "buildMarkdownBundle()",
+      "norm_label": "buildmarkdownbundle()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L628"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_collectcoverage",
+      "label": "collectCoverage()",
+      "norm_label": "collectcoverage()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L398"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_evaluategraphifyfreshness",
+      "label": "evaluateGraphifyFreshness()",
+      "norm_label": "evaluategraphifyfreshness()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L532"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_fileexists",
+      "label": "fileExists()",
+      "norm_label": "fileexists()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L144"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_formatvalidationcommand",
+      "label": "formatValidationCommand()",
+      "norm_label": "formatvalidationcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_getchangedfilesfromgit",
+      "label": "getChangedFilesFromGit()",
+      "norm_label": "getchangedfilesfromgit()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_islikelycodeorconfig",
+      "label": "isLikelyCodeOrConfig()",
+      "norm_label": "islikelycodeorconfig()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L493"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_islocalgeneratedartifactpath",
+      "label": "isLocalGeneratedArtifactPath()",
+      "norm_label": "islocalgeneratedartifactpath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L523"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_isworktreemetadatapath",
+      "label": "isWorktreeMetadataPath()",
+      "norm_label": "isworktreemetadatapath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L514"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_loadselfreviewtarget",
+      "label": "loadSelfReviewTarget()",
+      "norm_label": "loadselfreviewtarget()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L247"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_loadselfreviewtargets",
+      "label": "loadSelfReviewTargets()",
+      "norm_label": "loadselfreviewtargets()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L379"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_matchespathprefix",
+      "label": "matchesPathPrefix()",
+      "norm_label": "matchespathprefix()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_normalizebehaviorscenarioname",
+      "label": "normalizeBehaviorScenarioName()",
+      "norm_label": "normalizebehaviorscenarioname()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_normalizerepopath",
+      "label": "normalizeRepoPath()",
+      "norm_label": "normalizerepopath()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L96"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_normalizevalidationcommand",
+      "label": "normalizeValidationCommand()",
+      "norm_label": "normalizevalidationcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_parsecliarguments",
+      "label": "parseCliArguments()",
+      "norm_label": "parsecliarguments()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L801"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_parseruntimescenarios",
+      "label": "parseRuntimeScenarios()",
+      "norm_label": "parseruntimescenarios()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_quotecode",
+      "label": "quoteCode()",
+      "norm_label": "quotecode()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_readjsonfile",
+      "label": "readJsonFile()",
+      "norm_label": "readjsonfile()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_runharnessselfreview",
+      "label": "runHarnessSelfReview()",
+      "norm_label": "runharnessselfreview()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L850"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_runquietharnesscheck",
+      "label": "runQuietHarnessCheck()",
+      "norm_label": "runquietharnesscheck()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L600"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "harness_self_review_sortuniquepaths",
+      "label": "sortUniquePaths()",
+      "norm_label": "sortuniquepaths()",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L100"
+    },
+    {
+      "community": 65,
+      "file_type": "code",
+      "id": "scripts_harness_self_review_ts",
+      "label": "harness-self-review.ts",
+      "norm_label": "harness-self-review.ts",
+      "source_file": "scripts/harness-self-review.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -251029,7 +251047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 650,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -251038,7 +251056,7 @@
       "source_location": "L115"
     },
     {
-      "community": 651,
+      "community": 650,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -251047,7 +251065,7 @@
       "source_location": "L219"
     },
     {
-      "community": 651,
+      "community": 650,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -251056,7 +251074,7 @@
       "source_location": "L190"
     },
     {
-      "community": 652,
+      "community": 651,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -251065,7 +251083,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 651,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -251074,7 +251092,7 @@
       "source_location": "L10"
     },
     {
-      "community": 652,
+      "community": 651,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -251083,7 +251101,7 @@
       "source_location": "L16"
     },
     {
-      "community": 652,
+      "community": 651,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -251092,7 +251110,7 @@
       "source_location": "L4"
     },
     {
-      "community": 653,
+      "community": 652,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -251101,7 +251119,7 @@
       "source_location": "L387"
     },
     {
-      "community": 653,
+      "community": 652,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -251110,7 +251128,7 @@
       "source_location": "L407"
     },
     {
-      "community": 653,
+      "community": 652,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -251119,7 +251137,7 @@
       "source_location": "L282"
     },
     {
-      "community": 653,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -251128,7 +251146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -251137,7 +251155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 653,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -251146,7 +251164,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 654,
+      "community": 653,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -251155,7 +251173,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 654,
+      "community": 653,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -251164,7 +251182,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 655,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -251173,7 +251191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 654,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -251182,7 +251200,7 @@
       "source_location": "L177"
     },
     {
-      "community": 655,
+      "community": 654,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -251191,13 +251209,49 @@
       "source_location": "L68"
     },
     {
-      "community": 655,
+      "community": 654,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 655,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 656,
@@ -251346,217 +251400,217 @@
     {
       "community": 66,
       "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_actorfordirection",
-      "label": "actorForDirection()",
-      "norm_label": "actorfordirection()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L90"
+      "id": "legacystorefrontanalytics_buildcartchange",
+      "label": "buildCartChange()",
+      "norm_label": "buildcartchange()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L239"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_applycostoverlayrowwithctx",
-      "label": "applyCostOverlayRowWithCtx()",
-      "norm_label": "applycostoverlayrowwithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L393"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_assertcostoverlayworkfence",
-      "label": "assertCostOverlayWorkFence()",
-      "norm_label": "assertcostoverlayworkfence()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L28"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_classifycostoverlayundorowwithctx",
-      "label": "classifyCostOverlayUndoRowWithCtx()",
-      "norm_label": "classifycostoverlayundorowwithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L269"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_costoverlaypreparedimpact",
-      "label": "costOverlayPreparedImpact()",
-      "norm_label": "costoverlaypreparedimpact()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L123"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_finishorcontinue",
-      "label": "finishOrContinue()",
-      "norm_label": "finishorcontinue()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L829"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_getposition",
-      "label": "getPosition()",
-      "norm_label": "getposition()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L209"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_isexpectedvaluationdomainerror",
-      "label": "isExpectedValuationDomainError()",
-      "norm_label": "isexpectedvaluationdomainerror()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_isselectedcostoverlaydecision",
-      "label": "isSelectedCostOverlayDecision()",
-      "norm_label": "isselectedcostoverlaydecision()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L43"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_lineagedigest",
-      "label": "lineageDigest()",
-      "norm_label": "lineagedigest()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_markapplyexception",
-      "label": "markApplyException()",
-      "norm_label": "markapplyexception()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L373"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_markundoexception",
-      "label": "markUndoException()",
-      "norm_label": "markundoexception()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L533"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_mergelargestcostoverlayimpacts",
-      "label": "mergeLargestCostOverlayImpacts()",
-      "norm_label": "mergelargestcostoverlayimpacts()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_nextcostoverlayterminalstatus",
-      "label": "nextCostOverlayTerminalStatus()",
-      "norm_label": "nextcostoverlayterminalstatus()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_positionmatchespoststate",
-      "label": "positionMatchesPostState()",
-      "norm_label": "positionmatchespoststate()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_positionmatchesprestate",
-      "label": "positionMatchesPreState()",
-      "norm_label": "positionmatchesprestate()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L232"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_rollcostoverlaymanifestdigest",
-      "label": "rollCostOverlayManifestDigest()",
-      "norm_label": "rollcostoverlaymanifestdigest()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_rowfrozenlineages",
-      "label": "rowFrozenLineages()",
-      "norm_label": "rowfrozenlineages()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L71"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_safeadd",
-      "label": "safeAdd()",
-      "norm_label": "safeadd()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L105"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_safemultiply",
-      "label": "safeMultiply()",
-      "norm_label": "safemultiply()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L114"
-    },
-    {
-      "community": 66,
-      "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_schedulework",
-      "label": "scheduleWork()",
-      "norm_label": "schedulework()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "id": "legacystorefrontanalytics_buildlegacycontextpayload",
+      "label": "buildLegacyContextPayload()",
+      "norm_label": "buildlegacycontextpayload()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
       "source_location": "L177"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_undocostoverlayrowwithctx",
-      "label": "undoCostOverlayRowWithCtx()",
-      "norm_label": "undocostoverlayrowwithctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L553"
+      "id": "legacystorefrontanalytics_buildlegacyproductid",
+      "label": "buildLegacyProductId()",
+      "norm_label": "buildlegacyproductid()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L91"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "inventoryimportcostoverlaywork_valuationpositionquantitymatchesinventorycount",
-      "label": "valuationPositionQuantityMatchesInventoryCount()",
-      "norm_label": "valuationpositionquantitymatchesinventorycount()",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
-      "source_location": "L222"
+      "id": "legacystorefrontanalytics_compactpayload",
+      "label": "compactPayload()",
+      "norm_label": "compactpayload()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L249"
     },
     {
       "community": 66,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlaywork_ts",
-      "label": "inventoryImportCostOverlayWork.ts",
-      "norm_label": "inventoryimportcostoverlaywork.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "id": "legacystorefrontanalytics_compilelegacystorefrontanalyticsrow",
+      "label": "compileLegacyStorefrontAnalyticsRow()",
+      "norm_label": "compilelegacystorefrontanalyticsrow()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_compilelegacystorefrontanalyticsrows",
+      "label": "compileLegacyStorefrontAnalyticsRows()",
+      "norm_label": "compilelegacystorefrontanalyticsrows()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_compilelegacystorefrontanalyticsrowswithreport",
+      "label": "compileLegacyStorefrontAnalyticsRowsWithReport()",
+      "norm_label": "compilelegacystorefrontanalyticsrowswithreport()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_containssensitivetext",
+      "label": "containsSensitiveText()",
+      "norm_label": "containssensitivetext()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L339"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_ismissingrequiredpayload",
+      "label": "isMissingRequiredPayload()",
+      "norm_label": "ismissingrequiredpayload()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L224"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readcheckoutblocker",
+      "label": "readCheckoutBlocker()",
+      "norm_label": "readcheckoutblocker()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L305"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readcheckoutstate",
+      "label": "readCheckoutState()",
+      "norm_label": "readcheckoutstate()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L300"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readnumber",
+      "label": "readNumber()",
+      "norm_label": "readnumber()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readrawstring",
+      "label": "readRawString()",
+      "norm_label": "readrawstring()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readreferrerorigin",
+      "label": "readReferrerOrigin()",
+      "norm_label": "readreferrerorigin()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L322"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readroutepath",
+      "label": "readRoutePath()",
+      "norm_label": "readroutepath()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L310"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readsafecampaign",
+      "label": "readSafeCampaign()",
+      "norm_label": "readsafecampaign()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readsafeid",
+      "label": "readSafeId()",
+      "norm_label": "readsafeid()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L280"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readsafeslug",
+      "label": "readSafeSlug()",
+      "norm_label": "readsafeslug()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L285"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readsafestatus",
+      "label": "readSafeStatus()",
+      "norm_label": "readsafestatus()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_readstring",
+      "label": "readString()",
+      "norm_label": "readstring()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L265"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_resolveobservabilitycontexteventid",
+      "label": "resolveObservabilityContextEventId()",
+      "norm_label": "resolveobservabilitycontexteventid()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L158"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_resolvestorefrontcontexteventid",
+      "label": "resolveStorefrontContextEventId()",
+      "norm_label": "resolvestorefrontcontexteventid()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "legacystorefrontanalytics_sanitizepathname",
+      "label": "sanitizePathname()",
+      "norm_label": "sanitizepathname()",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
+      "source_location": "L350"
+    },
+    {
+      "community": 66,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_contexttracking_legacystorefrontanalytics_ts",
+      "label": "legacyStorefrontAnalytics.ts",
+      "norm_label": "legacystorefrontanalytics.ts",
+      "source_file": "packages/athena-webapp/convex/contextTracking/legacyStorefrontAnalytics.ts",
       "source_location": "L1"
     },
     {
@@ -251922,218 +251976,218 @@
     {
       "community": 67,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_skusearch_ts",
-      "label": "skuSearch.ts",
-      "norm_label": "skusearch.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L1"
+      "id": "inventoryimportcostoverlaywork_actorfordirection",
+      "label": "actorForDirection()",
+      "norm_label": "actorfordirection()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L90"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_buildproductskusearchprojection",
-      "label": "buildProductSkuSearchProjection()",
-      "norm_label": "buildproductskusearchprojection()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L287"
+      "id": "inventoryimportcostoverlaywork_applycostoverlayrowwithctx",
+      "label": "applyCostOverlayRowWithCtx()",
+      "norm_label": "applycostoverlayrowwithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L393"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_buildsearchtext",
-      "label": "buildSearchText()",
-      "norm_label": "buildsearchtext()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L249"
+      "id": "inventoryimportcostoverlaywork_assertcostoverlayworkfence",
+      "label": "assertCostOverlayWorkFence()",
+      "norm_label": "assertcostoverlayworkfence()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L28"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_capped",
-      "label": "capped()",
-      "norm_label": "capped()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L218"
+      "id": "inventoryimportcostoverlaywork_classifycostoverlayundorowwithctx",
+      "label": "classifyCostOverlayUndoRowWithCtx()",
+      "norm_label": "classifycostoverlayundorowwithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L269"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_hydratecanonicalprojection",
-      "label": "hydrateCanonicalProjection()",
-      "norm_label": "hydratecanonicalprojection()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L801"
+      "id": "inventoryimportcostoverlaywork_costoverlaypreparedimpact",
+      "label": "costOverlayPreparedImpact()",
+      "norm_label": "costoverlaypreparedimpact()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L123"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_isregistercatalogprojectionincluded",
-      "label": "isRegisterCatalogProjectionIncluded()",
-      "norm_label": "isregistercatalogprojectionincluded()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L394"
+      "id": "inventoryimportcostoverlaywork_finishorcontinue",
+      "label": "finishOrContinue()",
+      "norm_label": "finishorcontinue()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L829"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_mapprojectiontoresult",
-      "label": "mapProjectionToResult()",
-      "norm_label": "mapprojectiontoresult()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L711"
+      "id": "inventoryimportcostoverlaywork_getposition",
+      "label": "getPosition()",
+      "norm_label": "getposition()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L209"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_normalizeattributes",
-      "label": "normalizeAttributes()",
-      "norm_label": "normalizeattributes()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L228"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_normalizelookup",
-      "label": "normalizeLookup()",
-      "norm_label": "normalizelookup()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L213"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_projectionsequal",
-      "label": "projectionsEqual()",
-      "norm_label": "projectionsequal()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_refreshproductskusearchforcategory",
-      "label": "refreshProductSkuSearchForCategory()",
-      "norm_label": "refreshproductskusearchforcategory()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L634"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_refreshproductskusearchforcolor",
-      "label": "refreshProductSkuSearchForColor()",
-      "norm_label": "refreshproductskusearchforcolor()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L682"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_refreshproductskusearchforproduct",
-      "label": "refreshProductSkuSearchForProduct()",
-      "norm_label": "refreshproductskusearchforproduct()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L593"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_refreshproductskusearchforsubcategory",
-      "label": "refreshProductSkuSearchForSubcategory()",
-      "norm_label": "refreshproductskusearchforsubcategory()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L658"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_registercatalogprojectionsequal",
-      "label": "registerCatalogProjectionsEqual()",
-      "norm_label": "registercatalogprojectionsequal()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L415"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_removeproductskusearchprojection",
-      "label": "removeProductSkuSearchProjection()",
-      "norm_label": "removeproductskusearchprojection()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L533"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_removeproductskusearchprojections",
-      "label": "removeProductSkuSearchProjections()",
-      "norm_label": "removeproductskusearchprojections()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L574"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_requireproductskusearchaccess",
-      "label": "requireProductSkuSearchAccess()",
-      "norm_label": "requireproductskusearchaccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 67,
-      "file_type": "code",
-      "id": "skusearch_requireproductskusearchadmin",
-      "label": "requireProductSkuSearchAdmin()",
-      "norm_label": "requireproductskusearchadmin()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "id": "inventoryimportcostoverlaywork_isexpectedvaluationdomainerror",
+      "label": "isExpectedValuationDomainError()",
+      "norm_label": "isexpectedvaluationdomainerror()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
       "source_location": "L170"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_requireproductskusearchreadaccess",
-      "label": "requireProductSkuSearchReadAccess()",
-      "norm_label": "requireproductskusearchreadaccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L180"
+      "id": "inventoryimportcostoverlaywork_isselectedcostoverlaydecision",
+      "label": "isSelectedCostOverlayDecision()",
+      "norm_label": "isselectedcostoverlaydecision()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L43"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_syncproductskusearchforproduct",
-      "label": "syncProductSkuSearchForProduct()",
-      "norm_label": "syncproductskusearchforproduct()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L619"
+      "id": "inventoryimportcostoverlaywork_lineagedigest",
+      "label": "lineageDigest()",
+      "norm_label": "lineagedigest()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L83"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_syncproductskusearchprojection",
-      "label": "syncProductSkuSearchProjection()",
-      "norm_label": "syncproductskusearchprojection()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L461"
+      "id": "inventoryimportcostoverlaywork_markapplyexception",
+      "label": "markApplyException()",
+      "norm_label": "markapplyexception()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L373"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_upsertproductskusearchprojection",
-      "label": "upsertProductSkuSearchProjection()",
-      "norm_label": "upsertproductskusearchprojection()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L518"
+      "id": "inventoryimportcostoverlaywork_markundoexception",
+      "label": "markUndoException()",
+      "norm_label": "markundoexception()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L533"
     },
     {
       "community": 67,
       "file_type": "code",
-      "id": "skusearch_upsertproductskusearchprojections",
-      "label": "upsertProductSkuSearchProjections()",
-      "norm_label": "upsertproductskusearchprojections()",
-      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
-      "source_location": "L556"
+      "id": "inventoryimportcostoverlaywork_mergelargestcostoverlayimpacts",
+      "label": "mergeLargestCostOverlayImpacts()",
+      "norm_label": "mergelargestcostoverlayimpacts()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_nextcostoverlayterminalstatus",
+      "label": "nextCostOverlayTerminalStatus()",
+      "norm_label": "nextcostoverlayterminalstatus()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_positionmatchespoststate",
+      "label": "positionMatchesPostState()",
+      "norm_label": "positionmatchespoststate()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_positionmatchesprestate",
+      "label": "positionMatchesPreState()",
+      "norm_label": "positionmatchesprestate()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L232"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_rollcostoverlaymanifestdigest",
+      "label": "rollCostOverlayManifestDigest()",
+      "norm_label": "rollcostoverlaymanifestdigest()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_rowfrozenlineages",
+      "label": "rowFrozenLineages()",
+      "norm_label": "rowfrozenlineages()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L71"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_safeadd",
+      "label": "safeAdd()",
+      "norm_label": "safeadd()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L105"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_safemultiply",
+      "label": "safeMultiply()",
+      "norm_label": "safemultiply()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_schedulework",
+      "label": "scheduleWork()",
+      "norm_label": "schedulework()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_undocostoverlayrowwithctx",
+      "label": "undoCostOverlayRowWithCtx()",
+      "norm_label": "undocostoverlayrowwithctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "inventoryimportcostoverlaywork_valuationpositionquantitymatchesinventorycount",
+      "label": "valuationPositionQuantityMatchesInventoryCount()",
+      "norm_label": "valuationpositionquantitymatchesinventorycount()",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L222"
+    },
+    {
+      "community": 67,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlaywork_ts",
+      "label": "inventoryImportCostOverlayWork.ts",
+      "norm_label": "inventoryimportcostoverlaywork.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/inventoryImportCostOverlayWork.ts",
+      "source_location": "L1"
     },
     {
       "community": 670,
@@ -252498,218 +252552,218 @@
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_adjustregistersessionexpectedcashforsettlement",
-      "label": "adjustRegisterSessionExpectedCashForSettlement()",
-      "norm_label": "adjustregistersessionexpectedcashforsettlement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L900"
+      "id": "packages_athena_webapp_convex_inventory_skusearch_ts",
+      "label": "skuSearch.ts",
+      "norm_label": "skusearch.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L1"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_adjusttransactionitems",
-      "label": "adjustTransactionItems()",
-      "norm_label": "adjusttransactionitems()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L1268"
+      "id": "skusearch_buildproductskusearchprojection",
+      "label": "buildProductSkuSearchProjection()",
+      "norm_label": "buildproductskusearchprojection()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L287"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_applyapprovedadjustment",
-      "label": "applyApprovedAdjustment()",
-      "norm_label": "applyapprovedadjustment()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L957"
+      "id": "skusearch_buildsearchtext",
+      "label": "buildSearchText()",
+      "norm_label": "buildsearchtext()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L249"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_applyinventorydeltas",
-      "label": "applyInventoryDeltas()",
-      "norm_label": "applyinventorydeltas()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L691"
+      "id": "skusearch_capped",
+      "label": "capped()",
+      "norm_label": "capped()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L218"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_assertpayloadmatchesplan",
-      "label": "assertPayloadMatchesPlan()",
-      "norm_label": "assertpayloadmatchesplan()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L116"
+      "id": "skusearch_hydratecanonicalprojection",
+      "label": "hydrateCanonicalProjection()",
+      "norm_label": "hydratecanonicalprojection()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L801"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_buildadjustmentapprovalrequirement",
-      "label": "buildAdjustmentApprovalRequirement()",
-      "norm_label": "buildadjustmentapprovalrequirement()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L268"
+      "id": "skusearch_isregistercatalogprojectionincluded",
+      "label": "isRegisterCatalogProjectionIncluded()",
+      "norm_label": "isregistercatalogprojectionincluded()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L394"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_buildserveradjustmentplan",
-      "label": "buildServerAdjustmentPlan()",
-      "norm_label": "buildserveradjustmentplan()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L163"
+      "id": "skusearch_mapprojectiontoresult",
+      "label": "mapProjectionToResult()",
+      "norm_label": "mapprojectiontoresult()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L711"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_consumeitemadjustmentapprovalproof",
-      "label": "consumeItemAdjustmentApprovalProof()",
-      "norm_label": "consumeitemadjustmentapprovalproof()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L662"
+      "id": "skusearch_normalizeattributes",
+      "label": "normalizeAttributes()",
+      "norm_label": "normalizeattributes()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L228"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_createapprovalrequestforadjustment",
-      "label": "createApprovalRequestForAdjustment()",
-      "norm_label": "createapprovalrequestforadjustment()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L449"
+      "id": "skusearch_normalizelookup",
+      "label": "normalizeLookup()",
+      "norm_label": "normalizelookup()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L213"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_findappliedadjustmentbyfingerprint",
-      "label": "findAppliedAdjustmentByFingerprint()",
-      "norm_label": "findappliedadjustmentbyfingerprint()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L335"
+      "id": "skusearch_projectionsequal",
+      "label": "projectionsEqual()",
+      "norm_label": "projectionsequal()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L374"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_findappliedadjustmentfortransaction",
-      "label": "findAppliedAdjustmentForTransaction()",
-      "norm_label": "findappliedadjustmentfortransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L571"
+      "id": "skusearch_refreshproductskusearchforcategory",
+      "label": "refreshProductSkuSearchForCategory()",
+      "norm_label": "refreshproductskusearchforcategory()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L634"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_findpendingitemadjustmentapprovalrequest",
-      "label": "findPendingItemAdjustmentApprovalRequest()",
-      "norm_label": "findpendingitemadjustmentapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L546"
+      "id": "skusearch_refreshproductskusearchforcolor",
+      "label": "refreshProductSkuSearchForColor()",
+      "norm_label": "refreshproductskusearchforcolor()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L682"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_getregistersessionfortrace",
-      "label": "getRegisterSessionForTrace()",
-      "norm_label": "getregistersessionfortrace()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L383"
+      "id": "skusearch_refreshproductskusearchforproduct",
+      "label": "refreshProductSkuSearchForProduct()",
+      "norm_label": "refreshproductskusearchforproduct()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L593"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_markpendingadjustmentdecisionforapprovalrequest",
-      "label": "markPendingAdjustmentDecisionForApprovalRequest()",
-      "norm_label": "markpendingadjustmentdecisionforapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L589"
+      "id": "skusearch_refreshproductskusearchforsubcategory",
+      "label": "refreshProductSkuSearchForSubcategory()",
+      "norm_label": "refreshproductskusearchforsubcategory()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L658"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_readpayloadfromapprovalrequestmetadata",
-      "label": "readPayloadFromApprovalRequestMetadata()",
-      "norm_label": "readpayloadfromapprovalrequestmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L1429"
+      "id": "skusearch_registercatalogprojectionsequal",
+      "label": "registerCatalogProjectionsEqual()",
+      "norm_label": "registercatalogprojectionsequal()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L415"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_reconcilestalependingadjustment",
-      "label": "reconcileStalePendingAdjustment()",
-      "norm_label": "reconcilestalependingadjustment()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L133"
+      "id": "skusearch_removeproductskusearchprojection",
+      "label": "removeProductSkuSearchProjection()",
+      "norm_label": "removeproductskusearchprojection()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L533"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_recorditemadjustmentregistersessiontrace",
-      "label": "recordItemAdjustmentRegisterSessionTrace()",
-      "norm_label": "recorditemadjustmentregistersessiontrace()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L403"
+      "id": "skusearch_removeproductskusearchprojections",
+      "label": "removeProductSkuSearchProjections()",
+      "norm_label": "removeproductskusearchprojections()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L574"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_recordsettlementpaymentallocation",
-      "label": "recordSettlementPaymentAllocation()",
-      "norm_label": "recordsettlementpaymentallocation()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L849"
+      "id": "skusearch_requireproductskusearchaccess",
+      "label": "requireProductSkuSearchAccess()",
+      "norm_label": "requireproductskusearchaccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L191"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_requirecompletedtransaction",
-      "label": "requireCompletedTransaction()",
-      "norm_label": "requirecompletedtransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L318"
+      "id": "skusearch_requireproductskusearchadmin",
+      "label": "requireProductSkuSearchAdmin()",
+      "norm_label": "requireproductskusearchadmin()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L170"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_requirematchingpendingitemadjustmentapprovalrequest",
-      "label": "requireMatchingPendingItemAdjustmentApprovalRequest()",
-      "norm_label": "requirematchingpendingitemadjustmentapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "id": "skusearch_requireproductskusearchreadaccess",
+      "label": "requireProductSkuSearchReadAccess()",
+      "norm_label": "requireproductskusearchreadaccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L180"
+    },
+    {
+      "community": 68,
+      "file_type": "code",
+      "id": "skusearch_syncproductskusearchforproduct",
+      "label": "syncProductSkuSearchForProduct()",
+      "norm_label": "syncproductskusearchforproduct()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
       "source_location": "L619"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_resolvetransactionitemadjustmentapprovaldecisionwithctx",
-      "label": "resolveTransactionItemAdjustmentApprovalDecisionWithCtx()",
-      "norm_label": "resolvetransactionitemadjustmentapprovaldecisionwithctx()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L1441"
+      "id": "skusearch_syncproductskusearchprojection",
+      "label": "syncProductSkuSearchProjection()",
+      "norm_label": "syncproductskusearchprojection()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L461"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_roundamount",
-      "label": "roundAmount()",
-      "norm_label": "roundamount()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L108"
+      "id": "skusearch_upsertproductskusearchprojection",
+      "label": "upsertProductSkuSearchProjection()",
+      "norm_label": "upsertproductskusearchprojection()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L518"
     },
     {
       "community": 68,
       "file_type": "code",
-      "id": "adjusttransactionitems_transactionlabel",
-      "label": "transactionLabel()",
-      "norm_label": "transactionlabel()",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L112"
-    },
-    {
-      "community": 68,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_adjusttransactionitems_ts",
-      "label": "adjustTransactionItems.ts",
-      "norm_label": "adjusttransactionitems.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
-      "source_location": "L1"
+      "id": "skusearch_upsertproductskusearchprojections",
+      "label": "upsertProductSkuSearchProjections()",
+      "norm_label": "upsertproductskusearchprojections()",
+      "source_file": "packages/athena-webapp/convex/inventory/skuSearch.ts",
+      "source_location": "L556"
     },
     {
       "community": 680,
@@ -253074,217 +253128,217 @@
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_findcurrentstoredayopening",
-      "label": "findCurrentStoreDayOpening()",
-      "norm_label": "findcurrentstoredayopening()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L868"
+      "id": "adjusttransactionitems_adjustregistersessionexpectedcashforsettlement",
+      "label": "adjustRegisterSessionExpectedCashForSettlement()",
+      "norm_label": "adjustregistersessionexpectedcashforsettlement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L900"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_findlateststoredayopening",
-      "label": "findLatestStoreDayOpening()",
-      "norm_label": "findlateststoredayopening()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L917"
+      "id": "adjusttransactionitems_adjusttransactionitems",
+      "label": "adjustTransactionItems()",
+      "norm_label": "adjusttransactionitems()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L1268"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_getcompletedtransactions",
-      "label": "getCompletedTransactions()",
-      "norm_label": "getcompletedtransactions()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L358"
+      "id": "adjusttransactionitems_applyapprovedadjustment",
+      "label": "applyApprovedAdjustment()",
+      "norm_label": "applyapprovedadjustment()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L957"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_getpaymentmethods",
-      "label": "getPaymentMethods()",
-      "norm_label": "getpaymentmethods()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L106"
+      "id": "adjusttransactionitems_applyinventorydeltas",
+      "label": "applyInventoryDeltas()",
+      "norm_label": "applyinventorydeltas()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L691"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_getrecenttransactionswithcustomers",
-      "label": "getRecentTransactionsWithCustomers()",
-      "norm_label": "getrecenttransactionswithcustomers()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L702"
+      "id": "adjusttransactionitems_assertpayloadmatchesplan",
+      "label": "assertPayloadMatchesPlan()",
+      "norm_label": "assertpayloadmatchesplan()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L116"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_gettodaysummary",
-      "label": "getTodaySummary()",
-      "norm_label": "gettodaysummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L737"
+      "id": "adjusttransactionitems_buildadjustmentapprovalrequirement",
+      "label": "buildAdjustmentApprovalRequirement()",
+      "norm_label": "buildadjustmentapprovalrequirement()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L268"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_gettransaction",
-      "label": "getTransaction()",
-      "norm_label": "gettransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L333"
+      "id": "adjusttransactionitems_buildserveradjustmentplan",
+      "label": "buildServerAdjustmentPlan()",
+      "norm_label": "buildserveradjustmentplan()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L163"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_gettransactionbyid",
-      "label": "getTransactionById()",
-      "norm_label": "gettransactionbyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L451"
+      "id": "adjusttransactionitems_consumeitemadjustmentapprovalproof",
+      "label": "consumeItemAdjustmentApprovalProof()",
+      "norm_label": "consumeitemadjustmentapprovalproof()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L662"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_gettransactionsbystore",
-      "label": "getTransactionsByStore()",
-      "norm_label": "gettransactionsbystore()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L348"
+      "id": "adjusttransactionitems_createapprovalrequestforadjustment",
+      "label": "createApprovalRequestForAdjustment()",
+      "norm_label": "createapprovalrequestforadjustment()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L449"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_isactivepossummaryopeningat",
-      "label": "isActivePosSummaryOpeningAt()",
-      "norm_label": "isactivepossummaryopeningat()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L949"
+      "id": "adjusttransactionitems_findappliedadjustmentbyfingerprint",
+      "label": "findAppliedAdjustmentByFingerprint()",
+      "norm_label": "findappliedadjustmentbyfingerprint()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L335"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_isvalidpossummarywindowrange",
-      "label": "isValidPosSummaryWindowRange()",
-      "norm_label": "isvalidpossummarywindowrange()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L851"
+      "id": "adjusttransactionitems_findappliedadjustmentfortransaction",
+      "label": "findAppliedAdjustmentForTransaction()",
+      "norm_label": "findappliedadjustmentfortransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L571"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_listmixedservicelinesfortransaction",
-      "label": "listMixedServiceLinesForTransaction()",
-      "norm_label": "listmixedservicelinesfortransaction()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L284"
+      "id": "adjusttransactionitems_findpendingitemadjustmentapprovalrequest",
+      "label": "findPendingItemAdjustmentApprovalRequest()",
+      "norm_label": "findpendingitemadjustmentapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L546"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_liststaffnames",
-      "label": "listStaffNames()",
-      "norm_label": "liststaffnames()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L197"
+      "id": "adjusttransactionitems_getregistersessionfortrace",
+      "label": "getRegisterSessionForTrace()",
+      "norm_label": "getregistersessionfortrace()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L383"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_loadcorrectionevents",
-      "label": "loadCorrectionEvents()",
-      "norm_label": "loadcorrectionevents()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L119"
+      "id": "adjusttransactionitems_markpendingadjustmentdecisionforapprovalrequest",
+      "label": "markPendingAdjustmentDecisionForApprovalRequest()",
+      "norm_label": "markpendingadjustmentdecisionforapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L589"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_loadcustomerprofile",
-      "label": "loadCustomerProfile()",
-      "norm_label": "loadcustomerprofile()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L97"
+      "id": "adjusttransactionitems_readpayloadfromapprovalrequestmetadata",
+      "label": "readPayloadFromApprovalRequestMetadata()",
+      "norm_label": "readpayloadfromapprovalrequestmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L1429"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_loadpendingitemadjustmentapprovals",
-      "label": "loadPendingItemAdjustmentApprovals()",
-      "norm_label": "loadpendingitemadjustmentapprovals()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L138"
+      "id": "adjusttransactionitems_reconcilestalependingadjustment",
+      "label": "reconcileStalePendingAdjustment()",
+      "norm_label": "reconcilestalependingadjustment()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L133"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_loadpendingvoidapprovalrequest",
-      "label": "loadPendingVoidApprovalRequest()",
-      "norm_label": "loadpendingvoidapprovalrequest()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L164"
+      "id": "adjusttransactionitems_recorditemadjustmentregistersessiontrace",
+      "label": "recordItemAdjustmentRegisterSessionTrace()",
+      "norm_label": "recorditemadjustmentregistersessiontrace()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L403"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_normalizeadjustmentlineitem",
-      "label": "normalizeAdjustmentLineItem()",
-      "norm_label": "normalizeadjustmentlineitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L224"
+      "id": "adjusttransactionitems_recordsettlementpaymentallocation",
+      "label": "recordSettlementPaymentAllocation()",
+      "norm_label": "recordsettlementpaymentallocation()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L849"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_normalizeadjustmentmetadata",
-      "label": "normalizeAdjustmentMetadata()",
-      "norm_label": "normalizeadjustmentmetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L245"
+      "id": "adjusttransactionitems_requirecompletedtransaction",
+      "label": "requireCompletedTransaction()",
+      "norm_label": "requirecompletedtransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L318"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_numberfrommetadata",
-      "label": "numberFromMetadata()",
-      "norm_label": "numberfrommetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L214"
+      "id": "adjusttransactionitems_requirematchingpendingitemadjustmentapprovalrequest",
+      "label": "requireMatchingPendingItemAdjustmentApprovalRequest()",
+      "norm_label": "requirematchingpendingitemadjustmentapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L619"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_resolvecurrentpossummarywindow",
-      "label": "resolveCurrentPosSummaryWindow()",
-      "norm_label": "resolvecurrentpossummarywindow()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L797"
+      "id": "adjusttransactionitems_resolvetransactionitemadjustmentapprovaldecisionwithctx",
+      "label": "resolveTransactionItemAdjustmentApprovalDecisionWithCtx()",
+      "norm_label": "resolvetransactionitemadjustmentapprovaldecisionwithctx()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L1441"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_stringfrommetadata",
-      "label": "stringFromMetadata()",
-      "norm_label": "stringfrommetadata()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L220"
+      "id": "adjusttransactionitems_roundamount",
+      "label": "roundAmount()",
+      "norm_label": "roundamount()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L108"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "gettransactions_summarizecashiername",
-      "label": "summarizeCashierName()",
-      "norm_label": "summarizecashiername()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
-      "source_location": "L67"
+      "id": "adjusttransactionitems_transactionlabel",
+      "label": "transactionLabel()",
+      "norm_label": "transactionlabel()",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
+      "source_location": "L112"
     },
     {
       "community": 69,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
-      "label": "getTransactions.ts",
-      "norm_label": "gettransactions.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "id": "packages_athena_webapp_convex_pos_application_commands_adjusttransactionitems_ts",
+      "label": "adjustTransactionItems.ts",
+      "norm_label": "adjusttransactionitems.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/adjustTransactionItems.ts",
       "source_location": "L1"
     },
     {
@@ -254280,218 +254334,218 @@
     {
       "community": 70,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verify_ts",
-      "label": "verify.ts",
-      "norm_label": "verify.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
+      "id": "gettransactions_findcurrentstoredayopening",
+      "label": "findCurrentStoreDayOpening()",
+      "norm_label": "findcurrentstoredayopening()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L868"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_findlateststoredayopening",
+      "label": "findLatestStoreDayOpening()",
+      "norm_label": "findlateststoredayopening()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L917"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_getcompletedtransactions",
+      "label": "getCompletedTransactions()",
+      "norm_label": "getcompletedtransactions()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_getpaymentmethods",
+      "label": "getPaymentMethods()",
+      "norm_label": "getpaymentmethods()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L106"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_getrecenttransactionswithcustomers",
+      "label": "getRecentTransactionsWithCustomers()",
+      "norm_label": "getrecenttransactionswithcustomers()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L702"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_gettodaysummary",
+      "label": "getTodaySummary()",
+      "norm_label": "gettodaysummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L737"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_gettransaction",
+      "label": "getTransaction()",
+      "norm_label": "gettransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L333"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionbyid",
+      "label": "getTransactionById()",
+      "norm_label": "gettransactionbyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L451"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_gettransactionsbystore",
+      "label": "getTransactionsByStore()",
+      "norm_label": "gettransactionsbystore()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L348"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_isactivepossummaryopeningat",
+      "label": "isActivePosSummaryOpeningAt()",
+      "norm_label": "isactivepossummaryopeningat()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L949"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_isvalidpossummarywindowrange",
+      "label": "isValidPosSummaryWindowRange()",
+      "norm_label": "isvalidpossummarywindowrange()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L851"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_listmixedservicelinesfortransaction",
+      "label": "listMixedServiceLinesForTransaction()",
+      "norm_label": "listmixedservicelinesfortransaction()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L284"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_liststaffnames",
+      "label": "listStaffNames()",
+      "norm_label": "liststaffnames()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_loadcorrectionevents",
+      "label": "loadCorrectionEvents()",
+      "norm_label": "loadcorrectionevents()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_loadcustomerprofile",
+      "label": "loadCustomerProfile()",
+      "norm_label": "loadcustomerprofile()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L97"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_loadpendingitemadjustmentapprovals",
+      "label": "loadPendingItemAdjustmentApprovals()",
+      "norm_label": "loadpendingitemadjustmentapprovals()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_loadpendingvoidapprovalrequest",
+      "label": "loadPendingVoidApprovalRequest()",
+      "norm_label": "loadpendingvoidapprovalrequest()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L164"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_normalizeadjustmentlineitem",
+      "label": "normalizeAdjustmentLineItem()",
+      "norm_label": "normalizeadjustmentlineitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L224"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_normalizeadjustmentmetadata",
+      "label": "normalizeAdjustmentMetadata()",
+      "norm_label": "normalizeadjustmentmetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L245"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_numberfrommetadata",
+      "label": "numberFromMetadata()",
+      "norm_label": "numberfrommetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_resolvecurrentpossummarywindow",
+      "label": "resolveCurrentPosSummaryWindow()",
+      "norm_label": "resolvecurrentpossummarywindow()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L797"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_stringfrommetadata",
+      "label": "stringFromMetadata()",
+      "norm_label": "stringfrommetadata()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L220"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "gettransactions_summarizecashiername",
+      "label": "summarizeCashierName()",
+      "norm_label": "summarizecashiername()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 70,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_gettransactions_ts",
+      "label": "getTransactions.ts",
+      "norm_label": "gettransactions.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/getTransactions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_accumulatepayment",
-      "label": "accumulatePayment()",
-      "norm_label": "accumulatepayment()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1253"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_addmetrics",
-      "label": "addMetrics()",
-      "norm_label": "addmetrics()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L276"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_candidatewindow",
-      "label": "candidateWindow()",
-      "norm_label": "candidatewindow()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_computeexpectedday",
-      "label": "computeExpectedDay()",
-      "norm_label": "computeexpectedday()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L309"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_diffmetrics",
-      "label": "diffMetrics()",
-      "norm_label": "diffmetrics()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L636"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_diffpaymentposture",
-      "label": "diffPaymentPosture()",
-      "norm_label": "diffpaymentposture()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L665"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_foldedmetrics",
-      "label": "foldedMetrics()",
-      "norm_label": "foldedmetrics()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L711"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_inventoryattentionagrees",
-      "label": "inventoryAttentionAgrees()",
-      "norm_label": "inventoryattentionagrees()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1132"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_isoweekday",
-      "label": "isoWeekday()",
-      "norm_label": "isoweekday()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L857"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_recomputeverifiedvariance",
-      "label": "recomputeVerifiedVariance()",
-      "norm_label": "recomputeverifiedvariance()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1198"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_recountopeninventoryreviewgroups",
-      "label": "recountOpenInventoryReviewGroups()",
-      "norm_label": "recountopeninventoryreviewgroups()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1058"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_resolveverifiedframe",
-      "label": "resolveVerifiedFrame()",
-      "norm_label": "resolveverifiedframe()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L911"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_schedulegoverning",
-      "label": "scheduleGoverning()",
-      "norm_label": "schedulegoverning()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L869"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_scheduleincludesdate",
-      "label": "scheduleIncludesDate()",
-      "norm_label": "scheduleincludesdate()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L894"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_shiftlocaldate",
-      "label": "shiftLocalDate()",
-      "norm_label": "shiftlocaldate()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L862"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_storedweeklypayment",
-      "label": "storedWeeklyPayment()",
-      "norm_label": "storedweeklypayment()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1283"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_verifyacceptedcloseposture",
-      "label": "verifyAcceptedClosePosture()",
-      "norm_label": "verifyacceptedcloseposture()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L966"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_verifycurrentweekwithctx",
-      "label": "verifyCurrentWeekWithCtx()",
-      "norm_label": "verifycurrentweekwithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1301"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_verifydaywithctx",
-      "label": "verifyDayWithCtx()",
-      "norm_label": "verifydaywithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L740"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_verifystoresummarywithctx",
-      "label": "verifyStoreSummaryWithCtx()",
-      "norm_label": "verifystoresummarywithctx()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L807"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_weeklyverifiedmetrics",
-      "label": "weeklyVerifiedMetrics()",
-      "norm_label": "weeklyverifiedmetrics()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L725"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_zerometrics",
-      "label": "zeroMetrics()",
-      "norm_label": "zerometrics()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L263"
-    },
-    {
-      "community": 70,
-      "file_type": "code",
-      "id": "verify_zeropaymentcomparable",
-      "label": "zeroPaymentComparable()",
-      "norm_label": "zeropaymentcomparable()",
-      "source_file": "packages/athena-webapp/convex/reports/verify.ts",
-      "source_location": "L1273"
     },
     {
       "community": 700,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2750
-- Graph nodes: 11383
-- Graph edges: 13957
+- Graph nodes: 11385
+- Graph edges: 13960
 - Communities: 2675
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/reports/verify.test.ts
+++ b/packages/athena-webapp/convex/reports/verify.test.ts
@@ -13,6 +13,8 @@ import {
   diffMetrics,
   VERIFY_MAX_DAYS,
   VERIFY_MAX_DOCS_PER_DOMAIN,
+  VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD,
+  VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS,
   verifyDayWithCtx,
   verifyStoreSummaryWithCtx,
 } from "./verify";
@@ -645,11 +647,72 @@ describe("verify — payment posture", () => {
     });
   });
 
-  it("refuses a period that itself exceeds the allocation cap", async () => {
+  /**
+   * REGRESSION — production, 2026-08-02.
+   *
+   * The allocation scan used to read `[startAt - 90d, endAt]` under the
+   * 500-doc per-domain cap. On the live store that window held 1,050 rows, so
+   * every day of the week returned `incomplete/source_cap_exceeded` and the
+   * payment posture was unreadable. In-period volume alone, well past the old
+   * cap, must now verify.
+   */
+  it("verifies a day whose in-period allocations exceed the old 500 cap", async () => {
+    const COLLECTIONS = 1_200;
+    expect(COLLECTIONS).toBeGreaterThan(VERIFY_MAX_DOCS_PER_DOMAIN);
     const t = convexTest(schema, modules);
     const seeded = await t.run(async (ctx) => {
       const store = await seedStore(ctx);
-      for (let index = 0; index <= VERIFY_MAX_DOCS_PER_DOMAIN; index += 1) {
+      for (let index = 0; index < COLLECTIONS; index += 1) {
+        await seedPaymentAllocation(ctx, store, {
+          amount: 100,
+          recordedAt: at("09:00") + index,
+          targetId: `inside-${index}`,
+        });
+      }
+      await seedPaymentAllocation(ctx, store, {
+        amount: 5_000,
+        direction: "out",
+        recordedAt: at("16:00"),
+        targetId: "refund",
+      });
+      return store;
+    });
+
+    await t.run(async (ctx: QueryCtx) => {
+      const result = await verifyDayWithCtx(ctx, seeded.storeId, DAY1);
+      expect(result.truncated).toBe(false);
+      expect(result.expected).toMatchObject({
+        paymentAllocatedMinor: 115_000,
+        paymentsCollectedMinor: 120_000,
+        paymentsRefundedMinor: 5_000,
+      });
+      expect(result.paymentPosture).toMatchObject({
+        allocationCoverage: "complete",
+        coveredMinor: 115_000,
+        eligibleMinor: 115_000,
+        omittedMinor: 0,
+        outcome: "complete",
+        reason: "complete",
+        reversalLookback: { outcome: "complete", reason: "complete" },
+        unsettledMinor: 0,
+      });
+      // Nothing was withheld: this is a full verification, not a partial one.
+      expect(result.unverifiedFields).toEqual([]);
+    });
+    // Deliberately large fixtures: these three tests seed thousands of
+    // allocations to exercise the real ceilings, which outruns the default
+    // 5s budget when the whole suite is competing for workers.
+  }, 60_000);
+
+  it("refuses a period that exceeds the in-period allocation ceiling", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const store = await seedStore(ctx);
+      for (
+        let index = 0;
+        index <= VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD;
+        index += 1
+      ) {
         await seedPaymentAllocation(ctx, store, {
           amount: 100,
           recordedAt: at("09:00") + index,
@@ -664,11 +727,110 @@ describe("verify — payment posture", () => {
       // A capped read is a lower bound, never a total that happens to agree.
       expect(result.truncated).toBe(true);
       expect(result.matches).toBe(false);
+      expect(result.expected.paymentsCollectedMinor).toBeLessThan(
+        (VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD + 1) * 100,
+      );
       expect(result.paymentPosture).toMatchObject({
         allocationCoverage: "unknown",
         outcome: "incomplete",
         reason: "source_cap_exceeded",
         unsettledMinor: null,
+      });
+      // Incomplete, therefore unverified — never presented as a difference.
+      expect(
+        result.differences.filter((difference) =>
+          difference.field.startsWith("payment"),
+        ),
+      ).toEqual([]);
+      expect(result.unverifiedFields).toContain("paymentsCollectedMinor");
+    });
+  }, 60_000);
+
+  it("degrades only reversal detection when the lookback bound is exhausted", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const store = await seedStore(ctx);
+      // A long allocation history inside the reversal lookback window.
+      for (
+        let index = 0;
+        index <= VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS;
+        index += 1
+      ) {
+        await seedPaymentAllocation(ctx, store, {
+          amount: 100,
+          recordedAt: at("09:00") - 30 * 86_400_000 + index,
+          targetId: `historical-${index}`,
+        });
+      }
+      await seedPaymentAllocation(ctx, store, {
+        amount: 9_000,
+        recordedAt: at("09:00"),
+        targetId: "inside",
+      });
+      return store;
+    });
+
+    await t.run(async (ctx: QueryCtx) => {
+      const result = await verifyDayWithCtx(ctx, seeded.storeId, DAY1);
+      // The in-period posture still verifies; only the reversal lane is bounded.
+      expect(result.truncated).toBe(false);
+      expect(result.expected.paymentsCollectedMinor).toBe(9_000);
+      expect(result.paymentPosture).toMatchObject({
+        outcome: "complete",
+        reason: "complete",
+        reversalLookback: {
+          outcome: "incomplete",
+          reason: "lookback_cap_exceeded",
+        },
+      });
+      // Collection cannot be moved by an unseen historical void; anything a
+      // missed reversal could move is withheld, and named.
+      expect(result.unverifiedFields).not.toContain("paymentsCollectedMinor");
+      expect(result.unverifiedFields).toEqual(
+        expect.arrayContaining([
+          "paymentAllocatedMinor",
+          "paymentAllocationCoverage",
+          "paymentsRefundedMinor",
+        ]),
+      );
+    });
+  }, 60_000);
+
+  it("detects a void landing in-period against an older allocation", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const store = await seedStore(ctx);
+      await seedPaymentAllocation(ctx, store, {
+        amount: 5_000,
+        recordedAt: at("09:00"),
+        targetId: "inside",
+      });
+      const olderId = await seedPaymentAllocation(ctx, store, {
+        amount: 3_000,
+        recordedAt: at("09:00") - 30 * 86_400_000,
+        status: "voided",
+        targetId: "older",
+      });
+      await ctx.db.patch("paymentAllocation", olderId, {
+        voidedAt: at("11:00"),
+      });
+      return store;
+    });
+
+    await t.run(async (ctx: QueryCtx) => {
+      const { expected, paymentPosture } = await computeExpectedDay(
+        ctx,
+        seeded.storeId,
+        DAY1,
+      );
+      expect(expected).toMatchObject({
+        paymentAllocatedMinor: 2_000,
+        paymentsCollectedMinor: 5_000,
+        paymentsRefundedMinor: 3_000,
+      });
+      expect(paymentPosture).toMatchObject({
+        outcome: "complete",
+        reversalLookback: { outcome: "complete" },
       });
     });
   });
@@ -703,6 +865,122 @@ describe("verify — payment posture", () => {
         reason: "invalid_allocation",
         unsettledMinor: null,
       });
+    });
+  });
+});
+
+/**
+ * REGRESSION — production, 2026-08-02.
+ *
+ * With the payment lane incomplete, `expected` fell back to 0 and the diff
+ * emitted `{ field: "paymentsCollectedMinor", expected: 0, actual: 396000 }`
+ * with `matches: false`. "We could not check" read exactly like "this is
+ * wrong", and a real mismatch was indistinguishable from a cap. These two
+ * tests are the proof that the cases are now distinguishable.
+ */
+describe("verify — unverified is not mismatched", () => {
+  /** A folded day carrying real payment totals and nothing else. */
+  async function seedFoldedPaymentDay(
+    ctx: MutationCtx,
+    seeded: SeededStore,
+    paymentsCollectedMinor: number,
+  ): Promise<void> {
+    await ctx.db.insert("reportDay", {
+      currency: "GHS",
+      factCount: 1,
+      flags: {
+        hasUncostedRevenue: false,
+        mixedCurrency: false,
+        quarantinedFactCount: 0,
+      },
+      foldVersion: 1,
+      grossProfitMinor: 0,
+      grossSalesMinor: 0,
+      lastFactRecordedAt: NOW,
+      netSalesMinor: 0,
+      operatingDate: DAY1,
+      paymentAllocatedMinor: paymentsCollectedMinor,
+      paymentPosture: {
+        allocatedMinor: paymentsCollectedMinor,
+        allocationCoverage: "complete",
+        allocationOmittedMinor: 0,
+        collectedMinor: paymentsCollectedMinor,
+        hasInvalidAllocation: false,
+        refundedMinor: 0,
+        unsettledMinor: 0,
+      },
+      paymentsCollectedMinor,
+      paymentsRefundedMinor: 0,
+      refundsMinor: 0,
+      status: "open",
+      storeId: seeded.storeId,
+      uncostedRevenueMinor: 0,
+      unitsReturned: 0,
+      unitsSold: 0,
+    });
+  }
+
+  it("withholds payment fields rather than diffing them against a fallback 0", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const store = await seedStore(ctx);
+      // An untimed legacy void: the payment lane cannot complete.
+      await seedPaymentAllocation(ctx, store, {
+        amount: 2_000,
+        recordedAt: at("09:00"),
+        status: "voided",
+        targetId: "legacy",
+      });
+      await seedFoldedPaymentDay(ctx, store, 396_000);
+      return store;
+    });
+
+    await t.run(async (ctx: QueryCtx) => {
+      const result = await verifyDayWithCtx(ctx, seeded.storeId, DAY1);
+      expect(result.paymentPosture.outcome).toBe("incomplete");
+      // Not one payment field may masquerade as a discrepancy.
+      expect(result.differences).toEqual([]);
+      expect(result.paymentDifferences).toEqual([]);
+      expect(result.unverifiedFields).toEqual(
+        expect.arrayContaining([
+          "paymentAllocatedMinor",
+          "paymentAllocationCoverage",
+          "paymentAllocationOmittedMinor",
+          "paymentHasInvalidAllocation",
+          "paymentUnsettledMinor",
+          "paymentsCollectedMinor",
+          "paymentsRefundedMinor",
+        ]),
+      );
+      // Everything CHECKED agreed — which is partial verification, not a
+      // clean bill of health, and the field list is what says so.
+      expect(result.matches).toBe(true);
+      expect(result.unverifiedFields.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("still reports a genuine payment mismatch when the lane completes", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const store = await seedStore(ctx);
+      await seedPaymentAllocation(ctx, store, {
+        amount: 9_000,
+        recordedAt: at("09:00"),
+        targetId: "settled",
+      });
+      await seedFoldedPaymentDay(ctx, store, 396_000);
+      return store;
+    });
+
+    await t.run(async (ctx: QueryCtx) => {
+      const result = await verifyDayWithCtx(ctx, seeded.storeId, DAY1);
+      expect(result.paymentPosture.outcome).toBe("complete");
+      expect(result.unverifiedFields).toEqual([]);
+      expect(result.differences).toEqual([
+        { actual: 396_000, expected: 9_000, field: "paymentsCollectedMinor" },
+        { actual: 396_000, expected: 9_000, field: "paymentAllocatedMinor" },
+      ]);
+      expect(result.matches).toBe(false);
     });
   });
 });

--- a/packages/athena-webapp/convex/reports/verify.ts
+++ b/packages/athena-webapp/convex/reports/verify.ts
@@ -72,6 +72,17 @@ import {
  *    result.
  *
  * ---------------------------------------------------------------------------
+ * UNVERIFIED IS NOT MISMATCHED
+ * ---------------------------------------------------------------------------
+ * A field whose source-side expectation could not be established is reported
+ * on `unverifiedFields`, never in `differences`. `matches: true` means
+ * "everything CHECKED agreed" — read it together with `unverifiedFields`, and
+ * treat `matches: true` plus a non-empty list as partial verification. The
+ * alternative, which this module used to do, was to fall back to an expected
+ * value of 0 and emit a difference against the real folded total: monitoring
+ * output in which a cap and a genuine data discrepancy are indistinguishable.
+ *
+ * ---------------------------------------------------------------------------
  * ESCALATION — void sign convention
  * ---------------------------------------------------------------------------
  * The POS emitter carries `void` amounts as POSITIVE magnitudes
@@ -117,23 +128,63 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const STOREFRONT_REFUND_LOOKBACK_MS = 90 * DAY_MS;
 
 /**
- * How far back an allocation may have been RECORDED and still contribute to the
- * target day.
+ * How far back an allocation may have been RECORDED and still have its
+ * REVERSAL land on the target day.
  *
  * `paymentAllocation` is indexed on `recordedAt` only, but a row contributes to
  * the day at two instants: its original event at `recordedAt`, and — when it is
  * voided with a server timestamp — its reversal at `voidedAt`. A row voided
- * today may therefore have been recorded well before today. This lookback is
- * the same device the storefront refund scan already uses: it keeps the read
- * bounded to the VERIFIED PERIOD rather than to the store's lifetime, so a
- * store's five-hundredth allocation ever does not make every later day
- * permanently unverifiable.
+ * today may therefore have been recorded well before today.
+ *
+ * This lookback governs ONLY the reversal-detection read. The allocations that
+ * carry the period's own payment posture are read by their own in-period scan
+ * (see `VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD`), so exhausting this window
+ * costs reversal detection and nothing else.
  *
  * KNOWN BLIND SPOT (deliberate): a reversal of a row recorded more than this
  * far in the past is invisible to the verifier. That is bounded staleness, not
  * a silent partial total — the same trade the storefront lane documents.
  */
 const PAYMENT_VOID_LOOKBACK_MS = 90 * DAY_MS;
+
+/**
+ * Payment allocation ceilings.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY TWO NUMBERS AND NOT `VERIFY_MAX_DOCS_PER_DOMAIN`
+ * ---------------------------------------------------------------------------
+ * Until 2026-08-02 the payment lane read `[startAt - 90d, endAt]` under the
+ * 500-doc per-domain cap. Measured on production (Wigclub, store
+ * nn7byz68a3j4tfjvgdf9evpt3n78kk38, 2026-08-02) that window held 1,050 rows —
+ * roughly 12 allocations/day — so EVERY day of the week returned
+ * `incomplete/source_cap_exceeded` and the whole payment posture became
+ * unreadable, even though the rows the period actually needed numbered in the
+ * dozens. One over-wide read was costing the entire lane.
+ *
+ * The scan is now two reads with separate bounds, because they answer
+ * different questions and fail differently:
+ *
+ *  - IN-PERIOD (`recordedAt` within the candidate window): the rows that carry
+ *    the period's payment posture. The candidate window is one operating day
+ *    plus ±18h of slack, i.e. ~2.5 days ≈ 30 rows at the measured rate. The
+ *    ceiling is 5,000 — ~2,000 allocations/day, ~165x the measured rate and
+ *    10x the old per-domain cap. Exceeding it is an honest `incomplete`,
+ *    because a partial in-period read is a lower bound, never a total.
+ *
+ *  - REVERSAL LOOKBACK (`recordedAt` before the window, back
+ *    `PAYMENT_VOID_LOOKBACK_MS`): read newest-first, since a row voided in the
+ *    period is far likelier to be recent. 90 days at the measured 12/day is
+ *    ~1,080 rows; the ceiling is 3,000 — ~33/day, ~2.8x measured. Exceeding it
+ *    degrades ONLY reversal detection (see `VerifyPaymentPosture.reversalLookback`),
+ *    never the in-period posture.
+ *
+ * Read budget for the payment lane, per day: at most
+ * (5,000 + 1) + (3,000 + 1) index-backed documents, and in practice the
+ * measured ~30. Both reads are `.take`-bounded range scans on
+ * `by_storeId_recordedAt`; neither collects.
+ */
+export const VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD = 5_000;
+export const VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS = 3_000;
 
 // ---------------------------------------------------------------------------
 // Result shapes
@@ -176,6 +227,21 @@ export type VerifyPaymentPosture = {
   unsettledMinor: number | null;
   allocationCoverage: "complete" | "unknown";
   hasInvalidAllocation: boolean;
+  /**
+   * The reversal-detection lane, reported on its own so that a store with a
+   * long allocation history still gets a verified IN-PERIOD posture.
+   *
+   * `incomplete` means: allocations recorded before the period exceeded
+   * `VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS`, so a void landing in the
+   * period against an older allocation may have gone unseen. Everything
+   * derived from in-period rows alone (`paymentsCollectedMinor`) still holds;
+   * everything a missed reversal could move is reported as unverified rather
+   * than as a difference.
+   */
+  reversalLookback: {
+    outcome: "complete" | "incomplete";
+    reason: "complete" | "lookback_cap_exceeded";
+  };
 };
 
 export type VerifyPaymentDifference = {
@@ -194,8 +260,66 @@ export type VerifyDifference = {
   actual: number;
 };
 
+/**
+ * Fields whose source-side expectation can be UNKNOWN rather than wrong.
+ *
+ * An unchecked field is not a differing field. Everything named here is
+ * payment-side, because the payment lane is the only one whose expectation can
+ * be withheld while the rest of the day still verifies.
+ */
+export const VERIFY_PAYMENT_METRIC_KEYS = [
+  "paymentsCollectedMinor",
+  "paymentsRefundedMinor",
+  "paymentAllocatedMinor",
+] as const satisfies readonly (keyof VerifiedMetrics)[];
+
+export const VERIFY_PAYMENT_POSTURE_FIELDS = [
+  "paymentUnsettledMinor",
+  "paymentAllocationCoverage",
+  "paymentAllocationOmittedMinor",
+  "paymentHasInvalidAllocation",
+] as const satisfies readonly VerifyPaymentDifference["field"][];
+
+export type VerifyUnverifiedField =
+  | (typeof VERIFY_PAYMENT_METRIC_KEYS)[number]
+  | (typeof VERIFY_PAYMENT_POSTURE_FIELDS)[number];
+
+/**
+ * Which fields this posture declines to make a claim about.
+ *
+ * Two distinct degradations, deliberately unequal:
+ *  - the in-period lane did not complete → nothing payment-side was checked;
+ *  - only the reversal lookback was exhausted → in-period COLLECTION still
+ *    holds (it cannot be moved by an unseen historical void), but anything a
+ *    missed reversal could move — refunds, allocation, and every posture field
+ *    derived from them — is withheld.
+ */
+export function unverifiedPaymentFields(
+  posture: VerifyPaymentPosture,
+): VerifyUnverifiedField[] {
+  if (posture.outcome === "incomplete") {
+    return [...VERIFY_PAYMENT_METRIC_KEYS, ...VERIFY_PAYMENT_POSTURE_FIELDS];
+  }
+  if (posture.reversalLookback.outcome === "incomplete") {
+    return [
+      ...VERIFY_PAYMENT_METRIC_KEYS.filter(
+        (field) => field !== "paymentsCollectedMinor",
+      ),
+      ...VERIFY_PAYMENT_POSTURE_FIELDS,
+    ];
+  }
+  return [];
+}
+
 export type VerifyDayResult = {
   operatingDate: string;
+  /**
+   * Everything CHECKED agreed.
+   *
+   * `matches: true` with a non-empty `unverifiedFields` is PARTIAL
+   * verification, not a clean bill of health: the named fields were never
+   * compared. Alerting must read the two together.
+   */
   matches: boolean;
   differences: VerifyDifference[];
   factCount: number;
@@ -203,6 +327,13 @@ export type VerifyDayResult = {
   expected: VerifiedMetrics;
   paymentPosture: VerifyPaymentPosture;
   paymentDifferences: VerifyPaymentDifference[];
+  /**
+   * Fields no comparison was made on, because the source side could not be
+   * established. These NEVER appear in `differences` or `paymentDifferences`
+   * and never flip `matches` — "we could not check payments" must not be
+   * readable as "payments are wrong".
+   */
+  unverifiedFields: VerifyUnverifiedField[];
   /** A domain scan hit its bound; `expected` is a lower bound, not a total. */
   truncated: boolean;
 };
@@ -229,9 +360,7 @@ export type VerifyCurrentWeekResult =
   | {
       outcome: "incomplete";
       reason:
-        | "payment_source_incomplete"
         | "source_cap_exceeded"
-        | "invalid_payment_allocation"
         /**
          * An oversized-group repair is actively re-keying Open Work. Group
          * identity is mid-flight, so an independent recount would compare two
@@ -247,12 +376,21 @@ export type VerifyCurrentWeekResult =
       cycleStartDate: string;
       cycleEndDate: string;
       daysChecked: number;
+      /**
+       * Everything CHECKED agreed. As on `VerifyDayResult`, `matches: true`
+       * alongside a non-empty `unverifiedFields` is partial verification.
+       */
       matches: boolean;
       scheduleMatches: boolean;
       includedDifferences: VerifyDifference[];
       outsideScheduleDifferences: VerifyDifference[];
       includedPaymentDifferences: VerifyPaymentDifference[];
       outsideSchedulePaymentDifferences: VerifyPaymentDifference[];
+      /**
+       * Union across the frame's days of the fields no comparison was made
+       * on. Excluded from every difference list above by construction.
+       */
+      unverifiedFields: VerifyUnverifiedField[];
       truncated: boolean;
       varianceMatches: boolean;
       closeMatches: boolean;
@@ -544,23 +682,51 @@ export async function computeExpectedDay(
   // does not consult report facts or the fold's posture helper. A voided row
   // preserves its original event at recordedAt and contributes a separate
   // reversal only at the server-stamped voidedAt.
-  const allocations = await ctx.db
+  //
+  // TWO reads, bounded independently — see the ceiling constants for the
+  // production arithmetic behind the numbers. The in-period read carries the
+  // period's posture; the lookback read exists solely to catch a void that
+  // lands in-period against an older allocation, and its exhaustion is
+  // reported as a reversal-detection limitation rather than as an unverifiable
+  // payment lane.
+  const inPeriodAllocations = await ctx.db
+    .query("paymentAllocation")
+    .withIndex("by_storeId_recordedAt", (q) =>
+      q
+        .eq("storeId", storeId)
+        .gte("recordedAt", startAt)
+        .lte("recordedAt", endAt),
+    )
+    .take(VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD + 1);
+  const inPeriodCapExceeded =
+    inPeriodAllocations.length > VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD;
+  // A partial in-period read is a lower bound, never a total that happens to
+  // agree, so it degrades the whole day the way any capped domain scan does.
+  if (inPeriodCapExceeded) truncated = true;
+
+  // Newest-first: a row voided during the period is far likelier to be recent,
+  // so when this read caps out the rows it keeps are the ones that matter.
+  const reversalLookbackProbe = await ctx.db
     .query("paymentAllocation")
     .withIndex("by_storeId_recordedAt", (q) =>
       q
         .eq("storeId", storeId)
         .gte("recordedAt", startAt - PAYMENT_VOID_LOOKBACK_MS)
-        .lte("recordedAt", endAt),
+        .lt("recordedAt", startAt),
     )
-    .take(VERIFY_MAX_DOCS_PER_DOMAIN + 1);
-  const paymentCapExceeded = allocations.length > VERIFY_MAX_DOCS_PER_DOMAIN;
-  if (paymentCapExceeded) truncated = true;
+    .order("desc")
+    .take(VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS + 1);
+  const reversalLookbackCapExceeded =
+    reversalLookbackProbe.length > VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS;
 
   let paymentIncompleteReason: VerifyPaymentPosture["reason"] | null =
-    paymentCapExceeded ? "source_cap_exceeded" : null;
+    inPeriodCapExceeded ? "source_cap_exceeded" : null;
   let paymentOmittedMinor = 0;
 
-  for (const allocation of allocations.slice(0, VERIFY_MAX_DOCS_PER_DOMAIN)) {
+  for (const allocation of inPeriodAllocations.slice(
+    0,
+    VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD,
+  )) {
     const amountMinor = Math.abs(allocation.amount);
     const originalIsOnTargetDay = await onTargetDay(allocation.recordedAt);
 
@@ -599,6 +765,30 @@ export async function computeExpectedDay(
     }
   }
 
+  // Rows recorded BEFORE the window contribute nothing but their reversal:
+  // their original event belongs to an earlier day by construction.
+  for (const allocation of reversalLookbackProbe.slice(
+    0,
+    VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS,
+  )) {
+    if (allocation.status !== "voided") continue;
+    const amountMinor = Math.abs(allocation.amount);
+    if (allocation.direction === "out") {
+      paymentIncompleteReason ??= "voided_refund_unsupported";
+      paymentOmittedMinor += amountMinor;
+      continue;
+    }
+    if (allocation.voidedAt === undefined) {
+      paymentIncompleteReason ??= "legacy_void_missing_timestamp";
+      paymentOmittedMinor += amountMinor;
+      continue;
+    }
+    if (await onTargetDay(allocation.voidedAt)) {
+      expected.paymentsRefundedMinor += amountMinor;
+      expected.paymentAllocatedMinor -= amountMinor;
+    }
+  }
+
   const eligibleMinor = Math.max(
     0,
     expected.paymentsCollectedMinor - expected.paymentsRefundedMinor,
@@ -623,6 +813,12 @@ export async function computeExpectedDay(
       : null,
     allocationCoverage: paymentComplete ? "complete" : "unknown",
     hasInvalidAllocation,
+    reversalLookback: {
+      outcome: reversalLookbackCapExceeded ? "incomplete" : "complete",
+      reason: reversalLookbackCapExceeded
+        ? "lookback_cap_exceeded"
+        : "complete",
+    },
   };
 
   return { expected, paymentPosture, truncated };
@@ -754,7 +950,13 @@ export async function verifyDayWithCtx(
     storeId,
     operatingDate,
   );
-  const differences = diffMetrics(expected, foldedMetrics(day));
+  // Withheld before diffing, not filtered after: a field the source side could
+  // not establish is never a candidate for disagreement.
+  const unverifiedFields = unverifiedPaymentFields(paymentPosture);
+  const unverified = new Set<string>(unverifiedFields);
+  const differences = diffMetrics(expected, foldedMetrics(day)).filter(
+    (difference) => !unverified.has(difference.field),
+  );
   const paymentDifferences = diffPaymentPosture(
     paymentPosture,
     day?.paymentPosture
@@ -766,7 +968,7 @@ export async function verifyDayWithCtx(
           paymentHasInvalidAllocation: day.paymentPosture.hasInvalidAllocation,
         }
       : null,
-  );
+  ).filter((difference) => !unverified.has(difference.field));
 
   return {
     dayStatus: day?.status ?? "missing",
@@ -774,12 +976,16 @@ export async function verifyDayWithCtx(
     expected,
     paymentDifferences,
     paymentPosture,
+    unverifiedFields,
     factCount: day?.factCount ?? 0,
+    // "Everything checked agreed". An incomplete payment lane no longer flips
+    // this on its own — it withdraws those fields from the comparison and says
+    // so in `unverifiedFields` instead. A capped in-period read still sets
+    // `truncated`, and a lower bound can never be blessed as a total.
     matches:
       !truncated &&
       differences.length === 0 &&
-      paymentDifferences.length === 0 &&
-      paymentPosture.outcome === "complete",
+      paymentDifferences.length === 0,
     operatingDate,
     truncated,
   };
@@ -1355,6 +1561,10 @@ export async function verifyCurrentWeekWithCtx(
   let includedPayment = zeroPaymentComparable();
   let outsideSchedulePayment = zeroPaymentComparable();
   const expectedNetByDate = new Map<string, number>();
+  // Union across the frame: one day that could not establish its payment
+  // source withholds that field for the week, because the weekly total is the
+  // sum of the days.
+  const unverified = new Set<VerifyUnverifiedField>();
   for (const date of period.dates) {
     const result = await computeExpectedDay(ctx, storeId, date.localDate);
     if (result.truncated) {
@@ -1368,19 +1578,11 @@ export async function verifyCurrentWeekWithCtx(
     }
     addMetrics(date.included ? included : outsideSchedule, result.expected);
     expectedNetByDate.set(date.localDate, result.expected.netSalesMinor);
-    if (result.paymentPosture.outcome === "incomplete") {
-      return {
-        cycleEndDate: current.cycleEndDate,
-        cycleStartDate: current.cycleStartDate,
-        daysChecked: period.dates.length,
-        outcome: "incomplete",
-        reason:
-          result.paymentPosture.reason === "source_cap_exceeded"
-            ? "source_cap_exceeded"
-            : result.paymentPosture.reason === "invalid_allocation"
-              ? "invalid_payment_allocation"
-              : "payment_source_incomplete",
-      };
+    // A day whose payment lane could not complete no longer sinks the whole
+    // week: it withdraws the fields it could not establish and the rest of the
+    // frame is still verified against sources.
+    for (const field of unverifiedPaymentFields(result.paymentPosture)) {
+      unverified.add(field);
     }
     if (date.included) {
       includedPayment = accumulatePayment(
@@ -1397,22 +1599,34 @@ export async function verifyCurrentWeekWithCtx(
 
   const projectedIncluded = weeklyVerifiedMetrics(current.included);
   const projectedOutside = weeklyVerifiedMetrics(current.outsideSchedule);
-  const includedDifferences = diffMetrics(included, projectedIncluded);
-  const outsideScheduleDifferences = diffMetrics(
+  const unverifiedFields = [...unverified];
+  const isChecked = (field: string) =>
+    !unverified.has(field as VerifyUnverifiedField);
+  /** Metric diffs with the withheld fields removed before anyone reads them. */
+  const checkedDifferences = (
+    expectedMetrics: VerifiedMetrics,
+    actualMetrics: VerifiedMetrics,
+  ): VerifyDifference[] =>
+    diffMetrics(expectedMetrics, actualMetrics).filter((difference) =>
+      isChecked(difference.field),
+    );
+  const includedDifferences = checkedDifferences(included, projectedIncluded);
+  const outsideScheduleDifferences = checkedDifferences(
     outsideSchedule,
     projectedOutside,
   );
   // Both sides are live: the expectation is accumulated from the day postures
   // recomputed above, and the actual side is what the weekly projection
-  // persisted. Every one of the four comparisons can fail.
+  // persisted. Every one of the four comparisons can fail — unless the day
+  // lanes withheld it, in which case it is unverified, not differing.
   const includedPaymentDifferences = diffPaymentPosture(
     includedPayment,
     storedWeeklyPayment(current.included),
-  );
+  ).filter((difference) => isChecked(difference.field));
   const outsideSchedulePaymentDifferences = diffPaymentPosture(
     outsideSchedulePayment,
     storedWeeklyPayment(current.outsideSchedule),
-  );
+  ).filter((difference) => isChecked(difference.field));
   const scheduleMatches =
     current.cycleStartDate === period.startDate &&
     current.cycleEndDate === period.endDate &&
@@ -1536,11 +1750,13 @@ export async function verifyCurrentWeekWithCtx(
       current.closePosture?.status === expectedClosePosture?.status
     : current.acceptedBaselineId === undefined &&
       current.closePosture === undefined;
+  // Withheld fields cannot argue for an amendment either: an amendment is a
+  // claim that the week MOVED, and a field nobody checked has not moved.
   const acceptedIncludedDifferences = accepted
-    ? diffMetrics(included, weeklyVerifiedMetrics(accepted.included))
+    ? checkedDifferences(included, weeklyVerifiedMetrics(accepted.included))
     : [];
   const acceptedOutsideDifferences = accepted
-    ? diffMetrics(
+    ? checkedDifferences(
         outsideSchedule,
         weeklyVerifiedMetrics(accepted.outsideSchedule),
       )
@@ -1559,9 +1775,11 @@ export async function verifyCurrentWeekWithCtx(
     : !expectsAmendment
       ? current.amendment === undefined
       : current.amendment !== undefined &&
-        diffMetrics(included, weeklyVerifiedMetrics(current.amendment.included))
-          .length === 0 &&
-        diffMetrics(
+        checkedDifferences(
+          included,
+          weeklyVerifiedMetrics(current.amendment.included),
+        ).length === 0 &&
+        checkedDifferences(
           outsideSchedule,
           weeklyVerifiedMetrics(current.amendment.outsideSchedule),
         ).length === 0 &&
@@ -1601,6 +1819,7 @@ export async function verifyCurrentWeekWithCtx(
     outsideSchedulePaymentDifferences,
     scheduleMatches,
     truncated: false,
+    unverifiedFields,
     varianceMatches,
   };
 }

--- a/packages/athena-webapp/convex/reports/weeklyVerify.test.ts
+++ b/packages/athena-webapp/convex/reports/weeklyVerify.test.ts
@@ -575,7 +575,13 @@ describe("weekly source verification", () => {
     });
   });
 
-  it("keeps the weekly gate incomplete for an untimed legacy payment void", async () => {
+  /**
+   * REGRESSION — production, 2026-08-02. A day whose payment lane cannot
+   * complete used to sink the entire week to `incomplete`, discarding six
+   * verified lanes to say nothing about one. It now withholds the payment
+   * fields by name and verifies the rest.
+   */
+  it("withholds payment fields for an untimed legacy void, keeping the rest verified", async () => {
     const t = convexTest(schema, modules);
     const seeded = await t.run(async (ctx) => {
       const store = await seedStore(ctx);
@@ -616,12 +622,27 @@ describe("weekly source verification", () => {
       );
     });
     await t.run(async (ctx) => {
-      expect(await verifyCurrentWeekWithCtx(ctx, seeded.storeId)).toMatchObject(
-        {
-          daysChecked: 7,
-          outcome: "incomplete",
-          reason: "payment_source_incomplete",
-        },
+      const result = await verifyCurrentWeekWithCtx(ctx, seeded.storeId);
+      expect(result).toMatchObject({
+        daysChecked: 7,
+        includedPaymentDifferences: [],
+        outcome: "verified",
+        scheduleMatches: true,
+      });
+      if (result.outcome !== "verified") throw new Error("unreachable");
+      // The 2_000 collection the legacy void sits on is NOT reported as a
+      // discrepancy against the projection's 0 — it is reported as unchecked.
+      expect(
+        result.includedDifferences.filter((difference) =>
+          difference.field.startsWith("payment"),
+        ),
+      ).toEqual([]);
+      expect(result.unverifiedFields).toEqual(
+        expect.arrayContaining([
+          "paymentAllocatedMinor",
+          "paymentUnsettledMinor",
+          "paymentsCollectedMinor",
+        ]),
       );
     });
   });


### PR DESCRIPTION
Found by **running the verifier against production**, not by a test. Both defects were invisible to a green suite and only appeared at real data volume.

## Defect 1 — the payment lane could not return a verdict

`computeExpectedDay` scanned `paymentAllocation` over `[startAt - 90d, endAt]` under `VERIFY_MAX_DOCS_PER_DOMAIN = 500`. The window was correctly date-bounded (from `766bfe61`), but 90 days is too wide for a 500 cap: production Wigclub holds **1,050 allocations** in that window, ~12/day. So `verifyCurrentWeekAgainstSources` returned `incomplete/source_cap_exceeded`, and so did every per-day run for 2026-07-27..08-02.

The lookback exists because `paymentAllocation` is indexed on `recordedAt` only, so an allocation **recorded long ago but voided during the verified period** must still be found — a real but rare case that was costing the whole lane.

**Fix:** two independently bounded, index-backed range scans.
- In-period (`recordedAt` in `startAt..endAt`), ceiling `VERIFY_MAX_PAYMENT_ALLOCATIONS_IN_PERIOD = 5_000` — ~165× the measured rate, 10× the old cap.
- Reversal lookback (`[startAt - 90d, startAt)`), newest-first, ceiling `VERIFY_MAX_PAYMENT_REVERSAL_LOOKBACK_DOCS = 3_000` — ~2.8× measured. Pre-window rows contribute only their reversal; their original event belongs to an earlier day by construction.

Exhausting the **lookback** now degrades only reversal detection; the in-period posture still verifies. Arithmetic is documented beside the constants.

## Defect 2 — "unverifiable" was reported as "mismatched" (the more dangerous one)

With the lane incomplete, `expected` fell back to `0` and the diff builder emitted `{ field: "paymentsCollectedMinor", expected: 0, actual: 396000 }` with `matches: false`. Production output looked like corrupted data when **nothing had been checked**. A verifier that cannot distinguish "not checked" from "wrong" cries wolf, and a genuine mismatch becomes indistinguishable from a capacity limit.

**Fix:** `unverifiedFields` on the day and weekly results; withheld fields are filtered out of all six difference channels before anyone reads them. `matches` now means "everything checked agreed", and `matches: true` with a non-empty `unverifiedFields` is *partial* verification.

The degradation is deliberately **asymmetric**: an incomplete in-period lane withholds all seven payment fields, but an exhausted reversal lookback withholds all except `paymentsCollectedMinor` — in-period collection cannot be moved by an unseen historical void.

## Production evidence

- Weekly verification → `incomplete/source_cap_exceeded`.
- Per-day 2026-07-27..08-02: **sales lane verified clean on all seven days**, zero differences in net/gross/units/refunds. Only payments were affected. This also independently re-confirmed that the recent 106-day mass refold changed no values.

## Known limitations, recorded not glossed

- **Nothing reads `unverifiedFields` yet** — no dashboard, alert or UI. The unchecked-vs-wrong distinction exists in the return shape and in nothing an operator sees. The observability half is only half landed.
- The lookback is independent for the *capacity* path only; a pre-window `voided_refund_unsupported` or `legacy_void_missing_timestamp` still degrades in-period posture (correct — unrepresentable facts, not a capacity limit).
- `VERIFY_MAX_DOCS_PER_DOMAIN` remains 500 for five other lanes, none measured against production.

## Verification

- Full suite 674 files / 7,535 tests. A full run shows 1–2 failures in `usePosLocalSyncRuntime.test.ts` at ~5000ms — the known load flake: 96/96 in isolation, different tests failing per run.
- Falsified both fixes: restoring the 90-day/500 scan fails the over-cap test; making `unverifiedPaymentFields` return `[]` fails the withholding test.
- Deviation: the in-period lane uses a bounded `.take()` rather than pagination — Convex permits one `.paginate()` per function execution and this lane runs seven times inside one weekly verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)